### PR TITLE
add mbeddr publication to build against complete mbeddr

### DIFF
--- a/build/com.mbeddr/everythingElse/build.gradle
+++ b/build/com.mbeddr/everythingElse/build.gradle
@@ -21,6 +21,10 @@ configurations {
     mbeddrAllInOne {
         description = 'mbeddr allInOne'
     }
+
+    mbeddr {
+        description = 'mbeddr'
+    }
     mbeddrPlatform {
         description = 'mbeddr platform distribution'
     }
@@ -226,6 +230,17 @@ publishing {
     }
 }
 
+publishing {
+    publications {
+        mbeddr(MavenPublication) {
+            groupId 'com.mbeddr'
+            artifactId 'mbeddr'
+            version mbeddrBuildNumber
+            artifact(publish_mbeddr) {}
+        }
+    }
+}
+
 def script_build_mbeddrAllInOne = new File(scriptsBasePath + "/com.mbeddr.allInOne/" + "build.xml")
 
 task build_all_in_one(type: BuildLanguages, dependsOn: ':build:com.mbeddr:platform:copy_allScripts') {
@@ -235,6 +250,11 @@ task build_all_in_one(type: BuildLanguages, dependsOn: ':build:com.mbeddr:platfo
 task publish_all_in_one(type: Zip, dependsOn: build_all_in_one) {
     from rootProject.projectDir.absolutePath + "/artifacts/"
     include "com.mbeddr.allInOne/com.mbeddr.allInOne.zip"
+}
+
+task publish_mbeddr(type: Zip, dependsOn: build_all_in_one) {
+    from rootProject.projectDir.absolutePath + "/artifacts/mbeddr"
+    include "*.zip"
 }
 
 // :build:com.mbeddr.rcp


### PR DESCRIPTION
I had to add a new publication that contains all the individual zips of the mbeddr plugins in order to able to build other projects against mbeddr that depend of more than the platform.

@sergej-koscejev can you have look that I didn't screw up anything else with it?