### PR TITLE
core: declare typedef dependencies correctly

### DIFF
--- a/code/languages/com.mbeddr.core/languages/com.mbeddr.core.udt/languageModels/behavior.mps
+++ b/code/languages/com.mbeddr.core/languages/com.mbeddr.core.udt/languageModels/behavior.mps
@@ -2425,8 +2425,68 @@
       <property role="TrG5h" value="allReferencedModuleContents" />
       <ref role="13i0hy" to="qd6m:1zPfrUoUUqq" resolve="allReferencedModuleContents" />
       <node concept="3clFbS" id="24lM_j3_gQ2" role="3clF47">
+        <node concept="3cpWs8" id="6IBKEH6myIn" role="3cqZAp">
+          <node concept="3cpWsn" id="6IBKEH6myIq" role="3cpWs9">
+            <property role="TrG5h" value="res" />
+            <node concept="2I9FWS" id="6IBKEH6myIl" role="1tU5fm">
+              <ref role="2I9WkF" to="x27k:5_l8w1EmTdf" resolve="IModuleContent" />
+            </node>
+            <node concept="2ShNRf" id="6IBKEH6myM6" role="33vP2m">
+              <node concept="2T8Vx0" id="6IBKEH6myM4" role="2ShVmc">
+                <node concept="2I9FWS" id="6IBKEH6myM5" role="2T96Bj">
+                  <ref role="2I9WkF" to="x27k:5_l8w1EmTdf" resolve="IModuleContent" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="6IBKEH6muYq" role="3cqZAp">
+          <node concept="3clFbS" id="6IBKEH6muYs" role="3clFbx">
+            <node concept="3clFbF" id="6IBKEH6myPc" role="3cqZAp">
+              <node concept="2OqwBi" id="6IBKEH6mzBa" role="3clFbG">
+                <node concept="37vLTw" id="6IBKEH6myPb" role="2Oq$k0">
+                  <ref role="3cqZAo" node="6IBKEH6myIq" resolve="res" />
+                </node>
+                <node concept="TSZUe" id="6IBKEH6mBpD" role="2OqNvi">
+                  <node concept="1PxgMI" id="6IBKEH6mBPr" role="25WWJ7">
+                    <ref role="1PxNhF" to="x27k:5_l8w1EmTdf" resolve="IModuleContent" />
+                    <node concept="2OqwBi" id="6IBKEH6mysi" role="1PxMeX">
+                      <node concept="1PxgMI" id="6IBKEH6mykP" role="2Oq$k0">
+                        <ref role="1PxNhF" to="vs0r:7jSUHHvkAp9" resolve="IModuleContentRef" />
+                        <node concept="2OqwBi" id="6IBKEH6mx40" role="1PxMeX">
+                          <node concept="13iPFW" id="6IBKEH6mwWd" role="2Oq$k0" />
+                          <node concept="3TrEf2" id="6IBKEH6mx$U" role="2OqNvi">
+                            <ref role="3Tt5mk" to="clbe:5jyom5fO9Cm" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="2qgKlT" id="6IBKEH6myzI" role="2OqNvi">
+                        <ref role="37wK5l" to="hwgx:7jSUHHvkAph" resolve="referencedModuleContent" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="6IBKEH6mwA8" role="3clFbw">
+            <node concept="2OqwBi" id="6IBKEH6mv5T" role="2Oq$k0">
+              <node concept="13iPFW" id="6IBKEH6muYK" role="2Oq$k0" />
+              <node concept="3TrEf2" id="6IBKEH6mwhe" role="2OqNvi">
+                <ref role="3Tt5mk" to="clbe:5jyom5fO9Cm" />
+              </node>
+            </node>
+            <node concept="1mIQ4w" id="6IBKEH6mwQn" role="2OqNvi">
+              <node concept="chp4Y" id="6IBKEH6mwT4" role="cj9EA">
+                <ref role="cht4Q" to="vs0r:7jSUHHvkAp9" resolve="IModuleContentRef" />
+              </node>
+            </node>
+          </node>
+        </node>
         <node concept="3clFbF" id="61nbyEY4l_$" role="3cqZAp">
-          <node concept="10Nm6u" id="61nbyEY4l_z" role="3clFbG" />
+          <node concept="37vLTw" id="6IBKEH6mCk4" role="3clFbG">
+            <ref role="3cqZAo" node="6IBKEH6myIq" resolve="res" />
+          </node>
         </node>
       </node>
       <node concept="A3Dl8" id="24lM_j3_gQ3" role="3clF45">
@@ -5956,7 +6016,7 @@
   </node>
   <node concept="13h7C7" id="3qdsM6yQqoN">
     <property role="3GE5qa" value="su" />
-    <ref role="13h7C2" to="clbe:3qdsM6yQbcF" resolve="ArbitraryMemeberRef" />
+    <ref role="13h7C2" to="clbe:3qdsM6yQbcF" resolve="ArbitraryMemberRef" />
     <node concept="13hLZK" id="3qdsM6yQqoO" role="13h7CW">
       <node concept="3clFbS" id="3qdsM6yQqoP" role="2VODD2" />
     </node>

--- a/code/languages/com.mbeddr.core/tests/test.ex.core/test/ex/core/typedefsAndTypes.mps
+++ b/code/languages/com.mbeddr.core/tests/test.ex.core/test/ex/core/typedefsAndTypes.mps
@@ -66,6 +66,14 @@
       <concept id="6116558314501347863" name="com.mbeddr.core.udt.structure.TypeDefType" flags="ng" index="rcJHQ">
         <reference id="6116558314501347864" name="typeDef" index="rcJHT" />
       </concept>
+      <concept id="7099329415459817973" name="com.mbeddr.core.udt.structure.SUDeclaration" flags="ng" index="HsMI8">
+        <child id="7099329415459888018" name="members" index="HszBJ" />
+      </concept>
+      <concept id="5882395403881875736" name="com.mbeddr.core.udt.structure.Member" flags="ng" index="1dpRTG" />
+      <concept id="6394819151180597807" name="com.mbeddr.core.udt.structure.StructDeclaration" flags="ng" index="1sgJKc" />
+      <concept id="6394819151180597816" name="com.mbeddr.core.udt.structure.StructType" flags="ng" index="1sgJKr">
+        <reference id="6394819151180597817" name="struct" index="1sgJKq" />
+      </concept>
     </language>
     <language id="d4280a54-f6df-4383-aa41-d1b2bffa7eb1" name="com.mbeddr.core.base">
       <concept id="8375407818529178006" name="com.mbeddr.core.base.structure.TextBlock" flags="ng" index="OjmMv">
@@ -201,6 +209,32 @@
     <node concept="rcJHK" id="7lNBHBNC4_C" role="N3F5h">
       <property role="TrG5h" value="zahl" />
       <node concept="26Vqqz" id="4Pack3zSiTV" role="rcJHR" />
+    </node>
+    <node concept="2NXPZ9" id="6IBKEH6mtAo" role="N3F5h">
+      <property role="TrG5h" value="empty_1469256040133_3" />
+    </node>
+    <node concept="rcJHK" id="6IBKEH6mtqi" role="N3F5h">
+      <property role="TrG5h" value="str" />
+      <property role="2OOxQR" value="true" />
+      <node concept="1sgJKr" id="6IBKEH6mt_G" role="rcJHR">
+        <property role="2caQfQ" value="false" />
+        <property role="2c7vTL" value="false" />
+        <ref role="1sgJKq" node="6IBKEH6mt3p" resolve="aStruct" />
+      </node>
+    </node>
+    <node concept="1sgJKc" id="6IBKEH6mt3p" role="N3F5h">
+      <property role="TrG5h" value="aStruct" />
+      <property role="2OOxQR" value="true" />
+      <node concept="1dpRTG" id="6IBKEH6mteD" role="HszBJ">
+        <property role="TrG5h" value="dummy" />
+        <node concept="26Vqqz" id="6IBKEH6mteC" role="2C2TGm">
+          <property role="2caQfQ" value="false" />
+          <property role="2c7vTL" value="false" />
+        </node>
+      </node>
+    </node>
+    <node concept="2NXPZ9" id="6IBKEH6mtLF" role="N3F5h">
+      <property role="TrG5h" value="empty_1469256042096_4" />
     </node>
     <node concept="c0Qz5" id="7lNBHBNC4__" role="N3F5h">
       <property role="2OOxQR" value="true" />

--- a/code/languages/com.mbeddr.core/tests/test.ts.core/models/tests1@tests.mps
+++ b/code/languages/com.mbeddr.core/tests/test.ts.core/models/tests1@tests.mps
@@ -695,6 +695,41 @@
         <node concept="2NXPZ9" id="6mfXVgRsmvO" role="N3F5h">
           <property role="TrG5h" value="empty_1333553333464_2" />
         </node>
+        <node concept="2NXPZ9" id="6IBKEH6muee" role="N3F5h">
+          <property role="TrG5h" value="empty_1469256065215_5" />
+        </node>
+        <node concept="rcJHK" id="6IBKEH6mtqi" role="N3F5h">
+          <property role="TrG5h" value="str" />
+          <property role="2OOxQR" value="true" />
+          <node concept="1sgJKr" id="6IBKEH6mt_G" role="rcJHR">
+            <property role="2caQfQ" value="false" />
+            <property role="2c7vTL" value="false" />
+            <ref role="1sgJKq" node="6IBKEH6mt3p" resolve="aStruct" />
+          </node>
+        </node>
+        <node concept="1sgJKc" id="6IBKEH6mt3p" role="N3F5h">
+          <property role="TrG5h" value="aStruct" />
+          <node concept="1dpRTG" id="6IBKEH6mteD" role="HszBJ">
+            <property role="TrG5h" value="dummy" />
+            <node concept="26Vqqz" id="6IBKEH6mteC" role="2C2TGm">
+              <property role="2caQfQ" value="false" />
+              <property role="2c7vTL" value="false" />
+            </node>
+          </node>
+          <node concept="7CXmI" id="6IBKEH6mVu6" role="lGtFl">
+            <node concept="1TM$A" id="6IBKEH6mVu7" role="7EUXB">
+              <node concept="2PYRI3" id="6IBKEH6mVu8" role="3lydEf">
+                <ref role="39XzEq" to="p3tm:_Ibf584Jiw" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2NXPZ9" id="6IBKEH6muhn" role="N3F5h">
+          <property role="TrG5h" value="empty_1469256065965_7" />
+        </node>
+        <node concept="2NXPZ9" id="6IBKEH6mufG" role="N3F5h">
+          <property role="TrG5h" value="empty_1469256065396_6" />
+        </node>
         <node concept="rcJHK" id="7RiewQ_kbwX" role="N3F5h">
           <property role="TrG5h" value="zahl" />
           <node concept="26Vqqz" id="4Pack3zSiDs" role="rcJHR" />


### PR DESCRIPTION
if a typedef referenced a type that is a referece to an other module content
this module content was not returned as a dependencie. Causing the typesystem
checks not being aware of this dependency.

fixes #1439 