### PR TITLE
variable name changed causes value not showing in tooltip

### DIFF
--- a/code/languages/com.mbeddr.core/languages/com.mbeddr.core.unittest/languageAccessories/com/mbeddr/core/unittest/messages.mps
+++ b/code/languages/com.mbeddr.core/languages/com.mbeddr.core.unittest/languageAccessories/com/mbeddr/core/unittest/messages.mps
@@ -1549,7 +1549,7 @@
               <ref role="3ZUYvu" node="69xuLeTuklc" resolve="actual" />
             </node>
             <node concept="3ZUYvv" id="69xuLeTukkR" role="3O_q_j">
-              <ref role="3ZUYvu" node="69xuLeTukla" resolve="expected1" />
+              <ref role="3ZUYvu" node="69xuLeTukla" resolve="expected" />
             </node>
           </node>
         </node>
@@ -1560,13 +1560,10 @@
               <ref role="1S7826" node="171BYjwcnyZ" resolve="assert_fd" />
             </node>
             <node concept="3eV9cR" id="69xuLeTukkV" role="3O_q_j">
-              <property role="PhEJT" value="&lt;assert-failed expected1=&quot;%f&quot; expected2=&quot;%f&quot; actual=&quot;%f&quot; nodeId=&quot;%s&quot; modelId=&quot;%s&quot;&gt; %s &lt;/assert-failed&gt;" />
+              <property role="PhEJT" value="&lt;assert-failed expected=&quot;%s&quot; actual=&quot;%f&quot; nodeId=&quot;%s&quot; modelId=&quot;%s&quot;&gt; %s &lt;/assert-failed&gt;" />
             </node>
             <node concept="3ZUYvv" id="69xuLeTukkW" role="3O_q_j">
-              <ref role="3ZUYvu" node="69xuLeTukla" resolve="expected1" />
-            </node>
-            <node concept="3ZUYvv" id="69xuLeTukkX" role="3O_q_j">
-              <ref role="3ZUYvu" node="69xuLeTtSq$" resolve="expected2" />
+              <ref role="3ZUYvu" node="69xuLeTukla" resolve="expected" />
             </node>
             <node concept="3ZUYvv" id="69xuLeTukkY" role="3O_q_j">
               <ref role="3ZUYvu" node="69xuLeTuklc" resolve="actual" />
@@ -1610,17 +1607,14 @@
         </node>
       </node>
       <node concept="19RgSI" id="69xuLeTukla" role="1UOdpc">
-        <property role="TrG5h" value="expected1" />
-        <node concept="2fgwQN" id="69xuLeTuklb" role="2C2TGm">
+        <property role="TrG5h" value="expected" />
+        <node concept="3wxxNl" id="6UwMGbLx5vz" role="2C2TGm">
           <property role="2caQfQ" value="false" />
           <property role="2c7vTL" value="false" />
-        </node>
-      </node>
-      <node concept="19RgSI" id="69xuLeTtSq$" role="1UOdpc">
-        <property role="TrG5h" value="expected2" />
-        <node concept="2fgwQN" id="69xuLeTtSq_" role="2C2TGm">
-          <property role="2caQfQ" value="false" />
-          <property role="2c7vTL" value="false" />
+          <node concept="biTqx" id="6UwMGbLx5v$" role="2umbIo">
+            <property role="2caQfQ" value="false" />
+            <property role="2c7vTL" value="true" />
+          </node>
         </node>
       </node>
       <node concept="19RgSI" id="69xuLeTuklc" role="1UOdpc">


### PR DESCRIPTION
Hi,
https://github.com/mbeddr/mbeddr.core/pull/1660/commits

In the previous commit i have changed the variable name of method(failed_range_double) in Unittest_helper which causes the value not being shown in the tool tip. So I have reverted the variable name. Also i have changed the range value data type to previously it was.

Please review the commit and merge it with milestone

Regards,
Aswin Sugumaran