### PR TITLE
Column header of model consistency table is not shown properly and first column is unreadable.

### DIFF
--- a/code/languages/com.mbeddr.analyses/solutions/com.mbeddr.analyses.sat4j.fm/models/com/mbeddr/analyses/sat4j/fm/ui.mps
+++ b/code/languages/com.mbeddr.analyses/solutions/com.mbeddr.analyses.sat4j.fm/models/com/mbeddr/analyses/sat4j/fm/ui.mps
@@ -403,7 +403,7 @@
             <node concept="liA8E" id="68jd02EoevC" role="2OqNvi">
               <ref role="37wK5l" to="c8ee:~TableColumn.setMaxWidth(int):void" resolve="setMaxWidth" />
               <node concept="3cmrfG" id="68jd02Eoe_8" role="37wK5m">
-                <property role="3cmrfH" value="30" />
+                <property role="3cmrfH" value="32" />
               </node>
             </node>
           </node>


### PR DESCRIPTION
Hi,

After we apply the look and feel for model consistency, the column could not be expanded and content of the column header becomes unreadable.This is because when look and feel is applied, the width of the column is not enough for that particular font and other specifications.So i have increased the column width of first column in the table model consistency.Now the content of column header is shown and it is readable.Please review the changes and merge with milestone.