### PR TITLE
Tool-tip populated in some cases looses contents and stays a ghost images- need to kill the application to remove these.

### DIFF
--- a/code/plugins/sl-all/solutions/de.itemis.mps.tooltips.runtime/models/de/itemis/mps/tooltips/runtime.mps
+++ b/code/plugins/sl-all/solutions/de.itemis.mps.tooltips.runtime/models/de/itemis/mps/tooltips/runtime.mps
@@ -1894,9 +1894,6 @@
         </node>
       </node>
       <node concept="3clFbS" id="7CEHNszwtSW" role="3clF47">
-        <node concept="3clFbH" id="6PI4N6Jqr6s" role="3cqZAp" />
-        <node concept="3clFbH" id="6PI4N6JqqGc" role="3cqZAp" />
-        <node concept="3clFbH" id="6PI4N6JqqLt" role="3cqZAp" />
         <node concept="3cpWs8" id="6PI4N6Jqrmd" role="3cqZAp">
           <node concept="3cpWsn" id="6PI4N6Jqrme" role="3cpWs9">
             <property role="TrG5h" value="g" />
@@ -1920,64 +1917,88 @@
         </node>
         <node concept="2GUZhq" id="6PI4N6Jqqpx" role="3cqZAp">
           <node concept="3clFbS" id="6PI4N6Jqqpz" role="2GV8ay">
-            <node concept="3clFbF" id="6PI4N6Jqu2Y" role="3cqZAp">
-              <node concept="2YIFZM" id="6PI4N6JquhA" role="3clFbG">
-                <ref role="37wK5l" to="exr9:~EditorComponent.turnOnAliasingIfPossible(java.awt.Graphics2D):void" resolve="turnOnAliasingIfPossible" />
-                <ref role="1Pybhc" to="exr9:~EditorComponent" resolve="EditorComponent" />
-                <node concept="37vLTw" id="6PI4N6Jquke" role="37wK5m">
-                  <ref role="3cqZAo" node="6PI4N6Jqrme" resolve="g" />
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbF" id="6PI4N6JquRw" role="3cqZAp">
-              <node concept="2OqwBi" id="6PI4N6JquSO" role="3clFbG">
-                <node concept="37vLTw" id="6PI4N6JquRu" role="2Oq$k0">
-                  <ref role="3cqZAo" node="6PI4N6Jqrme" resolve="g" />
-                </node>
-                <node concept="liA8E" id="6PI4N6Jqv1A" role="2OqNvi">
-                  <ref role="37wK5l" to="z60i:~Graphics2D.translate(int,int):void" resolve="translate" />
-                  <node concept="3cpWs3" id="6PI4N6JqwWS" role="37wK5m">
-                    <node concept="37vLTw" id="6PI4N6Jqxen" role="3uHU7w">
-                      <ref role="3cqZAo" node="7CEHNszC8rg" resolve="X_PADDING" />
+            <node concept="3clFbJ" id="4ly_gLTU$5M" role="3cqZAp">
+              <node concept="3clFbS" id="4ly_gLTU$5O" role="3clFbx">
+                <node concept="3clFbF" id="6PI4N6Jqu2Y" role="3cqZAp">
+                  <node concept="2YIFZM" id="6PI4N6JquhA" role="3clFbG">
+                    <ref role="37wK5l" to="exr9:~EditorComponent.turnOnAliasingIfPossible(java.awt.Graphics2D):void" resolve="turnOnAliasingIfPossible" />
+                    <ref role="1Pybhc" to="exr9:~EditorComponent" resolve="EditorComponent" />
+                    <node concept="37vLTw" id="6PI4N6Jquke" role="37wK5m">
+                      <ref role="3cqZAo" node="6PI4N6Jqrme" resolve="g" />
                     </node>
-                    <node concept="1ZRNhn" id="6PI4N6Jqw7Y" role="3uHU7B">
-                      <node concept="2OqwBi" id="6PI4N6Jqvdv" role="2$L3a6">
-                        <node concept="37vLTw" id="6PI4N6Jqv6U" role="2Oq$k0">
-                          <ref role="3cqZAo" node="7CEHNszwtjr" resolve="myTooltipCell" />
+                  </node>
+                </node>
+                <node concept="3clFbF" id="6PI4N6JquRw" role="3cqZAp">
+                  <node concept="2OqwBi" id="6PI4N6JquSO" role="3clFbG">
+                    <node concept="37vLTw" id="6PI4N6JquRu" role="2Oq$k0">
+                      <ref role="3cqZAo" node="6PI4N6Jqrme" resolve="g" />
+                    </node>
+                    <node concept="liA8E" id="6PI4N6Jqv1A" role="2OqNvi">
+                      <ref role="37wK5l" to="z60i:~Graphics2D.translate(int,int):void" resolve="translate" />
+                      <node concept="3cpWs3" id="6PI4N6JqwWS" role="37wK5m">
+                        <node concept="37vLTw" id="6PI4N6Jqxen" role="3uHU7w">
+                          <ref role="3cqZAo" node="7CEHNszC8rg" resolve="X_PADDING" />
                         </node>
-                        <node concept="liA8E" id="6PI4N6Jqvjz" role="2OqNvi">
-                          <ref role="37wK5l" to="f4zo:~EditorCell.getX():int" resolve="getX" />
+                        <node concept="1ZRNhn" id="6PI4N6Jqw7Y" role="3uHU7B">
+                          <node concept="2OqwBi" id="6PI4N6Jqvdv" role="2$L3a6">
+                            <node concept="37vLTw" id="6PI4N6Jqv6U" role="2Oq$k0">
+                              <ref role="3cqZAo" node="7CEHNszwtjr" resolve="myTooltipCell" />
+                            </node>
+                            <node concept="liA8E" id="6PI4N6Jqvjz" role="2OqNvi">
+                              <ref role="37wK5l" to="f4zo:~EditorCell.getX():int" resolve="getX" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3cpWs3" id="6PI4N6JqxGv" role="37wK5m">
+                        <node concept="37vLTw" id="6PI4N6JqyvK" role="3uHU7w">
+                          <ref role="3cqZAo" node="3brlo9KRxuh" resolve="Y_PADDING" />
+                        </node>
+                        <node concept="1ZRNhn" id="6PI4N6JqwvA" role="3uHU7B">
+                          <node concept="2OqwBi" id="6PI4N6JqvIZ" role="2$L3a6">
+                            <node concept="37vLTw" id="6PI4N6JqvyK" role="2Oq$k0">
+                              <ref role="3cqZAo" node="7CEHNszwtjr" resolve="myTooltipCell" />
+                            </node>
+                            <node concept="liA8E" id="6PI4N6JqvTO" role="2OqNvi">
+                              <ref role="37wK5l" to="f4zo:~EditorCell.getY():int" resolve="getY" />
+                            </node>
+                          </node>
                         </node>
                       </node>
                     </node>
                   </node>
-                  <node concept="3cpWs3" id="6PI4N6JqxGv" role="37wK5m">
-                    <node concept="37vLTw" id="6PI4N6JqyvK" role="3uHU7w">
-                      <ref role="3cqZAo" node="3brlo9KRxuh" resolve="Y_PADDING" />
+                </node>
+                <node concept="3clFbF" id="7CEHNszwuDf" role="3cqZAp">
+                  <node concept="2OqwBi" id="7CEHNszwuEW" role="3clFbG">
+                    <node concept="37vLTw" id="7CEHNszwuDe" role="2Oq$k0">
+                      <ref role="3cqZAo" node="7CEHNszwtjr" resolve="myTooltipCell" />
                     </node>
-                    <node concept="1ZRNhn" id="6PI4N6JqwvA" role="3uHU7B">
-                      <node concept="2OqwBi" id="6PI4N6JqvIZ" role="2$L3a6">
-                        <node concept="37vLTw" id="6PI4N6JqvyK" role="2Oq$k0">
-                          <ref role="3cqZAo" node="7CEHNszwtjr" resolve="myTooltipCell" />
-                        </node>
-                        <node concept="liA8E" id="6PI4N6JqvTO" role="2OqNvi">
-                          <ref role="37wK5l" to="f4zo:~EditorCell.getY():int" resolve="getY" />
-                        </node>
+                    <node concept="liA8E" id="7CEHNszwv0x" role="2OqNvi">
+                      <ref role="37wK5l" to="g51k:~EditorCell.paint(java.awt.Graphics):void" resolve="paint" />
+                      <node concept="37vLTw" id="6PI4N6JqERf" role="37wK5m">
+                        <ref role="3cqZAo" node="6PI4N6Jqrme" resolve="g" />
                       </node>
                     </node>
                   </node>
                 </node>
               </node>
-            </node>
-            <node concept="3clFbF" id="7CEHNszwuDf" role="3cqZAp">
-              <node concept="2OqwBi" id="7CEHNszwuEW" role="3clFbG">
-                <node concept="37vLTw" id="7CEHNszwuDe" role="2Oq$k0">
-                  <ref role="3cqZAo" node="7CEHNszwtjr" resolve="myTooltipCell" />
-                </node>
-                <node concept="liA8E" id="7CEHNszwv0x" role="2OqNvi">
-                  <ref role="37wK5l" to="g51k:~EditorCell.paint(java.awt.Graphics):void" resolve="paint" />
-                  <node concept="37vLTw" id="6PI4N6JqERf" role="37wK5m">
-                    <ref role="3cqZAo" node="6PI4N6Jqrme" resolve="g" />
+              <node concept="3fqX7Q" id="4ly_gLTU_91" role="3clFbw">
+                <node concept="2OqwBi" id="4ly_gLTU_ta" role="3fr31v">
+                  <node concept="2OqwBi" id="4ly_gLTUxSS" role="2Oq$k0">
+                    <node concept="2OqwBi" id="4ly_gLTUxu$" role="2Oq$k0">
+                      <node concept="37vLTw" id="4ly_gLTUwAz" role="2Oq$k0">
+                        <ref role="3cqZAo" node="7CEHNszwtjr" resolve="myTooltipCell" />
+                      </node>
+                      <node concept="liA8E" id="4ly_gLTUxIf" role="2OqNvi">
+                        <ref role="37wK5l" to="f4zo:~EditorCell.getContext():jetbrains.mps.openapi.editor.EditorContext" resolve="getContext" />
+                      </node>
+                    </node>
+                    <node concept="liA8E" id="4ly_gLTUyoT" role="2OqNvi">
+                      <ref role="37wK5l" to="cj4x:~EditorContext.getEditorComponent():jetbrains.mps.openapi.editor.EditorComponent" resolve="getEditorComponent" />
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="4ly_gLTUA5g" role="2OqNvi">
+                    <ref role="37wK5l" to="cj4x:~EditorComponent.isDisposed():boolean" resolve="isDisposed" />
                   </node>
                 </node>
               </node>


### PR DESCRIPTION
Hi,

When the tool tip component tries to paint the tooltip messages,  sometimes the editor component gets disposed and so the partially painted tooltip remains there in the implementation module and does not disappear until you restart the application. You can see it in the following images.

![a](https://cloud.githubusercontent.com/assets/9694723/20296810/e8e6aa7e-ab32-11e6-9e9b-6506d9f9d46a.png)
![c](https://cloud.githubusercontent.com/assets/9694723/20296814/ec33a240-ab32-11e6-8bf4-8e88ef5e8e03.png)
![d](https://cloud.githubusercontent.com/assets/9694723/20296815/ed6a6f86-ab32-11e6-9efc-2348ab087fd3.png)


I am attaching the stack trace as text file here. 
[tooltip problem.txt](https://github.com/mbeddr/mbeddr.core/files/591273/tooltip.problem.txt)

In the below attached image, you could see that the stacktraces navigates me to the getMessage method of NodeHighlightManager where they have asserted whether the editor is disposed or not.
![f](https://cloud.githubusercontent.com/assets/9694723/20296821/f1329846-ab32-11e6-9390-abfb592f22cf.png)

I have added a check to show the tooltip only if the editorcomponent is not disposed.

Please review and merge in milestone/v15-3

Regards,

Dinesh