### PR TITLE
Ignore deleting the edges when we delete boxes in diagram editor

### DIFF
--- a/code/plugins/sl-all/diagram/languages/de.itemis.mps.editor.diagram/generator/template/main@generator.mps
+++ b/code/plugins/sl-all/diagram/languages/de.itemis.mps.editor.diagram/generator/template/main@generator.mps
@@ -248,6 +248,12 @@
       <concept id="1206629501431" name="jetbrains.mps.baseLanguage.structure.InstanceInitializer" flags="lg" index="3KIgzJ">
         <child id="1206629521979" name="statementList" index="3KIlGz" />
       </concept>
+      <concept id="6329021646629104957" name="jetbrains.mps.baseLanguage.structure.TextCommentPart" flags="nn" index="3SKdUq">
+        <property id="6329021646629104958" name="text" index="3SKdUp" />
+      </concept>
+      <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="nn" index="3SKdUt">
+        <child id="6329021646629175155" name="commentPart" index="3SKWNk" />
+      </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
       <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
       <concept id="1146644641414" name="jetbrains.mps.baseLanguage.structure.ProtectedVisibility" flags="nn" index="3Tmbuc" />
@@ -5748,6 +5754,74 @@
                             </node>
                           </node>
                         </node>
+                        <node concept="2tJIrI" id="7eLeaWFT8Xe" role="jymVt" />
+                        <node concept="3clFb_" id="7eLeaWFTaYV" role="jymVt">
+                          <property role="TrG5h" value="canDeleteEdgesAssociated" />
+                          <property role="1EzhhJ" value="false" />
+                          <node concept="10P_77" id="7eLeaWFTaYW" role="3clF45" />
+                          <node concept="3Tm1VV" id="7eLeaWFTaYX" role="1B3o_S" />
+                          <node concept="3clFbS" id="7eLeaWFTaZ2" role="3clF47">
+                            <node concept="3cpWs6" id="7eLeaWFTmbx" role="3cqZAp">
+                              <node concept="3clFbT" id="7eLeaWFTmiQ" role="3cqZAk">
+                                <property role="3clFbU" value="true" />
+                                <node concept="29HgVG" id="7eLeaWFTnXE" role="lGtFl">
+                                  <node concept="3NFfHV" id="7eLeaWFTnXF" role="3NFExx">
+                                    <node concept="3clFbS" id="7eLeaWFTnXG" role="2VODD2">
+                                      <node concept="3cpWs8" id="7eLeaWFTBjs" role="3cqZAp">
+                                        <node concept="3cpWsn" id="7eLeaWFTBjv" role="3cpWs9">
+                                          <property role="TrG5h" value="booleanConstant" />
+                                          <node concept="3Tqbb2" id="7eLeaWFTBjq" role="1tU5fm">
+                                            <ref role="ehGHo" to="tpee:fzclF81" resolve="BooleanConstant" />
+                                          </node>
+                                          <node concept="2ShNRf" id="7eLeaWFTHMp" role="33vP2m">
+                                            <node concept="3zrR0B" id="7eLeaWFTHG6" role="2ShVmc">
+                                              <node concept="3Tqbb2" id="7eLeaWFTHG7" role="3zrR0E">
+                                                <ref role="ehGHo" to="tpee:fzclF81" resolve="BooleanConstant" />
+                                              </node>
+                                            </node>
+                                          </node>
+                                        </node>
+                                      </node>
+                                      <node concept="3SKdUt" id="5aBcFaYuvnY" role="3cqZAp">
+                                        <node concept="3SKdUq" id="5aBcFaYuvo0" role="3SKWNk">
+                                          <property role="3SKdUp" value="Default behavior is deleting the associated edges." />
+                                        </node>
+                                      </node>
+                                      <node concept="3clFbF" id="7eLeaWFTCQT" role="3cqZAp">
+                                        <node concept="37vLTI" id="7eLeaWFTFVI" role="3clFbG">
+                                          <node concept="2OqwBi" id="7eLeaWFTDfL" role="37vLTJ">
+                                            <node concept="37vLTw" id="7eLeaWFTCQR" role="2Oq$k0">
+                                              <ref role="3cqZAo" node="7eLeaWFTBjv" resolve="booleanConstant" />
+                                            </node>
+                                            <node concept="3TrcHB" id="7eLeaWFTF3w" role="2OqNvi">
+                                              <ref role="3TsBF5" to="tpee:fzclF82" resolve="value" />
+                                            </node>
+                                          </node>
+                                          <node concept="3fqX7Q" id="5aBcFaYgZUF" role="37vLTx">
+                                            <node concept="2OqwBi" id="5aBcFaYgZUH" role="3fr31v">
+                                              <node concept="3TrcHB" id="5aBcFaYgZUI" role="2OqNvi">
+                                                <ref role="3TsBF5" to="2qld:7eLeaWFPq1P" resolve="ignoreEdgesOnDeletion" />
+                                              </node>
+                                              <node concept="30H73N" id="5aBcFaYgZUJ" role="2Oq$k0" />
+                                            </node>
+                                          </node>
+                                        </node>
+                                      </node>
+                                      <node concept="3cpWs6" id="7eLeaWFTIk2" role="3cqZAp">
+                                        <node concept="37vLTw" id="7eLeaWFTIEg" role="3cqZAk">
+                                          <ref role="3cqZAo" node="7eLeaWFTBjv" resolve="booleanConstant" />
+                                        </node>
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="2AHcQZ" id="7eLeaWFTaZ3" role="2AJF6D">
+                            <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                          </node>
+                        </node>
                         <node concept="37vLTw" id="5RIhRmzyAoI" role="37wK5m">
                           <ref role="3cqZAo" node="5qgNcfDodBw" resolve="node" />
                         </node>
@@ -9057,6 +9131,75 @@
                                                   <node concept="30H73N" id="7tKD69sBjax" role="2Oq$k0" />
                                                   <node concept="3TrEf2" id="7tKD69sBld0" role="2OqNvi">
                                                     <ref role="3Tt5mk" to="2qld:7tKD69sBkpf" resolve="dropHandler" />
+                                                  </node>
+                                                </node>
+                                              </node>
+                                            </node>
+                                          </node>
+                                        </node>
+                                      </node>
+                                      <node concept="2tJIrI" id="7eLeaWG2NVf" role="jymVt" />
+                                      <node concept="3clFb_" id="7eLeaWG2P8A" role="jymVt">
+                                        <property role="1EzhhJ" value="false" />
+                                        <property role="2aFKle" value="false" />
+                                        <property role="TrG5h" value="canDeleteEdgesAssociated" />
+                                        <node concept="3Tm1VV" id="7eLeaWG2P8B" role="1B3o_S" />
+                                        <node concept="10P_77" id="7eLeaWG2P8C" role="3clF45" />
+                                        <node concept="2AHcQZ" id="7eLeaWG2P8G" role="2AJF6D">
+                                          <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                                        </node>
+                                        <node concept="3clFbS" id="7eLeaWG2P8I" role="3clF47">
+                                          <node concept="3cpWs6" id="7eLeaWG2R1_" role="3cqZAp">
+                                            <node concept="3clFbT" id="7eLeaWG2R8U" role="3cqZAk">
+                                              <property role="3clFbU" value="true" />
+                                              <node concept="29HgVG" id="7eLeaWG2Sf2" role="lGtFl">
+                                                <node concept="3NFfHV" id="7eLeaWG2Sf3" role="3NFExx">
+                                                  <node concept="3clFbS" id="7eLeaWG2Sf4" role="2VODD2">
+                                                    <node concept="3cpWs8" id="5aBcFaXVSrI" role="3cqZAp">
+                                                      <node concept="3cpWsn" id="5aBcFaXVSrJ" role="3cpWs9">
+                                                        <property role="TrG5h" value="booleanConstant" />
+                                                        <node concept="3Tqbb2" id="5aBcFaXVSrK" role="1tU5fm">
+                                                          <ref role="ehGHo" to="tpee:fzclF81" resolve="BooleanConstant" />
+                                                        </node>
+                                                        <node concept="2ShNRf" id="5aBcFaXVSrL" role="33vP2m">
+                                                          <node concept="3zrR0B" id="5aBcFaXVSrM" role="2ShVmc">
+                                                            <node concept="3Tqbb2" id="5aBcFaXVSrN" role="3zrR0E">
+                                                              <ref role="ehGHo" to="tpee:fzclF81" resolve="BooleanConstant" />
+                                                            </node>
+                                                          </node>
+                                                        </node>
+                                                      </node>
+                                                    </node>
+                                                    <node concept="3SKdUt" id="5aBcFaYusei" role="3cqZAp">
+                                                      <node concept="3SKdUq" id="5aBcFaYusek" role="3SKWNk">
+                                                        <property role="3SKdUp" value="Default behavior is deleting the associated edges." />
+                                                      </node>
+                                                    </node>
+                                                    <node concept="3clFbF" id="5aBcFaXVSrO" role="3cqZAp">
+                                                      <node concept="37vLTI" id="5aBcFaXVSrP" role="3clFbG">
+                                                        <node concept="2OqwBi" id="5aBcFaXVSrQ" role="37vLTJ">
+                                                          <node concept="37vLTw" id="5aBcFaXVSrR" role="2Oq$k0">
+                                                            <ref role="3cqZAo" node="5aBcFaXVSrJ" resolve="booleanConstant" />
+                                                          </node>
+                                                          <node concept="3TrcHB" id="5aBcFaXVSrS" role="2OqNvi">
+                                                            <ref role="3TsBF5" to="tpee:fzclF82" resolve="value" />
+                                                          </node>
+                                                        </node>
+                                                        <node concept="3fqX7Q" id="5aBcFaYgVb6" role="37vLTx">
+                                                          <node concept="2OqwBi" id="5aBcFaYgVb8" role="3fr31v">
+                                                            <node concept="3TrcHB" id="5aBcFaYgVb9" role="2OqNvi">
+                                                              <ref role="3TsBF5" to="2qld:7eLeaWG2Tlc" resolve="ignoreEdgesOnDeletion" />
+                                                            </node>
+                                                            <node concept="30H73N" id="5aBcFaYgVba" role="2Oq$k0" />
+                                                          </node>
+                                                        </node>
+                                                      </node>
+                                                    </node>
+                                                    <node concept="3cpWs6" id="5aBcFaXVSrW" role="3cqZAp">
+                                                      <node concept="37vLTw" id="5aBcFaXVSrX" role="3cqZAk">
+                                                        <ref role="3cqZAo" node="5aBcFaXVSrJ" resolve="booleanConstant" />
+                                                      </node>
+                                                    </node>
                                                   </node>
                                                 </node>
                                               </node>

--- a/code/plugins/sl-all/diagram/languages/de.itemis.mps.editor.diagram/languageModels/editor.mps
+++ b/code/plugins/sl-all/diagram/languages/de.itemis.mps.editor.diagram/languageModels/editor.mps
@@ -1055,6 +1055,27 @@
         </node>
         <node concept="2EHx9g" id="63Tq0M9tPFK" role="2iSdaV" />
       </node>
+      <node concept="3F0ifn" id="5aBcFaYeoFv" role="3EZMnx" />
+      <node concept="3EZMnI" id="7eLeaWFPqdW" role="3EZMnx">
+        <node concept="VPM3Z" id="7eLeaWFPqdY" role="3F10Kt">
+          <property role="VOm3f" value="false" />
+        </node>
+        <node concept="VPXOz" id="5aBcFaYcv6z" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+        <node concept="3F0ifn" id="7eLeaWFPqe0" role="3EZMnx">
+          <property role="3F0ifm" value="Ignore associated edges while deleting box: " />
+          <ref role="1k5W1q" to="tpc5:hF4H1c8" resolve="property" />
+        </node>
+        <node concept="3F0A7n" id="7eLeaWFPqeI" role="3EZMnx">
+          <property role="1$x2rV" value="true" />
+          <ref role="1NtTu8" to="2qld:7eLeaWFPq1P" resolve="ignoreEdgesOnDeletion" />
+          <node concept="Vb9p2" id="5aBcFaYeMVR" role="3F10Kt">
+            <property role="Vbekb" value="ITALIC" />
+          </node>
+        </node>
+        <node concept="l2Vlx" id="7eLeaWFPqe1" role="2iSdaV" />
+      </node>
       <node concept="VPM3Z" id="63Tq0M9tPFL" role="3F10Kt">
         <property role="VOm3f" value="false" />
       </node>
@@ -2604,6 +2625,26 @@
       </node>
       <node concept="PMmxH" id="4GZkTSmg$TT" role="3EZMnx">
         <ref role="PMmxG" to="tpc5:1cEk0X7pP35" resolve="CellStyle_Component" />
+      </node>
+      <node concept="3F0ifn" id="5aBcFaYdYLc" role="3EZMnx" />
+      <node concept="3EZMnI" id="7eLeaWG2Vdr" role="3EZMnx">
+        <node concept="VPM3Z" id="7eLeaWG2Vds" role="3F10Kt">
+          <property role="VOm3f" value="false" />
+        </node>
+        <node concept="VPXOz" id="5aBcFaYcv4W" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+        <node concept="3F0ifn" id="7eLeaWG2Vdt" role="3EZMnx">
+          <property role="3F0ifm" value="Ignore associated edges while deleting box: " />
+          <ref role="1k5W1q" to="tpc5:hF4H1c8" resolve="property" />
+        </node>
+        <node concept="3F0A7n" id="7eLeaWG2Vdu" role="3EZMnx">
+          <ref role="1NtTu8" to="2qld:7eLeaWG2Tlc" resolve="ignoreEdgesOnDeletion" />
+          <node concept="Vb9p2" id="5aBcFaYeMWa" role="3F10Kt">
+            <property role="Vbekb" value="ITALIC" />
+          </node>
+        </node>
+        <node concept="l2Vlx" id="7eLeaWG2Vdv" role="2iSdaV" />
       </node>
       <node concept="2iRkQZ" id="4GZkTSmg$TU" role="2iSdaV" />
     </node>

--- a/code/plugins/sl-all/diagram/languages/de.itemis.mps.editor.diagram/languageModels/structure.mps
+++ b/code/plugins/sl-all/diagram/languages/de.itemis.mps.editor.diagram/languageModels/structure.mps
@@ -156,6 +156,11 @@
     <property role="34LRSv" value="diagram.box" />
     <property role="EcuMT" value="6237710625713195816" />
     <ref role="1TJDcQ" to="tpc2:fBEYTCT" resolve="EditorCellModel" />
+    <node concept="1TJgyi" id="7eLeaWFPq1P" role="1TKVEl">
+      <property role="IQ2nx" value="8336506710245351541" />
+      <property role="TrG5h" value="ignoreEdgesOnDeletion" />
+      <ref role="AX2Wp" to="tpck:fKAQMTB" resolve="boolean" />
+    </node>
     <node concept="1TJgyj" id="1mYz8rWOnbW" role="1TKVEi">
       <property role="20lmBu" value="aggregation" />
       <property role="20kJfa" value="ports2" />
@@ -920,6 +925,11 @@
     </node>
     <node concept="PrWs8" id="7L$rKAV50Iu" role="PzmwI">
       <ref role="PrY4T" node="2J9gLgxqr14" resolve="IDiagramContent" />
+    </node>
+    <node concept="1TJgyi" id="7eLeaWG2Tlc" role="1TKVEl">
+      <property role="IQ2nx" value="8336506710248887628" />
+      <property role="TrG5h" value="ignoreEdgesOnDeletion" />
+      <ref role="AX2Wp" to="tpck:fKAQMTB" resolve="boolean" />
     </node>
   </node>
   <node concept="1TIwiD" id="7L$rKAV31Yz">

--- a/code/plugins/sl-all/diagram/solutions/de.itemis.mps.editor.diagram.runtime/models/de/itemis/mps/editor/diagram/runtime/model.mps
+++ b/code/plugins/sl-all/diagram/solutions/de.itemis.mps.editor.diagram.runtime/models/de/itemis/mps/editor/diagram/runtime/model.mps
@@ -697,7 +697,18 @@
         </node>
       </node>
     </node>
-    <node concept="2tJIrI" id="27djZ8A0Rsj" role="jymVt" />
+    <node concept="312cEg" id="7eLeaWFQRJs" role="jymVt">
+      <property role="34CwA1" value="false" />
+      <property role="eg7rD" value="false" />
+      <property role="TrG5h" value="deleteEdgesOnDeletion" />
+      <property role="3TUv4t" value="false" />
+      <node concept="3Tm6S6" id="7eLeaWFQNy8" role="1B3o_S" />
+      <node concept="10P_77" id="7eLeaWFQRkY" role="1tU5fm" />
+      <node concept="3clFbT" id="7eLeaWFQVas" role="33vP2m">
+        <property role="3clFbU" value="false" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="7eLeaWFQJJ4" role="jymVt" />
     <node concept="3clFbW" id="7jhYr4hr4zZ" role="jymVt">
       <node concept="3cqZAl" id="7jhYr4hr4$1" role="3clF45" />
       <node concept="3Tm1VV" id="7jhYr4hr4$2" role="1B3o_S" />
@@ -2166,9 +2177,49 @@
       </node>
     </node>
     <node concept="2tJIrI" id="5lWUryyBNUJ" role="jymVt" />
+    <node concept="3clFb_" id="7eLeaWFRSqG" role="jymVt">
+      <property role="TrG5h" value="setDeleteEdgesOnDeletion" />
+      <node concept="3cqZAl" id="7eLeaWFRSqH" role="3clF45" />
+      <node concept="3Tm1VV" id="7eLeaWFRSqI" role="1B3o_S" />
+      <node concept="3clFbS" id="7eLeaWFRSqJ" role="3clF47">
+        <node concept="3clFbF" id="7eLeaWFRSqK" role="3cqZAp">
+          <node concept="37vLTI" id="7eLeaWFRSqL" role="3clFbG">
+            <node concept="37vLTw" id="7eLeaWFRSqM" role="37vLTx">
+              <ref role="3cqZAo" node="7eLeaWFRSqN" resolve="deleteEdgesOnDeletion" />
+            </node>
+            <node concept="2OqwBi" id="7eLeaWFSbt8" role="37vLTJ">
+              <node concept="Xjq3P" id="7eLeaWFSbJ1" role="2Oq$k0" />
+              <node concept="2OwXpG" id="7eLeaWFSbtb" role="2OqNvi">
+                <ref role="2Oxat5" node="7eLeaWFQRJs" resolve="deleteEdgesOnDeletion" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="7eLeaWFRSqN" role="3clF46">
+        <property role="TrG5h" value="deleteEdgesOnDeletion" />
+        <node concept="10P_77" id="7eLeaWFRSqO" role="1tU5fm" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="7eLeaWFRZVw" role="jymVt" />
     <node concept="3Tm1VV" id="27djZ8_YaUp" role="1B3o_S" />
     <node concept="3uibUv" id="2JYLxR6nKFM" role="EKbjA">
       <ref role="3uigEE" node="2JYLxR6nEai" resolve="IConnectionEndpoint_Internal" />
+    </node>
+    <node concept="3clFb_" id="7eLeaWFQZh_" role="jymVt">
+      <property role="TrG5h" value="canDeleteEdgesOnDeletion" />
+      <node concept="10P_77" id="7eLeaWFQZhA" role="3clF45" />
+      <node concept="3Tm1VV" id="7eLeaWFQZhB" role="1B3o_S" />
+      <node concept="3clFbS" id="7eLeaWFQZhC" role="3clF47">
+        <node concept="3cpWs6" id="7eLeaWFR7Je" role="3cqZAp">
+          <node concept="2OqwBi" id="7eLeaWFRf0F" role="3cqZAk">
+            <node concept="Xjq3P" id="7eLeaWFRbgd" role="2Oq$k0" />
+            <node concept="2OwXpG" id="7eLeaWFR_rr" role="2OqNvi">
+              <ref role="2Oxat5" node="7eLeaWFQRJs" resolve="deleteEdgesOnDeletion" />
+            </node>
+          </node>
+        </node>
+      </node>
     </node>
   </node>
   <node concept="312cEu" id="27djZ8_YaVo">
@@ -17280,6 +17331,14 @@
       <node concept="3Tm1VV" id="7tKD69s$9L5" role="1B3o_S" />
       <node concept="3clFbS" id="7tKD69s$9L6" role="3clF47" />
     </node>
+    <node concept="3clFb_" id="7eLeaWFSnRo" role="jymVt">
+      <property role="1EzhhJ" value="true" />
+      <property role="2aFKle" value="false" />
+      <property role="TrG5h" value="canDeleteEdgesAssociated" />
+      <node concept="3clFbS" id="7eLeaWFSnRr" role="3clF47" />
+      <node concept="3Tm1VV" id="7eLeaWFSnRs" role="1B3o_S" />
+      <node concept="10P_77" id="7eLeaWFSn9U" role="3clF45" />
+    </node>
     <node concept="3Tm1VV" id="4teJTSBwM8S" role="1B3o_S" />
     <node concept="3uibUv" id="4teJTSBx1U$" role="3HQHJm">
       <ref role="3uigEE" node="4teJTSBx0$0" resolve="IDiagramElementAccessor" />
@@ -20224,23 +20283,61 @@
         </node>
         <node concept="3clFbJ" id="7jhYr4hpIwy" role="3cqZAp">
           <node concept="3clFbS" id="7jhYr4hpIwz" role="3clFbx">
+            <node concept="3cpWs8" id="7eLeaWFSvS_" role="3cqZAp">
+              <node concept="3cpWsn" id="7eLeaWFSvSA" role="3cpWs9">
+                <property role="TrG5h" value="boxAccessor" />
+                <node concept="3uibUv" id="7eLeaWFSvS$" role="1tU5fm">
+                  <ref role="3uigEE" node="4teJTSBwM8R" resolve="IBoxAccessor" />
+                </node>
+                <node concept="10QFUN" id="7eLeaWFSvSB" role="33vP2m">
+                  <node concept="3uibUv" id="7eLeaWFSvSC" role="10QFUM">
+                    <ref role="3uigEE" node="4teJTSBwM8R" resolve="IBoxAccessor" />
+                  </node>
+                  <node concept="37vLTw" id="7eLeaWFSwp1" role="10QFUP">
+                    <ref role="3cqZAo" node="7jhYr4hpGiR" resolve="accessor" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs8" id="7eLeaWFSjqh" role="3cqZAp">
+              <node concept="3cpWsn" id="7eLeaWFSjqi" role="3cpWs9">
+                <property role="TrG5h" value="box" />
+                <node concept="3uibUv" id="7eLeaWFSjqe" role="1tU5fm">
+                  <ref role="3uigEE" node="27djZ8_YaUo" resolve="Box" />
+                </node>
+                <node concept="1rXfSq" id="7eLeaWFSjqj" role="33vP2m">
+                  <ref role="37wK5l" node="7jhYr4hpKWZ" resolve="createBox" />
+                  <node concept="37vLTw" id="7eLeaWFSvSE" role="37wK5m">
+                    <ref role="3cqZAo" node="7eLeaWFSvSA" resolve="boxAccessor" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="7eLeaWFSjWs" role="3cqZAp">
+              <node concept="2OqwBi" id="7eLeaWFSktN" role="3clFbG">
+                <node concept="37vLTw" id="7eLeaWFSjWq" role="2Oq$k0">
+                  <ref role="3cqZAo" node="7eLeaWFSjqi" resolve="box" />
+                </node>
+                <node concept="liA8E" id="7eLeaWFSm2N" role="2OqNvi">
+                  <ref role="37wK5l" node="7eLeaWFRSqG" resolve="setDeleteEdgesOnDeletion" />
+                  <node concept="2OqwBi" id="7eLeaWFSxdJ" role="37wK5m">
+                    <node concept="37vLTw" id="7eLeaWFSwQz" role="2Oq$k0">
+                      <ref role="3cqZAo" node="7eLeaWFSvSA" resolve="boxAccessor" />
+                    </node>
+                    <node concept="liA8E" id="7eLeaWFSxBj" role="2OqNvi">
+                      <ref role="37wK5l" node="7eLeaWFSnRo" resolve="canDeleteEdgesAssociated" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
             <node concept="3clFbF" id="5D3lA7lPQ4k" role="3cqZAp">
               <node concept="37vLTI" id="5D3lA7lPSw3" role="3clFbG">
                 <node concept="37vLTw" id="5D3lA7lPQ4j" role="37vLTJ">
                   <ref role="3cqZAo" node="5D3lA7lPIld" resolve="result" />
                 </node>
-                <node concept="1rXfSq" id="7jhYr4hpYs4" role="37vLTx">
-                  <ref role="37wK5l" node="7jhYr4hpKWZ" resolve="createBox" />
-                  <node concept="1eOMI4" id="7jhYr4hq38M" role="37wK5m">
-                    <node concept="10QFUN" id="7jhYr4hq38J" role="1eOMHV">
-                      <node concept="3uibUv" id="7jhYr4hq50h" role="10QFUM">
-                        <ref role="3uigEE" node="4teJTSBwM8R" resolve="IBoxAccessor" />
-                      </node>
-                      <node concept="37vLTw" id="7jhYr4hq09T" role="10QFUP">
-                        <ref role="3cqZAo" node="7jhYr4hpGiR" resolve="accessor" />
-                      </node>
-                    </node>
-                  </node>
+                <node concept="37vLTw" id="7eLeaWFSjqo" role="37vLTx">
+                  <ref role="3cqZAo" node="7eLeaWFSjqi" resolve="box" />
                 </node>
               </node>
             </node>
@@ -23667,6 +23764,19 @@
               </node>
             </node>
             <node concept="3YRAZt" id="1EGRR3nuDvK" role="2OqNvi" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="7eLeaWFPOWK" role="jymVt" />
+    <node concept="3clFb_" id="7eLeaWFP_EH" role="jymVt">
+      <property role="TrG5h" value="canDeleteEdgesAssociated" />
+      <node concept="10P_77" id="7eLeaWFP_EI" role="3clF45" />
+      <node concept="3Tm1VV" id="7eLeaWFP_EJ" role="1B3o_S" />
+      <node concept="3clFbS" id="7eLeaWFP_EK" role="3clF47">
+        <node concept="3cpWs6" id="7eLeaWFTiT4" role="3cqZAp">
+          <node concept="3clFbT" id="7eLeaWFTj4P" role="3cqZAk">
+            <property role="3clFbU" value="true" />
           </node>
         </node>
       </node>


### PR DESCRIPTION
The current implementation of diagram editor deletes the associated edges if we click and delete a box. 
![image](https://user-images.githubusercontent.com/10434575/31225743-16e4ea2c-a9f1-11e7-8cb7-e726cbf7be38.png) . This will be useful in most cases, but when user does not want this behavior for few boxes, currently there is no way to achieve this. So I introduced a boolean flag in the generic box query editor and diagram.box editor. Used this flag to check before deletion process in GraphSelection. Note: The default behavior is preserved if the user does not change the boolean flag.
