### PR TITLE
Changing the expected version of cbmc to 5.5

### DIFF
--- a/code/languages/com.mbeddr.analyses/languages/com.mbeddr.analyses.cbmc.rt/models/com/mbeddr/analyses/cbmc/rt/run.mps
+++ b/code/languages/com.mbeddr.analyses/languages/com.mbeddr.analyses.cbmc.rt/models/com/mbeddr/analyses/cbmc/rt/run.mps
@@ -10821,7 +10821,7 @@
                 </node>
                 <node concept="TSZUe" id="7Pk2mb7Mk7L" role="2OqNvi">
                   <node concept="Xl_RD" id="7Pk2mb7MkhW" role="25WWJ7">
-                    <property role="Xl_RC" value="expected CBMC version 5.3, 5.4 or 5.5 but" />
+                    <property role="Xl_RC" value="expected CBMC version 5.5 but" />
                   </node>
                 </node>
               </node>
@@ -10857,45 +10857,15 @@
               </node>
             </node>
           </node>
-          <node concept="1Wc70l" id="3iYcKRgT424" role="3clFbw">
-            <node concept="1Wc70l" id="3ea$Wa9jJwh" role="3uHU7B">
-              <node concept="3fqX7Q" id="7GloF9XTI7_" role="3uHU7B">
-                <node concept="2OqwBi" id="7GloF9XTI7B" role="3fr31v">
-                  <node concept="37vLTw" id="7GloF9XTI7C" role="2Oq$k0">
-                    <ref role="3cqZAo" node="7GloF9XT2HS" resolve="firstLine" />
-                  </node>
-                  <node concept="liA8E" id="7GloF9XTI7D" role="2OqNvi">
-                    <ref role="37wK5l" to="wyt6:~String.contains(java.lang.CharSequence):boolean" resolve="contains" />
-                    <node concept="Xl_RD" id="7GloF9XTI7E" role="37wK5m">
-                      <property role="Xl_RC" value="5.3" />
-                    </node>
-                  </node>
-                </node>
+          <node concept="3fqX7Q" id="3iYcKRgT8Qd" role="3clFbw">
+            <node concept="2OqwBi" id="3iYcKRgT8Qe" role="3fr31v">
+              <node concept="37vLTw" id="3iYcKRgT8Qf" role="2Oq$k0">
+                <ref role="3cqZAo" node="7GloF9XT2HS" resolve="firstLine" />
               </node>
-              <node concept="3fqX7Q" id="3ea$Wa9jLUc" role="3uHU7w">
-                <node concept="2OqwBi" id="3ea$Wa9jLUd" role="3fr31v">
-                  <node concept="37vLTw" id="3ea$Wa9jLUe" role="2Oq$k0">
-                    <ref role="3cqZAo" node="7GloF9XT2HS" resolve="firstLine" />
-                  </node>
-                  <node concept="liA8E" id="3ea$Wa9jLUf" role="2OqNvi">
-                    <ref role="37wK5l" to="wyt6:~String.contains(java.lang.CharSequence):boolean" resolve="contains" />
-                    <node concept="Xl_RD" id="3ea$Wa9jLUg" role="37wK5m">
-                      <property role="Xl_RC" value="5.4" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3fqX7Q" id="3iYcKRgT8Qd" role="3uHU7w">
-              <node concept="2OqwBi" id="3iYcKRgT8Qe" role="3fr31v">
-                <node concept="37vLTw" id="3iYcKRgT8Qf" role="2Oq$k0">
-                  <ref role="3cqZAo" node="7GloF9XT2HS" resolve="firstLine" />
-                </node>
-                <node concept="liA8E" id="3iYcKRgT8Qg" role="2OqNvi">
-                  <ref role="37wK5l" to="wyt6:~String.contains(java.lang.CharSequence):boolean" resolve="contains" />
-                  <node concept="Xl_RD" id="3iYcKRgT8Qh" role="37wK5m">
-                    <property role="Xl_RC" value="5.5" />
-                  </node>
+              <node concept="liA8E" id="3iYcKRgT8Qg" role="2OqNvi">
+                <ref role="37wK5l" to="wyt6:~String.contains(java.lang.CharSequence):boolean" resolve="contains" />
+                <node concept="Xl_RD" id="3iYcKRgT8Qh" role="37wK5m">
+                  <property role="Xl_RC" value="5.5" />
                 </node>
               </node>
             </node>


### PR DESCRIPTION
Hi,

Previously the expected version of cbmc was 5.3 or 5.4 or 5.5. Now I have changed the check to expect only 5.5 and the message conveyed also says 5.5.

I am not sure if mbeddr can support 5.3 and 5.4 also. This should not affect anything in mbeddr according to me.

Please review and merge in milestone/v15-3

Regards,

Dinesh