### PR TITLE
Ignoring certain references while using AssertNodeEquals for node comparisons

### DIFF
--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.compare/generator/template/main@generator.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.compare/generator/template/main@generator.mps
@@ -227,6 +227,17 @@
                 <node concept="10Nm6u" id="3C6_kMLS8Pd" role="33vP2m" />
               </node>
             </node>
+            <node concept="3cpWs8" id="3qPjHtYuXpt" role="3cqZAp">
+              <node concept="3cpWsn" id="3qPjHtYuXpu" role="3cpWs9">
+                <property role="TrG5h" value="references" />
+                <node concept="_YKpA" id="3qPjHtYuXpv" role="1tU5fm">
+                  <node concept="3uibUv" id="3qPjHtYuXF4" role="_ZDj9">
+                    <ref role="3uigEE" to="mqum:3qPjHtYqUfg" resolve="IgnoredReference" />
+                  </node>
+                </node>
+                <node concept="10Nm6u" id="3qPjHtYuXpx" role="33vP2m" />
+              </node>
+            </node>
             <node concept="9aQIb" id="3C6_kMLS8Pe" role="3cqZAp">
               <node concept="3clFbS" id="3C6_kMLS8Pf" role="9aQI4">
                 <node concept="3cpWs8" id="6fymoI4YiTz" role="3cqZAp">
@@ -246,7 +257,7 @@
                               <node concept="3clFbF" id="6fymoI4Yj02" role="3cqZAp">
                                 <node concept="2OqwBi" id="6fymoI4Yj03" role="3clFbG">
                                   <node concept="3TrEf2" id="6fymoI4Ylu7" role="2OqNvi">
-                                    <ref role="3Tt5mk" to="tpe3:7jPoEeD$ZP4" />
+                                    <ref role="3Tt5mk" to="tpe3:7jPoEeD$ZP4" resolve="expected" />
                                   </node>
                                   <node concept="30H73N" id="6fymoI4Yj05" role="2Oq$k0" />
                                 </node>
@@ -263,7 +274,7 @@
                               <node concept="3clFbF" id="6fymoI4Yj0a" role="3cqZAp">
                                 <node concept="2OqwBi" id="6fymoI4Yj0b" role="3clFbG">
                                   <node concept="3TrEf2" id="6fymoI4YlaU" role="2OqNvi">
-                                    <ref role="3Tt5mk" to="tpe3:7jPoEeD$ZP5" />
+                                    <ref role="3Tt5mk" to="tpe3:7jPoEeD$ZP5" resolve="actual" />
                                   </node>
                                   <node concept="30H73N" id="6fymoI4Yj0d" role="2Oq$k0" />
                                 </node>
@@ -283,7 +294,7 @@
                                     <node concept="2OqwBi" id="2Y6yZU2fqk7" role="3cqZAk">
                                       <node concept="30H73N" id="2Y6yZU2fqfW" role="2Oq$k0" />
                                       <node concept="3TrEf2" id="2Y6yZU2fqAR" role="2OqNvi">
-                                        <ref role="3Tt5mk" to="8do3:2lpUxXMduaL" />
+                                        <ref role="3Tt5mk" to="8do3:2lpUxXMduaL" resolve="ignoredProperties" />
                                       </node>
                                     </node>
                                   </node>
@@ -292,7 +303,7 @@
                                   <node concept="2OqwBi" id="2Y6yZU2fpC$" role="2Oq$k0">
                                     <node concept="30H73N" id="2Y6yZU2fp$3" role="2Oq$k0" />
                                     <node concept="3TrEf2" id="2Y6yZU2fpTU" role="2OqNvi">
-                                      <ref role="3Tt5mk" to="8do3:2lpUxXMduaL" />
+                                      <ref role="3Tt5mk" to="8do3:2lpUxXMduaL" resolve="ignoredProperties" />
                                     </node>
                                   </node>
                                   <node concept="3x8VRR" id="2Y6yZU2fqb9" role="2OqNvi" />
@@ -304,17 +315,76 @@
                                         <node concept="2pJPED" id="2Y6yZU2frTK" role="2pJPEn">
                                           <ref role="2pJxaS" to="tpee:gEShNN5" resolve="GenericNewExpression" />
                                           <node concept="2pIpSj" id="2Y6yZU2frZx" role="2pJxcM">
-                                            <ref role="2pIpSl" to="tpee:gEShVi6" />
+                                            <ref role="2pIpSl" to="tpee:gEShVi6" resolve="creator" />
                                             <node concept="2pJPED" id="2Y6yZU2ftl$" role="2pJxcZ">
                                               <ref role="2pJxaS" to="tp2q:gSTc6KI" resolve="ListCreatorWithInit" />
                                               <node concept="2pIpSj" id="2Y6yZU2ftrP" role="2pJxcM">
-                                                <ref role="2pIpSl" to="tp2q:i0HW$Uv" />
+                                                <ref role="2pIpSl" to="tp2q:i0HW$Uv" resolve="elementType" />
                                                 <node concept="2pJPED" id="2Y6yZU2fts4" role="2pJxcZ">
                                                   <ref role="2pJxaS" to="tpee:g7uibYu" resolve="ClassifierType" />
                                                   <node concept="2pIpSj" id="2Y6yZU2ftsf" role="2pJxcM">
-                                                    <ref role="2pIpSl" to="tpee:g7uigIF" />
+                                                    <ref role="2pIpSl" to="tpee:g7uigIF" resolve="classifier" />
                                                     <node concept="36bGnv" id="2Y6yZU2ftta" role="2pJxcZ">
                                                       <ref role="36bGnp" to="mqum:DYlgnBstFb" resolve="IgnoredProperty" />
+                                                    </node>
+                                                  </node>
+                                                </node>
+                                              </node>
+                                            </node>
+                                          </node>
+                                        </node>
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="37vLTw" id="3qPjHtYuXVW" role="37wK5m">
+                        <ref role="3cqZAo" node="3qPjHtYuXpu" resolve="references" />
+                        <node concept="29HgVG" id="3qPjHtYuXVX" role="lGtFl">
+                          <node concept="3NFfHV" id="3qPjHtYuXVY" role="3NFExx">
+                            <node concept="3clFbS" id="3qPjHtYuXVZ" role="2VODD2">
+                              <node concept="3clFbJ" id="3qPjHtYuXW0" role="3cqZAp">
+                                <node concept="3clFbS" id="3qPjHtYuXW1" role="3clFbx">
+                                  <node concept="3cpWs6" id="3qPjHtYuXW2" role="3cqZAp">
+                                    <node concept="2OqwBi" id="3qPjHtYuXW3" role="3cqZAk">
+                                      <node concept="30H73N" id="3qPjHtYuXW4" role="2Oq$k0" />
+                                      <node concept="3TrEf2" id="3qPjHtYuZqp" role="2OqNvi">
+                                        <ref role="3Tt5mk" to="8do3:3qPjHtYqU7z" resolve="ignoredReferences" />
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                                <node concept="2OqwBi" id="3qPjHtYuXW6" role="3clFbw">
+                                  <node concept="2OqwBi" id="3qPjHtYuXW7" role="2Oq$k0">
+                                    <node concept="30H73N" id="3qPjHtYuXW8" role="2Oq$k0" />
+                                    <node concept="3TrEf2" id="3qPjHtYuZ1B" role="2OqNvi">
+                                      <ref role="3Tt5mk" to="8do3:3qPjHtYqU7z" resolve="ignoredReferences" />
+                                    </node>
+                                  </node>
+                                  <node concept="3x8VRR" id="3qPjHtYuXWa" role="2OqNvi" />
+                                </node>
+                                <node concept="9aQIb" id="3qPjHtYuXWb" role="9aQIa">
+                                  <node concept="3clFbS" id="3qPjHtYuXWc" role="9aQI4">
+                                    <node concept="3cpWs6" id="3qPjHtYuXWd" role="3cqZAp">
+                                      <node concept="2pJPEk" id="3qPjHtYuXWe" role="3cqZAk">
+                                        <node concept="2pJPED" id="3qPjHtYuXWf" role="2pJPEn">
+                                          <ref role="2pJxaS" to="tpee:gEShNN5" resolve="GenericNewExpression" />
+                                          <node concept="2pIpSj" id="3qPjHtYuXWg" role="2pJxcM">
+                                            <ref role="2pIpSl" to="tpee:gEShVi6" resolve="creator" />
+                                            <node concept="2pJPED" id="3qPjHtYuXWh" role="2pJxcZ">
+                                              <ref role="2pJxaS" to="tp2q:gSTc6KI" resolve="ListCreatorWithInit" />
+                                              <node concept="2pIpSj" id="3qPjHtYuXWi" role="2pJxcM">
+                                                <ref role="2pIpSl" to="tp2q:i0HW$Uv" resolve="elementType" />
+                                                <node concept="2pJPED" id="3qPjHtYuXWj" role="2pJxcZ">
+                                                  <ref role="2pJxaS" to="tpee:g7uibYu" resolve="ClassifierType" />
+                                                  <node concept="2pIpSj" id="3qPjHtYuXWk" role="2pJxcM">
+                                                    <ref role="2pIpSl" to="tpee:g7uigIF" resolve="classifier" />
+                                                    <node concept="36bGnv" id="3qPjHtYuZA8" role="2pJxcZ">
+                                                      <ref role="36bGnp" to="mqum:3qPjHtYqUfg" resolve="IgnoredReference" />
                                                     </node>
                                                   </node>
                                                 </node>
@@ -402,7 +472,7 @@
                           <node concept="3clFbF" id="3C6_kMLXNUn" role="3cqZAp">
                             <node concept="2OqwBi" id="3C6_kMLXNUo" role="3clFbG">
                               <node concept="3TrEf2" id="3C6_kMLXNUp" role="2OqNvi">
-                                <ref role="3Tt5mk" to="8do3:3C6_kMLP2FN" />
+                                <ref role="3Tt5mk" to="8do3:3C6_kMLP2FN" resolve="size" />
                               </node>
                               <node concept="30H73N" id="3C6_kMLXNUq" role="2Oq$k0" />
                             </node>
@@ -422,7 +492,7 @@
                             <node concept="3clFbF" id="3C6_kMLZSKe" role="3cqZAp">
                               <node concept="2OqwBi" id="3C6_kMLZSK9" role="3clFbG">
                                 <node concept="3TrEf2" id="3C6_kMLZSKc" role="2OqNvi">
-                                  <ref role="3Tt5mk" to="8do3:3C6_kMLP2FL" />
+                                  <ref role="3Tt5mk" to="8do3:3C6_kMLP2FL" resolve="list" />
                                 </node>
                                 <node concept="30H73N" id="3C6_kMLZSKd" role="2Oq$k0" />
                               </node>
@@ -474,6 +544,17 @@
                 <node concept="10Nm6u" id="1_DWnhqnPCB" role="33vP2m" />
               </node>
             </node>
+            <node concept="3cpWs8" id="3qPjHtYuZGC" role="3cqZAp">
+              <node concept="3cpWsn" id="3qPjHtYuZGD" role="3cpWs9">
+                <property role="TrG5h" value="references" />
+                <node concept="_YKpA" id="3qPjHtYuZGE" role="1tU5fm">
+                  <node concept="3uibUv" id="3qPjHtYuZGF" role="_ZDj9">
+                    <ref role="3uigEE" to="mqum:3qPjHtYqUfg" resolve="IgnoredReference" />
+                  </node>
+                </node>
+                <node concept="10Nm6u" id="3qPjHtYuZGG" role="33vP2m" />
+              </node>
+            </node>
             <node concept="3clFbF" id="6fymoI4Yf0C" role="3cqZAp">
               <node concept="2OqwBi" id="6fymoI4YgTL" role="3clFbG">
                 <node concept="2YIFZM" id="6fymoI4Yffb" role="2Oq$k0">
@@ -487,7 +568,7 @@
                           <node concept="3clFbF" id="6fymoI4YfgS" role="3cqZAp">
                             <node concept="2OqwBi" id="6fymoI4YfgT" role="3clFbG">
                               <node concept="3TrEf2" id="6fymoI4YfgU" role="2OqNvi">
-                                <ref role="3Tt5mk" to="tpee:fJuHU4s" />
+                                <ref role="3Tt5mk" to="tpee:fJuHU4s" resolve="leftExpression" />
                               </node>
                               <node concept="30H73N" id="6fymoI4YfgV" role="2Oq$k0" />
                             </node>
@@ -504,7 +585,7 @@
                           <node concept="3clFbF" id="6fymoI4YfLa" role="3cqZAp">
                             <node concept="2OqwBi" id="6fymoI4YfLb" role="3clFbG">
                               <node concept="3TrEf2" id="6fymoI4YfLc" role="2OqNvi">
-                                <ref role="3Tt5mk" to="tpee:fJuHU4r" />
+                                <ref role="3Tt5mk" to="tpee:fJuHU4r" resolve="rightExpression" />
                               </node>
                               <node concept="30H73N" id="6fymoI4YfLd" role="2Oq$k0" />
                             </node>
@@ -533,7 +614,7 @@
                                 <node concept="37vLTI" id="6fymoI4YfWr" role="3clFbG">
                                   <node concept="2OqwBi" id="6fymoI4YfWs" role="37vLTx">
                                     <node concept="3TrEf2" id="6fymoI4YfWt" role="2OqNvi">
-                                      <ref role="3Tt5mk" to="8do3:1_DWnhqnLaj" />
+                                      <ref role="3Tt5mk" to="8do3:1_DWnhqnLaj" resolve="ignoredProperties" />
                                     </node>
                                     <node concept="30H73N" id="6fymoI4YfWu" role="2Oq$k0" />
                                   </node>
@@ -575,7 +656,7 @@
                                         </node>
                                       </node>
                                       <node concept="3TrEf2" id="6fymoI4YfWM" role="2OqNvi">
-                                        <ref role="3Tt5mk" to="8do3:3C6_kMLMVd3" />
+                                        <ref role="3Tt5mk" to="8do3:3C6_kMLMVd3" resolve="ignoredProperties" />
                                       </node>
                                     </node>
                                   </node>
@@ -607,6 +688,65 @@
                           <node concept="3cpWs6" id="6fymoI4YfWY" role="3cqZAp">
                             <node concept="37vLTw" id="6fymoI4YfWZ" role="3cqZAk">
                               <ref role="3cqZAo" node="6fymoI4YfWl" resolve="ignoredProperties" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="37vLTw" id="3qPjHtY$9_G" role="37wK5m">
+                    <ref role="3cqZAo" node="3qPjHtYuZGD" resolve="references" />
+                    <node concept="29HgVG" id="3qPjHtY$9S3" role="lGtFl">
+                      <node concept="3NFfHV" id="3qPjHtY$9S4" role="3NFExx">
+                        <node concept="3clFbS" id="3qPjHtY$9S5" role="2VODD2">
+                          <node concept="3clFbJ" id="3qPjHtY$aLN" role="3cqZAp">
+                            <node concept="3clFbS" id="3qPjHtY$aLO" role="3clFbx">
+                              <node concept="3cpWs6" id="3qPjHtY$aLP" role="3cqZAp">
+                                <node concept="2OqwBi" id="3qPjHtY$aLQ" role="3cqZAk">
+                                  <node concept="30H73N" id="3qPjHtY$aLR" role="2Oq$k0" />
+                                  <node concept="3TrEf2" id="3qPjHtY$bTr" role="2OqNvi">
+                                    <ref role="3Tt5mk" to="8do3:3qPjHtY$alZ" resolve="ignoredReferences" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="2OqwBi" id="3qPjHtY$aLT" role="3clFbw">
+                              <node concept="2OqwBi" id="3qPjHtY$aLU" role="2Oq$k0">
+                                <node concept="30H73N" id="3qPjHtY$aLV" role="2Oq$k0" />
+                                <node concept="3TrEf2" id="3qPjHtY$bBA" role="2OqNvi">
+                                  <ref role="3Tt5mk" to="8do3:3qPjHtY$alZ" resolve="ignoredReferences" />
+                                </node>
+                              </node>
+                              <node concept="3x8VRR" id="3qPjHtY$aLX" role="2OqNvi" />
+                            </node>
+                            <node concept="9aQIb" id="3qPjHtY$aLY" role="9aQIa">
+                              <node concept="3clFbS" id="3qPjHtY$aLZ" role="9aQI4">
+                                <node concept="3cpWs6" id="3qPjHtY$aM0" role="3cqZAp">
+                                  <node concept="2pJPEk" id="3qPjHtY$aM1" role="3cqZAk">
+                                    <node concept="2pJPED" id="3qPjHtY$aM2" role="2pJPEn">
+                                      <ref role="2pJxaS" to="tpee:gEShNN5" resolve="GenericNewExpression" />
+                                      <node concept="2pIpSj" id="3qPjHtY$aM3" role="2pJxcM">
+                                        <ref role="2pIpSl" to="tpee:gEShVi6" resolve="creator" />
+                                        <node concept="2pJPED" id="3qPjHtY$aM4" role="2pJxcZ">
+                                          <ref role="2pJxaS" to="tp2q:gSTc6KI" resolve="ListCreatorWithInit" />
+                                          <node concept="2pIpSj" id="3qPjHtY$aM5" role="2pJxcM">
+                                            <ref role="2pIpSl" to="tp2q:i0HW$Uv" resolve="elementType" />
+                                            <node concept="2pJPED" id="3qPjHtY$aM6" role="2pJxcZ">
+                                              <ref role="2pJxaS" to="tpee:g7uibYu" resolve="ClassifierType" />
+                                              <node concept="2pIpSj" id="3qPjHtY$aM7" role="2pJxcM">
+                                                <ref role="2pIpSl" to="tpee:g7uigIF" resolve="classifier" />
+                                                <node concept="36bGnv" id="3qPjHtY$aM8" role="2pJxcZ">
+                                                  <ref role="36bGnp" to="mqum:3qPjHtYqUfg" resolve="IgnoredReference" />
+                                                </node>
+                                              </node>
+                                            </node>
+                                          </node>
+                                        </node>
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
                             </node>
                           </node>
                         </node>

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.compare/languageModels/editor.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.compare/languageModels/editor.mps
@@ -548,10 +548,10 @@
       </node>
       <node concept="3EZMnI" id="3qPjHtY$alk" role="3EZMnx">
         <node concept="3F0ifn" id="3qPjHtY$all" role="3EZMnx">
-          <property role="3F0ifm" value="ignored properties:" />
+          <property role="3F0ifm" value="ignored references:" />
         </node>
         <node concept="3F1sOY" id="3qPjHtY$alm" role="3EZMnx">
-          <ref role="1NtTu8" to="8do3:1_DWnhqnLaj" resolve="ignoredProperties" />
+          <ref role="1NtTu8" to="8do3:3qPjHtY$alZ" resolve="ignoredReferences" />
         </node>
         <node concept="2iRfu4" id="3qPjHtY$aln" role="2iSdaV" />
       </node>

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.compare/languageModels/editor.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.compare/languageModels/editor.mps
@@ -184,53 +184,64 @@
           <property role="VOm3f" value="false" />
         </node>
       </node>
-      <node concept="3EZMnI" id="3C6_kMLMVMF" role="3EZMnx">
-        <node concept="VPM3Z" id="3C6_kMLMVMH" role="3F10Kt">
+      <node concept="3F0ifn" id="h3vlOlH" role="3EZMnx">
+        <property role="3F0ifm" value=";" />
+        <node concept="11L4FC" id="35P6krskVwG" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+      <node concept="3EZMnI" id="3qPjHtYqUHD" role="3EZMnx">
+        <node concept="VPM3Z" id="3qPjHtYqUHF" role="3F10Kt">
           <property role="VOm3f" value="false" />
         </node>
-        <node concept="3F0ifn" id="2lpUxXMduU_" role="3EZMnx">
-          <property role="3F0ifm" value="(" />
-          <node concept="11LMrY" id="2lpUxXMduZ4" role="3F10Kt">
-            <property role="VOm3f" value="true" />
+        <node concept="3EZMnI" id="3C6_kMLMVMF" role="3EZMnx">
+          <node concept="VPM3Z" id="3C6_kMLMVMH" role="3F10Kt">
+            <property role="VOm3f" value="false" />
           </node>
-        </node>
-        <node concept="3F0ifn" id="2lpUxXMduUZ" role="3EZMnx">
-          <property role="3F0ifm" value="ignore properties:" />
-          <node concept="11L4FC" id="2lpUxXMdv0_" role="3F10Kt">
-            <property role="VOm3f" value="true" />
+          <node concept="3F0ifn" id="2lpUxXMduU_" role="3EZMnx">
+            <property role="3F0ifm" value="(" />
+            <node concept="11LMrY" id="2lpUxXMduZ4" role="3F10Kt">
+              <property role="VOm3f" value="true" />
+            </node>
           </node>
-        </node>
-        <node concept="3F1sOY" id="2lpUxXMduVr" role="3EZMnx">
-          <ref role="1NtTu8" to="8do3:2lpUxXMduaL" resolve="ignoredProperties" />
-        </node>
-        <node concept="3F0ifn" id="2lpUxXMduVS" role="3EZMnx">
-          <property role="3F0ifm" value=")" />
-          <node concept="11L4FC" id="2lpUxXMdv3J" role="3F10Kt">
-            <property role="VOm3f" value="true" />
+          <node concept="3F0ifn" id="2lpUxXMduUZ" role="3EZMnx">
+            <property role="3F0ifm" value="ignore properties:" />
+            <node concept="11L4FC" id="2lpUxXMdv0_" role="3F10Kt">
+              <property role="VOm3f" value="true" />
+            </node>
           </node>
-        </node>
-        <node concept="2iRfu4" id="3C6_kMLMVMK" role="2iSdaV" />
-        <node concept="pkWqt" id="3C6_kMLMVNw" role="pqm2j">
-          <node concept="3clFbS" id="3C6_kMLMVNx" role="2VODD2">
-            <node concept="3clFbF" id="3C6_kMLMW0a" role="3cqZAp">
-              <node concept="2YIFZM" id="1TS1BLOX$z7" role="3clFbG">
-                <ref role="37wK5l" to="w1kc:~NodeReadAccessCasterInEditor.runReadTransparentAction(jetbrains.mps.util.Computable):java.lang.Object" resolve="runReadTransparentAction" />
-                <ref role="1Pybhc" to="w1kc:~NodeReadAccessCasterInEditor" resolve="NodeReadAccessCasterInEditor" />
-                <node concept="1bVj0M" id="1TS1BLOX$z8" role="37wK5m">
-                  <node concept="3clFbS" id="1TS1BLOX$z9" role="1bW5cS">
-                    <node concept="3clFbF" id="1TS1BLOX$za" role="3cqZAp">
-                      <node concept="2OqwBi" id="1TS1BLOX$zb" role="3clFbG">
-                        <node concept="2OqwBi" id="1TS1BLOX$zc" role="2Oq$k0">
-                          <node concept="pncrf" id="1TS1BLOX$zd" role="2Oq$k0" />
-                          <node concept="2Xjw5R" id="1TS1BLOX$ze" role="2OqNvi">
-                            <node concept="1xMEDy" id="1TS1BLOX$zf" role="1xVPHs">
-                              <node concept="chp4Y" id="1TS1BLOX$zg" role="ri$Ld">
-                                <ref role="cht4Q" to="8do3:_QVyJyxpbR" resolve="IgnoredPropertiesProvider" />
+          <node concept="3F1sOY" id="2lpUxXMduVr" role="3EZMnx">
+            <ref role="1NtTu8" to="8do3:2lpUxXMduaL" resolve="ignoredProperties" />
+          </node>
+          <node concept="3F0ifn" id="2lpUxXMduVS" role="3EZMnx">
+            <property role="3F0ifm" value=")" />
+            <node concept="11L4FC" id="2lpUxXMdv3J" role="3F10Kt">
+              <property role="VOm3f" value="true" />
+            </node>
+          </node>
+          <node concept="2iRfu4" id="3C6_kMLMVMK" role="2iSdaV" />
+          <node concept="pkWqt" id="3C6_kMLMVNw" role="pqm2j">
+            <node concept="3clFbS" id="3C6_kMLMVNx" role="2VODD2">
+              <node concept="3clFbF" id="3C6_kMLMW0a" role="3cqZAp">
+                <node concept="2YIFZM" id="1TS1BLOX$z7" role="3clFbG">
+                  <ref role="1Pybhc" to="w1kc:~NodeReadAccessCasterInEditor" resolve="NodeReadAccessCasterInEditor" />
+                  <ref role="37wK5l" to="w1kc:~NodeReadAccessCasterInEditor.runReadTransparentAction(jetbrains.mps.util.Computable):java.lang.Object" resolve="runReadTransparentAction" />
+                  <node concept="1bVj0M" id="1TS1BLOX$z8" role="37wK5m">
+                    <node concept="3clFbS" id="1TS1BLOX$z9" role="1bW5cS">
+                      <node concept="3clFbF" id="1TS1BLOX$za" role="3cqZAp">
+                        <node concept="2OqwBi" id="1TS1BLOX$zb" role="3clFbG">
+                          <node concept="2OqwBi" id="1TS1BLOX$zc" role="2Oq$k0">
+                            <node concept="pncrf" id="1TS1BLOX$zd" role="2Oq$k0" />
+                            <node concept="2Xjw5R" id="1TS1BLOX$ze" role="2OqNvi">
+                              <node concept="1xMEDy" id="1TS1BLOX$zf" role="1xVPHs">
+                                <node concept="chp4Y" id="1TS1BLOX$zg" role="ri$Ld">
+                                  <ref role="cht4Q" to="8do3:_QVyJyxpbR" resolve="IgnoredPropertiesProvider" />
+                                </node>
                               </node>
                             </node>
                           </node>
+                          <node concept="3w_OXm" id="1TS1BLOX$zh" role="2OqNvi" />
                         </node>
-                        <node concept="3w_OXm" id="1TS1BLOX$zh" role="2OqNvi" />
                       </node>
                     </node>
                   </node>
@@ -239,12 +250,34 @@
             </node>
           </node>
         </node>
-      </node>
-      <node concept="3F0ifn" id="h3vlOlH" role="3EZMnx">
-        <property role="3F0ifm" value=";" />
-        <node concept="11L4FC" id="35P6krskVwG" role="3F10Kt">
-          <property role="VOm3f" value="true" />
+        <node concept="3EZMnI" id="3qPjHtYqVRv" role="3EZMnx">
+          <node concept="VPM3Z" id="3qPjHtYqVRw" role="3F10Kt">
+            <property role="VOm3f" value="false" />
+          </node>
+          <node concept="3F0ifn" id="3qPjHtYqVRx" role="3EZMnx">
+            <property role="3F0ifm" value="(" />
+            <node concept="11LMrY" id="3qPjHtYqVRy" role="3F10Kt">
+              <property role="VOm3f" value="true" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="3qPjHtYqVRz" role="3EZMnx">
+            <property role="3F0ifm" value="ignore references:" />
+            <node concept="11L4FC" id="3qPjHtYqVR$" role="3F10Kt">
+              <property role="VOm3f" value="true" />
+            </node>
+          </node>
+          <node concept="3F1sOY" id="3qPjHtYqVR_" role="3EZMnx">
+            <ref role="1NtTu8" to="8do3:3qPjHtYqU7z" resolve="ignoredReferences" />
+          </node>
+          <node concept="3F0ifn" id="3qPjHtYqVRA" role="3EZMnx">
+            <property role="3F0ifm" value=")" />
+            <node concept="11L4FC" id="3qPjHtYqVRB" role="3F10Kt">
+              <property role="VOm3f" value="true" />
+            </node>
+          </node>
+          <node concept="2iRfu4" id="3qPjHtYqVRC" role="2iSdaV" />
         </node>
+        <node concept="2iRkQZ" id="3qPjHtYqUHI" role="2iSdaV" />
       </node>
       <node concept="l2Vlx" id="i0MG184" role="2iSdaV" />
     </node>
@@ -503,14 +536,26 @@
       </node>
       <node concept="2iRfu4" id="1_DWnhqnL_9" role="2iSdaV" />
     </node>
-    <node concept="3EZMnI" id="1_DWnhqnLAa" role="6VMZX">
-      <node concept="3F0ifn" id="1_DWnhqnLAn" role="3EZMnx">
-        <property role="3F0ifm" value="ignored properties:" />
+    <node concept="3EZMnI" id="3qPjHtY$akV" role="6VMZX">
+      <node concept="3EZMnI" id="1_DWnhqnLAa" role="3EZMnx">
+        <node concept="3F0ifn" id="1_DWnhqnLAn" role="3EZMnx">
+          <property role="3F0ifm" value="ignored properties:" />
+        </node>
+        <node concept="3F1sOY" id="1_DWnhqnLAz" role="3EZMnx">
+          <ref role="1NtTu8" to="8do3:1_DWnhqnLaj" resolve="ignoredProperties" />
+        </node>
+        <node concept="2iRfu4" id="1_DWnhqnLAd" role="2iSdaV" />
       </node>
-      <node concept="3F1sOY" id="1_DWnhqnLAz" role="3EZMnx">
-        <ref role="1NtTu8" to="8do3:1_DWnhqnLaj" resolve="ignoredProperties" />
+      <node concept="3EZMnI" id="3qPjHtY$alk" role="3EZMnx">
+        <node concept="3F0ifn" id="3qPjHtY$all" role="3EZMnx">
+          <property role="3F0ifm" value="ignored properties:" />
+        </node>
+        <node concept="3F1sOY" id="3qPjHtY$alm" role="3EZMnx">
+          <ref role="1NtTu8" to="8do3:1_DWnhqnLaj" resolve="ignoredProperties" />
+        </node>
+        <node concept="2iRfu4" id="3qPjHtY$aln" role="2iSdaV" />
       </node>
-      <node concept="2iRfu4" id="1_DWnhqnLAd" role="2iSdaV" />
+      <node concept="2iRkQZ" id="3qPjHtY$akW" role="2iSdaV" />
     </node>
   </node>
 </model>

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.compare/languageModels/structure.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.compare/languageModels/structure.mps
@@ -67,6 +67,12 @@
       <property role="IQ2ns" value="2691439673111601841" />
       <ref role="20lvS9" to="tpee:fz3vP1J" resolve="Expression" />
     </node>
+    <node concept="1TJgyj" id="3qPjHtYqU7z" role="1TKVEi">
+      <property role="IQ2ns" value="3942143736278655459" />
+      <property role="20lmBu" value="aggregation" />
+      <property role="20kJfa" value="ignoredReferences" />
+      <ref role="20lvS9" to="tpee:fz3vP1J" resolve="Expression" />
+    </node>
   </node>
   <node concept="1TIwiD" id="3C6_kMLO68Y">
     <property role="TrG5h" value="AssertHasElements" />
@@ -151,6 +157,12 @@
       <property role="20lmBu" value="aggregation" />
       <property role="20kJfa" value="ignoredProperties" />
       <property role="IQ2ns" value="1831260205537497747" />
+      <ref role="20lvS9" to="tpee:fz3vP1J" resolve="Expression" />
+    </node>
+    <node concept="1TJgyj" id="3qPjHtY$alZ" role="1TKVEi">
+      <property role="20lmBu" value="aggregation" />
+      <property role="20kJfa" value="ignoredReferences" />
+      <property role="IQ2ns" value="3942143736281081215" />
       <ref role="20lvS9" to="tpee:fz3vP1J" resolve="Expression" />
     </node>
   </node>

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.compare/languageModels/typesystem.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.compare/languageModels/typesystem.mps
@@ -108,7 +108,30 @@
                 <ref role="1YBMHb" node="2lpUxXMeGs5" resolve="assertNodeEquals" />
               </node>
               <node concept="3TrEf2" id="2lpUxXMeK8J" role="2OqNvi">
-                <ref role="3Tt5mk" to="8do3:2lpUxXMduaL" />
+                <ref role="3Tt5mk" to="8do3:2lpUxXMduaL" resolve="ignoredProperties" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1Z5TYs" id="3qPjHtYqU7C" role="3cqZAp">
+        <node concept="mw_s8" id="3qPjHtYqU7D" role="1ZfhKB">
+          <node concept="2c44tf" id="3qPjHtYqU7E" role="mwGJk">
+            <node concept="_YKpA" id="3qPjHtYqU7F" role="2c44tc">
+              <node concept="3uibUv" id="3qPjHtYqUrU" role="_ZDj9">
+                <ref role="3uigEE" to="mqum:3qPjHtYqUfg" resolve="IgnoredReference" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="mw_s8" id="3qPjHtYqU7H" role="1ZfhK$">
+          <node concept="1Z2H0r" id="3qPjHtYqU7I" role="mwGJk">
+            <node concept="2OqwBi" id="3qPjHtYqU7J" role="1Z2MuG">
+              <node concept="1YBJjd" id="3qPjHtYqU7K" role="2Oq$k0">
+                <ref role="1YBMHb" node="2lpUxXMeGs5" resolve="assertNodeEquals" />
+              </node>
+              <node concept="3TrEf2" id="3qPjHtYqUDR" role="2OqNvi">
+                <ref role="3Tt5mk" to="8do3:3qPjHtYqU7z" resolve="ignoredReferences" />
               </node>
             </node>
           </node>
@@ -123,7 +146,7 @@
                 <ref role="1YBMHb" node="2lpUxXMeGs5" resolve="assertNodeEquals" />
               </node>
               <node concept="3TrEf2" id="2lpUxXMeYlH" role="2OqNvi">
-                <ref role="3Tt5mk" to="tpe3:7jPoEeD$ZP5" />
+                <ref role="3Tt5mk" to="tpe3:7jPoEeD$ZP5" resolve="actual" />
               </node>
             </node>
           </node>
@@ -143,7 +166,7 @@
                 <ref role="1YBMHb" node="2lpUxXMeGs5" resolve="assertNodeEquals" />
               </node>
               <node concept="3TrEf2" id="2lpUxXMf6TK" role="2OqNvi">
-                <ref role="3Tt5mk" to="tpe3:7jPoEeD$ZP4" />
+                <ref role="3Tt5mk" to="tpe3:7jPoEeD$ZP4" resolve="expected" />
               </node>
             </node>
           </node>
@@ -176,7 +199,7 @@
                 <ref role="1YBMHb" node="3C6_kMLO7Z1" resolve="assertHasElements" />
               </node>
               <node concept="3TrEf2" id="3C6_kMLZpAY" role="2OqNvi">
-                <ref role="3Tt5mk" to="8do3:3C6_kMLP2FL" />
+                <ref role="3Tt5mk" to="8do3:3C6_kMLP2FL" resolve="list" />
               </node>
             </node>
           </node>
@@ -191,7 +214,7 @@
                 <ref role="1YBMHb" node="3C6_kMLO7Z1" resolve="assertHasElements" />
               </node>
               <node concept="3TrEf2" id="3C6_kMLZsns" role="2OqNvi">
-                <ref role="3Tt5mk" to="8do3:3C6_kMLP2FN" />
+                <ref role="3Tt5mk" to="8do3:3C6_kMLP2FN" resolve="size" />
               </node>
             </node>
           </node>
@@ -229,7 +252,30 @@
                 <ref role="1YBMHb" node="1_DWnhqnLJ$" resolve="areEqualExpression" />
               </node>
               <node concept="3TrEf2" id="1_DWnhqnMW6" role="2OqNvi">
-                <ref role="3Tt5mk" to="8do3:1_DWnhqnLaj" />
+                <ref role="3Tt5mk" to="8do3:1_DWnhqnLaj" resolve="ignoredProperties" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1Z5TYs" id="3qPjHtY$at_" role="3cqZAp">
+        <node concept="mw_s8" id="3qPjHtY$atA" role="1ZfhKB">
+          <node concept="2c44tf" id="3qPjHtY$atB" role="mwGJk">
+            <node concept="_YKpA" id="3qPjHtY$atC" role="2c44tc">
+              <node concept="3uibUv" id="3qPjHtY$a$O" role="_ZDj9">
+                <ref role="3uigEE" to="mqum:3qPjHtYqUfg" resolve="IgnoredReference" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="mw_s8" id="3qPjHtY$atE" role="1ZfhK$">
+          <node concept="1Z2H0r" id="3qPjHtY$atF" role="mwGJk">
+            <node concept="2OqwBi" id="3qPjHtY$atG" role="1Z2MuG">
+              <node concept="1YBJjd" id="3qPjHtY$atH" role="2Oq$k0">
+                <ref role="1YBMHb" node="1_DWnhqnLJ$" resolve="areEqualExpression" />
+              </node>
+              <node concept="3TrEf2" id="3qPjHtY$aIY" role="2OqNvi">
+                <ref role="3Tt5mk" to="8do3:3qPjHtY$alZ" resolve="ignoredReferences" />
               </node>
             </node>
           </node>
@@ -244,7 +290,7 @@
                 <ref role="1YBMHb" node="1_DWnhqnLJ$" resolve="areEqualExpression" />
               </node>
               <node concept="3TrEf2" id="1_DWnhqnNES" role="2OqNvi">
-                <ref role="3Tt5mk" to="tpee:fJuHU4s" />
+                <ref role="3Tt5mk" to="tpee:fJuHU4s" resolve="leftExpression" />
               </node>
             </node>
           </node>
@@ -264,7 +310,7 @@
                 <ref role="1YBMHb" node="1_DWnhqnLJ$" resolve="areEqualExpression" />
               </node>
               <node concept="3TrEf2" id="1_DWnhqnOce" role="2OqNvi">
-                <ref role="3Tt5mk" to="tpee:fJuHU4r" />
+                <ref role="3Tt5mk" to="tpee:fJuHU4r" resolve="rightExpression" />
               </node>
             </node>
           </node>
@@ -301,7 +347,7 @@
                 <ref role="1YBMHb" node="1_DWnhqnLJ$" resolve="areEqualExpression" />
               </node>
               <node concept="3TrEf2" id="5qLQfLPiBft" role="2OqNvi">
-                <ref role="3Tt5mk" to="tpee:fJuHU4s" />
+                <ref role="3Tt5mk" to="tpee:fJuHU4s" resolve="leftExpression" />
               </node>
             </node>
           </node>
@@ -313,7 +359,7 @@
                 <ref role="1YBMHb" node="1_DWnhqnLJ$" resolve="areEqualExpression" />
               </node>
               <node concept="3TrEf2" id="5qLQfLPiBfy" role="2OqNvi">
-                <ref role="3Tt5mk" to="tpee:fJuHU4r" />
+                <ref role="3Tt5mk" to="tpee:fJuHU4r" resolve="rightExpression" />
               </node>
             </node>
           </node>

--- a/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.comparator/models/com/mbeddr/cimport/comparator/code/IgnoredReference.mpsr
+++ b/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.comparator/models/com/mbeddr/cimport/comparator/code/IgnoredReference.mpsr
@@ -1,0 +1,143 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:ec874b45-e888-42e6-995a-a298cefdff55(com.mbeddr.cimport.comparator.code)" content="root">
+  <persistence version="9" />
+  <imports />
+  <registry>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
+        <child id="1068498886297" name="rValue" index="37vLTx" />
+        <child id="1068498886295" name="lValue" index="37vLTJ" />
+      </concept>
+      <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="ng" index="2tJIrI" />
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1201370618622" name="jetbrains.mps.baseLanguage.structure.Property" flags="ig" index="2RhdJD">
+        <property id="1201371481316" name="propertyName" index="2RkwnN" />
+        <child id="1201371521209" name="type" index="2RkE6I" />
+        <child id="1201372378714" name="propertyImplementation" index="2RnVtd" />
+      </concept>
+      <concept id="1201372606839" name="jetbrains.mps.baseLanguage.structure.DefaultPropertyImplementation" flags="ng" index="2RoN1w">
+        <child id="1202065356069" name="defaultGetAccessor" index="3wFrgM" />
+        <child id="1202078082794" name="defaultSetAccessor" index="3xrYvX" />
+      </concept>
+      <concept id="1201385106094" name="jetbrains.mps.baseLanguage.structure.PropertyReference" flags="nn" index="2S8uIT">
+        <reference id="1201385237847" name="property" index="2S8YL0" />
+      </concept>
+      <concept id="1070475354124" name="jetbrains.mps.baseLanguage.structure.ThisExpression" flags="nn" index="Xjq3P" />
+      <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu" />
+      <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
+        <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
+      </concept>
+      <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
+      <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
+      <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
+      <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
+        <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
+      <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
+        <child id="1068580123133" name="returnType" index="3clF45" />
+        <child id="1068580123134" name="parameter" index="3clF46" />
+        <child id="1068580123135" name="body" index="3clF47" />
+      </concept>
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068580123140" name="jetbrains.mps.baseLanguage.structure.ConstructorDeclaration" flags="ig" index="3clFbW" />
+      <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
+      <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
+        <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
+      </concept>
+      <concept id="1202065242027" name="jetbrains.mps.baseLanguage.structure.DefaultGetAccessor" flags="ng" index="3wEZqW" />
+      <concept id="1202077725299" name="jetbrains.mps.baseLanguage.structure.DefaultSetAccessor" flags="ng" index="3xqBd$">
+        <child id="1202077744034" name="visibility" index="3xqFEP" />
+      </concept>
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
+        <child id="1178549979242" name="visibility" index="1B3o_S" />
+      </concept>
+      <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
+      <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
+    </language>
+    <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="6677504323281689838" name="jetbrains.mps.lang.smodel.structure.SConceptType" flags="in" index="3bZ5Sz" />
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="312cEu" id="3qPjHtYqUfg">
+    <property role="TrG5h" value="IgnoredReference" />
+    <node concept="2RhdJD" id="3qPjHtYqUfh" role="jymVt">
+      <property role="2RkwnN" value="concept" />
+      <node concept="3Tm1VV" id="3qPjHtYqUfi" role="1B3o_S" />
+      <node concept="2RoN1w" id="3qPjHtYqUfj" role="2RnVtd">
+        <node concept="3wEZqW" id="3qPjHtYqUfk" role="3wFrgM" />
+        <node concept="3xqBd$" id="3qPjHtYqUfl" role="3xrYvX">
+          <node concept="3Tm6S6" id="3qPjHtYqUfm" role="3xqFEP" />
+        </node>
+      </node>
+      <node concept="3bZ5Sz" id="3qPjHtYqUfn" role="2RkE6I" />
+    </node>
+    <node concept="2RhdJD" id="3qPjHtYqUfo" role="jymVt">
+      <property role="2RkwnN" value="reference" />
+      <node concept="3Tm1VV" id="3qPjHtYqUfp" role="1B3o_S" />
+      <node concept="2RoN1w" id="3qPjHtYqUfq" role="2RnVtd">
+        <node concept="3wEZqW" id="3qPjHtYqUfr" role="3wFrgM" />
+        <node concept="3xqBd$" id="3qPjHtYqUfs" role="3xrYvX">
+          <node concept="3Tm6S6" id="3qPjHtYqUft" role="3xqFEP" />
+        </node>
+      </node>
+      <node concept="17QB3L" id="3qPjHtYqUfu" role="2RkE6I" />
+    </node>
+    <node concept="2tJIrI" id="3qPjHtYqUfv" role="jymVt" />
+    <node concept="3clFbW" id="3qPjHtYqUfw" role="jymVt">
+      <node concept="37vLTG" id="3qPjHtYqUfx" role="3clF46">
+        <property role="TrG5h" value="concept" />
+        <node concept="3bZ5Sz" id="3qPjHtYqUfy" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="3qPjHtYqUfz" role="3clF46">
+        <property role="TrG5h" value="reference" />
+        <node concept="17QB3L" id="3qPjHtYqUf$" role="1tU5fm" />
+      </node>
+      <node concept="3cqZAl" id="3qPjHtYqUf_" role="3clF45" />
+      <node concept="3clFbS" id="3qPjHtYqUfA" role="3clF47">
+        <node concept="3clFbF" id="3qPjHtYqUfB" role="3cqZAp">
+          <node concept="37vLTI" id="3qPjHtYqUfC" role="3clFbG">
+            <node concept="37vLTw" id="3qPjHtYqUfD" role="37vLTx">
+              <ref role="3cqZAo" node="3qPjHtYqUfx" resolve="concept" />
+            </node>
+            <node concept="2OqwBi" id="3qPjHtYqUfE" role="37vLTJ">
+              <node concept="Xjq3P" id="3qPjHtYqUfF" role="2Oq$k0" />
+              <node concept="2S8uIT" id="3qPjHtYqUfG" role="2OqNvi">
+                <ref role="2S8YL0" node="3qPjHtYqUfh" resolve="concept" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="3qPjHtYqUfH" role="3cqZAp">
+          <node concept="37vLTI" id="3qPjHtYqUfI" role="3clFbG">
+            <node concept="37vLTw" id="3qPjHtYqUfJ" role="37vLTx">
+              <ref role="3cqZAo" node="3qPjHtYqUfz" resolve="reference" />
+            </node>
+            <node concept="2OqwBi" id="3qPjHtYqUfK" role="37vLTJ">
+              <node concept="Xjq3P" id="3qPjHtYqUfL" role="2Oq$k0" />
+              <node concept="2S8uIT" id="3qPjHtYqUfM" role="2OqNvi">
+                <ref role="2S8YL0" node="3qPjHtYqUfo" resolve="reference" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="3qPjHtYqUfN" role="1B3o_S" />
+    </node>
+    <node concept="2tJIrI" id="3qPjHtYqUfO" role="jymVt" />
+    <node concept="3Tm1VV" id="3qPjHtYqUfP" role="1B3o_S" />
+  </node>
+</model>
+

--- a/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.comparator/models/com/mbeddr/cimport/comparator/code/MPSNodeComparator.mpsr
+++ b/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.comparator/models/com/mbeddr/cimport/comparator/code/MPSNodeComparator.mpsr
@@ -455,6 +455,64 @@
         <node concept="10P_77" id="6fymoI4Tzhk" role="1tU5fm" />
       </node>
     </node>
+    <node concept="2tJIrI" id="4zngrhRwb0q" role="jymVt" />
+    <node concept="2YIFZL" id="4zngrhRwdqI" role="jymVt">
+      <property role="TrG5h" value="compare" />
+      <property role="od$2w" value="false" />
+      <property role="DiZV1" value="false" />
+      <property role="2aFKle" value="false" />
+      <node concept="3clFbS" id="4zngrhRwdqJ" role="3clF47">
+        <node concept="3cpWs6" id="4zngrhRwfJ1" role="3cqZAp">
+          <node concept="1rXfSq" id="4zngrhRwfTA" role="3cqZAk">
+            <ref role="37wK5l" node="6fymoI4RKZK" resolve="compare" />
+            <node concept="37vLTw" id="4zngrhRwfTB" role="37wK5m">
+              <ref role="3cqZAo" node="4zngrhRwds$" resolve="expected" />
+            </node>
+            <node concept="37vLTw" id="4zngrhRwfTC" role="37wK5m">
+              <ref role="3cqZAo" node="4zngrhRwdsA" resolve="actual" />
+            </node>
+            <node concept="37vLTw" id="4zngrhRwhkL" role="37wK5m">
+              <ref role="3cqZAo" node="4zngrhRwdsC" resolve="ignoredProperties" />
+            </node>
+            <node concept="10Nm6u" id="4zngrhRwfTE" role="37wK5m" />
+            <node concept="37vLTw" id="4zngrhRwfTF" role="37wK5m">
+              <ref role="3cqZAo" node="4zngrhRwdsI" resolve="compareChildren" />
+            </node>
+            <node concept="37vLTw" id="4zngrhRwhyX" role="37wK5m">
+              <ref role="3cqZAo" node="4zngrhRwdsK" resolve="verbose" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="4zngrhRwdsy" role="1B3o_S" />
+      <node concept="3uibUv" id="4zngrhRwdsz" role="3clF45">
+        <ref role="3uigEE" node="494SuRWLRaN" resolve="MPSNodeComparisonResult" />
+      </node>
+      <node concept="37vLTG" id="4zngrhRwds$" role="3clF46">
+        <property role="TrG5h" value="expected" />
+        <node concept="3Tqbb2" id="4zngrhRwds_" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="4zngrhRwdsA" role="3clF46">
+        <property role="TrG5h" value="actual" />
+        <node concept="3Tqbb2" id="4zngrhRwdsB" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="4zngrhRwdsC" role="3clF46">
+        <property role="TrG5h" value="ignoredProperties" />
+        <node concept="_YKpA" id="4zngrhRwdsD" role="1tU5fm">
+          <node concept="3uibUv" id="4zngrhRwdsE" role="_ZDj9">
+            <ref role="3uigEE" node="DYlgnBstFb" resolve="IgnoredProperty" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="4zngrhRwdsI" role="3clF46">
+        <property role="TrG5h" value="compareChildren" />
+        <node concept="10P_77" id="4zngrhRwdsJ" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="4zngrhRwdsK" role="3clF46">
+        <property role="TrG5h" value="verbose" />
+        <node concept="10P_77" id="4zngrhRwdsL" role="1tU5fm" />
+      </node>
+    </node>
     <node concept="2tJIrI" id="6fymoI4Tr4S" role="jymVt" />
     <node concept="2YIFZL" id="6fymoI4RKZK" role="jymVt">
       <property role="TrG5h" value="compare" />

--- a/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.comparator/models/com/mbeddr/cimport/comparator/code/MPSNodeComparator.mpsr
+++ b/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.comparator/models/com/mbeddr/cimport/comparator/code/MPSNodeComparator.mpsr
@@ -428,6 +428,7 @@
               <ref role="3cqZAo" node="6fymoI4TvGR" resolve="actual" />
             </node>
             <node concept="10Nm6u" id="6fymoI4TvGL" role="37wK5m" />
+            <node concept="10Nm6u" id="3qPjHtYsMKE" role="37wK5m" />
             <node concept="37vLTw" id="6fymoI4TKlE" role="37wK5m">
               <ref role="3cqZAo" node="6fymoI4Tzfh" resolve="compareChildren" />
             </node>
@@ -696,6 +697,9 @@
                   <node concept="37vLTw" id="6fymoI4W_n5" role="37wK5m">
                     <ref role="3cqZAo" node="6fymoI4RPkF" resolve="ignoredProperties" />
                   </node>
+                  <node concept="37vLTw" id="3qPjHtYsPiY" role="37wK5m">
+                    <ref role="3cqZAo" node="3qPjHtYsu0a" resolve="ignoredReferences" />
+                  </node>
                   <node concept="37vLTw" id="6fymoI4W_ai" role="37wK5m">
                     <ref role="3cqZAo" node="6fymoI4RPkl" resolve="verbose" />
                   </node>
@@ -746,6 +750,9 @@
                       <node concept="37vLTw" id="6fymoI4Xgf9" role="37wK5m">
                         <ref role="3cqZAo" node="6fymoI4RPkF" resolve="ignoredProperties" />
                       </node>
+                      <node concept="37vLTw" id="3qPjHtYsQZu" role="37wK5m">
+                        <ref role="3cqZAo" node="3qPjHtYsu0a" resolve="ignoredReferences" />
+                      </node>
                       <node concept="37vLTw" id="6fymoI4Xgs_" role="37wK5m">
                         <ref role="3cqZAo" node="6fymoI4TziN" resolve="compareChildren" />
                       </node>
@@ -785,6 +792,14 @@
         <node concept="_YKpA" id="6fymoI4RPkG" role="1tU5fm">
           <node concept="3uibUv" id="6fymoI4RPkH" role="_ZDj9">
             <ref role="3uigEE" node="DYlgnBstFb" resolve="IgnoredProperty" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="3qPjHtYsu0a" role="3clF46">
+        <property role="TrG5h" value="ignoredReferences" />
+        <node concept="_YKpA" id="3qPjHtYsu0b" role="1tU5fm">
+          <node concept="3uibUv" id="3qPjHtYswkA" role="_ZDj9">
+            <ref role="3uigEE" node="3qPjHtYqUfg" resolve="IgnoredReference" />
           </node>
         </node>
       </node>
@@ -1818,6 +1833,125 @@
       <node concept="10P_77" id="780iRhLCMbQ" role="3clF45" />
       <node concept="3Tm6S6" id="780iRhLC$KX" role="1B3o_S" />
     </node>
+    <node concept="2tJIrI" id="3qPjHtYt38V" role="jymVt" />
+    <node concept="2YIFZL" id="3qPjHtYt08F" role="jymVt">
+      <property role="TrG5h" value="isIgnoredReference" />
+      <property role="IEkAT" value="false" />
+      <property role="DiZV1" value="false" />
+      <property role="od$2w" value="false" />
+      <node concept="3clFbS" id="3qPjHtYt08G" role="3clF47">
+        <node concept="3cpWs8" id="3qPjHtYt08H" role="3cqZAp">
+          <node concept="3cpWsn" id="3qPjHtYt08I" role="3cpWs9">
+            <property role="TrG5h" value="simpleIsIgnored" />
+            <node concept="10P_77" id="3qPjHtYt08J" role="1tU5fm" />
+            <node concept="2OqwBi" id="3qPjHtYt08K" role="33vP2m">
+              <node concept="37vLTw" id="3qPjHtYt08L" role="2Oq$k0">
+                <ref role="3cqZAo" node="3qPjHtYt0bS" resolve="ignoredReferences" />
+              </node>
+              <node concept="2HwmR7" id="3qPjHtYt08M" role="2OqNvi">
+                <node concept="1bVj0M" id="3qPjHtYt08N" role="23t8la">
+                  <node concept="3clFbS" id="3qPjHtYt08O" role="1bW5cS">
+                    <node concept="3clFbF" id="3qPjHtYt08P" role="3cqZAp">
+                      <node concept="1Wc70l" id="3qPjHtYt08Q" role="3clFbG">
+                        <node concept="2OqwBi" id="3qPjHtYt08R" role="3uHU7w">
+                          <node concept="37vLTw" id="3qPjHtYt08S" role="2Oq$k0">
+                            <ref role="3cqZAo" node="3qPjHtYt0bV" resolve="role" />
+                          </node>
+                          <node concept="liA8E" id="3qPjHtYt08T" role="2OqNvi">
+                            <ref role="37wK5l" to="wyt6:~String.equals(java.lang.Object):boolean" resolve="equals" />
+                            <node concept="2OqwBi" id="3qPjHtYt08U" role="37wK5m">
+                              <node concept="37vLTw" id="3qPjHtYtzrm" role="2Oq$k0">
+                                <ref role="3cqZAo" node="3qPjHtYt09d" resolve="it" />
+                              </node>
+                              <node concept="2S8uIT" id="3qPjHtYt_uw" role="2OqNvi">
+                                <ref role="2S8YL0" node="3qPjHtYqUfo" resolve="reference" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="1eOMI4" id="3qPjHtYt08X" role="3uHU7B">
+                          <node concept="22lmx$" id="3qPjHtYt08Y" role="1eOMHV">
+                            <node concept="2OqwBi" id="3qPjHtYt08Z" role="3uHU7B">
+                              <node concept="37vLTw" id="3qPjHtYt090" role="2Oq$k0">
+                                <ref role="3cqZAo" node="3qPjHtYt0bO" resolve="expected" />
+                              </node>
+                              <node concept="1mIQ4w" id="3qPjHtYt091" role="2OqNvi">
+                                <node concept="25Kdxt" id="3qPjHtYt092" role="cj9EA">
+                                  <node concept="2OqwBi" id="3qPjHtYt093" role="25KhWn">
+                                    <node concept="37vLTw" id="3qPjHtYtq0g" role="2Oq$k0">
+                                      <ref role="3cqZAo" node="3qPjHtYt09d" resolve="it" />
+                                    </node>
+                                    <node concept="2S8uIT" id="3qPjHtYtsUE" role="2OqNvi">
+                                      <ref role="2S8YL0" node="3qPjHtYqUfh" resolve="concept" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="2OqwBi" id="3qPjHtYt096" role="3uHU7w">
+                              <node concept="37vLTw" id="3qPjHtYt097" role="2Oq$k0">
+                                <ref role="3cqZAo" node="3qPjHtYt0bQ" resolve="actual" />
+                              </node>
+                              <node concept="1mIQ4w" id="3qPjHtYt098" role="2OqNvi">
+                                <node concept="25Kdxt" id="3qPjHtYt099" role="cj9EA">
+                                  <node concept="2OqwBi" id="3qPjHtYt09a" role="25KhWn">
+                                    <node concept="37vLTw" id="3qPjHtYtupZ" role="2Oq$k0">
+                                      <ref role="3cqZAo" node="3qPjHtYt09d" resolve="it" />
+                                    </node>
+                                    <node concept="2S8uIT" id="3qPjHtYtwGK" role="2OqNvi">
+                                      <ref role="2S8YL0" node="3qPjHtYqUfh" resolve="concept" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="Rh6nW" id="3qPjHtYt09d" role="1bW2Oz">
+                    <property role="TrG5h" value="it" />
+                    <node concept="2jxLKc" id="3qPjHtYt09e" role="1tU5fm" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="3qPjHtYt0bM" role="3cqZAp">
+          <node concept="37vLTw" id="3qPjHtYt0bN" role="3cqZAk">
+            <ref role="3cqZAo" node="3qPjHtYt08I" resolve="simpleIsIgnored" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="3qPjHtYt0bO" role="3clF46">
+        <property role="TrG5h" value="expected" />
+        <node concept="3Tqbb2" id="3qPjHtYt0bP" role="1tU5fm">
+          <ref role="ehGHo" to="tpck:gw2VY9q" resolve="BaseConcept" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="3qPjHtYt0bQ" role="3clF46">
+        <property role="TrG5h" value="actual" />
+        <node concept="3Tqbb2" id="3qPjHtYt0bR" role="1tU5fm">
+          <ref role="ehGHo" to="tpck:gw2VY9q" resolve="BaseConcept" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="3qPjHtYt0bS" role="3clF46">
+        <property role="TrG5h" value="ignoredReferences" />
+        <node concept="_YKpA" id="3qPjHtYt0bT" role="1tU5fm">
+          <node concept="3uibUv" id="3qPjHtYt6Jv" role="_ZDj9">
+            <ref role="3uigEE" node="3qPjHtYqUfg" resolve="IgnoredReference" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="3qPjHtYt0bV" role="3clF46">
+        <property role="TrG5h" value="role" />
+        <node concept="17QB3L" id="3qPjHtYt0bW" role="1tU5fm" />
+      </node>
+      <node concept="10P_77" id="3qPjHtYt0bX" role="3clF45" />
+      <node concept="3Tm6S6" id="3qPjHtYt0bY" role="1B3o_S" />
+    </node>
     <node concept="2tJIrI" id="DYlgnBvwx3" role="jymVt" />
     <node concept="2YIFZL" id="6fymoI4W4Lw" role="jymVt">
       <property role="TrG5h" value="fillDifferencesOnReferences" />
@@ -1900,7 +2034,7 @@
                         </node>
                       </node>
                     </node>
-                    <node concept="15s5l7" id="6fymoI4WvA7" role="lGtFl" />
+                    <node concept="15s5l7" id="5xdxKAKUKGc" role="lGtFl" />
                   </node>
                 </node>
                 <node concept="Rh6nW" id="DYlgnAA7yZ" role="1bW2Oz">
@@ -1981,18 +2115,36 @@
               <node concept="3clFbS" id="4YRIhSKPnlO" role="3clFbx">
                 <node concept="3N13vt" id="4YRIhSKPFJ2" role="3cqZAp" />
               </node>
-              <node concept="2OqwBi" id="4YRIhSKPC2S" role="3clFbw">
-                <node concept="37vLTw" id="6fymoI4Xoq6" role="2Oq$k0">
-                  <ref role="3cqZAo" node="6fymoI4XkoJ" resolve="smodelAttribute" />
+              <node concept="22lmx$" id="3qPjHtYtUnK" role="3clFbw">
+                <node concept="2OqwBi" id="4YRIhSKPC2S" role="3uHU7B">
+                  <node concept="37vLTw" id="6fymoI4Xoq6" role="2Oq$k0">
+                    <ref role="3cqZAo" node="6fymoI4XkoJ" resolve="smodelAttribute" />
+                  </node>
+                  <node concept="liA8E" id="4YRIhSKPFDS" role="2OqNvi">
+                    <ref role="37wK5l" to="wyt6:~String.equals(java.lang.Object):boolean" resolve="equals" />
+                    <node concept="2GrUjf" id="4YRIhSKPFF_" role="37wK5m">
+                      <ref role="2Gs0qQ" node="DYlgnAA7zl" resolve="role" />
+                    </node>
+                  </node>
                 </node>
-                <node concept="liA8E" id="4YRIhSKPFDS" role="2OqNvi">
-                  <ref role="37wK5l" to="wyt6:~String.equals(java.lang.Object):boolean" resolve="equals" />
-                  <node concept="2GrUjf" id="4YRIhSKPFF_" role="37wK5m">
+                <node concept="1rXfSq" id="3qPjHtYtMpp" role="3uHU7w">
+                  <ref role="37wK5l" node="3qPjHtYt08F" resolve="isIgnoredReference" />
+                  <node concept="37vLTw" id="3qPjHtYtMH0" role="37wK5m">
+                    <ref role="3cqZAo" node="DYlgnAA7yk" resolve="expected" />
+                  </node>
+                  <node concept="37vLTw" id="3qPjHtYtN7h" role="37wK5m">
+                    <ref role="3cqZAo" node="DYlgnAA7ym" resolve="actual" />
+                  </node>
+                  <node concept="37vLTw" id="3qPjHtYtNvB" role="37wK5m">
+                    <ref role="3cqZAo" node="3qPjHtYsMPq" resolve="ignoredReferences" />
+                  </node>
+                  <node concept="2GrUjf" id="3qPjHtYtNNE" role="37wK5m">
                     <ref role="2Gs0qQ" node="DYlgnAA7zl" resolve="role" />
                   </node>
                 </node>
               </node>
             </node>
+            <node concept="3clFbH" id="3qPjHtYtSbo" role="3cqZAp" />
             <node concept="3clFbJ" id="5uUCR4LTuCn" role="3cqZAp">
               <node concept="3clFbS" id="5uUCR4LTuCo" role="3clFbx">
                 <node concept="3clFbJ" id="5uUCR4LTuCp" role="3cqZAp">
@@ -2501,6 +2653,9 @@
                       <node concept="37vLTw" id="6fymoI4Wqbh" role="37wK5m">
                         <ref role="3cqZAo" node="6fymoI4WjfR" resolve="ignoredProperties" />
                       </node>
+                      <node concept="37vLTw" id="3qPjHtYsTb6" role="37wK5m">
+                        <ref role="3cqZAo" node="3qPjHtYsMPq" resolve="ignoredReferences" />
+                      </node>
                       <node concept="3clFbT" id="3n2rqT9V7TZ" role="37wK5m">
                         <property role="3clFbU" value="false" />
                       </node>
@@ -2757,6 +2912,14 @@
         <node concept="_YKpA" id="6fymoI4WjfS" role="1tU5fm">
           <node concept="3uibUv" id="6fymoI4WjfT" role="_ZDj9">
             <ref role="3uigEE" node="DYlgnBstFb" resolve="IgnoredProperty" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="3qPjHtYsMPq" role="3clF46">
+        <property role="TrG5h" value="ignoredReferences" />
+        <node concept="_YKpA" id="3qPjHtYsMPr" role="1tU5fm">
+          <node concept="3uibUv" id="3qPjHtYsMPs" role="_ZDj9">
+            <ref role="3uigEE" node="3qPjHtYqUfg" resolve="IgnoredReference" />
           </node>
         </node>
       </node>
@@ -3102,6 +3265,9 @@
                             <node concept="37vLTw" id="6fymoI4WI2T" role="37wK5m">
                               <ref role="3cqZAo" node="6fymoI4WBMC" resolve="ignoredProperties" />
                             </node>
+                            <node concept="37vLTw" id="3qPjHtYsWV8" role="37wK5m">
+                              <ref role="3cqZAo" node="3qPjHtYsWaR" resolve="ignoredReferences" />
+                            </node>
                             <node concept="37vLTw" id="6fymoI4WIwA" role="37wK5m">
                               <ref role="3cqZAo" node="6fymoI4WCfm" resolve="compareChildren" />
                             </node>
@@ -3257,6 +3423,14 @@
         <node concept="_YKpA" id="6fymoI4WBMD" role="1tU5fm">
           <node concept="3uibUv" id="6fymoI4WBME" role="_ZDj9">
             <ref role="3uigEE" node="DYlgnBstFb" resolve="IgnoredProperty" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="3qPjHtYsWaR" role="3clF46">
+        <property role="TrG5h" value="ignoredReferences" />
+        <node concept="_YKpA" id="3qPjHtYsWaS" role="1tU5fm">
+          <node concept="3uibUv" id="3qPjHtYsWaT" role="_ZDj9">
+            <ref role="3uigEE" node="3qPjHtYqUfg" resolve="IgnoredReference" />
           </node>
         </node>
       </node>
@@ -4022,6 +4196,9 @@
                             <node concept="37vLTw" id="6fymoI4X1Nk" role="37wK5m">
                               <ref role="3cqZAo" node="6fymoI4WQoo" resolve="ignoredProperties" />
                             </node>
+                            <node concept="37vLTw" id="3qPjHtYsYTM" role="37wK5m">
+                              <ref role="3cqZAo" node="3qPjHtYsPoe" resolve="ignoredReferences" />
+                            </node>
                             <node concept="37vLTw" id="6fymoI4X2j5" role="37wK5m">
                               <ref role="3cqZAo" node="6fymoI4WQor" resolve="compareChildren" />
                             </node>
@@ -4174,6 +4351,14 @@
         <node concept="_YKpA" id="6fymoI4WQop" role="1tU5fm">
           <node concept="3uibUv" id="6fymoI4WQoq" role="_ZDj9">
             <ref role="3uigEE" node="DYlgnBstFb" resolve="IgnoredProperty" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="3qPjHtYsPoe" role="3clF46">
+        <property role="TrG5h" value="ignoredReferences" />
+        <node concept="_YKpA" id="3qPjHtYsPof" role="1tU5fm">
+          <node concept="3uibUv" id="3qPjHtYsPog" role="_ZDj9">
+            <ref role="3uigEE" node="3qPjHtYqUfg" resolve="IgnoredReference" />
           </node>
         </node>
       </node>


### PR DESCRIPTION
When using AssertNodeEquals (com.mbeddr.mpsutil.compare) for comparing two nodes, currently there is no provision to ignore certain references alone during comparisons. So i have introduced a class IgnoreReferece(similar to IgnoreProperty class which exists already) and used it in the generator of AssertNodeEquals and AreEqualExpression. 