### PR TITLE
Improvement-Ignore deleting the edges when we delete boxes in diagram editor

### DIFF
--- a/code/plugins/sl-all/diagram/languages/de.itemis.mps.editor.diagram/generator/template/main@generator.mps
+++ b/code/plugins/sl-all/diagram/languages/de.itemis.mps.editor.diagram/generator/template/main@generator.mps
@@ -9155,52 +9155,32 @@
                                               <node concept="29HgVG" id="7eLeaWG2Sf2" role="lGtFl">
                                                 <node concept="3NFfHV" id="7eLeaWG2Sf3" role="3NFExx">
                                                   <node concept="3clFbS" id="7eLeaWG2Sf4" role="2VODD2">
-                                                    <node concept="3cpWs8" id="5aBcFaXVSrI" role="3cqZAp">
-                                                      <node concept="3cpWsn" id="5aBcFaXVSrJ" role="3cpWs9">
-                                                        <property role="TrG5h" value="booleanConstant" />
-                                                        <node concept="3Tqbb2" id="5aBcFaXVSrK" role="1tU5fm">
-                                                          <ref role="ehGHo" to="tpee:fzclF81" resolve="BooleanConstant" />
+                                                    <node concept="3cpWs6" id="3uS6dOiThWi" role="3cqZAp">
+                                                      <node concept="2OqwBi" id="3uS6dOjrwlP" role="3cqZAk">
+                                                        <node concept="30H73N" id="3uS6dOjrwlQ" role="2Oq$k0" />
+                                                        <node concept="3TrEf2" id="3uS6dOjrwlR" role="2OqNvi">
+                                                          <ref role="3Tt5mk" to="2qld:3uS6dOiR6Sv" resolve="canDeleteEdges" />
                                                         </node>
-                                                        <node concept="2ShNRf" id="5aBcFaXVSrL" role="33vP2m">
-                                                          <node concept="3zrR0B" id="5aBcFaXVSrM" role="2ShVmc">
-                                                            <node concept="3Tqbb2" id="5aBcFaXVSrN" role="3zrR0E">
-                                                              <ref role="ehGHo" to="tpee:fzclF81" resolve="BooleanConstant" />
-                                                            </node>
-                                                          </node>
-                                                        </node>
-                                                      </node>
-                                                    </node>
-                                                    <node concept="3SKdUt" id="5aBcFaYusei" role="3cqZAp">
-                                                      <node concept="3SKdUq" id="5aBcFaYusek" role="3SKWNk">
-                                                        <property role="3SKdUp" value="Default behavior is deleting the associated edges." />
-                                                      </node>
-                                                    </node>
-                                                    <node concept="3clFbF" id="5aBcFaXVSrO" role="3cqZAp">
-                                                      <node concept="37vLTI" id="5aBcFaXVSrP" role="3clFbG">
-                                                        <node concept="2OqwBi" id="5aBcFaXVSrQ" role="37vLTJ">
-                                                          <node concept="37vLTw" id="5aBcFaXVSrR" role="2Oq$k0">
-                                                            <ref role="3cqZAo" node="5aBcFaXVSrJ" resolve="booleanConstant" />
-                                                          </node>
-                                                          <node concept="3TrcHB" id="5aBcFaXVSrS" role="2OqNvi">
-                                                            <ref role="3TsBF5" to="tpee:fzclF82" resolve="value" />
-                                                          </node>
-                                                        </node>
-                                                        <node concept="3fqX7Q" id="5aBcFaYgVb6" role="37vLTx">
-                                                          <node concept="2OqwBi" id="5aBcFaYgVb8" role="3fr31v">
-                                                            <node concept="3TrcHB" id="5aBcFaYgVb9" role="2OqNvi">
-                                                              <ref role="3TsBF5" to="2qld:7eLeaWG2Tlc" resolve="ignoreEdgesOnDeletion" />
-                                                            </node>
-                                                            <node concept="30H73N" id="5aBcFaYgVba" role="2Oq$k0" />
-                                                          </node>
-                                                        </node>
-                                                      </node>
-                                                    </node>
-                                                    <node concept="3cpWs6" id="5aBcFaXVSrW" role="3cqZAp">
-                                                      <node concept="37vLTw" id="5aBcFaXVSrX" role="3cqZAk">
-                                                        <ref role="3cqZAo" node="5aBcFaXVSrJ" resolve="booleanConstant" />
                                                       </node>
                                                     </node>
                                                   </node>
+                                                </node>
+                                              </node>
+                                            </node>
+                                          </node>
+                                        </node>
+                                        <node concept="1W57fq" id="3uS6dOj1qpw" role="lGtFl">
+                                          <node concept="3IZrLx" id="3uS6dOj1qpy" role="3IZSJc">
+                                            <node concept="3clFbS" id="3uS6dOj1qp$" role="2VODD2">
+                                              <node concept="3clFbF" id="3uS6dOj1rqA" role="3cqZAp">
+                                                <node concept="2OqwBi" id="3uS6dOj1t3q" role="3clFbG">
+                                                  <node concept="2OqwBi" id="3uS6dOj1rqC" role="2Oq$k0">
+                                                    <node concept="30H73N" id="3uS6dOj1rqD" role="2Oq$k0" />
+                                                    <node concept="3TrEf2" id="3uS6dOj1rqE" role="2OqNvi">
+                                                      <ref role="3Tt5mk" to="2qld:3uS6dOiR6Sv" resolve="canDeleteEdges" />
+                                                    </node>
+                                                  </node>
+                                                  <node concept="3x8VRR" id="3uS6dOj1tKX" role="2OqNvi" />
                                                 </node>
                                               </node>
                                             </node>

--- a/code/plugins/sl-all/diagram/languages/de.itemis.mps.editor.diagram/languageModels/editor.mps
+++ b/code/plugins/sl-all/diagram/languages/de.itemis.mps.editor.diagram/languageModels/editor.mps
@@ -95,6 +95,7 @@
       <concept id="3308396621974580100" name="jetbrains.mps.lang.editor.structure.SubstituteMenu_Default" flags="ng" index="3p36aQ" />
       <concept id="1088185857835" name="jetbrains.mps.lang.editor.structure.InlineEditorComponent" flags="ig" index="1sVBvm" />
       <concept id="1139848536355" name="jetbrains.mps.lang.editor.structure.CellModel_WithRole" flags="ng" index="1$h60E">
+        <property id="1214560368769" name="emptyNoTargetText" index="39s7Ar" />
         <property id="1139852716018" name="noTargetText" index="1$x2rV" />
         <property id="1140017977771" name="readOnly" index="1Intyy" />
         <reference id="1140103550593" name="relationDeclaration" index="1NtTu8" />
@@ -2602,6 +2603,26 @@
           </node>
           <node concept="2iRfu4" id="7tKD69sBktw" role="2iSdaV" />
         </node>
+        <node concept="3EZMnI" id="3uS6dOiR6XJ" role="3EZMnx">
+          <node concept="VPM3Z" id="3uS6dOiRS9J" role="3F10Kt">
+            <property role="VOm3f" value="false" />
+          </node>
+          <node concept="VPXOz" id="3uS6dOiRS9K" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
+          <node concept="3F0ifn" id="3uS6dOiR6XN" role="3EZMnx">
+            <property role="3F0ifm" value="can delete edges " />
+          </node>
+          <node concept="3F1sOY" id="3uS6dOiR72a" role="3EZMnx">
+            <property role="39s7Ar" value="true" />
+            <property role="1$x2rV" value="true" />
+            <ref role="1NtTu8" to="2qld:3uS6dOiR6Sv" resolve="canDeleteEdges" />
+            <node concept="VPXOz" id="3uS6dOiSEDo" role="3F10Kt">
+              <property role="VOm3f" value="true" />
+            </node>
+          </node>
+          <node concept="2iRfu4" id="3uS6dOiR6XO" role="2iSdaV" />
+        </node>
         <node concept="VPM3Z" id="7L$rKAV3q3j" role="3F10Kt">
           <property role="VOm3f" value="false" />
         </node>
@@ -2625,26 +2646,6 @@
       </node>
       <node concept="PMmxH" id="4GZkTSmg$TT" role="3EZMnx">
         <ref role="PMmxG" to="tpc5:1cEk0X7pP35" resolve="CellStyle_Component" />
-      </node>
-      <node concept="3F0ifn" id="5aBcFaYdYLc" role="3EZMnx" />
-      <node concept="3EZMnI" id="7eLeaWG2Vdr" role="3EZMnx">
-        <node concept="VPM3Z" id="7eLeaWG2Vds" role="3F10Kt">
-          <property role="VOm3f" value="false" />
-        </node>
-        <node concept="VPXOz" id="5aBcFaYcv4W" role="3F10Kt">
-          <property role="VOm3f" value="true" />
-        </node>
-        <node concept="3F0ifn" id="7eLeaWG2Vdt" role="3EZMnx">
-          <property role="3F0ifm" value="Ignore associated edges while deleting box: " />
-          <ref role="1k5W1q" to="tpc5:hF4H1c8" resolve="property" />
-        </node>
-        <node concept="3F0A7n" id="7eLeaWG2Vdu" role="3EZMnx">
-          <ref role="1NtTu8" to="2qld:7eLeaWG2Tlc" resolve="ignoreEdgesOnDeletion" />
-          <node concept="Vb9p2" id="5aBcFaYeMWa" role="3F10Kt">
-            <property role="Vbekb" value="ITALIC" />
-          </node>
-        </node>
-        <node concept="l2Vlx" id="7eLeaWG2Vdv" role="2iSdaV" />
       </node>
       <node concept="2iRkQZ" id="4GZkTSmg$TU" role="2iSdaV" />
     </node>

--- a/code/plugins/sl-all/diagram/languages/de.itemis.mps.editor.diagram/languageModels/structure.mps
+++ b/code/plugins/sl-all/diagram/languages/de.itemis.mps.editor.diagram/languageModels/structure.mps
@@ -923,13 +923,14 @@
       <property role="IQ2ns" value="8606559630272579151" />
       <ref role="20lvS9" node="7tKD69sB2Fv" resolve="DropHandler" />
     </node>
+    <node concept="1TJgyj" id="3uS6dOiR6Sv" role="1TKVEi">
+      <property role="IQ2ns" value="4014986405584072223" />
+      <property role="20lmBu" value="aggregation" />
+      <property role="20kJfa" value="canDeleteEdges" />
+      <ref role="20lvS9" to="tpee:fz3vP1J" resolve="Expression" />
+    </node>
     <node concept="PrWs8" id="7L$rKAV50Iu" role="PzmwI">
       <ref role="PrY4T" node="2J9gLgxqr14" resolve="IDiagramContent" />
-    </node>
-    <node concept="1TJgyi" id="7eLeaWG2Tlc" role="1TKVEl">
-      <property role="IQ2nx" value="8336506710248887628" />
-      <property role="TrG5h" value="ignoreEdgesOnDeletion" />
-      <ref role="AX2Wp" to="tpck:fKAQMTB" resolve="boolean" />
     </node>
   </node>
   <node concept="1TIwiD" id="7L$rKAV31Yz">

--- a/code/plugins/sl-all/diagram/languages/de.itemis.mps.editor.diagram/languageModels/typesystem.mps
+++ b/code/plugins/sl-all/diagram/languages/de.itemis.mps.editor.diagram/languageModels/typesystem.mps
@@ -810,6 +810,29 @@
           </node>
         </node>
       </node>
+      <node concept="1ZobV4" id="3uS6dOiTdsG" role="3cqZAp">
+        <node concept="mw_s8" id="3uS6dOiTdsH" role="1ZfhKB">
+          <node concept="2ShNRf" id="3uS6dOiTdsI" role="mwGJk">
+            <node concept="3zrR0B" id="3uS6dOiTdsJ" role="2ShVmc">
+              <node concept="3Tqbb2" id="3uS6dOiTdsK" role="3zrR0E">
+                <ref role="ehGHo" to="tpee:f_0P_4Y" resolve="BooleanType" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="mw_s8" id="3uS6dOiTdsL" role="1ZfhK$">
+          <node concept="1Z2H0r" id="3uS6dOiTdsM" role="mwGJk">
+            <node concept="2OqwBi" id="3uS6dOiTdsN" role="1Z2MuG">
+              <node concept="1YBJjd" id="3uS6dOiTdsO" role="2Oq$k0">
+                <ref role="1YBMHb" node="D0N6Dj0ofZ" resolve="node" />
+              </node>
+              <node concept="3TrEf2" id="3uS6dOiTdKW" role="2OqNvi">
+                <ref role="3Tt5mk" to="2qld:3uS6dOiR6Sv" resolve="canDeleteEdges" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
       <node concept="2Gpval" id="iP2DEOXI7w" role="3cqZAp">
         <node concept="2GrKxI" id="iP2DEOXI7x" role="2Gsz3X">
           <property role="TrG5h" value="refTarget" />

--- a/code/plugins/sl-all/diagram/solutions/de.itemis.mps.editor.diagram.runtime/models/de/itemis/mps/editor/diagram/runtime/model.mps
+++ b/code/plugins/sl-all/diagram/solutions/de.itemis.mps.editor.diagram.runtime/models/de/itemis/mps/editor/diagram/runtime/model.mps
@@ -28108,6 +28108,24 @@
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
+    <node concept="2tJIrI" id="3uS6dOj1N5E" role="jymVt" />
+    <node concept="3clFb_" id="3uS6dOj1wit" role="jymVt">
+      <property role="1EzhhJ" value="false" />
+      <property role="2aFKle" value="false" />
+      <property role="TrG5h" value="canDeleteEdgesAssociated" />
+      <node concept="3Tm1VV" id="3uS6dOj1wiv" role="1B3o_S" />
+      <node concept="10P_77" id="3uS6dOj1wiw" role="3clF45" />
+      <node concept="3clFbS" id="3uS6dOj1wiy" role="3clF47">
+        <node concept="3clFbF" id="3uS6dOj1wi_" role="3cqZAp">
+          <node concept="3clFbT" id="3uS6dOj1wi$" role="3clFbG">
+            <property role="3clFbU" value="true" />
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="3uS6dOj1wiz" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
     <node concept="2tJIrI" id="6OhZPz3IKWr" role="jymVt" />
     <node concept="3clFb_" id="6OhZPz3IK9g" role="jymVt">
       <property role="1EzhhJ" value="false" />


### PR DESCRIPTION
This is an improvement to the earlier [pull request](https://github.com/mbeddr/mbeddr.core/pull/1777).
Earlier we stored the state as boolean field property in **Content_GenericBoxQuery** . But when we need different behaviors for the nodes of the same box query, we are unable to achieve it. So i have changed the boolean property as an optional Expression child(similar to the other children like allowScaling/allowConnections). 