### PR TITLE
documentation:

### DIFF
--- a/code/applications/tutorial/solutions/com.mbeddr.tutorial.documentation/models/com/mbeddr/tutorial/documentation/ug/_main.mps
+++ b/code/applications/tutorial/solutions/com.mbeddr.tutorial.documentation/models/com/mbeddr/tutorial/documentation/ug/_main.mps
@@ -37,7 +37,6 @@
         <child id="7992580511422656152" name="text" index="20TvsS" />
       </concept>
       <concept id="6165313375056012512" name="com.mbeddr.doc.structure.DocumentInclude" flags="ng" index="$CzcT">
-        <property id="324047639344492301" name="referenceOnly" index="1P4p2h" />
         <child id="6165313375056012515" name="ref" index="$CzcU" />
       </concept>
       <concept id="6165313375055797476" name="com.mbeddr.doc.structure.FormattedText" flags="ng" index="$DsGX">
@@ -229,55 +228,46 @@
     </node>
     <node concept="3xmJbL" id="QRmqzHO4hm" role="1_0VJ0" />
     <node concept="$CzcT" id="hZfTLLCm6j" role="1_0VJ0">
-      <property role="1P4p2h" value="true" />
       <node concept="1_0j5j" id="hZfTLLCm6D" role="$CzcU">
         <ref role="1_0j5g" to="9w7i:1ig5Eljjfz2" resolve="Z_CHAPTER_Concepts" />
       </node>
     </node>
     <node concept="$CzcT" id="hZfTLLvFnn" role="1_0VJ0">
-      <property role="1P4p2h" value="true" />
       <node concept="1_0j5j" id="4v5hnzpb3dK" role="$CzcU">
         <ref role="1_0j5g" to="xojk:1OEOMsplgM2" resolve="Z_CHAPTER_Installation" />
       </node>
     </node>
     <node concept="$CzcT" id="1OEOMsplizW" role="1_0VJ0">
-      <property role="1P4p2h" value="true" />
       <node concept="1_0j5j" id="1OEOMsplizX" role="$CzcU">
         <ref role="1_0j5g" to="bmc6:1ig5EljjfWv" resolve="Z_CHAPTER_Fundamentals" />
       </node>
     </node>
     <node concept="$CzcT" id="1OEOMsplkC6" role="1_0VJ0">
-      <property role="1P4p2h" value="true" />
       <node concept="1_0j5j" id="1OEOMsplkCN" role="$CzcU">
         <ref role="1_0j5g" to="c4ys:1OEOMspli$k" resolve="Z_CHAPTER_mbeddrCvsC99" />
       </node>
     </node>
     <node concept="$CzcT" id="hZfTLMek95" role="1_0VJ0">
-      <property role="1P4p2h" value="true" />
       <node concept="1_0j5j" id="hZfTLMek9i" role="$CzcU">
         <ref role="1_0j5g" to="4v62:1ig5EljjfWv" resolve="Z_CHAPTER_GeneratedCode" />
       </node>
     </node>
     <node concept="$CzcT" id="1OEOMsplgLG" role="1_0VJ0">
-      <property role="1P4p2h" value="true" />
       <node concept="1_0j5j" id="1OEOMsplgLZ" role="$CzcU">
         <ref role="1_0j5g" to="4kwm:1OEOMsplf5g" resolve="Z_CHAPTER_CTooling" />
       </node>
     </node>
     <node concept="$CzcT" id="1OEOMspldIM" role="1_0VJ0">
-      <property role="1P4p2h" value="true" />
       <node concept="1_0j5j" id="1OEOMspldJf" role="$CzcU">
         <ref role="1_0j5g" to="vaym:1OEOMspkYrg" resolve="Z_CHAPTER_CExtensions" />
       </node>
     </node>
     <node concept="$CzcT" id="hZfTLMezS0" role="1_0VJ0">
-      <property role="1P4p2h" value="true" />
       <node concept="1_0j5j" id="1OEOMsplmvX" role="$CzcU">
         <ref role="1_0j5g" to="vi23:1OEOMsplkCQ" resolve="Z_CHAPTER_ProcessSupport" />
       </node>
     </node>
     <node concept="$CzcT" id="1OEOMsplmv$" role="1_0VJ0">
-      <property role="1P4p2h" value="true" />
       <node concept="1_0j5j" id="1OEOMsplmv_" role="$CzcU">
         <ref role="1_0j5g" to="us0v:1ig5EljjfWv" resolve="Z_CHAPTER_Analyses" />
       </node>

--- a/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc.gen_xhtml/generator/template/com/mbeddr/doc/gen_xhtml/generator/template/main@generator.mps
+++ b/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc.gen_xhtml/generator/template/com/mbeddr/doc/gen_xhtml/generator/template/main@generator.mps
@@ -850,10 +850,15 @@
           <node concept="3NFfHV" id="1ZiHc0gK7BE" role="3NFExx">
             <node concept="3clFbS" id="1ZiHc0gK7BF" role="2VODD2">
               <node concept="3clFbF" id="1ZiHc0gK7BG" role="3cqZAp">
-                <node concept="2OqwBi" id="1ZiHc0gK7C2" role="3clFbG">
-                  <node concept="30H73N" id="1ZiHc0gK7BH" role="2Oq$k0" />
-                  <node concept="3TrEf2" id="1ZiHc0gKfkM" role="2OqNvi">
-                    <ref role="3Tt5mk" to="2c95:5gTlpaky6t1" resolve="root" />
+                <node concept="2OqwBi" id="1j$XeLdRWIU" role="3clFbG">
+                  <node concept="2OqwBi" id="1ZiHc0gK7C2" role="2Oq$k0">
+                    <node concept="30H73N" id="1ZiHc0gK7BH" role="2Oq$k0" />
+                    <node concept="3TrEf2" id="1ZiHc0gKfkM" role="2OqNvi">
+                      <ref role="3Tt5mk" to="2c95:5gTlpaky6t1" resolve="root" />
+                    </node>
+                  </node>
+                  <node concept="3TrEf2" id="1j$XeLdRWZz" role="2OqNvi">
+                    <ref role="3Tt5mk" to="2c95:2TZO3DbvI5E" resolve="doc" />
                   </node>
                 </node>
               </node>
@@ -2150,6 +2155,10 @@
   </node>
   <node concept="bUwia" id="QRmqzHYKG4">
     <property role="TrG5h" value="structure" />
+    <node concept="3aamgX" id="2CRkjeiqbCz" role="3acgRq">
+      <ref role="30HIoZ" to="2c95:2CRkjeimvKE" resolve="DocumentRefSection" />
+      <node concept="b5Tf3" id="2CRkjeiqcTm" role="1lVwrX" />
+    </node>
     <node concept="3aamgX" id="2HzhasNyuz$" role="3acgRq">
       <property role="36QftV" value="true" />
       <ref role="30HIoZ" to="2c95:2TZO3Dbv6Ju" resolve="AbstractSection" />
@@ -4233,6 +4242,115 @@
               <node concept="1mIQ4w" id="QRmqzJHPrL" role="2OqNvi">
                 <node concept="chp4Y" id="QRmqzJHPrM" role="cj9EA">
                   <ref role="cht4Q" to="2c95:2TZO3Dbv6N7" resolve="Section" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3aamgX" id="2CRkjeiq6vu" role="3acgRq">
+      <ref role="30HIoZ" to="lsus:QRmqzJj_2W" resolve="TocEntry" />
+      <node concept="gft3U" id="2CRkjeiq6vv" role="1lVwrX">
+        <node concept="2pNNFK" id="2CRkjeiq6vw" role="gfFT$">
+          <property role="2pNNFO" value="div" />
+          <node concept="2pNUuL" id="2CRkjeiq6vx" role="2pNNFR">
+            <property role="2pNUuO" value="class" />
+            <node concept="2pMdtt" id="2CRkjeiq6vy" role="2pMdts">
+              <property role="2pMdty" value="tocSection" />
+            </node>
+          </node>
+          <node concept="2zltFL" id="2CRkjeiq6vz" role="3o6s8t">
+            <property role="2pNNFO" value="a" />
+            <node concept="3o6iSG" id="2CRkjeiq6v$" role="3o6s8t">
+              <property role="3o6i5n" value="SectionTitle" />
+              <node concept="17Uvod" id="2CRkjeiq6v_" role="lGtFl">
+                <property role="P4ACc" value="479c7a8c-02f9-43b5-9139-d910cb22f298/1622293396948952339/1622293396948953704" />
+                <property role="2qtEX9" value="value" />
+                <node concept="3zFVjK" id="2CRkjeiq6vA" role="3zH0cK">
+                  <node concept="3clFbS" id="2CRkjeiq6vB" role="2VODD2">
+                    <node concept="3clFbF" id="2CRkjeiq6vC" role="3cqZAp">
+                      <node concept="2OqwBi" id="2CRkjeiq6vD" role="3clFbG">
+                        <node concept="2qgKlT" id="2CRkjeiq6vE" role="2OqNvi">
+                          <ref role="37wK5l" to="4gky:5wmuVxvF0fD" resolve="getIndexedText" />
+                        </node>
+                        <node concept="2OqwBi" id="2CRkjeiq6vF" role="2Oq$k0">
+                          <node concept="30H73N" id="2CRkjeiq6vG" role="2Oq$k0" />
+                          <node concept="3TrEf2" id="2CRkjeiq6vH" role="2OqNvi">
+                            <ref role="3Tt5mk" to="lsus:QRmqzJj_2X" resolve="section" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="2pNUuL" id="2CRkjeiq6vI" role="2pNNFR">
+              <property role="2pNUuO" value="href" />
+              <node concept="2pMdtt" id="2CRkjeiq6vJ" role="2pMdts">
+                <property role="2pMdty" value="#index" />
+                <node concept="17Uvod" id="2CRkjeiq6vK" role="lGtFl">
+                  <property role="P4ACc" value="479c7a8c-02f9-43b5-9139-d910cb22f298/6666499814681541919/6666499814681541920" />
+                  <property role="2qtEX9" value="text" />
+                  <node concept="3zFVjK" id="2CRkjeiq6vL" role="3zH0cK">
+                    <node concept="3clFbS" id="2CRkjeiq6vM" role="2VODD2">
+                      <node concept="3clFbF" id="2CRkjeirvTv" role="3cqZAp">
+                        <node concept="3cpWs3" id="2CRkjeirzvB" role="3clFbG">
+                          <node concept="Xl_RD" id="2CRkjeirzHx" role="3uHU7w">
+                            <property role="Xl_RC" value=".html" />
+                          </node>
+                          <node concept="2OqwBi" id="2CRkjeirxYV" role="3uHU7B">
+                            <node concept="2OqwBi" id="2CRkjeirwkI" role="2Oq$k0">
+                              <node concept="30H73N" id="2CRkjeirw3F" role="2Oq$k0" />
+                              <node concept="3TrEf2" id="2CRkjeirxqs" role="2OqNvi">
+                                <ref role="3Tt5mk" to="lsus:QRmqzJj_2X" resolve="section" />
+                              </node>
+                            </node>
+                            <node concept="3TrcHB" id="2CRkjeiry_k" role="2OqNvi">
+                              <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2pNNFK" id="2CRkjeiq6vV" role="3o6s8t">
+            <property role="2pNNFO" value="div" />
+            <node concept="2b32R4" id="2CRkjeiq6vW" role="lGtFl">
+              <node concept="3JmXsc" id="2CRkjeiq6vX" role="2P8S$">
+                <node concept="3clFbS" id="2CRkjeiq6vY" role="2VODD2">
+                  <node concept="3clFbF" id="2CRkjeiq6vZ" role="3cqZAp">
+                    <node concept="2OqwBi" id="2CRkjeiq6w0" role="3clFbG">
+                      <node concept="3Tsc0h" id="2CRkjeiq6w1" role="2OqNvi">
+                        <ref role="3TtcxE" to="lsus:QRmqzJj_30" resolve="subEntries" />
+                      </node>
+                      <node concept="30H73N" id="2CRkjeiq6w2" role="2Oq$k0" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="30G5F_" id="2CRkjeiq6w3" role="30HLyM">
+        <node concept="3clFbS" id="2CRkjeiq6w4" role="2VODD2">
+          <node concept="3clFbF" id="2CRkjeiq6w5" role="3cqZAp">
+            <node concept="2OqwBi" id="2CRkjeiq6w6" role="3clFbG">
+              <node concept="2OqwBi" id="2CRkjeiq6w7" role="2Oq$k0">
+                <node concept="30H73N" id="2CRkjeiq6w8" role="2Oq$k0" />
+                <node concept="3TrEf2" id="2CRkjeiq6w9" role="2OqNvi">
+                  <ref role="3Tt5mk" to="lsus:QRmqzJj_2X" resolve="section" />
+                </node>
+              </node>
+              <node concept="1mIQ4w" id="2CRkjeiq6wa" role="2OqNvi">
+                <node concept="chp4Y" id="2CRkjeiq7gE" role="cj9EA">
+                  <ref role="cht4Q" to="2c95:2CRkjeimvKE" resolve="DocumentRefSection" />
                 </node>
               </node>
             </node>

--- a/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc.gen_xhtml/generator/template/com/mbeddr/doc/gen_xhtml/generator/template/main@generator.mps
+++ b/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc.gen_xhtml/generator/template/com/mbeddr/doc/gen_xhtml/generator/template/main@generator.mps
@@ -5343,6 +5343,22 @@
     <node concept="n94m4" id="6nbrqGTCR1$" role="lGtFl">
       <ref role="n9lRv" to="2c95:5gTlpaky6t5" resolve="IncludableExport" />
     </node>
+    <node concept="17Uvod" id="6nbrqGTE1$m" role="lGtFl">
+      <property role="P4ACc" value="ceab5195-25ea-4f22-9b92-103b95ca8c0c/1169194658468/1169194664001" />
+      <property role="2qtEX9" value="name" />
+      <node concept="3zFVjK" id="6nbrqGTE1$n" role="3zH0cK">
+        <node concept="3clFbS" id="6nbrqGTE1$o" role="2VODD2">
+          <node concept="3clFbF" id="6nbrqGTE24C" role="3cqZAp">
+            <node concept="2OqwBi" id="6nbrqGTE2ls" role="3clFbG">
+              <node concept="30H73N" id="6nbrqGTE24B" role="2Oq$k0" />
+              <node concept="3TrcHB" id="6nbrqGTE2ZE" role="2OqNvi">
+                <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
   </node>
 </model>
 

--- a/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc.gen_xhtml/generator/template/com/mbeddr/doc/gen_xhtml/generator/template/main@generator.mps
+++ b/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc.gen_xhtml/generator/template/com/mbeddr/doc/gen_xhtml/generator/template/main@generator.mps
@@ -438,7 +438,7 @@
     </node>
     <node concept="3lhOvk" id="1ZiHc0gKfkN" role="3lj3bC">
       <ref role="30HIoZ" to="2c95:5gTlpaky6t5" resolve="IncludableExport" />
-      <ref role="3lhOvi" node="1ZiHc0gK7Aw" resolve="map_IncludableExport" />
+      <ref role="3lhOvi" node="6nbrqGTCR1x" resolve="map_IncludableExport" />
       <node concept="30G5F_" id="1ZiHc0gKfkO" role="30HLyM">
         <node concept="3clFbS" id="1ZiHc0gKfkP" role="2VODD2">
           <node concept="3clFbF" id="1ZiHc0gKfkQ" role="3cqZAp">
@@ -476,6 +476,25 @@
   </node>
   <node concept="1Xc25A" id="2TZO3DbvV1h">
     <property role="TrG5h" value="map_DocumentExport" />
+    <node concept="n94m4" id="2TZO3DbvV1k" role="lGtFl">
+      <ref role="n9lRv" to="2c95:2TZO3DbvPDI" resolve="DocumentExport" />
+    </node>
+    <node concept="17Uvod" id="5yxqZJwyynX" role="lGtFl">
+      <property role="2qtEX9" value="name" />
+      <property role="P4ACc" value="ceab5195-25ea-4f22-9b92-103b95ca8c0c/1169194658468/1169194664001" />
+      <node concept="3zFVjK" id="5yxqZJwyyo0" role="3zH0cK">
+        <node concept="3clFbS" id="5yxqZJwyyo1" role="2VODD2">
+          <node concept="3clFbF" id="5yxqZJwyyo2" role="3cqZAp">
+            <node concept="2OqwBi" id="5yxqZJwyyo3" role="3clFbG">
+              <node concept="3TrcHB" id="5yxqZJwyyo4" role="2OqNvi">
+                <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+              </node>
+              <node concept="30H73N" id="5yxqZJwyyo5" role="2Oq$k0" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
     <node concept="3rIKKV" id="2TZO3DbvV1i" role="2pMbU3">
       <node concept="2pNNFK" id="2TZO3DbvV1l" role="2pNm8H">
         <property role="2pNNFO" value="html" />
@@ -685,25 +704,6 @@
         </node>
       </node>
     </node>
-    <node concept="n94m4" id="2TZO3DbvV1k" role="lGtFl">
-      <ref role="n9lRv" to="2c95:2TZO3DbvPDI" resolve="DocumentExport" />
-    </node>
-    <node concept="17Uvod" id="5yxqZJwyynX" role="lGtFl">
-      <property role="2qtEX9" value="name" />
-      <property role="P4ACc" value="ceab5195-25ea-4f22-9b92-103b95ca8c0c/1169194658468/1169194664001" />
-      <node concept="3zFVjK" id="5yxqZJwyyo0" role="3zH0cK">
-        <node concept="3clFbS" id="5yxqZJwyyo1" role="2VODD2">
-          <node concept="3clFbF" id="5yxqZJwyyo2" role="3cqZAp">
-            <node concept="2OqwBi" id="5yxqZJwyyo3" role="3clFbG">
-              <node concept="3TrcHB" id="5yxqZJwyyo4" role="2OqNvi">
-                <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
-              </node>
-              <node concept="30H73N" id="5yxqZJwyyo5" role="2Oq$k0" />
-            </node>
-          </node>
-        </node>
-      </node>
-    </node>
   </node>
   <node concept="1pmfR0" id="5yxqZJwzYOv">
     <property role="TrG5h" value="storeExportInDocument" />
@@ -834,54 +834,6 @@
                   </node>
                 </node>
               </node>
-            </node>
-          </node>
-        </node>
-      </node>
-    </node>
-  </node>
-  <node concept="1Xc25A" id="1ZiHc0gK7Aw">
-    <property role="TrG5h" value="map_IncludableExport" />
-    <node concept="3rIKKV" id="1ZiHc0gK7Ax" role="2pMbU3">
-      <node concept="2pNNFK" id="1ZiHc0gK7Ay" role="2pNm8H">
-        <property role="2pNNFO" value="html" />
-        <property role="qg3DV" value="true" />
-        <node concept="29HgVG" id="1ZiHc0gK7BD" role="lGtFl">
-          <node concept="3NFfHV" id="1ZiHc0gK7BE" role="3NFExx">
-            <node concept="3clFbS" id="1ZiHc0gK7BF" role="2VODD2">
-              <node concept="3clFbF" id="1ZiHc0gK7BG" role="3cqZAp">
-                <node concept="2OqwBi" id="1j$XeLdRWIU" role="3clFbG">
-                  <node concept="2OqwBi" id="1ZiHc0gK7C2" role="2Oq$k0">
-                    <node concept="30H73N" id="1ZiHc0gK7BH" role="2Oq$k0" />
-                    <node concept="3TrEf2" id="1ZiHc0gKfkM" role="2OqNvi">
-                      <ref role="3Tt5mk" to="2c95:5gTlpaky6t1" resolve="root" />
-                    </node>
-                  </node>
-                  <node concept="3TrEf2" id="1j$XeLdRWZz" role="2OqNvi">
-                    <ref role="3Tt5mk" to="2c95:2TZO3DbvI5E" resolve="doc" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="2pNm8N" id="1ZiHc0gK7Bl" role="2pNm8Q" />
-    </node>
-    <node concept="n94m4" id="1ZiHc0gK7Bn" role="lGtFl">
-      <ref role="n9lRv" to="2c95:5gTlpaky6t5" resolve="IncludableExport" />
-    </node>
-    <node concept="17Uvod" id="1ZiHc0gK7Bo" role="lGtFl">
-      <property role="2qtEX9" value="name" />
-      <property role="P4ACc" value="ceab5195-25ea-4f22-9b92-103b95ca8c0c/1169194658468/1169194664001" />
-      <node concept="3zFVjK" id="1ZiHc0gK7Bp" role="3zH0cK">
-        <node concept="3clFbS" id="1ZiHc0gK7Bq" role="2VODD2">
-          <node concept="3clFbF" id="1ZiHc0gK7Br" role="3cqZAp">
-            <node concept="2OqwBi" id="1ZiHc0gK7Bs" role="3clFbG">
-              <node concept="3TrcHB" id="1ZiHc0gK7Bt" role="2OqNvi">
-                <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
-              </node>
-              <node concept="30H73N" id="1ZiHc0gK7Bu" role="2Oq$k0" />
             </node>
           </node>
         </node>
@@ -5175,6 +5127,221 @@
           </node>
         </node>
       </node>
+    </node>
+  </node>
+  <node concept="1Xc25A" id="6nbrqGTCR1x">
+    <property role="TrG5h" value="map_IncludableExport" />
+    <node concept="3rIKKV" id="6nbrqGTCR1y" role="2pMbU3">
+      <node concept="2pNm8N" id="6nbrqGTCSwO" role="2pNm8Q">
+        <node concept="3W$oVP" id="6nbrqGTCSwQ" role="BGLLu">
+          <property role="1D$jbd" value="1.0" />
+          <property role="1UZly_" value="utf-8" />
+        </node>
+      </node>
+      <node concept="2pNNFK" id="6nbrqGTCSwU" role="2pNm8H">
+        <property role="2pNNFO" value="html" />
+        <node concept="2pNNFK" id="6nbrqGTCSwV" role="3o6s8t">
+          <property role="2pNNFO" value="head" />
+          <node concept="2pNNFK" id="6nbrqGTCSwW" role="3o6s8t">
+            <property role="2pNNFO" value="meta" />
+            <node concept="2pNUuL" id="6nbrqGTCSwX" role="2pNNFR">
+              <property role="2pNUuO" value="charset" />
+              <node concept="2pMdtt" id="6nbrqGTCSwY" role="2pMdts">
+                <property role="2pMdty" value="utf-8" />
+              </node>
+            </node>
+            <node concept="3o6iSG" id="6nbrqGTCSwZ" role="3o6s8t" />
+          </node>
+          <node concept="2pNNFK" id="6nbrqGTCSx0" role="3o6s8t">
+            <property role="2pNNFO" value="title" />
+            <node concept="3o6iSG" id="6nbrqGTCSx1" role="3o6s8t">
+              <property role="3o6i5n" value="title" />
+              <node concept="17Uvod" id="6nbrqGTCSx2" role="lGtFl">
+                <property role="2qtEX9" value="value" />
+                <property role="P4ACc" value="479c7a8c-02f9-43b5-9139-d910cb22f298/1622293396948952339/1622293396948953704" />
+                <node concept="3zFVjK" id="6nbrqGTCSx3" role="3zH0cK">
+                  <node concept="3clFbS" id="6nbrqGTCSx4" role="2VODD2">
+                    <node concept="3clFbF" id="6nbrqGTCSx5" role="3cqZAp">
+                      <node concept="2OqwBi" id="6nbrqGTCSx6" role="3clFbG">
+                        <node concept="30H73N" id="6nbrqGTCSx7" role="2Oq$k0" />
+                        <node concept="3TrcHB" id="6nbrqGTCTvx" role="2OqNvi">
+                          <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2pNNFK" id="6nbrqGTCSx9" role="3o6s8t">
+            <property role="2pNNFO" value="link" />
+            <property role="qg3DV" value="true" />
+            <node concept="2pNUuL" id="6nbrqGTCSxa" role="2pNNFR">
+              <property role="2pNUuO" value="rel" />
+              <node concept="2pMdtt" id="6nbrqGTCSxb" role="2pMdts">
+                <property role="2pMdty" value="stylesheet" />
+              </node>
+            </node>
+            <node concept="2pNUuL" id="6nbrqGTCSxc" role="2pNNFR">
+              <property role="2pNUuO" value="type" />
+              <node concept="2pMdtt" id="6nbrqGTCSxd" role="2pMdts">
+                <property role="2pMdty" value="text/css" />
+              </node>
+            </node>
+            <node concept="2pNUuL" id="6nbrqGTCSxe" role="2pNNFR">
+              <property role="2pNUuO" value="href" />
+              <node concept="2pMdtt" id="6nbrqGTCSxf" role="2pMdts">
+                <property role="2pMdty" value="ss.css" />
+                <node concept="17Uvod" id="6nbrqGTCSxg" role="lGtFl">
+                  <property role="2qtEX9" value="text" />
+                  <property role="P4ACc" value="479c7a8c-02f9-43b5-9139-d910cb22f298/6666499814681541919/6666499814681541920" />
+                  <node concept="3zFVjK" id="6nbrqGTCSxh" role="3zH0cK">
+                    <node concept="3clFbS" id="6nbrqGTCSxi" role="2VODD2">
+                      <node concept="3clFbF" id="6nbrqGTCSxj" role="3cqZAp">
+                        <node concept="2OqwBi" id="6nbrqGTCSxk" role="3clFbG">
+                          <node concept="1PxgMI" id="6nbrqGTCSxl" role="2Oq$k0">
+                            <node concept="2OqwBi" id="6nbrqGTCSxm" role="1m5AlR">
+                              <node concept="30H73N" id="6nbrqGTCSxn" role="2Oq$k0" />
+                              <node concept="3TrEf2" id="6nbrqGTCSxo" role="2OqNvi">
+                                <ref role="3Tt5mk" to="2c95:5gTlpaky6sZ" resolve="renderer" />
+                              </node>
+                            </node>
+                            <node concept="chp4Y" id="6nbrqGTCSxp" role="3oSUPX">
+                              <ref role="cht4Q" to="lsus:2TZO3DbvUdt" resolve="HTMLRenderer" />
+                            </node>
+                          </node>
+                          <node concept="3TrcHB" id="6nbrqGTCSxq" role="2OqNvi">
+                            <ref role="3TsBF5" to="lsus:3RseghIclET" resolve="stylesheet" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="1W57fq" id="6nbrqGTCSxr" role="lGtFl">
+              <node concept="3IZrLx" id="6nbrqGTCSxs" role="3IZSJc">
+                <node concept="3clFbS" id="6nbrqGTCSxt" role="2VODD2">
+                  <node concept="3clFbF" id="6nbrqGTCSxu" role="3cqZAp">
+                    <node concept="2OqwBi" id="6nbrqGTCSxv" role="3clFbG">
+                      <node concept="2OqwBi" id="6nbrqGTCSxw" role="2Oq$k0">
+                        <node concept="1PxgMI" id="6nbrqGTCSxx" role="2Oq$k0">
+                          <node concept="2OqwBi" id="6nbrqGTCSxy" role="1m5AlR">
+                            <node concept="30H73N" id="6nbrqGTCSxz" role="2Oq$k0" />
+                            <node concept="3TrEf2" id="6nbrqGTCSx$" role="2OqNvi">
+                              <ref role="3Tt5mk" to="2c95:5gTlpaky6sZ" resolve="renderer" />
+                            </node>
+                          </node>
+                          <node concept="chp4Y" id="6nbrqGTCSx_" role="3oSUPX">
+                            <ref role="cht4Q" to="lsus:2TZO3DbvUdt" resolve="HTMLRenderer" />
+                          </node>
+                        </node>
+                        <node concept="3TrcHB" id="6nbrqGTCSxA" role="2OqNvi">
+                          <ref role="3TsBF5" to="lsus:3RseghIclET" resolve="stylesheet" />
+                        </node>
+                      </node>
+                      <node concept="17RvpY" id="6nbrqGTCSxB" role="2OqNvi" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2pNNFK" id="6nbrqGTCSxC" role="3o6s8t">
+            <property role="2pNNFO" value="style" />
+            <node concept="2pNUuL" id="6nbrqGTCSxD" role="2pNNFR">
+              <property role="2pNUuO" value="type" />
+              <node concept="2pMdtt" id="6nbrqGTCSxE" role="2pMdts">
+                <property role="2pMdty" value="text/css" />
+              </node>
+            </node>
+            <node concept="3o6iSG" id="6nbrqGTCSxF" role="3o6s8t">
+              <property role="3o6i5n" value="text" />
+              <node concept="29HgVG" id="6nbrqGTCSxG" role="lGtFl">
+                <node concept="3NFfHV" id="6nbrqGTCSxH" role="3NFExx">
+                  <node concept="3clFbS" id="6nbrqGTCSxI" role="2VODD2">
+                    <node concept="3clFbF" id="6nbrqGTCSxJ" role="3cqZAp">
+                      <node concept="2OqwBi" id="6nbrqGTCSxK" role="3clFbG">
+                        <node concept="1PxgMI" id="6nbrqGTCSxL" role="2Oq$k0">
+                          <node concept="2OqwBi" id="6nbrqGTCSxM" role="1m5AlR">
+                            <node concept="30H73N" id="6nbrqGTCSxN" role="2Oq$k0" />
+                            <node concept="3TrEf2" id="6nbrqGTCSxO" role="2OqNvi">
+                              <ref role="3Tt5mk" to="2c95:5gTlpaky6sZ" resolve="renderer" />
+                            </node>
+                          </node>
+                          <node concept="chp4Y" id="6nbrqGTCSxP" role="3oSUPX">
+                            <ref role="cht4Q" to="lsus:2TZO3DbvUdt" resolve="HTMLRenderer" />
+                          </node>
+                        </node>
+                        <node concept="3TrEf2" id="6nbrqGTCSxQ" role="2OqNvi">
+                          <ref role="3Tt5mk" to="lsus:QRmqzIqw10" resolve="cssSpec" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="1W57fq" id="6nbrqGTCSxR" role="lGtFl">
+              <node concept="3IZrLx" id="6nbrqGTCSxS" role="3IZSJc">
+                <node concept="3clFbS" id="6nbrqGTCSxT" role="2VODD2">
+                  <node concept="3clFbF" id="6nbrqGTCSxU" role="3cqZAp">
+                    <node concept="2OqwBi" id="6nbrqGTCSxV" role="3clFbG">
+                      <node concept="2OqwBi" id="6nbrqGTCSxW" role="2Oq$k0">
+                        <node concept="1PxgMI" id="6nbrqGTCSxX" role="2Oq$k0">
+                          <node concept="2OqwBi" id="6nbrqGTCSxY" role="1m5AlR">
+                            <node concept="30H73N" id="6nbrqGTCSxZ" role="2Oq$k0" />
+                            <node concept="3TrEf2" id="6nbrqGTCSy0" role="2OqNvi">
+                              <ref role="3Tt5mk" to="2c95:5gTlpaky6sZ" resolve="renderer" />
+                            </node>
+                          </node>
+                          <node concept="chp4Y" id="6nbrqGTCSy1" role="3oSUPX">
+                            <ref role="cht4Q" to="lsus:2TZO3DbvUdt" resolve="HTMLRenderer" />
+                          </node>
+                        </node>
+                        <node concept="3TrEf2" id="6nbrqGTCSy2" role="2OqNvi">
+                          <ref role="3Tt5mk" to="lsus:QRmqzIqw10" resolve="cssSpec" />
+                        </node>
+                      </node>
+                      <node concept="3x8VRR" id="6nbrqGTCSy3" role="2OqNvi" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2pNNFK" id="6nbrqGTCSy4" role="3o6s8t">
+          <property role="2pNNFO" value="body" />
+          <node concept="2pNNFK" id="6nbrqGTCSy5" role="3o6s8t">
+            <property role="2pNNFO" value="rootChapter" />
+            <node concept="29HgVG" id="6nbrqGTCSy6" role="lGtFl">
+              <node concept="3NFfHV" id="6nbrqGTCSy7" role="3NFExx">
+                <node concept="3clFbS" id="6nbrqGTCSy8" role="2VODD2">
+                  <node concept="3clFbF" id="6nbrqGTCUdG" role="3cqZAp">
+                    <node concept="2OqwBi" id="6nbrqGTCV8j" role="3clFbG">
+                      <node concept="2OqwBi" id="6nbrqGTCUq9" role="2Oq$k0">
+                        <node concept="30H73N" id="6nbrqGTCUdF" role="2Oq$k0" />
+                        <node concept="3TrEf2" id="6nbrqGTCUIz" role="2OqNvi">
+                          <ref role="3Tt5mk" to="2c95:5gTlpaky6t1" resolve="root" />
+                        </node>
+                      </node>
+                      <node concept="3TrEf2" id="6nbrqGTCVoW" role="2OqNvi">
+                        <ref role="3Tt5mk" to="2c95:2TZO3DbvI5E" resolve="doc" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="n94m4" id="6nbrqGTCR1$" role="lGtFl">
+      <ref role="n9lRv" to="2c95:5gTlpaky6t5" resolve="IncludableExport" />
     </node>
   </node>
 </model>

--- a/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/generator/template/com/mbeddr/doc/generator/template/main@generator.mps
+++ b/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/generator/template/com/mbeddr/doc/generator/template/main@generator.mps
@@ -89,10 +89,16 @@
         <child id="1068581517665" name="statement" index="3cqZAp" />
       </concept>
       <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
+      <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
+        <child id="1068581517676" name="expression" index="3cqZAk" />
+      </concept>
       <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
         <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
       </concept>
       <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
+      <concept id="1081516740877" name="jetbrains.mps.baseLanguage.structure.NotExpression" flags="nn" index="3fqX7Q">
+        <child id="1081516765348" name="expression" index="3fr31v" />
+      </concept>
       <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
@@ -135,6 +141,9 @@
         <property id="6386504476136521408" name="fileName" index="2Sb_kV" />
         <reference id="6386504476136521409" name="path" index="2Sb_kU" />
       </concept>
+      <concept id="6386504476136554612" name="com.mbeddr.doc.structure.PathMapping" flags="ng" index="2SbEIf">
+        <reference id="6386504476136554613" name="pathDef" index="2SbEIe" />
+      </concept>
       <concept id="6386504476136472795" name="com.mbeddr.doc.structure.PathDefinition" flags="ng" index="2SbYGw">
         <child id="2642765975824057986" name="pathPicker" index="9PVG_" />
       </concept>
@@ -142,6 +151,16 @@
         <child id="5785245534401182264" name="defaultTempPath" index="Cbewh" />
         <child id="6386504476136472817" name="paths" index="2SbYGa" />
       </concept>
+      <concept id="3041989355252612138" name="com.mbeddr.doc.structure.DocumentRefSection" flags="ng" index="2SrEOp" />
+      <concept id="6068976060904002601" name="com.mbeddr.doc.structure.AbstractExport" flags="ng" index="30Gg6V">
+        <child id="6068976060904007487" name="renderer" index="30GjaH" />
+        <child id="6068976060904007490" name="mappings" index="30Gjbg" />
+        <child id="6068976060904007488" name="inactiveRenderer" index="30Gjbi" />
+        <child id="6068976060904007489" name="root" index="30Gjbj" />
+      </concept>
+      <concept id="6068976060904007493" name="com.mbeddr.doc.structure.IncludableExport" flags="ng" index="30Gjbn" />
+      <concept id="3350625596580269173" name="com.mbeddr.doc.structure.NullRenderer" flags="ng" index="1_05Lf" />
+      <concept id="3350625596580225385" name="com.mbeddr.doc.structure.DocumentRef" flags="ng" index="1_0j5j" />
       <concept id="3350625596580089586" name="com.mbeddr.doc.structure.TextParagraph" flags="ng" index="1_0LV8">
         <child id="3350625596580089613" name="text" index="1_0LWR" />
       </concept>
@@ -169,18 +188,27 @@
       <concept id="1202776937179" name="jetbrains.mps.lang.generator.structure.AbandonInput_RuleConsequence" flags="lg" index="b5Tf3" />
       <concept id="1095416546421" name="jetbrains.mps.lang.generator.structure.MappingConfiguration" flags="ig" index="bUwia">
         <property id="1184950341882" name="topPriorityGroup" index="3$yP7D" />
+        <child id="1200911492601" name="mappingLabel" index="2rTMjI" />
         <child id="1167328349397" name="reductionMappingRule" index="3acgRq" />
+        <child id="1167514678247" name="rootMappingRule" index="3lj3bC" />
         <child id="1195502100749" name="preMappingScript" index="1puA0r" />
       </concept>
       <concept id="1177093525992" name="jetbrains.mps.lang.generator.structure.InlineTemplate_RuleConsequence" flags="lg" index="gft3U">
         <child id="1177093586806" name="templateNode" index="gfFT$" />
       </concept>
-      <concept id="1168619357332" name="jetbrains.mps.lang.generator.structure.RootTemplateAnnotation" flags="lg" index="n94m4" />
+      <concept id="1168619357332" name="jetbrains.mps.lang.generator.structure.RootTemplateAnnotation" flags="lg" index="n94m4">
+        <reference id="1168619429071" name="applicableConcept" index="n9lRv" />
+      </concept>
       <concept id="1095672379244" name="jetbrains.mps.lang.generator.structure.TemplateFragment" flags="ng" index="raruj" />
+      <concept id="1200911316486" name="jetbrains.mps.lang.generator.structure.MappingLabelDeclaration" flags="lg" index="2rT7sh">
+        <reference id="1200911342686" name="sourceConcept" index="2rTdP9" />
+        <reference id="1200913004646" name="targetConcept" index="2rZz_L" />
+      </concept>
       <concept id="1167168920554" name="jetbrains.mps.lang.generator.structure.BaseMappingRule_Condition" flags="in" index="30G5F_" />
       <concept id="1167169188348" name="jetbrains.mps.lang.generator.structure.TemplateFunctionParameter_sourceNode" flags="nn" index="30H73N" />
       <concept id="1167169308231" name="jetbrains.mps.lang.generator.structure.BaseMappingRule" flags="ng" index="30H$t8">
         <property id="1167272244852" name="applyToConceptInheritors" index="36QftV" />
+        <reference id="1200917515464" name="labelDeclaration" index="2sgKRv" />
         <reference id="1167169349424" name="applicableConcept" index="30HIoZ" />
         <child id="1167169362365" name="conditionFunction" index="30HLyM" />
       </concept>
@@ -189,6 +217,9 @@
       </concept>
       <concept id="1167327847730" name="jetbrains.mps.lang.generator.structure.Reduction_MappingRule" flags="lg" index="3aamgX">
         <child id="1169672767469" name="ruleConsequence" index="1lVwrX" />
+      </concept>
+      <concept id="1167514355419" name="jetbrains.mps.lang.generator.structure.Root_MappingRule" flags="lg" index="3lhOvk">
+        <reference id="1167514355421" name="template" index="3lhOvi" />
       </concept>
       <concept id="1195499912406" name="jetbrains.mps.lang.generator.structure.MappingScript" flags="lg" index="1pmfR0">
         <property id="1195595592106" name="scriptKind" index="1v3f2W" />
@@ -201,6 +232,10 @@
       </concept>
       <concept id="1167756080639" name="jetbrains.mps.lang.generator.structure.PropertyMacro_GetPropertyValue" flags="in" index="3zFVjK" />
       <concept id="1167770111131" name="jetbrains.mps.lang.generator.structure.ReferenceMacro_GetReferent" flags="in" index="3$xsQk" />
+      <concept id="1311078761699563727" name="jetbrains.mps.lang.generator.structure.InsertMacro_CreateNodeQuery" flags="in" index="3_AbJw" />
+      <concept id="1311078761699563726" name="jetbrains.mps.lang.generator.structure.InsertMacro" flags="ln" index="3_AbJx">
+        <child id="1311078761699602381" name="createNodeQuery" index="3_A0Ny" />
+      </concept>
       <concept id="1167951910403" name="jetbrains.mps.lang.generator.structure.SourceSubstituteMacro_SourceNodesQuery" flags="in" index="3JmXsc" />
       <concept id="8900764248744213868" name="jetbrains.mps.lang.generator.structure.InlineTemplateWithContext_RuleConsequence" flags="lg" index="1Koe21">
         <child id="8900764248744213871" name="contentNode" index="1Koe22" />
@@ -225,7 +260,12 @@
       <concept id="1229477454423" name="jetbrains.mps.lang.generator.generationContext.structure.GenerationContextOp_GetOriginalCopiedInputByOutput" flags="nn" index="12$id9">
         <child id="1229477520175" name="outputNode" index="12$y8L" />
       </concept>
+      <concept id="1216860049627" name="jetbrains.mps.lang.generator.generationContext.structure.GenerationContextOp_GetOutputByLabelAndInput" flags="nn" index="1iwH70">
+        <reference id="1216860049628" name="label" index="1iwH77" />
+        <child id="1216860049632" name="inputNode" index="1iwH7V" />
+      </concept>
       <concept id="1216860049635" name="jetbrains.mps.lang.generator.generationContext.structure.TemplateFunctionParameter_generationContext" flags="nn" index="1iwH7S" />
+      <concept id="1217004708011" name="jetbrains.mps.lang.generator.generationContext.structure.GenerationContextOp_GetInputModel" flags="nn" index="1r8y6K" />
     </language>
     <language id="d3a0fd26-445a-466c-900e-10444ddfed52" name="com.mbeddr.mpsutil.filepicker">
       <concept id="2642765975824060179" name="com.mbeddr.mpsutil.filepicker.structure.SolutionRelativeDirPicker" flags="ng" index="9PVaO" />
@@ -309,6 +349,7 @@
       <concept id="1203518072036" name="jetbrains.mps.baseLanguage.collections.structure.SmartClosureParameterDeclaration" flags="ig" index="Rh6nW" />
       <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="nn" index="TSZUe" />
       <concept id="1162934736510" name="jetbrains.mps.baseLanguage.collections.structure.GetElementOperation" flags="nn" index="34jXtK" />
+      <concept id="1165525191778" name="jetbrains.mps.baseLanguage.collections.structure.GetFirstOperation" flags="nn" index="1uHKPH" />
       <concept id="1202128969694" name="jetbrains.mps.baseLanguage.collections.structure.SelectOperation" flags="nn" index="3$u5V9" />
       <concept id="1184963466173" name="jetbrains.mps.baseLanguage.collections.structure.ToArrayOperation" flags="nn" index="3_kTaI" />
     </language>
@@ -746,6 +787,28 @@
   <node concept="bUwia" id="2fGuOSYaPra">
     <property role="TrG5h" value="resolveIncludes" />
     <property role="3$yP7D" value="true" />
+    <node concept="2rT7sh" id="2CRkjeipWOL" role="2rTMjI">
+      <property role="TrG5h" value="exportedDoc" />
+      <ref role="2rTdP9" to="2c95:5mf_X_Lbqjw" resolve="DocumentInclude" />
+      <ref role="2rZz_L" to="2c95:5gTlpaky6t5" resolve="IncludableExport" />
+    </node>
+    <node concept="3lhOvk" id="2CRkjeio2R$" role="3lj3bC">
+      <ref role="30HIoZ" to="2c95:5mf_X_Lbqjw" resolve="DocumentInclude" />
+      <ref role="3lhOvi" node="2CRkjeio4xr" resolve="IncludedDocument" />
+      <ref role="2sgKRv" node="2CRkjeipWOL" resolve="exportedDoc" />
+      <node concept="30G5F_" id="2CRkjeio3b8" role="30HLyM">
+        <node concept="3clFbS" id="2CRkjeio3b9" role="2VODD2">
+          <node concept="3clFbF" id="2CRkjeio3ii" role="3cqZAp">
+            <node concept="2OqwBi" id="2CRkjeio3yn" role="3clFbG">
+              <node concept="30H73N" id="2CRkjeio3ih" role="2Oq$k0" />
+              <node concept="3TrcHB" id="2CRkjeio3S5" role="2OqNvi">
+                <ref role="3TsBF5" to="2c95:hZfTLLrEWd" resolve="referenceOnly" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
     <node concept="1puMqW" id="6jiGbW_aM$5" role="1puA0r">
       <ref role="1puQsG" node="6jiGbW_aM4A" resolve="putStableIds" />
     </node>
@@ -782,6 +845,110 @@
                     </node>
                   </node>
                 </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="30G5F_" id="2CRkjeio1Ea" role="30HLyM">
+        <node concept="3clFbS" id="2CRkjeio1Eb" role="2VODD2">
+          <node concept="3clFbF" id="2CRkjeio1XI" role="3cqZAp">
+            <node concept="3fqX7Q" id="2CRkjeio2H$" role="3clFbG">
+              <node concept="2OqwBi" id="2CRkjeio2HA" role="3fr31v">
+                <node concept="30H73N" id="2CRkjeio2HB" role="2Oq$k0" />
+                <node concept="3TrcHB" id="2CRkjeio2HC" role="2OqNvi">
+                  <ref role="3TsBF5" to="2c95:hZfTLLrEWd" resolve="referenceOnly" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3aamgX" id="2CRkjeiosub" role="3acgRq">
+      <ref role="30HIoZ" to="2c95:5mf_X_Lbqjw" resolve="DocumentInclude" />
+      <node concept="gft3U" id="2CRkjeiouEH" role="1lVwrX">
+        <node concept="2SrEOp" id="2CRkjeipWbM" role="gfFT$">
+          <property role="TrG5h" value="docName" />
+          <property role="1_0VJr" value="docName" />
+          <node concept="1ZhdrF" id="2CRkjeipWkE" role="lGtFl">
+            <property role="P3scX" value="2374bc90-7e37-41f1-a9c4-c2e35194c36a/3041989355252612138/3041989355253004704" />
+            <property role="2qtEX8" value="externalDocument" />
+            <node concept="3$xsQk" id="2CRkjeipWkF" role="3$ytzL">
+              <node concept="3clFbS" id="2CRkjeipWkG" role="2VODD2">
+                <node concept="3clFbF" id="2CRkjeipXwH" role="3cqZAp">
+                  <node concept="2OqwBi" id="2CRkjeipXEz" role="3clFbG">
+                    <node concept="1iwH7S" id="2CRkjeipXwG" role="2Oq$k0" />
+                    <node concept="1iwH70" id="2CRkjeipXKE" role="2OqNvi">
+                      <ref role="1iwH77" node="2CRkjeipWOL" resolve="exportedDoc" />
+                      <node concept="30H73N" id="2CRkjeipXR5" role="1iwH7V" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="17Uvod" id="2CRkjeirlbB" role="lGtFl">
+            <property role="P4ACc" value="2374bc90-7e37-41f1-a9c4-c2e35194c36a/3350625596580064222/3350625596580064225" />
+            <property role="2qtEX9" value="text" />
+            <node concept="3zFVjK" id="2CRkjeirlbC" role="3zH0cK">
+              <node concept="3clFbS" id="2CRkjeirlbD" role="2VODD2">
+                <node concept="3clFbF" id="2CRkjeirlmh" role="3cqZAp">
+                  <node concept="2OqwBi" id="2CRkjeirnby" role="3clFbG">
+                    <node concept="2OqwBi" id="2CRkjeirmvH" role="2Oq$k0">
+                      <node concept="2OqwBi" id="2CRkjeirlAY" role="2Oq$k0">
+                        <node concept="30H73N" id="2CRkjeirlmg" role="2Oq$k0" />
+                        <node concept="3TrEf2" id="2CRkjeirlXW" role="2OqNvi">
+                          <ref role="3Tt5mk" to="2c95:5mf_X_Lbqjz" resolve="ref" />
+                        </node>
+                      </node>
+                      <node concept="3TrEf2" id="2CRkjeirmNF" role="2OqNvi">
+                        <ref role="3Tt5mk" to="2c95:2TZO3DbvI5E" resolve="doc" />
+                      </node>
+                    </node>
+                    <node concept="3TrcHB" id="2CRkjeirn_y" role="2OqNvi">
+                      <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="17Uvod" id="2CRkjeiro78" role="lGtFl">
+            <property role="P4ACc" value="ceab5195-25ea-4f22-9b92-103b95ca8c0c/1169194658468/1169194664001" />
+            <property role="2qtEX9" value="name" />
+            <node concept="3zFVjK" id="2CRkjeiro79" role="3zH0cK">
+              <node concept="3clFbS" id="2CRkjeiro7a" role="2VODD2">
+                <node concept="3clFbF" id="2CRkjeirooO" role="3cqZAp">
+                  <node concept="2OqwBi" id="2CRkjeirooP" role="3clFbG">
+                    <node concept="2OqwBi" id="2CRkjeirooQ" role="2Oq$k0">
+                      <node concept="2OqwBi" id="2CRkjeirooR" role="2Oq$k0">
+                        <node concept="30H73N" id="2CRkjeirooS" role="2Oq$k0" />
+                        <node concept="3TrEf2" id="2CRkjeirooT" role="2OqNvi">
+                          <ref role="3Tt5mk" to="2c95:5mf_X_Lbqjz" resolve="ref" />
+                        </node>
+                      </node>
+                      <node concept="3TrEf2" id="2CRkjeirooU" role="2OqNvi">
+                        <ref role="3Tt5mk" to="2c95:2TZO3DbvI5E" resolve="doc" />
+                      </node>
+                    </node>
+                    <node concept="3TrcHB" id="2CRkjeirooV" role="2OqNvi">
+                      <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="30G5F_" id="2CRkjeiosNe" role="30HLyM">
+        <node concept="3clFbS" id="2CRkjeiosNf" role="2VODD2">
+          <node concept="3clFbF" id="2CRkjeiosUo" role="3cqZAp">
+            <node concept="2OqwBi" id="2CRkjeiotg2" role="3clFbG">
+              <node concept="30H73N" id="2CRkjeiosUn" role="2Oq$k0" />
+              <node concept="3TrcHB" id="2CRkjeiouwU" role="2OqNvi">
+                <ref role="3TsBF5" to="2c95:hZfTLLrEWd" resolve="referenceOnly" />
               </node>
             </node>
           </node>
@@ -1283,6 +1450,188 @@
                   <property role="TrG5h" value="section" />
                   <node concept="2jxLKc" id="6jiGbW_aSUn" role="1tU5fm" />
                 </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="30Gjbn" id="2CRkjeio4xr">
+    <property role="TrG5h" value="IncludedDocument" />
+    <node concept="1_05Lf" id="2CRkjeio4xs" role="30GjaH">
+      <node concept="3_AbJx" id="2CRkjeio56e" role="lGtFl">
+        <node concept="3_AbJw" id="2CRkjeio56g" role="3_A0Ny">
+          <node concept="3clFbS" id="2CRkjeio56i" role="2VODD2">
+            <node concept="3cpWs8" id="2CRkjeiod4b" role="3cqZAp">
+              <node concept="3cpWsn" id="2CRkjeiod4c" role="3cpWs9">
+                <property role="TrG5h" value="documentExport" />
+                <node concept="3Tqbb2" id="2CRkjeiod46" role="1tU5fm">
+                  <ref role="ehGHo" to="2c95:2TZO3DbvPDI" resolve="DocumentExport" />
+                </node>
+                <node concept="2OqwBi" id="68diWT3GB$p" role="33vP2m">
+                  <node concept="2OqwBi" id="68diWT3GB$q" role="2Oq$k0">
+                    <node concept="2OqwBi" id="68diWT3GB$r" role="2Oq$k0">
+                      <node concept="1iwH7S" id="68diWT3GB$s" role="2Oq$k0" />
+                      <node concept="1r8y6K" id="68diWT3GB$t" role="2OqNvi" />
+                    </node>
+                    <node concept="2SmgA7" id="68diWT3GB$u" role="2OqNvi">
+                      <node concept="chp4Y" id="68diWT3GB$v" role="1dBWTz">
+                        <ref role="cht4Q" to="2c95:2TZO3DbvPDI" resolve="DocumentExport" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="1uHKPH" id="68diWT3GB$w" role="2OqNvi" />
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs6" id="2CRkjeiof4O" role="3cqZAp">
+              <node concept="2OqwBi" id="2CRkjeiof4Q" role="3cqZAk">
+                <node concept="2OqwBi" id="2CRkjeiof4R" role="2Oq$k0">
+                  <node concept="37vLTw" id="2CRkjeiof4S" role="2Oq$k0">
+                    <ref role="3cqZAo" node="2CRkjeiod4c" resolve="documentExport" />
+                  </node>
+                  <node concept="3TrEf2" id="2CRkjeiof4T" role="2OqNvi">
+                    <ref role="3Tt5mk" to="2c95:5gTlpaky6sZ" resolve="renderer" />
+                  </node>
+                </node>
+                <node concept="1$rogu" id="2CRkjeiof4U" role="2OqNvi" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1_0j5j" id="2CRkjeio4xt" role="30Gjbj">
+      <node concept="1ZhdrF" id="2CRkjeiofI1" role="lGtFl">
+        <property role="P3scX" value="2374bc90-7e37-41f1-a9c4-c2e35194c36a/3350625596580225385/3350625596580225386" />
+        <property role="2qtEX8" value="doc" />
+        <node concept="3$xsQk" id="2CRkjeiofI2" role="3$ytzL">
+          <node concept="3clFbS" id="2CRkjeiofI3" role="2VODD2">
+            <node concept="3clFbF" id="2CRkjeiofMq" role="3cqZAp">
+              <node concept="2OqwBi" id="2CRkjeiogH2" role="3clFbG">
+                <node concept="2OqwBi" id="2CRkjeiog14" role="2Oq$k0">
+                  <node concept="30H73N" id="2CRkjeiofMp" role="2Oq$k0" />
+                  <node concept="3TrEf2" id="2CRkjeiogjW" role="2OqNvi">
+                    <ref role="3Tt5mk" to="2c95:5mf_X_Lbqjz" resolve="ref" />
+                  </node>
+                </node>
+                <node concept="3TrEf2" id="2CRkjeiogWU" role="2OqNvi">
+                  <ref role="3Tt5mk" to="2c95:2TZO3DbvI5E" resolve="doc" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="n94m4" id="2CRkjeio4xu" role="lGtFl">
+      <ref role="n9lRv" to="2c95:5mf_X_Lbqjw" resolve="DocumentInclude" />
+    </node>
+    <node concept="1_05Lf" id="2CRkjeiofqo" role="30Gjbi">
+      <node concept="3_AbJx" id="2CRkjeiofxs" role="lGtFl">
+        <node concept="3_AbJw" id="2CRkjeiofxu" role="3_A0Ny">
+          <node concept="3clFbS" id="2CRkjeiofxw" role="2VODD2">
+            <node concept="3cpWs8" id="2CRkjeiof$T" role="3cqZAp">
+              <node concept="3cpWsn" id="2CRkjeiof$U" role="3cpWs9">
+                <property role="TrG5h" value="documentExport" />
+                <node concept="3Tqbb2" id="2CRkjeiof$V" role="1tU5fm">
+                  <ref role="ehGHo" to="2c95:2TZO3DbvPDI" resolve="DocumentExport" />
+                </node>
+                <node concept="2OqwBi" id="68diWT3GBHl" role="33vP2m">
+                  <node concept="2OqwBi" id="68diWT3GBHm" role="2Oq$k0">
+                    <node concept="2OqwBi" id="68diWT3GBHn" role="2Oq$k0">
+                      <node concept="1iwH7S" id="68diWT3GBHo" role="2Oq$k0" />
+                      <node concept="1r8y6K" id="68diWT3GBHp" role="2OqNvi" />
+                    </node>
+                    <node concept="2SmgA7" id="68diWT3GBHq" role="2OqNvi">
+                      <node concept="chp4Y" id="68diWT3GBHr" role="1dBWTz">
+                        <ref role="cht4Q" to="2c95:2TZO3DbvPDI" resolve="DocumentExport" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="1uHKPH" id="68diWT3GBHs" role="2OqNvi" />
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs6" id="2CRkjeiof_4" role="3cqZAp">
+              <node concept="2OqwBi" id="2CRkjeiof_5" role="3cqZAk">
+                <node concept="2OqwBi" id="2CRkjeiof_6" role="2Oq$k0">
+                  <node concept="37vLTw" id="2CRkjeiof_7" role="2Oq$k0">
+                    <ref role="3cqZAo" node="2CRkjeiof$U" resolve="documentExport" />
+                  </node>
+                  <node concept="3TrEf2" id="2CRkjeiof_8" role="2OqNvi">
+                    <ref role="3Tt5mk" to="2c95:5gTlpaky6sZ" resolve="renderer" />
+                  </node>
+                </node>
+                <node concept="1$rogu" id="2CRkjeiof_9" role="2OqNvi" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2SbEIf" id="2CRkjeiooo5" role="30Gjbg">
+      <ref role="2SbEIe" node="627_yy35IQp" resolve="p" />
+      <node concept="2b32R4" id="68diWT3GxoZ" role="lGtFl">
+        <node concept="3JmXsc" id="68diWT3Gxp2" role="2P8S$">
+          <node concept="3clFbS" id="68diWT3Gxp3" role="2VODD2">
+            <node concept="3cpWs8" id="68diWT3GAnN" role="3cqZAp">
+              <node concept="3cpWsn" id="68diWT3GAnO" role="3cpWs9">
+                <property role="TrG5h" value="docExport" />
+                <node concept="3Tqbb2" id="68diWT3GAnI" role="1tU5fm">
+                  <ref role="ehGHo" to="2c95:2TZO3DbvPDI" resolve="DocumentExport" />
+                </node>
+                <node concept="2OqwBi" id="68diWT3GAnP" role="33vP2m">
+                  <node concept="2OqwBi" id="68diWT3GAnQ" role="2Oq$k0">
+                    <node concept="2OqwBi" id="68diWT3GAnR" role="2Oq$k0">
+                      <node concept="1iwH7S" id="68diWT3GAnS" role="2Oq$k0" />
+                      <node concept="1r8y6K" id="68diWT3GAnT" role="2OqNvi" />
+                    </node>
+                    <node concept="2SmgA7" id="68diWT3GAnU" role="2OqNvi">
+                      <node concept="chp4Y" id="68diWT3GAnV" role="1dBWTz">
+                        <ref role="cht4Q" to="2c95:2TZO3DbvPDI" resolve="DocumentExport" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="1uHKPH" id="68diWT3GAnW" role="2OqNvi" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="68diWT3GATo" role="3cqZAp">
+              <node concept="2OqwBi" id="68diWT3GB8I" role="3clFbG">
+                <node concept="37vLTw" id="68diWT3GATm" role="2Oq$k0">
+                  <ref role="3cqZAo" node="68diWT3GAnO" resolve="docExport" />
+                </node>
+                <node concept="3Tsc0h" id="68diWT3GBsh" role="2OqNvi">
+                  <ref role="3TtcxE" to="2c95:5gTlpaky6t2" resolve="mappings" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="17Uvod" id="2CRkjeirO5g" role="lGtFl">
+      <property role="P4ACc" value="ceab5195-25ea-4f22-9b92-103b95ca8c0c/1169194658468/1169194664001" />
+      <property role="2qtEX9" value="name" />
+      <node concept="3zFVjK" id="2CRkjeirO5h" role="3zH0cK">
+        <node concept="3clFbS" id="2CRkjeirO5i" role="2VODD2">
+          <node concept="3clFbF" id="2CRkjeirOmE" role="3cqZAp">
+            <node concept="2OqwBi" id="2CRkjeirQ5j" role="3clFbG">
+              <node concept="2OqwBi" id="2CRkjeirPpu" role="2Oq$k0">
+                <node concept="2OqwBi" id="2CRkjeirOBn" role="2Oq$k0">
+                  <node concept="30H73N" id="2CRkjeirOmD" role="2Oq$k0" />
+                  <node concept="3TrEf2" id="2CRkjeirOYl" role="2OqNvi">
+                    <ref role="3Tt5mk" to="2c95:5mf_X_Lbqjz" resolve="ref" />
+                  </node>
+                </node>
+                <node concept="3TrEf2" id="2CRkjeirPHs" role="2OqNvi">
+                  <ref role="3Tt5mk" to="2c95:2TZO3DbvI5E" resolve="doc" />
+                </node>
+              </node>
+              <node concept="3TrcHB" id="2CRkjeirQxu" role="2OqNvi">
+                <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
               </node>
             </node>
           </node>

--- a/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/languageModels/editor.mps
+++ b/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/languageModels/editor.mps
@@ -12065,5 +12065,163 @@
       <ref role="2$4xQ3" to="r4b4:7xesQBpJXuT" resolve="presentationMode" />
     </node>
   </node>
+  <node concept="24kQdi" id="2CRkjeiouOD">
+    <property role="3GE5qa" value="structure" />
+    <ref role="1XX52x" to="2c95:2CRkjeimvKE" resolve="DocumentRefSection" />
+    <node concept="3EZMnI" id="2CRkjeiqF_r" role="2wV5jI">
+      <node concept="2iRkQZ" id="2CRkjeiqF_s" role="2iSdaV" />
+      <node concept="gc7cB" id="2CRkjeiqF_Y" role="3EZMnx">
+        <node concept="3VJUX4" id="2CRkjeiqF_Z" role="3YsKMw">
+          <node concept="3clFbS" id="2CRkjeiqFA0" role="2VODD2">
+            <node concept="3clFbF" id="2CRkjeiqFA1" role="3cqZAp">
+              <node concept="2ShNRf" id="2CRkjeiqFA2" role="3clFbG">
+                <node concept="1pGfFk" id="2CRkjeiqFA3" role="2ShVmc">
+                  <ref role="37wK5l" to="r4b4:5$bT90Zfi_h" resolve="VerticalWhitespaceCell" />
+                  <node concept="pncrf" id="2CRkjeiqFA4" role="37wK5m" />
+                  <node concept="3cmrfG" id="2CRkjeiqFA5" role="37wK5m">
+                    <property role="3cmrfH" value="10" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3EZMnI" id="2CRkjeiqFA6" role="3EZMnx">
+        <node concept="2iRfu4" id="2CRkjeiqFA7" role="2iSdaV" />
+        <node concept="PMmxH" id="2CRkjeiqFA8" role="3EZMnx">
+          <property role="1cu_pB" value="0" />
+          <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
+          <ref role="1k5W1q" node="2TZO3DbviIs" resolve="structure" />
+          <node concept="VPxyj" id="2CRkjeiqFA9" role="3F10Kt">
+            <property role="VOm3f" value="false" />
+          </node>
+        </node>
+        <node concept="1HlG4h" id="2CRkjeiqFAa" role="3EZMnx">
+          <node concept="1HfYo3" id="2CRkjeiqFAb" role="1HlULh">
+            <node concept="3TQlhw" id="2CRkjeiqFAc" role="1Hhtcw">
+              <node concept="3clFbS" id="2CRkjeiqFAd" role="2VODD2">
+                <node concept="3clFbF" id="2CRkjeiqFAe" role="3cqZAp">
+                  <node concept="2OqwBi" id="2CRkjeiqFAf" role="3clFbG">
+                    <node concept="pncrf" id="2CRkjeiqFAg" role="2Oq$k0" />
+                    <node concept="2qgKlT" id="2CRkjeiqFAh" role="2OqNvi">
+                      <ref role="37wK5l" to="4gky:4vQSg$Aq5vD" resolve="nestingIndex" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="VechU" id="2CRkjeiqFAi" role="3F10Kt">
+            <property role="Vb096" value="gray" />
+          </node>
+          <node concept="VPM3Z" id="2CRkjeiqFAj" role="3F10Kt">
+            <property role="VOm3f" value="false" />
+          </node>
+          <node concept="VPxyj" id="2CRkjeiqFAk" role="3F10Kt">
+            <property role="VOm3f" value="false" />
+          </node>
+        </node>
+        <node concept="3F0ifn" id="2CRkjeiqFAl" role="3EZMnx">
+          <property role="3F0ifm" value="[" />
+          <ref role="1k5W1q" node="2TZO3DbviIs" resolve="structure" />
+          <node concept="11LMrY" id="2CRkjeiqFAm" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
+        </node>
+        <node concept="3F0A7n" id="2CRkjeiqFAn" role="3EZMnx">
+          <ref role="1k5W1q" node="2TZO3DbviIs" resolve="structure" />
+          <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
+        </node>
+        <node concept="3F0ifn" id="2CRkjeiqFAo" role="3EZMnx">
+          <property role="3F0ifm" value="]" />
+          <ref role="1k5W1q" node="2TZO3DbviIs" resolve="structure" />
+          <node concept="11L4FC" id="2CRkjeiqFAp" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
+        </node>
+        <node concept="3F0A7n" id="2CRkjeiqFAq" role="3EZMnx">
+          <ref role="1NtTu8" to="2c95:2TZO3Dbv6Jx" resolve="text" />
+        </node>
+        <node concept="3F0ifn" id="2CRkjeiqFAr" role="3EZMnx">
+          <property role="3F0ifm" value="{" />
+          <ref role="1k5W1q" node="2TZO3DbviIs" resolve="structure" />
+          <node concept="3mYdg7" id="2CRkjeiqFAs" role="3F10Kt">
+            <property role="1413C4" value="sectionBraces" />
+          </node>
+        </node>
+      </node>
+      <node concept="1iCGBv" id="2CRkjeiqGUR" role="3EZMnx">
+        <ref role="1NtTu8" to="2c95:2CRkjeinZAw" resolve="externalDocument" />
+        <node concept="1sVBvm" id="2CRkjeiqGUT" role="1sWHZn">
+          <node concept="3F0A7n" id="2CRkjeiqHli" role="2wV5jI">
+            <property role="1Intyy" value="true" />
+            <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
+          </node>
+        </node>
+      </node>
+      <node concept="gc7cB" id="2CRkjeiqFAF" role="3EZMnx">
+        <node concept="3VJUX4" id="2CRkjeiqFAG" role="3YsKMw">
+          <node concept="3clFbS" id="2CRkjeiqFAH" role="2VODD2">
+            <node concept="3clFbF" id="2CRkjeiqFAI" role="3cqZAp">
+              <node concept="2ShNRf" id="2CRkjeiqFAJ" role="3clFbG">
+                <node concept="1pGfFk" id="2CRkjeiqFAK" role="2ShVmc">
+                  <ref role="37wK5l" to="r4b4:5$bT90Zfi_h" resolve="VerticalWhitespaceCell" />
+                  <node concept="pncrf" id="2CRkjeiqFAL" role="37wK5m" />
+                  <node concept="3cmrfG" id="2CRkjeiqFAM" role="37wK5m">
+                    <property role="3cmrfH" value="10" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3EZMnI" id="2CRkjeiqFAN" role="3EZMnx">
+        <node concept="2iRfu4" id="2CRkjeiqFAO" role="2iSdaV" />
+        <node concept="3F0ifn" id="2CRkjeiqFAP" role="3EZMnx">
+          <property role="3F0ifm" value="}" />
+          <ref role="1k5W1q" node="2TZO3DbviIs" resolve="structure" />
+          <node concept="3mYdg7" id="2CRkjeiqFAQ" role="3F10Kt">
+            <property role="1413C4" value="sectionBraces" />
+          </node>
+        </node>
+        <node concept="1HlG4h" id="2CRkjeiqFAR" role="3EZMnx">
+          <ref role="1k5W1q" node="1Y3rEQ3k8Vi" resolve="readOnlyStructure" />
+          <node concept="1HfYo3" id="2CRkjeiqFAS" role="1HlULh">
+            <node concept="3TQlhw" id="2CRkjeiqFAT" role="1Hhtcw">
+              <node concept="3clFbS" id="2CRkjeiqFAU" role="2VODD2">
+                <node concept="3clFbF" id="2CRkjeiqFAV" role="3cqZAp">
+                  <node concept="3cpWs3" id="2CRkjeiqFAW" role="3clFbG">
+                    <node concept="3cpWs3" id="2CRkjeiqFAX" role="3uHU7B">
+                      <node concept="Xl_RD" id="2CRkjeiqFAY" role="3uHU7w">
+                        <property role="Xl_RC" value=" " />
+                      </node>
+                      <node concept="2OqwBi" id="2CRkjeiqFAZ" role="3uHU7B">
+                        <node concept="pncrf" id="2CRkjeiqFB0" role="2Oq$k0" />
+                        <node concept="2qgKlT" id="2CRkjeiqFB1" role="2OqNvi">
+                          <ref role="37wK5l" to="4gky:4vQSg$Aq5vD" resolve="nestingIndex" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="2OqwBi" id="2CRkjeiqFB2" role="3uHU7w">
+                      <node concept="pncrf" id="2CRkjeiqFB3" role="2Oq$k0" />
+                      <node concept="3TrcHB" id="2CRkjeiqFB4" role="2OqNvi">
+                        <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="3p36aQ" id="2CRkjeiouPg">
+    <property role="3GE5qa" value="structure" />
+    <ref role="aqKnT" to="2c95:2CRkjeimvKE" resolve="DocumentRefSection" />
+  </node>
 </model>
 

--- a/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/languageModels/structure.mps
+++ b/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/languageModels/structure.mps
@@ -1652,5 +1652,20 @@
       <ref role="20lvS9" to="tp25:nJmxU5cSSu" resolve="ModuleIdentity" />
     </node>
   </node>
+  <node concept="1TIwiD" id="2CRkjeimvKE">
+    <property role="EcuMT" value="3041989355252612138" />
+    <property role="3GE5qa" value="structure" />
+    <property role="TrG5h" value="DocumentRefSection" />
+    <property role="34LRSv" value="ExternalDocRef" />
+    <property role="R4oN_" value="Not visible for end user and only used for including external documents links in table of contents" />
+    <ref role="1TJDcQ" node="2TZO3Dbv6Ju" resolve="AbstractSection" />
+    <node concept="1TJgyj" id="2CRkjeinZAw" role="1TKVEi">
+      <property role="IQ2ns" value="3041989355253004704" />
+      <property role="20lmBu" value="reference" />
+      <property role="20kJfa" value="externalDocument" />
+      <property role="20lbJX" value="1" />
+      <ref role="20lvS9" node="5gTlpaky5gD" resolve="AbstractExport" />
+    </node>
+  </node>
 </model>
 

--- a/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/languageModels/typesystem.mps
+++ b/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/languageModels/typesystem.mps
@@ -47,6 +47,7 @@
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
       <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
+      <concept id="1225271283259" name="jetbrains.mps.baseLanguage.structure.NPEEqualsExpression" flags="nn" index="17R0WA" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
       </concept>
@@ -98,6 +99,9 @@
     <language id="7a5dda62-9140-4668-ab76-d5ed1746f2b2" name="jetbrains.mps.lang.typesystem">
       <concept id="1207055528241" name="jetbrains.mps.lang.typesystem.structure.WarningStatement" flags="nn" index="a7r0C">
         <child id="1207055552304" name="warningText" index="a7wSD" />
+      </concept>
+      <concept id="1175517400280" name="jetbrains.mps.lang.typesystem.structure.AssertStatement" flags="nn" index="2Mj0R9">
+        <child id="1175517761460" name="condition" index="2MkoU_" />
       </concept>
       <concept id="1175517767210" name="jetbrains.mps.lang.typesystem.structure.ReportErrorStatement" flags="nn" index="2MkqsV">
         <child id="1175517851849" name="errorString" index="2MkJ7o" />
@@ -1132,6 +1136,59 @@
           </node>
         </node>
       </node>
+    </node>
+  </node>
+  <node concept="18kY7G" id="2CRkjeisemW">
+    <property role="TrG5h" value="check_DocumentInclude" />
+    <node concept="3clFbS" id="2CRkjeisemX" role="18ibNy">
+      <node concept="3clFbJ" id="2CRkjeisen3" role="3cqZAp">
+        <node concept="2OqwBi" id="2CRkjeisezK" role="3clFbw">
+          <node concept="1YBJjd" id="2CRkjeiseni" role="2Oq$k0">
+            <ref role="1YBMHb" node="2CRkjeisemZ" resolve="documentInclude" />
+          </node>
+          <node concept="3TrcHB" id="2CRkjeiseKe" role="2OqNvi">
+            <ref role="3TsBF5" to="2c95:hZfTLLrEWd" resolve="referenceOnly" />
+          </node>
+        </node>
+        <node concept="3clFbS" id="2CRkjeisen5" role="3clFbx">
+          <node concept="2Mj0R9" id="2CRkjeiseMO" role="3cqZAp">
+            <node concept="17R0WA" id="2CRkjeisfzp" role="2MkoU_">
+              <node concept="2OqwBi" id="2CRkjeishdl" role="3uHU7w">
+                <node concept="2OqwBi" id="2CRkjeisgJe" role="2Oq$k0">
+                  <node concept="2OqwBi" id="2CRkjeisfOw" role="2Oq$k0">
+                    <node concept="1YBJjd" id="2CRkjeisfAB" role="2Oq$k0">
+                      <ref role="1YBMHb" node="2CRkjeisemZ" resolve="documentInclude" />
+                    </node>
+                    <node concept="3TrEf2" id="2CRkjeisg3D" role="2OqNvi">
+                      <ref role="3Tt5mk" to="2c95:5mf_X_Lbqjz" resolve="ref" />
+                    </node>
+                  </node>
+                  <node concept="3TrEf2" id="2CRkjeisgTJ" role="2OqNvi">
+                    <ref role="3Tt5mk" to="2c95:2TZO3DbvI5E" resolve="doc" />
+                  </node>
+                </node>
+                <node concept="I4A8Y" id="2CRkjeisht_" role="2OqNvi" />
+              </node>
+              <node concept="2OqwBi" id="2CRkjeiseZK" role="3uHU7B">
+                <node concept="1YBJjd" id="2CRkjeiseNc" role="2Oq$k0">
+                  <ref role="1YBMHb" node="2CRkjeisemZ" resolve="documentInclude" />
+                </node>
+                <node concept="I4A8Y" id="2CRkjeisfeP" role="2OqNvi" />
+              </node>
+            </node>
+            <node concept="Xl_RD" id="2CRkjeish$$" role="2MkJ7o">
+              <property role="Xl_RC" value="Currently only references to nodes in the same model are supported" />
+            </node>
+            <node concept="1YBJjd" id="2CRkjeishG4" role="2OEOjV">
+              <ref role="1YBMHb" node="2CRkjeisemZ" resolve="documentInclude" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1YaCAy" id="2CRkjeisemZ" role="1YuTPh">
+      <property role="TrG5h" value="documentInclude" />
+      <ref role="1YaFvo" to="2c95:5mf_X_Lbqjw" resolve="DocumentInclude" />
     </node>
   </node>
 </model>


### PR DESCRIPTION
-Fixed includable export generation in html
-Implemented a documentRefSection. This is not visible for the user we just need it during generation for building the table of contents and should be abandoned aftwerwards
-Document includes with reference only are generated down into includable exports
-DocumentRefSection generates a link to an external document in table of contents
-Implemented checking rule: document includes with reference only are valid only for documents contained in the same model