### PR TITLE
Suggestions

### DIFF
--- a/code/languages/com.mbeddr.core/languages/com.mbeddr.core.arrays/languageModels/textGen.mps
+++ b/code/languages/com.mbeddr.core/languages/com.mbeddr.core.arrays/languageModels/textGen.mps
@@ -304,7 +304,7 @@
       <node concept="3clFbS" id="4AGl5dzxFV7" role="2VODD2">
         <node concept="lc7rE" id="4AGl5dzxFV8" role="3cqZAp">
           <node concept="la8eA" id="4AGl5dzxFVa" role="lcghm">
-            <property role="lacIc" value="0" />
+            <property role="lacIc" value="(void*)0" />
           </node>
         </node>
       </node>

--- a/code/languages/com.mbeddr.core/languages/com.mbeddr.core.arrays/languageModels/textGen.mps
+++ b/code/languages/com.mbeddr.core/languages/com.mbeddr.core.arrays/languageModels/textGen.mps
@@ -304,7 +304,7 @@
       <node concept="3clFbS" id="4AGl5dzxFV7" role="2VODD2">
         <node concept="lc7rE" id="4AGl5dzxFV8" role="3cqZAp">
           <node concept="la8eA" id="4AGl5dzxFVa" role="lcghm">
-            <property role="lacIc" value="(void*)0" />
+            <property role="lacIc" value="0" />
           </node>
         </node>
       </node>


### PR DESCRIPTION
null (NULL) can be explicitly (void*)0 instead of 0. Invisible with gcc, but makes cbmc on windows aware of null pointers and all (with flag --pointer-check).

Misra C 2004 Sec. 6.11 refers to NULL only as the "null pointer constant (the value 0 cast to type void*)". 
However, C11 Sec. 6.3.2.3 paragraph 3 says that "an integer constant expression with the value 0, or such an expression cast to type void *, is called a null pointer constant" -- thus also covering the 0 constant without cast.