### PR TITLE
NoSuchMethodException while selecting words from comment statement

### DIFF
--- a/code/plugins/sl-all/mps-richtext/languages/richtext/models/de/slisson/mps/richtext/runtime/selection.mps
+++ b/code/plugins/sl-all/mps-richtext/languages/richtext/models/de/slisson/mps/richtext/runtime/selection.mps
@@ -635,8 +635,8 @@
       </node>
       <node concept="37vLTG" id="1laD9eY9cE6" role="3clF46">
         <property role="TrG5h" value="cellInfo" />
-        <node concept="3uibUv" id="1laD9eY9cE7" role="1tU5fm">
-          <ref role="3uigEE" to="g51k:~CellInfo" resolve="CellInfo" />
+        <node concept="3uibUv" id="61NsQrwHMTD" role="1tU5fm">
+          <ref role="3uigEE" to="f4zo:~CellInfo" resolve="CellInfo" />
         </node>
       </node>
       <node concept="3cqZAl" id="2_D0AvWRqTU" role="3clF45" />
@@ -2851,7 +2851,7 @@
                       <ref role="3cqZAo" node="4OHf36xNmlr" resolve="textNode" />
                     </node>
                     <node concept="3Tsc0h" id="4OHf36xNmop" role="2OqNvi">
-                      <ref role="3TtcxE" to="87nw:2dWzqxEBBFI" />
+                      <ref role="3TtcxE" to="87nw:2dWzqxEBBFI" resolve="words" />
                     </node>
                   </node>
                   <node concept="1uHKPH" id="4OHf36xNmoS" role="2OqNvi" />
@@ -2878,7 +2878,7 @@
                       <ref role="3cqZAo" node="4OHf36xNmlr" resolve="textNode" />
                     </node>
                     <node concept="3Tsc0h" id="4OHf36xNmKF" role="2OqNvi">
-                      <ref role="3TtcxE" to="87nw:2dWzqxEBBFI" />
+                      <ref role="3TtcxE" to="87nw:2dWzqxEBBFI" resolve="words" />
                     </node>
                   </node>
                   <node concept="1yVyf7" id="4OHf36xNmKW" role="2OqNvi" />
@@ -2960,7 +2960,7 @@
                         <ref role="3cqZAo" node="4OHf36xNmlr" resolve="textNode" />
                       </node>
                       <node concept="3Tsc0h" id="4OHf36xNmPv" role="2OqNvi">
-                        <ref role="3TtcxE" to="87nw:2dWzqxEBBFI" />
+                        <ref role="3TtcxE" to="87nw:2dWzqxEBBFI" resolve="words" />
                       </node>
                     </node>
                     <node concept="34oBXx" id="4OHf36xNmPZ" role="2OqNvi" />
@@ -2996,7 +2996,7 @@
                         <ref role="3cqZAo" node="4OHf36xNmlr" resolve="textNode" />
                       </node>
                       <node concept="3Tsc0h" id="4OHf36xNmRi" role="2OqNvi">
-                        <ref role="3TtcxE" to="87nw:2dWzqxEBBFI" />
+                        <ref role="3TtcxE" to="87nw:2dWzqxEBBFI" resolve="words" />
                       </node>
                     </node>
                     <node concept="34oBXx" id="4OHf36xNmRj" role="2OqNvi" />


### PR DESCRIPTION
Hi,

This pull request is part of the defect accent-2407.

When shift+up is done on any rich text , no such method exception is thrown on the constructor of RichTextSelection class file. In the SelectionInfoImpl.createSelection method, jetbrains is using reflection to get the constructor and create a new instance out of it. 

![image](https://cloud.githubusercontent.com/assets/9694723/19924010/1d3aad70-a110-11e6-9785-7cad251b2343.png)

The CellInfo.class is part of j.m.o.editor.cells but the RichTextSelection has implemented a constructor having a different CellInfo.class which is part of j.m.nodeEditor.cells and it is deprecated. I have updated this reference. Please review and merge into milestone/v15-3

Regards,

Dinesh