### PR TITLE
build: change the default task to build_platform

### DIFF
--- a/build/com.mbeddr/languages/build.gradle
+++ b/build/com.mbeddr/languages/build.gradle
@@ -218,7 +218,7 @@ publishing {
     }
 }
 
-rootProject.defaultTasks 'build_mbeddr'
+
 
 task publishMbeddrToLocal (dependsOn: ['publishMbeddrPublicationToMavenLocal',
 ':build:com.mbeddr:platform:publishMbeddrPlatformToLocal']) {}

--- a/build/com.mbeddr/platform/build.gradle
+++ b/build/com.mbeddr/platform/build.gradle
@@ -82,6 +82,21 @@ task publish_mbeddrPlatform(type: Zip, dependsOn: test_mbeddr_platform) {
     include "com.mbeddr.platform/**"
 }
 
+task defaultWrapper(dependsOn: build_platform) {
+    doFirst {
+        println "######################################################################################"
+        println "#                      THE DEFAULT TASKED HAS BEEN CHANGED                           #"
+        println "#                                                                                    #"
+        println "# The default tasked now only builds the mbeddr platform and no longer all of mbeddr #"
+        println "# including the C part. In order to build everything you will have to invoke the     #"
+        println "# task build_mbeddr. This will give you the old behaviour of building everything.    #"
+        println "######################################################################################"
+    }
+
+}
+
+rootProject.defaultTasks 'defaultWrapper'
+
 task publishMbeddrPlatformToLocal(dependsOn: ['publishMbeddrAllScriptsPublicationToMavenLocal', 'publishMbeddrPlatformPublicationToMavenLocal'])
 
 tasks.getByPath(':build:com.mbeddr:install').dependsOn install_actionsfilter


### PR DESCRIPTION
By popular requests we are changing the default task to only build the platform. In order to inform the user about this change a banner is presented after the build if the user invoked the default task:

```
:build:com.mbeddr:platform:defaultWrapper
######################################################################################
#                      THE DEFAULT TASKED HAS BEEN CHANGED                           #
#                                                                                    #
# The default tasked now only builds the mbeddr platform and no longer all of mbeddr #
# including the C part. In order to build everything you will have to invoke the     #
# task build_mbeddr. This will give you the old behaviour of building everything.    #
######################################################################################

BUILD SUCCESSFUL

Total time: 11 mins 16.661 secs
```

Todo:
- [x] check documentation for `./gradelw` statements that should build all of mbeddr
- [x] update `building mbeddr` [wiki page](https://github.com/mbeddr/mbeddr.core/wiki/Building-mbeddr)
