### PR TITLE
 changing the c standard front end option to adapt cbmc 5.7

### DIFF
--- a/code/languages/com.mbeddr.analyses/languages/com.mbeddr.analyses.cbmc.rt/models/com/mbeddr/analyses/cbmc/rt/run.mps
+++ b/code/languages/com.mbeddr.analyses/languages/com.mbeddr.analyses.cbmc.rt/models/com/mbeddr/analyses/cbmc/rt/run.mps
@@ -4439,7 +4439,7 @@
                 </node>
                 <node concept="TSZUe" id="7_kHFWojKCv" role="2OqNvi">
                   <node concept="Xl_RD" id="7_kHFWojKLb" role="25WWJ7">
-                    <property role="Xl_RC" value="--std99" />
+                    <property role="Xl_RC" value="--c99" />
                   </node>
                 </node>
               </node>
@@ -4470,7 +4470,7 @@
                   </node>
                   <node concept="TSZUe" id="7_kHFWojN$g" role="2OqNvi">
                     <node concept="Xl_RD" id="7_kHFWojN$h" role="25WWJ7">
-                      <property role="Xl_RC" value="--std11" />
+                      <property role="Xl_RC" value="--c11" />
                     </node>
                   </node>
                 </node>


### PR DESCRIPTION
Hi,

The argument to be supplied to the CBMC changed from *--std99* to *--c99* and from *--std11* to *--c11*

Updated the strings.

Regards,
Dinesh