### PR TITLE
Debugger defect fix for state machine junction

### DIFF
--- a/code/languages/com.mbeddr.debugger/languages/com.mbeddr.core.debug/languageModels/debugger.mps
+++ b/code/languages/com.mbeddr.debugger/languages/com.mbeddr.core.debug/languageModels/debugger.mps
@@ -33853,55 +33853,19 @@
             </node>
           </node>
         </node>
-        <node concept="3clFbF" id="5Acmi3lBU3W" role="3cqZAp">
-          <node concept="2OqwBi" id="5Acmi3lBUZ6" role="3clFbG">
-            <node concept="37vLTw" id="5Acmi3lBU3U" role="2Oq$k0">
-              <ref role="3cqZAo" node="6Zad41Tri3h" resolve="contributorHierarchy" />
-            </node>
-            <node concept="TSZUe" id="5Acmi3lC02d" role="2OqNvi">
-              <node concept="2ShNRf" id="5Acmi3lC3iT" role="25WWJ7">
-                <node concept="1pGfFk" id="5Acmi3lC4I7" role="2ShVmc">
-                  <ref role="37wK5l" node="57r6BQpGnfH" resolve="TNodeProxy" />
-                  <node concept="37vLTw" id="5Acmi3lC4Oy" role="37wK5m">
-                    <ref role="3cqZAo" node="6Zad41Tri3o" resolve="stackFrameContributor" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbH" id="5Acmi3lC4R1" role="3cqZAp" />
-        <node concept="3clFbJ" id="5Acmi3lC7aY" role="3cqZAp">
-          <node concept="3clFbS" id="5Acmi3lC7aZ" role="3clFbx">
-            <node concept="3clFbF" id="5Acmi3lC7b2" role="3cqZAp">
-              <node concept="37vLTI" id="5Acmi3lC7b3" role="3clFbG">
-                <node concept="37vLTw" id="5Acmi3lC7b4" role="37vLTJ">
-                  <ref role="3cqZAo" node="6Zad41Tri3o" resolve="stackFrameContributor" />
-                </node>
-                <node concept="2OqwBi" id="5Acmi3lC7b5" role="37vLTx">
-                  <node concept="37vLTw" id="5Acmi3lC7b6" role="2Oq$k0">
-                    <ref role="3cqZAo" node="6Zad41Tri3o" resolve="stackFrameContributor" />
-                  </node>
-                  <node concept="2Xjw5R" id="5Acmi3lC7b7" role="2OqNvi">
-                    <node concept="1xMEDy" id="5Acmi3lC7b8" role="1xVPHs">
-                      <node concept="chp4Y" id="5Acmi3lC7b9" role="ri$Ld">
-                        <ref role="cht4Q" to="2gv2:2LXb$uuiv7q" resolve="IStackFrameContributor" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbF" id="5Acmi3lC7ba" role="3cqZAp">
-              <node concept="2OqwBi" id="5Acmi3lC7bb" role="3clFbG">
-                <node concept="3cpWsa" id="5Acmi3lC7bc" role="2Oq$k0">
+        <node concept="3clFbH" id="4ywUOGq3YdY" role="3cqZAp" />
+        <node concept="3clFbJ" id="4ywUOGq42B0" role="3cqZAp">
+          <node concept="3clFbS" id="4ywUOGq42B2" role="3clFbx">
+            <node concept="3clFbF" id="5Acmi3lBU3W" role="3cqZAp">
+              <node concept="2OqwBi" id="5Acmi3lBUZ6" role="3clFbG">
+                <node concept="37vLTw" id="5Acmi3lBU3U" role="2Oq$k0">
                   <ref role="3cqZAo" node="6Zad41Tri3h" resolve="contributorHierarchy" />
                 </node>
-                <node concept="TSZUe" id="5Acmi3lC7bd" role="2OqNvi">
-                  <node concept="2ShNRf" id="5Acmi3lC7be" role="25WWJ7">
-                    <node concept="1pGfFk" id="5Acmi3lC7bf" role="2ShVmc">
+                <node concept="TSZUe" id="5Acmi3lC02d" role="2OqNvi">
+                  <node concept="2ShNRf" id="5Acmi3lC3iT" role="25WWJ7">
+                    <node concept="1pGfFk" id="5Acmi3lC4I7" role="2ShVmc">
                       <ref role="37wK5l" node="57r6BQpGnfH" resolve="TNodeProxy" />
-                      <node concept="37vLTw" id="5Acmi3lC7bg" role="37wK5m">
+                      <node concept="37vLTw" id="5Acmi3lC4Oy" role="37wK5m">
                         <ref role="3cqZAo" node="6Zad41Tri3o" resolve="stackFrameContributor" />
                       </node>
                     </node>
@@ -33909,19 +33873,67 @@
                 </node>
               </node>
             </node>
-          </node>
-          <node concept="2OqwBi" id="5Acmi3lC7bo" role="3clFbw">
-            <node concept="37vLTw" id="5Acmi3lC7bp" role="2Oq$k0">
-              <ref role="3cqZAo" node="6Zad41Tri3o" resolve="stackFrameContributor" />
-            </node>
-            <node concept="1mIQ4w" id="5Acmi3lC7bq" role="2OqNvi">
-              <node concept="chp4Y" id="5Acmi3lC7br" role="cj9EA">
-                <ref role="cht4Q" to="2gv2:UWuwz3o4rv" resolve="IVirtualStackFrameContributor" />
+            <node concept="3clFbH" id="4ywUOGq8WTX" role="3cqZAp" />
+            <node concept="3clFbJ" id="5Acmi3lC7aY" role="3cqZAp">
+              <node concept="3clFbS" id="5Acmi3lC7aZ" role="3clFbx">
+                <node concept="3clFbF" id="5Acmi3lC7b2" role="3cqZAp">
+                  <node concept="37vLTI" id="5Acmi3lC7b3" role="3clFbG">
+                    <node concept="37vLTw" id="5Acmi3lC7b4" role="37vLTJ">
+                      <ref role="3cqZAo" node="6Zad41Tri3o" resolve="stackFrameContributor" />
+                    </node>
+                    <node concept="2OqwBi" id="5Acmi3lC7b5" role="37vLTx">
+                      <node concept="37vLTw" id="5Acmi3lC7b6" role="2Oq$k0">
+                        <ref role="3cqZAo" node="6Zad41Tri3o" resolve="stackFrameContributor" />
+                      </node>
+                      <node concept="2Xjw5R" id="5Acmi3lC7b7" role="2OqNvi">
+                        <node concept="1xMEDy" id="5Acmi3lC7b8" role="1xVPHs">
+                          <node concept="chp4Y" id="5Acmi3lC7b9" role="ri$Ld">
+                            <ref role="cht4Q" to="2gv2:2LXb$uuiv7q" resolve="IStackFrameContributor" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbF" id="5Acmi3lC7ba" role="3cqZAp">
+                  <node concept="2OqwBi" id="5Acmi3lC7bb" role="3clFbG">
+                    <node concept="3cpWsa" id="5Acmi3lC7bc" role="2Oq$k0">
+                      <ref role="3cqZAo" node="6Zad41Tri3h" resolve="contributorHierarchy" />
+                    </node>
+                    <node concept="TSZUe" id="5Acmi3lC7bd" role="2OqNvi">
+                      <node concept="2ShNRf" id="5Acmi3lC7be" role="25WWJ7">
+                        <node concept="1pGfFk" id="5Acmi3lC7bf" role="2ShVmc">
+                          <ref role="37wK5l" node="57r6BQpGnfH" resolve="TNodeProxy" />
+                          <node concept="37vLTw" id="5Acmi3lC7bg" role="37wK5m">
+                            <ref role="3cqZAo" node="6Zad41Tri3o" resolve="stackFrameContributor" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
               </node>
+              <node concept="2OqwBi" id="5Acmi3lC7bo" role="3clFbw">
+                <node concept="37vLTw" id="5Acmi3lC7bp" role="2Oq$k0">
+                  <ref role="3cqZAo" node="6Zad41Tri3o" resolve="stackFrameContributor" />
+                </node>
+                <node concept="1mIQ4w" id="5Acmi3lC7bq" role="2OqNvi">
+                  <node concept="chp4Y" id="5Acmi3lC7br" role="cj9EA">
+                    <ref role="cht4Q" to="2gv2:UWuwz3o4rv" resolve="IVirtualStackFrameContributor" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbH" id="7v8$3AgRIoT" role="3cqZAp" />
+          </node>
+          <node concept="3y3z36" id="4ywUOGq49kf" role="3clFbw">
+            <node concept="10Nm6u" id="4ywUOGq4bwH" role="3uHU7w" />
+            <node concept="37vLTw" id="4ywUOGq44UJ" role="3uHU7B">
+              <ref role="3cqZAo" node="6Zad41Tri3o" resolve="stackFrameContributor" />
             </node>
           </node>
         </node>
-        <node concept="3clFbH" id="7v8$3AgRIoT" role="3cqZAp" />
+        <node concept="3clFbH" id="4ywUOGq8YXQ" role="3cqZAp" />
         <node concept="3SKdUt" id="5Acmi3lBq_S" role="3cqZAp">
           <node concept="3SKdUq" id="5Acmi3lBq_T" role="3SKWNk">
             <property role="3SKdUp" value="from the current node, we collect all ascending StackFramContributors" />

--- a/code/languages/com.mbeddr.ext/languages/com.mbeddr.ext.statemachines/generator/template/main@generator.mps
+++ b/code/languages/com.mbeddr.ext/languages/com.mbeddr.ext.statemachines/generator/template/main@generator.mps
@@ -5973,22 +5973,18 @@
                   </node>
                 </node>
                 <node concept="3clFbH" id="602uc2JSTG4" role="3cqZAp" />
-                <node concept="1X3_iC" id="5GwePVE7yWW" role="lGtFl">
-                  <property role="3V$3am" value="statement" />
-                  <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-                  <node concept="3clFbF" id="602uc2JSPDW" role="8Wnug">
-                    <node concept="2YIFZM" id="602uc2JSPYP" role="3clFbG">
-                      <ref role="1Pybhc" to="fwk:~TracingUtil" resolve="TracingUtil" />
-                      <ref role="37wK5l" to="fwk:~TracingUtil.fillOriginalNode(org.jetbrains.mps.openapi.model.SNode,org.jetbrains.mps.openapi.model.SNode,boolean):void" resolve="fillOriginalNode" />
-                      <node concept="2GrUjf" id="602uc2JSPZ7" role="37wK5m">
-                        <ref role="2Gs0qQ" node="17MIiXb5Er1" resolve="j" />
-                      </node>
-                      <node concept="37vLTw" id="602uc2JSQMD" role="37wK5m">
-                        <ref role="3cqZAo" node="17MIiXb5GLK" resolve="newState" />
-                      </node>
-                      <node concept="3clFbT" id="602uc2JSSdE" role="37wK5m">
-                        <property role="3clFbU" value="false" />
-                      </node>
+                <node concept="3clFbF" id="602uc2JSPDW" role="3cqZAp">
+                  <node concept="2YIFZM" id="602uc2JSPYP" role="3clFbG">
+                    <ref role="1Pybhc" to="fwk:~TracingUtil" resolve="TracingUtil" />
+                    <ref role="37wK5l" to="fwk:~TracingUtil.fillOriginalNode(org.jetbrains.mps.openapi.model.SNode,org.jetbrains.mps.openapi.model.SNode,boolean):void" resolve="fillOriginalNode" />
+                    <node concept="2GrUjf" id="602uc2JSPZ7" role="37wK5m">
+                      <ref role="2Gs0qQ" node="17MIiXb5Er1" resolve="j" />
+                    </node>
+                    <node concept="37vLTw" id="602uc2JSQMD" role="37wK5m">
+                      <ref role="3cqZAo" node="17MIiXb5GLK" resolve="newState" />
+                    </node>
+                    <node concept="3clFbT" id="602uc2JSSdE" role="37wK5m">
+                      <property role="3clFbU" value="false" />
                     </node>
                   </node>
                 </node>
@@ -6193,22 +6189,18 @@
                       </node>
                     </node>
                     <node concept="3clFbH" id="602uc2JXXE_" role="3cqZAp" />
-                    <node concept="1X3_iC" id="5GwePVE7yWX" role="lGtFl">
-                      <property role="3V$3am" value="statement" />
-                      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-                      <node concept="3clFbF" id="602uc2JSXse" role="8Wnug">
-                        <node concept="2YIFZM" id="602uc2JSXsf" role="3clFbG">
-                          <ref role="1Pybhc" to="fwk:~TracingUtil" resolve="TracingUtil" />
-                          <ref role="37wK5l" to="fwk:~TracingUtil.fillOriginalNode(org.jetbrains.mps.openapi.model.SNode,org.jetbrains.mps.openapi.model.SNode,boolean):void" resolve="fillOriginalNode" />
-                          <node concept="2GrUjf" id="602uc2JSXwE" role="37wK5m">
-                            <ref role="2Gs0qQ" node="16ykm_LQ0YF" resolve="et" />
-                          </node>
-                          <node concept="37vLTw" id="602uc2JSY8T" role="37wK5m">
-                            <ref role="3cqZAo" node="602uc2JSX9u" resolve="transition" />
-                          </node>
-                          <node concept="3clFbT" id="602uc2JSXsi" role="37wK5m">
-                            <property role="3clFbU" value="false" />
-                          </node>
+                    <node concept="3clFbF" id="602uc2JSXse" role="3cqZAp">
+                      <node concept="2YIFZM" id="602uc2JSXsf" role="3clFbG">
+                        <ref role="1Pybhc" to="fwk:~TracingUtil" resolve="TracingUtil" />
+                        <ref role="37wK5l" to="fwk:~TracingUtil.fillOriginalNode(org.jetbrains.mps.openapi.model.SNode,org.jetbrains.mps.openapi.model.SNode,boolean):void" resolve="fillOriginalNode" />
+                        <node concept="2GrUjf" id="602uc2JSXwE" role="37wK5m">
+                          <ref role="2Gs0qQ" node="16ykm_LQ0YF" resolve="et" />
+                        </node>
+                        <node concept="37vLTw" id="602uc2JSY8T" role="37wK5m">
+                          <ref role="3cqZAo" node="602uc2JSX9u" resolve="transition" />
+                        </node>
+                        <node concept="3clFbT" id="602uc2JSXsi" role="37wK5m">
+                          <property role="3clFbU" value="false" />
                         </node>
                       </node>
                     </node>
@@ -6372,22 +6364,18 @@
                       </node>
                     </node>
                     <node concept="3clFbH" id="602uc2JTxT3" role="3cqZAp" />
-                    <node concept="1X3_iC" id="5GwePVE7yWY" role="lGtFl">
-                      <property role="3V$3am" value="statement" />
-                      <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-                      <node concept="3clFbF" id="602uc2JTzsP" role="8Wnug">
-                        <node concept="2YIFZM" id="602uc2JTzsQ" role="3clFbG">
-                          <ref role="1Pybhc" to="fwk:~TracingUtil" resolve="TracingUtil" />
-                          <ref role="37wK5l" to="fwk:~TracingUtil.fillOriginalNode(org.jetbrains.mps.openapi.model.SNode,org.jetbrains.mps.openapi.model.SNode,boolean):void" resolve="fillOriginalNode" />
-                          <node concept="2GrUjf" id="602uc2JTzVL" role="37wK5m">
-                            <ref role="2Gs0qQ" node="16ykm_LSJ2C" resolve="s" />
-                          </node>
-                          <node concept="37vLTw" id="602uc2JT_NS" role="37wK5m">
-                            <ref role="3cqZAo" node="602uc2JTvsw" resolve="triggerSelf" />
-                          </node>
-                          <node concept="3clFbT" id="602uc2JTzsT" role="37wK5m">
-                            <property role="3clFbU" value="false" />
-                          </node>
+                    <node concept="3clFbF" id="602uc2JTzsP" role="3cqZAp">
+                      <node concept="2YIFZM" id="602uc2JTzsQ" role="3clFbG">
+                        <ref role="1Pybhc" to="fwk:~TracingUtil" resolve="TracingUtil" />
+                        <ref role="37wK5l" to="fwk:~TracingUtil.fillOriginalNode(org.jetbrains.mps.openapi.model.SNode,org.jetbrains.mps.openapi.model.SNode,boolean):void" resolve="fillOriginalNode" />
+                        <node concept="2GrUjf" id="602uc2JTzVL" role="37wK5m">
+                          <ref role="2Gs0qQ" node="16ykm_LSJ2C" resolve="s" />
+                        </node>
+                        <node concept="37vLTw" id="602uc2JT_NS" role="37wK5m">
+                          <ref role="3cqZAo" node="602uc2JTvsw" resolve="triggerSelf" />
+                        </node>
+                        <node concept="3clFbT" id="602uc2JTzsT" role="37wK5m">
+                          <property role="3clFbU" value="false" />
                         </node>
                       </node>
                     </node>


### PR DESCRIPTION
Problem Statement 1:
While debugging, the breakpoints support is not allowed for Epsilons Transactions & Junctions.

Solution & Fix 1:
The problem is because of the Trace-link(trace.info file) is missing for Epsilons Transactions & Junctions for state machine, hence fixing the defect by uncommenting the code which is avoiding trace linking of Epsilons Transactions & Junctions.

Problem Statement 2:
While debugging in many cases we are getting null pointer while resuming the debugging process.

Solution & Fix 2:
There is a null stack frame contributor for certain cases where it is including parent Implementation Module node into state frame, hence added a null check for stackFrameContributor in getContributorHierarchy() method of MFrameMapperImpl class to avoid null pointer exception.