### PR TITLE
Language name visible in the code-completion instead of alias name in exported Base concept

### DIFF
--- a/code/languages/com.mbeddr.core/languages/com.mbeddr.core.modules/languageModels/editor.mps
+++ b/code/languages/com.mbeddr.core/languages/com.mbeddr.core.modules/languageModels/editor.mps
@@ -5670,10 +5670,15 @@
             <node concept="3clFbS" id="2cvVnUv6BZi" role="2VODD2">
               <node concept="3clFbF" id="2cvVnUv6BZj" role="3cqZAp">
                 <node concept="3cpWs3" id="2cvVnUv6BZl" role="3clFbG">
+                  <node concept="2OqwBi" id="2vVcRzhcMEr" role="3uHU7w">
+                    <node concept="2ZBlsa" id="2cvVnUv6BZk" role="2Oq$k0" />
+                    <node concept="liA8E" id="2vVcRzhg7OE" role="2OqNvi">
+                      <ref role="37wK5l" to="c17a:~SAbstractConcept.getConceptAlias():java.lang.String" resolve="getConceptAlias" />
+                    </node>
+                  </node>
                   <node concept="Xl_RD" id="2cvVnUv6BZm" role="3uHU7B">
                     <property role="Xl_RC" value="" />
                   </node>
-                  <node concept="2ZBlsa" id="2cvVnUv6BZk" role="3uHU7w" />
                 </node>
               </node>
             </node>
@@ -5818,10 +5823,15 @@
             <node concept="3clFbS" id="2cvVnUv6C0z" role="2VODD2">
               <node concept="3clFbF" id="2cvVnUv6C0$" role="3cqZAp">
                 <node concept="3cpWs3" id="2cvVnUv6C0A" role="3clFbG">
+                  <node concept="2OqwBi" id="2vVcRzhg8iO" role="3uHU7w">
+                    <node concept="2ZBlsa" id="2cvVnUv6C0_" role="2Oq$k0" />
+                    <node concept="liA8E" id="2vVcRzhg8K8" role="2OqNvi">
+                      <ref role="37wK5l" to="c17a:~SAbstractConcept.getConceptAlias():java.lang.String" resolve="getConceptAlias" />
+                    </node>
+                  </node>
                   <node concept="Xl_RD" id="2cvVnUv6C0B" role="3uHU7B">
                     <property role="Xl_RC" value="" />
                   </node>
-                  <node concept="2ZBlsa" id="2cvVnUv6C0_" role="3uHU7w" />
                 </node>
               </node>
             </node>


### PR DESCRIPTION
Hi,

In the implementation module, after inserting the **exported** from base concept when you code complete you can see the list of concepts with language name instead of alias name(refer the image attached). I have changed to return with the conceptalias name of the language. Please review the changes and merge with milestone

![export_name_1](https://user-images.githubusercontent.com/25502999/28169759-f452eda6-6800-11e7-98f3-a124177b01da.png)


Regards,
Aswin Sugumaran