### PR TITLE
doc: fix absolut path generation

### DIFF
--- a/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc.gen_xhtml/generator/template/com/mbeddr/doc/gen_xhtml/generator/template/main@generator.mps
+++ b/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc.gen_xhtml/generator/template/com/mbeddr/doc/gen_xhtml/generator/template/main@generator.mps
@@ -259,6 +259,9 @@
       </concept>
     </language>
     <language id="d7706f63-9be2-479c-a3da-ae92af1e64d5" name="jetbrains.mps.lang.generator.generationContext">
+      <concept id="1229477454423" name="jetbrains.mps.lang.generator.generationContext.structure.GenerationContextOp_GetOriginalCopiedInputByOutput" flags="nn" index="12$id9">
+        <child id="1229477520175" name="outputNode" index="12$y8L" />
+      </concept>
       <concept id="1216860049635" name="jetbrains.mps.lang.generator.generationContext.structure.TemplateFunctionParameter_generationContext" flags="nn" index="1iwH7S" />
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
@@ -363,7 +366,7 @@
       <ref role="aOQi4" to="2c95:5yxqZJwzC3e" resolve="DocumentConfig" />
     </node>
     <node concept="3lhOvk" id="2TZO3DbvUtX" role="3lj3bC">
-      <ref role="3lhOvi" node="2TZO3DbvV1h" resolve="map_DocumentExport" />
+      <ref role="3lhOvi" node="2TZO3DbvV1h" resolve="map_Document" />
       <ref role="30HIoZ" to="2c95:2TZO3DbuxwK" resolve="Document" />
       <node concept="30G5F_" id="3RseghIcrvP" role="30HLyM">
         <node concept="3clFbS" id="3RseghIcrvQ" role="2VODD2">
@@ -396,7 +399,7 @@
     </node>
   </node>
   <node concept="1Xc25A" id="2TZO3DbvV1h">
-    <property role="TrG5h" value="map_DocumentExport" />
+    <property role="TrG5h" value="map_Document" />
     <node concept="n94m4" id="2TZO3DbvV1k" role="lGtFl">
       <ref role="n9lRv" to="2c95:2TZO3DbuxwK" resolve="Document" />
     </node>
@@ -3248,6 +3251,30 @@
                             </node>
                           </node>
                         </node>
+                        <node concept="3cpWs8" id="1lMVil7883s" role="3cqZAp">
+                          <node concept="3cpWsn" id="1lMVil7883t" role="3cpWs9">
+                            <property role="TrG5h" value="res" />
+                            <node concept="3Tqbb2" id="1lMVil7883n" role="1tU5fm">
+                              <ref role="ehGHo" to="2c95:5yxqZJwzNUZ" resolve="Resource" />
+                            </node>
+                            <node concept="1PxgMI" id="1lMVil78aSz" role="33vP2m">
+                              <node concept="chp4Y" id="1lMVil78bbt" role="3oSUPX">
+                                <ref role="cht4Q" to="2c95:5yxqZJwzNUZ" resolve="Resource" />
+                              </node>
+                              <node concept="2OqwBi" id="1lMVil7883u" role="1m5AlR">
+                                <node concept="1iwH7S" id="1lMVil7883v" role="2Oq$k0" />
+                                <node concept="12$id9" id="1lMVil7883w" role="2OqNvi">
+                                  <node concept="2OqwBi" id="1lMVil7883x" role="12$y8L">
+                                    <node concept="30H73N" id="1lMVil7883y" role="2Oq$k0" />
+                                    <node concept="3TrEf2" id="1lMVil7883z" role="2OqNvi">
+                                      <ref role="3Tt5mk" to="2c95:5yxqZJwzQtY" resolve="resource" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
                         <node concept="3clFbF" id="3RseghIcyfj" role="3cqZAp">
                           <node concept="2OqwBi" id="3RseghIcyfE" role="3clFbG">
                             <node concept="37vLTw" id="5Hxjapw9v9V" role="2Oq$k0">
@@ -3255,11 +3282,8 @@
                             </node>
                             <node concept="2qgKlT" id="3RseghIcyfK" role="2OqNvi">
                               <ref role="37wK5l" to="4gky:3RseghIcx1t" resolve="getMappedResourceFilename" />
-                              <node concept="2OqwBi" id="3RseghIcyg6" role="37wK5m">
-                                <node concept="30H73N" id="3RseghIcyfL" role="2Oq$k0" />
-                                <node concept="3TrEf2" id="3RseghIcygc" role="2OqNvi">
-                                  <ref role="3Tt5mk" to="2c95:5yxqZJwzQtY" resolve="resource" />
-                                </node>
+                              <node concept="37vLTw" id="1lMVil789dc" role="37wK5m">
+                                <ref role="3cqZAo" node="1lMVil7883t" resolve="res" />
                               </node>
                             </node>
                           </node>

--- a/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/languageModels/behavior.mps
+++ b/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/languageModels/behavior.mps
@@ -893,22 +893,54 @@
                   <node concept="1z4cxt" id="5yxqZJwzZ2X" role="2OqNvi">
                     <node concept="1bVj0M" id="5yxqZJwzZ2Y" role="23t8la">
                       <node concept="3clFbS" id="5yxqZJwzZ2Z" role="1bW5cS">
-                        <node concept="3clFbF" id="5yxqZJwzZ30" role="3cqZAp">
-                          <node concept="3clFbC" id="5yxqZJwzZ31" role="3clFbG">
-                            <node concept="2OqwBi" id="5yxqZJwzZ32" role="3uHU7w">
-                              <node concept="37vLTw" id="3RseghIcyfd" role="2Oq$k0">
+                        <node concept="3cpWs8" id="1lMVil77ynR" role="3cqZAp">
+                          <node concept="3cpWsn" id="1lMVil77ynS" role="3cpWs9">
+                            <property role="TrG5h" value="pathDef" />
+                            <node concept="3Tqbb2" id="1lMVil77ynJ" role="1tU5fm">
+                              <ref role="ehGHo" to="2c95:5yxqZJwzC3r" resolve="PathDefinition" />
+                            </node>
+                            <node concept="2OqwBi" id="1lMVil77ynT" role="33vP2m">
+                              <node concept="37vLTw" id="1lMVil77ynU" role="2Oq$k0">
+                                <ref role="3cqZAo" node="5yxqZJwzZ3a" resolve="it" />
+                              </node>
+                              <node concept="3TrEf2" id="1lMVil77ynV" role="2OqNvi">
+                                <ref role="3Tt5mk" to="2c95:5yxqZJwzW1P" resolve="pathDef" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3cpWs8" id="1lMVil77yFU" role="3cqZAp">
+                          <node concept="3cpWsn" id="1lMVil77yFV" role="3cpWs9">
+                            <property role="TrG5h" value="path" />
+                            <node concept="3Tqbb2" id="1lMVil77yFT" role="1tU5fm">
+                              <ref role="ehGHo" to="2c95:5yxqZJwzC3r" resolve="PathDefinition" />
+                            </node>
+                            <node concept="2OqwBi" id="1lMVil77yFW" role="33vP2m">
+                              <node concept="37vLTw" id="1lMVil77yFX" role="2Oq$k0">
                                 <ref role="3cqZAo" node="3RseghIcyf0" resolve="r" />
                               </node>
-                              <node concept="3TrEf2" id="5yxqZJwzZ36" role="2OqNvi">
+                              <node concept="3TrEf2" id="1lMVil77yFY" role="2OqNvi">
                                 <ref role="3Tt5mk" to="2c95:5yxqZJwzNV1" resolve="path" />
                               </node>
                             </node>
-                            <node concept="2OqwBi" id="5yxqZJwzZ37" role="3uHU7B">
-                              <node concept="37vLTw" id="5yxqZJwzZ38" role="2Oq$k0">
-                                <ref role="3cqZAo" node="5yxqZJwzZ3a" resolve="it" />
+                          </node>
+                        </node>
+                        <node concept="3clFbF" id="5yxqZJwzZ30" role="3cqZAp">
+                          <node concept="3clFbC" id="5yxqZJwzZ31" role="3clFbG">
+                            <node concept="2OqwBi" id="1lMVil78_re" role="3uHU7w">
+                              <node concept="37vLTw" id="1lMVil77yFZ" role="2Oq$k0">
+                                <ref role="3cqZAo" node="1lMVil77yFV" resolve="path" />
                               </node>
-                              <node concept="3TrEf2" id="5yxqZJwzZ39" role="2OqNvi">
-                                <ref role="3Tt5mk" to="2c95:5yxqZJwzW1P" resolve="pathDef" />
+                              <node concept="3TrcHB" id="1lMVil78AcK" role="2OqNvi">
+                                <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                              </node>
+                            </node>
+                            <node concept="2OqwBi" id="1lMVil78$b3" role="3uHU7B">
+                              <node concept="37vLTw" id="1lMVil77ynW" role="2Oq$k0">
+                                <ref role="3cqZAo" node="1lMVil77ynS" resolve="pathDef" />
+                              </node>
+                              <node concept="3TrcHB" id="1lMVil78$Mt" role="2OqNvi">
+                                <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
                               </node>
                             </node>
                           </node>


### PR DESCRIPTION
The looks up for that path difenetion didn't work correctly because it
was doing node comparison and they were from different (transient) models.

PathMapping lookup now done via name.