### PR TITLE
Removing the export from implementation module on code-completion

### DIFF
--- a/code/languages/com.mbeddr.core/languages/com.mbeddr.core.modules/languageModels/editor.mps
+++ b/code/languages/com.mbeddr.core/languages/com.mbeddr.core.modules/languageModels/editor.mps
@@ -1902,6 +1902,7 @@
     <property role="TrG5h" value="exportedFlag" />
     <ref role="1XX52x" to="x27k:5_l8w1EmTdf" resolve="IModuleContent" />
     <node concept="1kHk_G" id="7bCENxTSAK4" role="2wV5jI">
+      <property role="ZpkCL" value="true" />
       <ref role="1NtTu8" to="x27k:19a6$uAA0vK" resolve="exported" />
       <ref role="1k5W1q" to="r4b4:2CEi94dgHKA" resolve="KW" />
     </node>


### PR DESCRIPTION
Hi,

In the implementation module, on code-completion and type **exported** we have huge list of exported for various concepts. This is little bit confusing and since we have the exported from the base concept. I have removed those exported by changing the do-not substitute action of exported editor component.Please review the changes and merge it with milestone.

Regards,
Aswin Sugumaran

