### PR TITLE
No type system error thrown for mismatch of units in assert statements

### DIFF
--- a/code/languages/com.mbeddr.build/solutions/com.mbeddr.build/models/com/mbeddr/build/build.mps
+++ b/code/languages/com.mbeddr.build/solutions/com.mbeddr.build/models/com/mbeddr/build/build.mps
@@ -898,8 +898,8 @@
       <node concept="m$_yC" id="3JmJHJb_ebT" role="m$_yJ">
         <ref role="m$_y1" node="7eF9rfAuDVh" resolve="com.mbeddr.analyses.base" />
       </node>
-      <node concept="m$_yC" id="4O5goBasYDq" role="m$_yJ">
-        <ref role="m$_y1" to="al5i:7tNo_gxoK8h" resolve="com.mbeddr.doc" />
+      <node concept="m$_yC" id="3JmJHJb_Y82" role="m$_yJ">
+        <ref role="m$_y1" node="7eF9rfAuFw7" resolve="com.mbeddr.analyses.cbmc" />
       </node>
     </node>
     <node concept="m$_wf" id="7eF9rfAuSO7" role="3989C9">
@@ -999,31 +999,10 @@
         </node>
       </node>
     </node>
-    <node concept="m$_wf" id="3qyGNHcRb2h" role="3989C9">
-      <property role="m$_wk" value="com.mbeddr.xmodel" />
-      <node concept="3_J27D" id="3qyGNHcRb2j" role="m$_yQ">
-        <node concept="3Mxwew" id="3qyGNHcRhDJ" role="3MwsjC">
-          <property role="3MwjfP" value="com.mbeddr.xmodel" />
-        </node>
-      </node>
-      <node concept="3_J27D" id="3qyGNHcRb2l" role="m_cZH">
-        <node concept="3Mxwew" id="3qyGNHcRhDN" role="3MwsjC">
-          <property role="3MwjfP" value="mbeddr-xmodel" />
-        </node>
-      </node>
-      <node concept="3_J27D" id="3qyGNHcRb2n" role="m$_w8">
-        <node concept="3Mxwey" id="3qyGNHcRidh" role="3MwsjC">
-          <ref role="3Mxwex" node="7TN8EE6trd1" resolve="mbeddr.version" />
-        </node>
-      </node>
-      <node concept="m$f5U" id="3qyGNHcRiKJ" role="m$_yh">
-        <ref role="m$f5T" node="3qyGNHcQRJZ" resolve="come.mbeddr.xmodel" />
-      </node>
-    </node>
     <node concept="2igEWh" id="$bJ0jguQs8" role="1hWBAP">
       <property role="2igJW4" value="true" />
-      <property role="3UIfUI" value="16384" />
-      <property role="1YnnvL" value="4096" />
+      <property role="3UIfUI" value="6096" />
+      <property role="1YnnvL" value="1024" />
     </node>
     <node concept="1wNqPr" id="2B1T7v1mQt2" role="3989C9">
       <property role="1wNuhc" value="true" />
@@ -1671,12 +1650,6 @@
           <node concept="3bR9La" id="6YaWssNYc5h" role="1SiIV1">
             <property role="3bR36h" value="false" />
             <ref role="3bR37D" node="6YaWssNXVWy" resolve="Eclipse.Debugger" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="65o8lrfJi7" role="3bR37C">
-          <node concept="3bR9La" id="65o8lrfJi8" role="1SiIV1">
-            <property role="3bR36h" value="false" />
-            <ref role="3bR37D" to="al5i:5qO$P$Pp2$u" resolve="com.mbeddr.mpsutil.genutil" />
           </node>
         </node>
       </node>
@@ -2964,15 +2937,9 @@
               <ref role="3bR37D" node="7uZw0yZ43K6" resolve="com.mbeddr.core.modules.gen" />
             </node>
           </node>
-          <node concept="1SiIV0" id="2wu1bNQpf_e" role="3bR37C">
-            <node concept="3bR9La" id="2wu1bNQpf_d" role="1SiIV1">
+          <node concept="1SiIV0" id="gUS73Y1Uf_" role="3bR37C">
+            <node concept="3bR9La" id="gUS73Y1Uf$" role="1SiIV1">
               <ref role="3bR37D" to="al5i:$bJ0jguQfJ" resolve="com.mbeddr.core.base#8626086128958648025" />
-            </node>
-          </node>
-          <node concept="1SiIV0" id="3PukFly5OuH" role="3bR37C">
-            <node concept="3bR9La" id="3PukFly5OuI" role="1SiIV1">
-              <property role="3bR36h" value="false" />
-              <ref role="3bR37D" to="al5i:5qO$P$Pp2$u" resolve="com.mbeddr.mpsutil.genutil" />
             </node>
           </node>
         </node>
@@ -3644,24 +3611,6 @@
           </node>
         </node>
       </node>
-      <node concept="1E1JtA" id="6eRyKv6Ss7I" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="com.mbeddr.core.modules.gen.rt" />
-        <property role="3LESm3" value="4f4aece1-173b-4822-9f43-c693c18d901f" />
-        <property role="2GAjPV" value="false" />
-        <node concept="398BVA" id="6eRyKv6Stim" role="3LF7KH">
-          <ref role="398BVh" node="7uZw0yZ43N8" resolve="mbeddr.core" />
-          <node concept="2Ry0Ak" id="6eRyKv6Suoq" role="iGT6I">
-            <property role="2Ry0Am" value="solutions" />
-            <node concept="2Ry0Ak" id="6eRyKv6SxEm" role="2Ry0An">
-              <property role="2Ry0Am" value="com.mbeddr.core.modules.gen.rt" />
-              <node concept="2Ry0Ak" id="6eRyKv6SyKp" role="2Ry0An">
-                <property role="2Ry0Am" value="com.mbeddr.core.modules.gen.rt.msd" />
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
       <node concept="1E1JtD" id="WadEn6CWbr" role="2G$12L">
         <property role="BnDLt" value="true" />
         <property role="TrG5h" value="com.mbeddr.core.buildconfig" />
@@ -3722,24 +3671,6 @@
               <ref role="3bR37D" to="ffeo:1TaHNgiIbIQ" resolve="MPS.Core" />
             </node>
           </node>
-          <node concept="1SiIV0" id="6eRyKv6SzQH" role="3bR37C">
-            <node concept="3bR9La" id="6eRyKv6SzQI" role="1SiIV1">
-              <property role="3bR36h" value="false" />
-              <ref role="3bR37D" node="6eRyKv6Ss7I" resolve="com.mbeddr.core.modules.gen.rt" />
-            </node>
-          </node>
-          <node concept="1SiIV0" id="6eRyKv6SzQJ" role="3bR37C">
-            <node concept="3bR9La" id="6eRyKv6SzQK" role="1SiIV1">
-              <property role="3bR36h" value="false" />
-              <ref role="3bR37D" to="ffeo:7Kfy9QB6Lg8" resolve="jetbrains.mps.runtime" />
-            </node>
-          </node>
-          <node concept="1SiIV0" id="3PukFly5NUL" role="3bR37C">
-            <node concept="3bR9La" id="3PukFly5NUM" role="1SiIV1">
-              <property role="3bR36h" value="false" />
-              <ref role="3bR37D" node="7uZw0yZ43K6" resolve="com.mbeddr.core.modules.gen" />
-            </node>
-          </node>
         </node>
         <node concept="1SiIV0" id="3xxBtygh0L0" role="3bR37C">
           <node concept="3bR9La" id="3xxBtygh0L1" role="1SiIV1">
@@ -3780,12 +3711,6 @@
         <node concept="1SiIV0" id="QusaP267vE" role="3bR37C">
           <node concept="1Busua" id="QusaP267vF" role="1SiIV1">
             <ref role="1Busuk" node="7uZw0yZ43LU" resolve="com.mbeddr.core.expressions" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="ybcgwyO2qG" role="3bR37C">
-          <node concept="3bR9La" id="ybcgwyO2qH" role="1SiIV1">
-            <property role="3bR36h" value="false" />
-            <ref role="3bR37D" to="al5i:5qO$P$Pp2$u" resolve="com.mbeddr.mpsutil.genutil" />
           </node>
         </node>
       </node>
@@ -4078,20 +4003,14 @@
               <ref role="3bR37D" to="90a9:31bAEZ0srt5" resolve="org.apache.commons" />
             </node>
           </node>
-          <node concept="1SiIV0" id="2wu1bNQpfCz" role="3bR37C">
-            <node concept="3bR9La" id="2wu1bNQpfCy" role="1SiIV1">
-              <ref role="3bR37D" node="HiHZpX4D2N" resolve="com.mbeddr.core.util#4354378109086982934" />
-            </node>
-          </node>
-          <node concept="1SiIV0" id="2wu1bNQpfC_" role="3bR37C">
-            <node concept="3bR9La" id="2wu1bNQpfC$" role="1SiIV1">
+          <node concept="1SiIV0" id="gUS73Y1UiS" role="3bR37C">
+            <node concept="3bR9La" id="gUS73Y1UiR" role="1SiIV1">
               <ref role="3bR37D" node="HiHZpX4CZy" resolve="com.mbeddr.core.modules.gen#1758019824472882132" />
             </node>
           </node>
-          <node concept="1SiIV0" id="3PukFly5Nmw" role="3bR37C">
-            <node concept="3bR9La" id="3PukFly5Nmx" role="1SiIV1">
-              <property role="3bR36h" value="false" />
-              <ref role="3bR37D" to="al5i:5qO$P$Pp2$u" resolve="com.mbeddr.mpsutil.genutil" />
+          <node concept="1SiIV0" id="gUS73Y1UiU" role="3bR37C">
+            <node concept="3bR9La" id="gUS73Y1UiT" role="1SiIV1">
+              <ref role="3bR37D" node="HiHZpX4D2N" resolve="com.mbeddr.core.util#4354378109086982934" />
             </node>
           </node>
         </node>
@@ -4153,6 +4072,11 @@
           <node concept="3bR9La" id="cq0bwoh1hI" role="1SiIV1">
             <property role="3bR36h" value="false" />
             <ref role="3bR37D" to="ffeo:5cCcm$KATVz" resolve="jetbrains.mps.lang.migration.runtime" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="1TjxVBA2zdB" role="3bR37C">
+          <node concept="3bR9La" id="1TjxVBA2zO$" role="1SiIV1">
+            <ref role="3bR37D" node="4tQt_imgpDj" resolve="com.mbeddr.ext.units.runtime" />
           </node>
         </node>
       </node>
@@ -5208,12 +5132,6 @@
             <ref role="3bR37D" to="ffeo:1TaHNgiIbIQ" resolve="MPS.Core" />
           </node>
         </node>
-        <node concept="1SiIV0" id="ybcgwyO2Zo" role="3bR37C">
-          <node concept="3bR9La" id="ybcgwyO2Zp" role="1SiIV1">
-            <property role="3bR36h" value="false" />
-            <ref role="3bR37D" node="7eF9rfAuAOO" resolve="com.mbeddr.ext.components.gen_nomw" />
-          </node>
-        </node>
         <node concept="1yeLz9" id="7eF9rfAuAP5" role="1TViLv">
           <property role="TrG5h" value="com.mbeddr.ext.components.gen_nomw#8105003328815413560" />
           <property role="3LESm3" value="6285e77c-f535-44cc-be5b-103da66e3c19" />
@@ -5236,15 +5154,9 @@
               <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
             </node>
           </node>
-          <node concept="1SiIV0" id="2wu1bNQpfGG" role="3bR37C">
-            <node concept="3bR9La" id="2wu1bNQpfGF" role="1SiIV1">
+          <node concept="1SiIV0" id="gUS73Y1Un1" role="3bR37C">
+            <node concept="3bR9La" id="gUS73Y1Un0" role="1SiIV1">
               <ref role="3bR37D" node="HiHZpX4CZ7" resolve="com.mbeddr.core.modules#1758019824472891829" />
-            </node>
-          </node>
-          <node concept="1SiIV0" id="3PukFly5MeE" role="3bR37C">
-            <node concept="3bR9La" id="3PukFly5MeF" role="1SiIV1">
-              <property role="3bR36h" value="false" />
-              <ref role="3bR37D" to="ffeo:1H905DlDUSw" resolve="MPS.OpenAPI" />
             </node>
           </node>
         </node>
@@ -5295,15 +5207,9 @@
           <property role="TrG5h" value="com.mbeddr.ext.components.test#8230733038425113223" />
           <property role="3LESm3" value="832d5cdc-83d7-47bd-b28e-65007aadc7ce" />
           <property role="2GAjPV" value="false" />
-          <node concept="1SiIV0" id="2wu1bNQpfH6" role="3bR37C">
-            <node concept="3bR9La" id="2wu1bNQpfH5" role="1SiIV1">
+          <node concept="1SiIV0" id="gUS73Y1Unr" role="3bR37C">
+            <node concept="3bR9La" id="gUS73Y1Unq" role="1SiIV1">
               <ref role="3bR37D" node="7eF9rfAuAP5" resolve="com.mbeddr.ext.components.gen_nomw#8105003328815413560" />
-            </node>
-          </node>
-          <node concept="1SiIV0" id="3PukFly5MMC" role="3bR37C">
-            <node concept="3bR9La" id="3PukFly5MMD" role="1SiIV1">
-              <property role="3bR36h" value="false" />
-              <ref role="3bR37D" to="ffeo:1H905DlDUSw" resolve="MPS.OpenAPI" />
             </node>
           </node>
         </node>
@@ -7767,6 +7673,12 @@
             <ref role="3bR37D" to="al5i:$bJ0jguQdz" resolve="com.mbeddr.core.base.pluginSolution" />
           </node>
         </node>
+        <node concept="1SiIV0" id="1TjxVBA2xeg" role="3bR37C">
+          <node concept="3bR9La" id="1TjxVBA2xeh" role="1SiIV1">
+            <property role="3bR36h" value="false" />
+            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
+          </node>
+        </node>
       </node>
       <node concept="1E1JtA" id="5qO$P$PrHbj" role="2G$12L">
         <property role="BnDLt" value="true" />
@@ -8499,18 +8411,6 @@
           <node concept="3bR9La" id="6UnenVLWdbv" role="1SiIV1">
             <property role="3bR36h" value="false" />
             <ref role="3bR37D" node="7eF9rfAuDV$" resolve="com.mbeddr.analyses.base" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="7sWVAK3s0vF" role="3bR37C">
-          <node concept="3bR9La" id="7sWVAK3s0vG" role="1SiIV1">
-            <property role="3bR36h" value="false" />
-            <ref role="3bR37D" to="ffeo:2eDSGe9d1qi" resolve="jetbrains.mps.ide" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="7bmaDMxYXa6" role="3bR37C">
-          <node concept="3bR9La" id="7bmaDMxYXa7" role="1SiIV1">
-            <property role="3bR36h" value="false" />
-            <ref role="3bR37D" node="7eF9rfAuFx$" resolve="com.mbeddr.analyses.cbmc.rt" />
           </node>
         </node>
         <node concept="398BVA" id="7eF9rfAuDWm" role="3LF7KH">
@@ -10695,12 +10595,6 @@
             <ref role="3bR37D" to="ffeo:1TaHNgiIbIQ" resolve="MPS.Core" />
           </node>
         </node>
-        <node concept="1SiIV0" id="79ucxortrNE" role="3bR37C">
-          <node concept="3bR9La" id="79ucxortrNF" role="1SiIV1">
-            <property role="3bR36h" value="false" />
-            <ref role="3bR37D" node="yklW1G3HMa" resolve="com.mbeddr.ext.units" />
-          </node>
-        </node>
       </node>
       <node concept="1E1JtA" id="16rWggKnQuV" role="2G$12L">
         <property role="BnDLt" value="true" />
@@ -11068,6 +10962,17 @@
             <ref role="1Busuk" node="7eF9rfAuDV$" resolve="com.mbeddr.analyses.base" />
           </node>
         </node>
+        <node concept="1SiIV0" id="6gqrH$0ihYU" role="3bR37C">
+          <node concept="3bR9La" id="6gqrH$0ihYV" role="1SiIV1">
+            <property role="3bR36h" value="false" />
+            <ref role="3bR37D" node="3JmJHJb_0E1" resolve="com.mbeddr.analyses.spin.rt" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="6gqrH$0ihYW" role="3bR37C">
+          <node concept="1Busua" id="6gqrH$0ihYX" role="1SiIV1">
+            <ref role="1Busuk" node="WadEn6CWbr" resolve="com.mbeddr.core.buildconfig" />
+          </node>
+        </node>
         <node concept="398BVA" id="3JmJHJb$Gu0" role="3LF7KH">
           <ref role="398BVh" node="7eF9rfAuDUw" resolve="mbeddr.analyses" />
           <node concept="2Ry0Ak" id="3JmJHJb$HZd" role="iGT6I">
@@ -11095,77 +11000,6 @@
               <property role="3bR36h" value="false" />
               <ref role="3bR37D" node="WadEn6CWbr" resolve="com.mbeddr.core.buildconfig" />
             </node>
-          </node>
-          <node concept="1SiIV0" id="5uY69zv9dZu" role="3bR37C">
-            <node concept="3bR9La" id="5uY69zv9dZv" role="1SiIV1">
-              <property role="3bR36h" value="false" />
-              <ref role="3bR37D" to="al5i:$bJ0jguQfr" resolve="com.mbeddr.core.base" />
-            </node>
-          </node>
-          <node concept="1SiIV0" id="5uY69zv9dZw" role="3bR37C">
-            <node concept="3bR9La" id="5uY69zv9dZx" role="1SiIV1">
-              <property role="3bR36h" value="false" />
-              <ref role="3bR37D" node="3JmJHJb$M36" resolve="com.mbeddr.analyses.spin.promela" />
-            </node>
-          </node>
-          <node concept="1SiIV0" id="5uY69zv9dZy" role="3bR37C">
-            <node concept="3bR9La" id="5uY69zv9dZz" role="1SiIV1">
-              <property role="3bR36h" value="false" />
-              <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
-            </node>
-          </node>
-          <node concept="1SiIV0" id="5uY69zv9dZ$" role="3bR37C">
-            <node concept="3bR9La" id="5uY69zv9dZ_" role="1SiIV1">
-              <property role="3bR36h" value="false" />
-              <ref role="3bR37D" node="7uZw0yZ43L9" resolve="com.mbeddr.core.modules" />
-            </node>
-          </node>
-          <node concept="1SiIV0" id="5uY69zv9dZA" role="3bR37C">
-            <node concept="3bR9La" id="5uY69zv9dZB" role="1SiIV1">
-              <property role="3bR36h" value="false" />
-              <ref role="3bR37D" to="90a9:31bAEZ0srt5" resolve="org.apache.commons" />
-            </node>
-          </node>
-          <node concept="1SiIV0" id="5uY69zv9dZC" role="3bR37C">
-            <node concept="3bR9La" id="5uY69zv9dZD" role="1SiIV1">
-              <property role="3bR36h" value="false" />
-              <ref role="3bR37D" node="HiHZpX4CZy" resolve="com.mbeddr.core.modules.gen#1758019824472882132" />
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="6gqrH$0ihYU" role="3bR37C">
-          <node concept="3bR9La" id="6gqrH$0ihYV" role="1SiIV1">
-            <property role="3bR36h" value="false" />
-            <ref role="3bR37D" node="3JmJHJb_0E1" resolve="com.mbeddr.analyses.spin.rt" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="6gqrH$0ihYW" role="3bR37C">
-          <node concept="1Busua" id="6gqrH$0ihYX" role="1SiIV1">
-            <ref role="1Busuk" node="WadEn6CWbr" resolve="com.mbeddr.core.buildconfig" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="5uY69zv9dZq" role="3bR37C">
-          <node concept="3bR9La" id="5uY69zv9dZr" role="1SiIV1">
-            <property role="3bR36h" value="false" />
-            <ref role="3bR37D" to="ffeo:1H905DlDUSw" resolve="MPS.OpenAPI" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="5uY69zv9dZs" role="3bR37C">
-          <node concept="3bR9La" id="5uY69zv9dZt" role="1SiIV1">
-            <property role="3bR36h" value="false" />
-            <ref role="3bR37D" node="7eF9rfAuDWl" resolve="com.mbeddr.analyses.utils" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="4O5goBat7_3" role="3bR37C">
-          <node concept="3bR9La" id="4O5goBat7_4" role="1SiIV1">
-            <property role="3bR36h" value="false" />
-            <ref role="3bR37D" node="5HlC91LJU65" resolve="com.mbeddr.analyses.spin.documentation" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="4O5goBataXp" role="3bR37C">
-          <node concept="3bR9La" id="4O5goBataXq" role="1SiIV1">
-            <property role="3bR36h" value="true" />
-            <ref role="3bR37D" to="al5i:5NpY9mnqtrM" resolve="com.mbeddr.doc.aspect.runtime" />
           </node>
         </node>
       </node>
@@ -11576,42 +11410,6 @@
             <ref role="3bR37D" node="6y2eE4zZsnH" resolve="com.mbeddr.core.stdlib" />
           </node>
         </node>
-        <node concept="1SiIV0" id="5uY69zv9e$3" role="3bR37C">
-          <node concept="3bR9La" id="5uY69zv9e$4" role="1SiIV1">
-            <property role="3bR36h" value="false" />
-            <ref role="3bR37D" to="al5i:$bJ0jguQfr" resolve="com.mbeddr.core.base" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="4l47ydymiM_" role="3bR37C">
-          <node concept="3bR9La" id="4l47ydymiMA" role="1SiIV1">
-            <property role="3bR36h" value="false" />
-            <ref role="3bR37D" node="3JmJHJb$FXz" resolve="com.mbeddr.analyses.spin" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="5HlC91LJX6X" role="3bR37C">
-          <node concept="3bR9La" id="5HlC91LJX6Y" role="1SiIV1">
-            <property role="3bR36h" value="false" />
-            <ref role="3bR37D" node="5HlC91LJU65" resolve="com.mbeddr.analyses.spin.documentation" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="4O5goBatbxB" role="3bR37C">
-          <node concept="3bR9La" id="4O5goBatbxC" role="1SiIV1">
-            <property role="3bR36h" value="true" />
-            <ref role="3bR37D" to="al5i:5NpY9mnqtrM" resolve="com.mbeddr.doc.aspect.runtime" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="3KP_mg124Wg" role="3bR37C">
-          <node concept="3bR9La" id="3KP_mg124Wh" role="1SiIV1">
-            <property role="3bR36h" value="false" />
-            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="Ctc1NI6uP7" role="3bR37C">
-          <node concept="3bR9La" id="Ctc1NI6uP8" role="1SiIV1">
-            <property role="3bR36h" value="false" />
-            <ref role="3bR37D" node="3JmJHJb$UhK" resolve="com.mbeddr.analyses.spin.c" />
-          </node>
-        </node>
       </node>
       <node concept="1E1JtD" id="4b2d3GUsTDW" role="2G$12L">
         <property role="BnDLt" value="true" />
@@ -11668,36 +11466,6 @@
               <property role="3bR36h" value="false" />
               <ref role="3bR37D" to="ffeo:7Kfy9QB6L9O" resolve="jetbrains.mps.lang.smodel" />
             </node>
-          </node>
-        </node>
-      </node>
-      <node concept="1E1JtA" id="5HlC91LJU65" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="com.mbeddr.analyses.spin.documentation" />
-        <property role="3LESm3" value="1dcacc1a-8e53-470e-987d-f654ba2e645c" />
-        <property role="2GAjPV" value="false" />
-        <node concept="398BVA" id="5HlC91LJUU6" role="3LF7KH">
-          <ref role="398BVh" node="7eF9rfAuDUw" resolve="mbeddr.analyses" />
-          <node concept="2Ry0Ak" id="5HlC91LJUU7" role="iGT6I">
-            <property role="2Ry0Am" value="solutions" />
-            <node concept="2Ry0Ak" id="5HlC91LJUU8" role="2Ry0An">
-              <property role="2Ry0Am" value="com.mbeddr.analyses.spin.documentation" />
-              <node concept="2Ry0Ak" id="5HlC91LJW0k" role="2Ry0An">
-                <property role="2Ry0Am" value="com.mbeddr.analyses.spin.documentation.msd" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="5HlC91LJWzm" role="3bR37C">
-          <node concept="3bR9La" id="5HlC91LJWzn" role="1SiIV1">
-            <property role="3bR36h" value="false" />
-            <ref role="3bR37D" node="3JmJHJb$WUS" resolve="com.mbeddr.analyses.spin.c.patterns" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="5HlC91LJWzo" role="3bR37C">
-          <node concept="3bR9La" id="5HlC91LJWzp" role="1SiIV1">
-            <property role="3bR36h" value="false" />
-            <ref role="3bR37D" node="3JmJHJb$FXz" resolve="com.mbeddr.analyses.spin" />
           </node>
         </node>
       </node>
@@ -11920,20 +11688,8 @@
         <node concept="3LEDTy" id="6efVUW9IoKv" role="3LEDUa">
           <ref role="3LEDTV" node="3JmJHJb$WUS" resolve="com.mbeddr.analyses.spin.c.patterns" />
         </node>
-        <node concept="3LEz8M" id="4l47ydymoEh" role="3LEz9a">
-          <ref role="3LEz8N" node="7uZw0yZ43Kv" resolve="com.mbeddr.core" />
-        </node>
-        <node concept="3LEDTy" id="5HlC91L_yGd" role="3LEDUa">
-          <ref role="3LEDTV" node="3JmJHJb$FXz" resolve="com.mbeddr.analyses.spin" />
-        </node>
-        <node concept="3LEDTy" id="5HlC91L_yGe" role="3LEDUa">
-          <ref role="3LEDTV" node="3JmJHJb$M36" resolve="com.mbeddr.analyses.spin.promela" />
-        </node>
-        <node concept="3LEDTy" id="5HlC91L_yGf" role="3LEDUa">
-          <ref role="3LEDTV" node="3JmJHJb$PCC" resolve="com.mbeddr.analyses.spin.promela.patterns" />
-        </node>
-        <node concept="3LEDTM" id="5HlC91LPPgi" role="3LEDUa">
-          <ref role="3LEDTN" node="5HlC91LJU65" resolve="com.mbeddr.analyses.spin.documentation" />
+        <node concept="3LEz8M" id="6efVUW9Ipjl" role="3LEz9a">
+          <ref role="3LEz8N" node="6efVUW9Id0E" resolve="com.mbeddr.analyses.promela" />
         </node>
       </node>
     </node>
@@ -12068,7 +11824,7 @@
         </node>
         <node concept="1SiIV0" id="7eF9rfAuSQo" role="3bR37C">
           <node concept="3bR9La" id="7eF9rfAuSQp" role="1SiIV1">
-            <property role="3bR36h" value="true" />
+            <property role="3bR36h" value="false" />
             <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
           </node>
         </node>
@@ -12327,53 +12083,6 @@
           <node concept="3bR9La" id="5dchr4Qji$3" role="1SiIV1">
             <property role="3bR36h" value="false" />
             <ref role="3bR37D" to="al5i:7Pr7tifzlku" resolve="com.mbeddr.platform" />
-          </node>
-        </node>
-      </node>
-    </node>
-    <node concept="2G$12M" id="3qyGNHcQRJZ" role="3989C9">
-      <property role="TrG5h" value="come.mbeddr.xmodel" />
-      <node concept="1E1JtA" id="3qyGNHcQWG9" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="com.mbeddr.xmodel.plan" />
-        <property role="3LESm3" value="ba2ac496-8745-40ba-babe-060b0c8daaad" />
-        <property role="2GAjPV" value="false" />
-        <node concept="398BVA" id="3qyGNHcQXf$" role="3LF7KH">
-          <ref role="398BVh" node="7uZw0yZ2_Jf" resolve="mbeddr.github.core.home" />
-          <node concept="2Ry0Ak" id="3qyGNHcQXMX" role="iGT6I">
-            <property role="2Ry0Am" value="code" />
-            <node concept="2Ry0Ak" id="3qyGNHcR1Eo" role="2Ry0An">
-              <property role="2Ry0Am" value="languages" />
-              <node concept="2Ry0Ak" id="3qyGNHcR3kq" role="2Ry0An">
-                <property role="2Ry0Am" value="com.mbeddr.xmodel" />
-                <node concept="2Ry0Ak" id="3qyGNHcR4r9" role="2Ry0An">
-                  <property role="2Ry0Am" value="solutions" />
-                  <node concept="2Ry0Ak" id="3qyGNHcR5xS" role="2Ry0An">
-                    <property role="2Ry0Am" value="com.mbeddr.xmodel.plan" />
-                    <node concept="2Ry0Ak" id="3qyGNHcR6CB" role="2Ry0An">
-                      <property role="2Ry0Am" value="com.mbeddr.xmodel.plan.msd" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="1E1JtA" id="6AA6Z09kE7k" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="com.mbeddr.analyses.cbmc.xmodel.plan" />
-        <property role="3LESm3" value="89149c16-0102-4ac4-b76c-cce9604a7e8c" />
-        <node concept="398BVA" id="6AA6Z09kF4k" role="3LF7KH">
-          <ref role="398BVh" node="7eF9rfAuDUw" resolve="mbeddr.analyses" />
-          <node concept="2Ry0Ak" id="6AA6Z09kF4l" role="iGT6I">
-            <property role="2Ry0Am" value="solutions" />
-            <node concept="2Ry0Ak" id="6AA6Z09kF4m" role="2Ry0An">
-              <property role="2Ry0Am" value="com.mbeddr.analyses.cbmc.xmodel.plan" />
-              <node concept="2Ry0Ak" id="6AA6Z09kLSk" role="2Ry0An">
-                <property role="2Ry0Am" value="com.mbeddr.analyses.cbmc.xmodel.plan.msd" />
-              </node>
-            </node>
           </node>
         </node>
       </node>
@@ -12710,9 +12419,6 @@
       </node>
       <node concept="m$_wl" id="62XMcUo5Gn_" role="39821P">
         <ref role="m_rDy" node="62XMcUo5GnA" resolve="com.mbeddr.debugger.testing" />
-      </node>
-      <node concept="m$_wl" id="3qyGNHcRjTb" role="39821P">
-        <ref role="m_rDy" node="3qyGNHcRb2h" resolve="com.mbeddr.xmodel" />
       </node>
       <node concept="L2wRC" id="7XKze7RPycH" role="39821P">
         <ref role="L2wRA" node="5dchr4QjhF_" resolve="com.mbeddr.build" />

--- a/code/languages/com.mbeddr.core/languages/com.mbeddr.core.unittest/languageModels/typesystem.mps
+++ b/code/languages/com.mbeddr.core/languages/com.mbeddr.core.unittest/languageModels/typesystem.mps
@@ -19,6 +19,7 @@
     <import index="c4fa" ref="r:9f0e84b6-2ec7-4f9e-83e0-feedc77b63a3(com.mbeddr.core.statements.structure)" />
     <import index="dqn8" ref="r:6f177fc3-8a05-4826-8d08-fd8676623247(com.mbeddr.mpsutil.suppresswarning.behavior)" />
     <import index="btm1" ref="b0f8641f-bd77-4421-8425-30d9088a82f7/java:org.apache.commons.lang3(org.apache.commons/)" />
+    <import index="gkt" ref="r:f29b6853-4e1d-40bc-a331-9233266a6f31(com.mbeddr.ext.units.runtime.plugin)" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
     <import index="rmg4" ref="r:18211265-1331-48c8-8298-565ed01be497(com.mbeddr.core.unittest.behavior)" implicit="true" />
   </imports>
@@ -32,6 +33,7 @@
         <child id="1068498886295" name="lValue" index="37vLTJ" />
       </concept>
       <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
+      <concept id="1224500799915" name="jetbrains.mps.baseLanguage.structure.BitwiseXorExpression" flags="nn" index="pVQyQ" />
       <concept id="1154032098014" name="jetbrains.mps.baseLanguage.structure.AbstractLoopStatement" flags="nn" index="2LF5Ji">
         <child id="1154032183016" name="body" index="2LFqv$" />
       </concept>
@@ -1235,6 +1237,35 @@
               </node>
             </node>
           </node>
+          <node concept="3clFbJ" id="16Hl1ytZbjw" role="3cqZAp">
+            <node concept="3clFbS" id="16Hl1ytZbjx" role="3clFbx">
+              <node concept="2MkqsV" id="16Hl1ytZbjy" role="3cqZAp">
+                <node concept="Xl_RD" id="16Hl1ytZbjz" role="2MkJ7o">
+                  <property role="Xl_RC" value="An annotated type and a non-annotated type is not comparable!" />
+                </node>
+                <node concept="1YBJjd" id="16Hl1yu26FD" role="2OEOjV">
+                  <ref role="1YBMHb" node="x1qBkTy4v" resolve="sboas" />
+                </node>
+              </node>
+            </node>
+            <node concept="pVQyQ" id="16Hl1ytZbj_" role="3clFbw">
+              <node concept="2YIFZM" id="16Hl1ytZbjA" role="3uHU7B">
+                <ref role="1Pybhc" to="gkt:4jkbLB5RJZL" resolve="UnitConversionUtil" />
+                <ref role="37wK5l" to="gkt:26hWC1Idg93" resolve="isUnitLessType" />
+                <node concept="37vLTw" id="16Hl1yu25X6" role="37wK5m">
+                  <ref role="3cqZAo" node="3xLG8$efdn$" resolve="exp" />
+                </node>
+              </node>
+              <node concept="2YIFZM" id="16Hl1ytZbjC" role="3uHU7w">
+                <ref role="37wK5l" to="gkt:26hWC1Idg93" resolve="isUnitLessType" />
+                <ref role="1Pybhc" to="gkt:4jkbLB5RJZL" resolve="UnitConversionUtil" />
+                <node concept="37vLTw" id="16Hl1yu26vj" role="37wK5m">
+                  <ref role="3cqZAo" node="3xLG8$efdnH" resolve="act" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbH" id="16Hl1yu25nK" role="3cqZAp" />
         </node>
         <node concept="2OqwBi" id="6Kj2zNCqk8Q" role="3clFbw">
           <node concept="2qgKlT" id="6Kj2zNCqkpY" role="2OqNvi">

--- a/code/languages/com.mbeddr.core/languages/com.mbeddr.core.unittest/unittest.mpl
+++ b/code/languages/com.mbeddr.core/languages/com.mbeddr.core.unittest/unittest.mpl
@@ -27,7 +27,6 @@
         <dependency reexport="false">2ed50273-af07-4e30-9004-b1f89545178a(com.mbeddr.core.stdlib)</dependency>
         <dependency reexport="false">d4280a54-f6df-4383-aa41-d1b2bffa7eb1(com.mbeddr.core.base)</dependency>
         <dependency reexport="false">b0f8641f-bd77-4421-8425-30d9088a82f7(org.apache.commons)</dependency>
-        <dependency reexport="false">b67a6ca0-735e-4903-b238-4b525bddf96a(com.mbeddr.mpsutil.genutil)</dependency>
       </dependencies>
       <languageVersions>
         <language slang="l:d4280a54-f6df-4383-aa41-d1b2bffa7eb1:com.mbeddr.core.base" version="4" />
@@ -194,6 +193,7 @@
     <dependency reexport="false">2d7fadf5-33f6-4e80-a78f-0f739add2bde(com.mbeddr.core.buildconfig)</dependency>
     <dependency reexport="false">b0f8641f-bd77-4421-8425-30d9088a82f7(org.apache.commons)</dependency>
     <dependency reexport="false">528ff3b9-5fc4-40dd-931f-c6ce3650640e(jetbrains.mps.lang.migration.runtime)</dependency>
+    <dependency reexport="false">30d40e06-2249-4bd3-b8ab-109459f5021f(com.mbeddr.ext.units.runtime)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:d4280a54-f6df-4383-aa41-d1b2bffa7eb1:com.mbeddr.core.base" version="4" />


### PR DESCRIPTION
For example consider assert equals statement:
Example:
double val;
assert-equals(3) d == 4 s;

There is no type system error thrown here as annotated type and non annotated type cannot be compared.So i have added type system check for units in assert statements.Please consider the changes and merge with milestone.