### PR TITLE
build: Refactor install tasks and path selector

### DIFF
--- a/build/com.mbeddr/build.gradle
+++ b/build/com.mbeddr/build.gradle
@@ -1,19 +1,5 @@
 import de.itemis.mps.gradle.GitBasedVersioning
 
-def userHome = System.properties['user.home']
-def mpsPluginsDirPattern
-if (System.properties['os.name'].toLowerCase().contains('mac')) {
-    mpsPluginsDirPattern = "$userHome/Library/Application Support/%s"
-} else {
-    mpsPluginsDirPattern = "$userHome/.%s/config/plugins"
-}
-
-if (project.hasProperty("MPS_PATHS_SELECTOR")) {
-    ext.mpsPluginsDir = sprintf(mpsPluginsDirPattern, project.getProperty("MPS_PATHS_SELECTOR"))
-} else {
-    ext.mpsPluginsDir = sprintf(mpsPluginsDirPattern, "MPS$mpsMajor")
-}
-
 ext.mbeddrMajor = "1"
 ext.mbeddrMinor = "0"
 
@@ -59,6 +45,31 @@ if (project.hasProperty("mbeddrVersion")) {
 // the root directory).
 ext.skipResolveMps = project.hasProperty('mpsHomeDir')
 ext.mpsHomeDir = rootProject.file(project.findProperty('mpsHomeDir') ?: "MPS/MPS-mbeddr-$mpsBuild/")
+
+def userHome = System.properties['user.home']
+def mpsPluginsDirPattern
+if (System.properties['os.name'].toLowerCase().contains('mac')) {
+    mpsPluginsDirPattern = "$userHome/Library/Application Support/%s"
+} else {
+    mpsPluginsDirPattern = "$userHome/.%s/config/plugins"
+}
+
+if (project.hasProperty("MPS_PATHS_SELECTOR")) {
+    ext.mpsPluginsDir = sprintf(mpsPluginsDirPattern, project.getProperty("MPS_PATHS_SELECTOR"))
+} else {
+    ext.mpsPluginsDir = sprintf(mpsPluginsDirPattern, "MPS$mpsMajor")
+}
+
+task install() {
+    doFirst {
+        // check parent gradle file for definition of the variables
+        println "Installing required mbeddr plugins to '$mpsPluginsDir'"
+        if (!project.hasProperty("MPS_PATHS_SELECTOR")) {
+            println "To change 'MPS<>' part, pass MPS_PATHS_SELECTOR property to gradle with -PMPS_PATHS_SELECTOR=<custom path selector>"
+            println "The path selector only contains the the actual selector for instance \"MPS2017.3\" not the full qualifies path to the user plugin directory."
+        }
+    }
+}
 
 logger.info "skipResolveMps: {}, mpsHomeDir: {}", ext.skipResolveMps, ext.mpsHomeDir
 

--- a/build/com.mbeddr/languages/build.gradle
+++ b/build/com.mbeddr/languages/build.gradle
@@ -65,17 +65,6 @@ task install_spawner(type: Copy, dependsOn: build_spawner) {
     into "$mpsPluginsDir"
 }
 
-task install(dependsOn: [install_spawner, ':build:com.mbeddr:platform:install_sl_all_nativelibs', ':build:com.mbeddr:platform:install_actionsfilter']) {}
-
-gradle.taskGraph.whenReady {taskGraph ->
-    if (taskGraph.hasTask(install)) {
-        println "Installing required mbeddr plugins to '$mpsPluginsDir'"
-        if (!project.hasProperty("MPS_PATHS_SELECTOR")) {
-            println "To change 'MPS<>' part, pass MPS_PATHS_SELECTOR property to gradle with -PMPS_PATHS_SELECTOR=<custom path selectot>"
-        }
-    }
-}
-
 ant.taskdef(name: 'junit', classname: 'org.apache.tools.ant.taskdefs.optional.junit.JUnitTask',
         classpath: configurations.junitAnt.asPath)
 ant.taskdef(name: 'junitreport', classname: 'org.apache.tools.ant.taskdefs.optional.junit.XMLResultAggregator',
@@ -235,3 +224,6 @@ task publishMbeddrToLocal (dependsOn: ['publishMbeddrPublicationToMavenLocal',
 ':build:com.mbeddr:platform:publishMbeddrPlatformToLocal']) {}
 
 check.dependsOn test_mbeddr
+
+tasks.getByPath(':build:com.mbeddr:install').dependsOn install_spawner
+//dependsOn: [install_spawner, ':build:com.mbeddr:platform:install_sl_all_nativelibs', ':build:com.mbeddr:platform:install_actionsfilter']

--- a/build/com.mbeddr/platform/build.gradle
+++ b/build/com.mbeddr/platform/build.gradle
@@ -45,14 +45,11 @@ task copy_sl_all_nativelibs(type: Copy, dependsOn: build_sl_all) {
     into "$mpsHomeDir/plugins"
 }
 
-
 task install_sl_all_nativelibs(type: Copy, dependsOn: build_sl_all) {
     from "$rootDir/artifacts/mps-sl-all/"
     include "de.itemis.mps.nativelibs.loader/"
     into "$mpsPluginsDir"
 }
-
-
 
 task build_platform(type: BuildLanguages, dependsOn: copy_sl_all_nativelibs) {
     script scriptFile('com.mbeddr.platform/build.xml')
@@ -86,6 +83,9 @@ task publish_mbeddrPlatform(type: Zip, dependsOn: test_mbeddr_platform) {
 }
 
 task publishMbeddrPlatformToLocal(dependsOn: ['publishMbeddrAllScriptsPublicationToMavenLocal', 'publishMbeddrPlatformPublicationToMavenLocal'])
+
+tasks.getByPath(':build:com.mbeddr:install').dependsOn install_actionsfilter
+tasks.getByPath(':build:com.mbeddr:install').dependsOn install_sl_all_nativelibs
 
 publishing {
     publications {


### PR DESCRIPTION
The logic inthe gradle scripts about dealing with the MPS path selector
was pretty distributed through multiple script files. Everything related
to the install tasked is now moved into the ":build:mbeddr.com" script.
Dependencies to the install tasked are then added dynamically.

Fixes #1837