### PR TITLE
Restricting Multiple Entries (for Number Literal) in the code completion menu

### DIFF
--- a/code/languages/com.mbeddr.core/languages/com.mbeddr.core.expressions/languageModels/editor.mps
+++ b/code/languages/com.mbeddr.core/languages/com.mbeddr.core.expressions/languageModels/editor.mps
@@ -4579,5 +4579,32 @@
   <node concept="3p36aQ" id="2cvVnUv6F2g">
     <ref role="aqKnT" to="mj1l:3MUk0N5szEJ" resolve="PreIncrementExpression" />
   </node>
+  <node concept="24kQdi" id="7$nPHWGQQS$">
+    <property role="3GE5qa" value="literals" />
+    <ref role="1XX52x" to="mj1l:68dbbc7rHp$" resolve="UnsignedIntegerLiteral" />
+    <node concept="1WcQYu" id="7$nPHWGQQWL" role="2wV5jI">
+      <node concept="2ElW$n" id="7$nPHWGQQWM" role="2El2Yn">
+        <node concept="2OqwBi" id="7$nPHWGQQWN" role="2EmURo">
+          <node concept="2EmZKS" id="7$nPHWGQQWO" role="2Oq$k0" />
+          <node concept="2qgKlT" id="7$nPHWGQQWP" role="2OqNvi">
+            <ref role="37wK5l" to="ywuz:5HxjapwgqKu" resolve="getPriolevel" />
+          </node>
+        </node>
+      </node>
+      <node concept="3EZMnI" id="7$nPHWGQQWQ" role="1LiK7o">
+        <node concept="1kIj98" id="7$nPHWGQQWR" role="3EZMnx">
+          <node concept="2lNzut" id="7$nPHWGQQWS" role="1kIj9b">
+            <ref role="1NtTu8" to="mj1l:1UQ4qqfV3yK" resolve="value" />
+            <ref role="1k5W1q" to="r4b4:2CEi94dgUHC" resolve="Number" />
+            <node concept="bYqod" id="7$nPHWGQQWT" role="2lD6_D" />
+          </node>
+        </node>
+        <node concept="2iRfu4" id="7$nPHWGQQWU" role="2iSdaV" />
+      </node>
+    </node>
+    <node concept="PMmxH" id="7$nPHWGQR1i" role="6VMZX">
+      <ref role="PMmxG" node="5CDgsyZbE9V" resolve="staticValueComponent" />
+    </node>
+  </node>
 </model>
 


### PR DESCRIPTION
Hi,

The unsigned integer literal which was made abstract and deprecated by Sascha was reverted by me yesterday and as a result of that, multiple entries are being listed in the code completion menu if you type a number. For example, if you type "10", it was not automatically mapping it as number literal and it shows two entries as "10" in the code completion menu.
![image](https://cloud.githubusercontent.com/assets/9694723/19956190/83f3d24a-a1af-11e6-8f53-12ec69aabf0b.png)

The unsigned integer literal was abstract previously, abstract concepts are not listed in the code completion by default. Since I reverted it and made non-abstract, it made itself available for the code completion.

This behaviour was easily found by a failing unit test in the accent repository.

So I have specified an editor for the unsigned integer literal and the problem of multiple entries in the code completion menu is not occuring anymore.

Please review and merge in milestone/v15-3

Regards,

Dinesh 