### PR TITLE
add MPS versions back to file names

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,5 @@
+import de.itemis.mps.gradle.GitBasedVersioning
+
 ext.releaseRepository = 'https://projects.itemis.de/nexus/content/repositories/mbeddr'
 ext.snapshotRepository = 'https://projects.itemis.de/nexus/content/repositories/mbeddr_snapshots'
 
@@ -24,6 +26,45 @@ subprojects {
     // required plugins
     apply plugin: "base"
     apply plugin: "maven-publish"
+    ext.mbeddrMajor = "1"
+    ext.mbeddrMinor = "0"
+
+    if (project.hasProperty("mbeddrVersion")) {
+        ext.mbeddrBuildNumber = project.getProperty('mbeddrVersion')
+    } else {
+        // locally versions are SNAPSHOT
+        if (ciBuild) {
+            // setting mbeddrMajor
+            if (project.hasProperty('mbeddrMajor')) {
+                ext.mbeddrMajor = project.getProperty('mbeddrMajor')
+            }
+
+            // setting mbeddrMinor
+            if (project.hasProperty('mbeddrMinor')) {
+                ext.mbeddrMinor = project.getProperty('mbeddrMinor')
+            }
+
+            // setting mbeddrBuild
+            if (project.hasProperty('mbeddrBuild')) {
+                ext.mbeddrBuild = project.getProperty('mbeddrBuild')
+            } else {
+                ext.mbeddrBuild = GitBasedVersioning.getGitBranch()
+            }
+
+            if (project.hasProperty("mbeddrBuildCounter")) {
+                ext.mbeddrBuildCounter = project.getProperty("mbeddrBuildCounter")
+            } else {
+                ext.mbeddrBuildCounter = GitBasedVersioning.getGitCommitCount()
+            }
+            if(mbeddrBuild == "stable") {
+                mbeddrBuild = "master"
+            }
+            ext.mbeddrBuildNumber = GitBasedVersioning.getVersion(mbeddrBuild, mbeddrMajor, mbeddrMinor, mbeddrBuildCounter)
+        } else {
+            println "Local build detected. Build will be a SNAPSHOT."
+            ext.mbeddrBuildNumber = "1.0-SNAPSHOT"
+        }
+    }
 }
 
 task wrapper(type: Wrapper) {

--- a/build/com.mbeddr/build.gradle
+++ b/build/com.mbeddr/build.gradle
@@ -1,44 +1,4 @@
-import de.itemis.mps.gradle.GitBasedVersioning
 
-ext.mbeddrMajor = "1"
-ext.mbeddrMinor = "0"
-
-if (project.hasProperty("mbeddrVersion")) {
-    ext.mbeddrBuildNumber = project.getProperty('mbeddrVersion')
-} else {
-    // locally versions are SNAPSHOT
-    if (ciBuild) {
-        // setting mbeddrMajor
-        if (project.hasProperty('mbeddrMajor')) {
-            ext.mbeddrMajor = project.getProperty('mbeddrMajor')
-        }
-
-        // setting mbeddrMinor
-        if (project.hasProperty('mbeddrMinor')) {
-            ext.mbeddrMinor = project.getProperty('mbeddrMinor')
-        }
-
-        // setting mbeddrBuild
-        if (project.hasProperty('mbeddrBuild')) {
-            ext.mbeddrBuild = project.getProperty('mbeddrBuild')
-        } else {
-            ext.mbeddrBuild = GitBasedVersioning.getGitBranch()
-        }
-
-        if (project.hasProperty("mbeddrBuildCounter")) {
-            ext.mbeddrBuildCounter = project.getProperty("mbeddrBuildCounter")
-        } else {
-            ext.mbeddrBuildCounter = GitBasedVersioning.getGitCommitCount()
-        }
-        if(mbeddrBuild == "stable") {
-            mbeddrBuild = "master"
-        }
-        ext.mbeddrBuildNumber = GitBasedVersioning.getVersion(mbeddrBuild, mbeddrMajor, mbeddrMinor, mbeddrBuildCounter)
-    } else {
-        println "Local build detected. Build will be a SNAPSHOT."
-        ext.mbeddrBuildNumber = "1.0-SNAPSHOT"
-    }
-}
 
 // path variables
 // If mpsHomeDir is set explicitly, skip the MPS resolution step and use the explicit path (which may be relative from
@@ -91,9 +51,9 @@ logger.info "jdk_home: $jdk_home"
 ext.mps_home = '-Dmps.home=' + mpsHomeDir.getAbsolutePath()
 ext.build_dir = '-Dbuild.dir=' + file(rootProject.projectDir.absolutePath).getAbsolutePath()
 ext.artifacts_root = '-Dartifacts.root=' + file(rootProject.projectDir.absolutePath + "/artifacts").getAbsolutePath()
-String buildVersion = '-Dbuild=' + mbeddrBuildNumber
-String majorVersion = '-Dmajor.version=' + mbeddrMajor
-String minorVersion = '-Dminor.version=' + mbeddrMinor
+String buildVersion = '-Dbuild=' + ext.mbeddrBuildNumber
+String majorVersion = '-Dmajor.version=' + ext.mbeddrMajor
+String minorVersion = '-Dminor.version=' + ext.mbeddrMinor
 ext.mbeddr_home = ['-Dmbeddr.github.core.home=' + file(rootProject.projectDir.absolutePath).getAbsolutePath(), minorVersion, majorVersion, buildVersion]
 ext.slall_home = ['-Dsl-all.home=' + file(rootProject.projectDir.absolutePath + '/code/plugins/sl-all').getAbsolutePath(), minorVersion, majorVersion, buildVersion]
 ext.dependsOnMPS_scriptArgs = [mps_home, build_dir, artifacts_root]
@@ -170,6 +130,6 @@ private static void configureRepositories(Project project) {
 
 task printVersion {
     doLast {
-        println "mbeddrBuildNumber: ${mbeddrBuildNumber}"
+        println "mbeddrBuildNumber: ${ext.mbeddrBuildNumber}"
     }
 }

--- a/build/publishing/build.gradle
+++ b/build/publishing/build.gradle
@@ -63,21 +63,21 @@ task renameMacosFile(type: Copy) {
 		rename ('mbeddr-macos.dmg', macosFileName)
 }
 
-task renameAllInOne(type: Copy) {
+task renameAllInOne(type: Copy, dependsOn: ':build:com.mbeddr:distribution:build_all_in_one') {
     from(artifactsRoot + "/com.mbeddr.allInOne/")
     into(artifactsRoot + "/com.mbeddr.allInOne/")
     include("com.mbeddr.allInOne.zip")
     rename("com.mbeddr.allInOne.zip", allInOneFileName)
 }
 
-task renameTutorial(type: Copy) {
+task renameTutorial(type: Copy, dependsOn: ':build:com.mbeddr:distribution:package_tutorial') {
     from(artifactsRoot + "/com.mbeddr.tutorial/")
     into(artifactsRoot + "/com.mbeddr.tutorial/")
     include("com.mbeddr.tutorial.zip")
     rename("com.mbeddr.tutorial.zip", tutorialFileName)
 }
 
-task renamePlarform(type: Copy) {
+task renamePlarform(type: Copy, dependsOn: ':build:com.mbeddr:distribution:build_platform_distribution') {
     from(artifactsRoot + "/com.mbeddr.platform.distribution/")
     into(artifactsRoot + "/com.mbeddr.platform.distribution/")
     include("platform-distribution.zip")
@@ -96,7 +96,4 @@ githubRelease.dependsOn copyRenameAndDeleteWindowsSetupFile,
         copyRenameAndDeleteMacosSetupFile,
         renameAllInOne,
         renamePlarform,
-        renameTutorial,
-        ':build:com.mbeddr:distribution:build_platform_distribution',
-        ':build:com.mbeddr:distribution:package_tutorial',
-        ':build:com.mbeddr:distribution:build_all_in_one'
+        renameTutorial

--- a/build/publishing/build.gradle
+++ b/build/publishing/build.gradle
@@ -25,6 +25,12 @@ def windowsFileName = "mbeddr-win-" + t.getYear() + "-" +
 
 def macosFileName = "mbeddr-macos-" + t.getYear() + "-" +
 				t.getMonthValue() +"-"+ t.getDayOfMonth() +".dmg"
+
+
+def allInOneFileName = "com.mbeddr.allInOne-${mpsBuild}.zip"
+def tutorialFileName = "com.mbeddr.tutorial-${mpsBuild}.zip"
+def platformFileName = "platform-distribution-${mpsBuild}.zip"
+
 github {
     owner = 'mbeddr'
     repo = 'mbeddr.core'
@@ -35,9 +41,9 @@ github {
     body = releaseNotes
     prerelease = true
     assets = [
-            artifactsRoot + "/com.mbeddr.allInOne/com.mbeddr.allInOne.zip",
-            artifactsRoot + "/com.mbeddr.tutorial/com.mbeddr.tutorial.zip",
-            artifactsRoot + "/com.mbeddr.platform.distribution/platform-distribution.zip",
+            artifactsRoot + "/com.mbeddr.allInOne/" + allInOneFileName,
+            artifactsRoot + "/com.mbeddr.tutorial/" + tutorialFileName,
+            artifactsRoot + "/com.mbeddr.platform.distribution/" + platformFileName,
             artifactsRoot + "/rcp/" + windowsFileName,
             artifactsRoot + "/rcp/" + macosFileName
     ]
@@ -57,6 +63,27 @@ task renameMacosFile(type: Copy) {
 		rename ('mbeddr-macos.dmg', macosFileName)
 }
 
+task renameAllInOne(type: Copy) {
+    from(artifactsRoot + "/com.mbeddr.allInOne/")
+    into(artifactsRoot + "/com.mbeddr.allInOne/")
+    include("com.mbeddr.allInOne.zip")
+    rename("com.mbeddr.allInOne.zip", allInOneFileName)
+}
+
+task renameTutorial(type: Copy) {
+    from(artifactsRoot + "/com.mbeddr.tutorial/")
+    into(artifactsRoot + "/com.mbeddr.tutorial/")
+    include("com.mbeddr.tutorial.zip")
+    rename("com.mbeddr.tutorial.zip", tutorialFileName)
+}
+
+task renamePlarform(type: Copy) {
+    from(artifactsRoot + "/com.mbeddr.platform.distribution/")
+    into(artifactsRoot + "/com.mbeddr.platform.distribution/")
+    include("platform-distribution.zip")
+    rename("platform-distribution.zip", platformFileName)
+}
+
 task copyRenameAndDeleteWindowsSetupFile(type: Delete, dependsOn: [renameWindowsFile]) {
 		delete artifactsRoot + "/rcp/Setup.exe"
 }
@@ -65,7 +92,11 @@ task copyRenameAndDeleteMacosSetupFile(type: Delete, dependsOn: [renameMacosFile
 		delete artifactsRoot + "/rcp/mbeddr-macos.dmg"
 }
 
-githubRelease.dependsOn copyRenameAndDeleteWindowsSetupFile, copyRenameAndDeleteMacosSetupFile,
- ':build:com.mbeddr:distribution:build_platform_distribution',
- ':build:com.mbeddr:distribution:package_tutorial',
- ':build:com.mbeddr:distribution:build_all_in_one'
+githubRelease.dependsOn copyRenameAndDeleteWindowsSetupFile,
+        copyRenameAndDeleteMacosSetupFile,
+        renameAllInOne,
+        renamePlarform,
+        renameTutorial,
+        ':build:com.mbeddr:distribution:build_platform_distribution',
+        ':build:com.mbeddr:distribution:package_tutorial',
+        ':build:com.mbeddr:distribution:build_all_in_one'

--- a/build/publishing/build.gradle
+++ b/build/publishing/build.gradle
@@ -27,9 +27,9 @@ def macosFileName = "mbeddr-macos-" + t.getYear() + "-" +
 				t.getMonthValue() +"-"+ t.getDayOfMonth() +".dmg"
 
 
-def allInOneFileName = "com.mbeddr.allInOne-${mpsBuild}.zip"
-def tutorialFileName = "com.mbeddr.tutorial-${mpsBuild}.zip"
-def platformFileName = "platform-distribution-${mpsBuild}.zip"
+def allInOneFileName = "com.mbeddr.allInOne-${ext.mbeddrBuildNumber}-MPS-${mpsBuild}.zip"
+def tutorialFileName = "com.mbeddr.tutorial-${ext.mbeddrBuildNumber}-MPS-${mpsBuild}.zip"
+def platformFileName = "platform-distribution-${ext.mbeddrBuildNumber}-MPS-${mpsBuild}.zip"
 
 github {
     owner = 'mbeddr'

--- a/build/thirdparty/build.gradle
+++ b/build/thirdparty/build.gradle
@@ -20,4 +20,5 @@ subprojects {
             }
         }
     }
+
 }


### PR DESCRIPTION
As @eugenschindler reported in #1722 due to our build infrastructure changes, the build number was no longer part of the file name that was uploaded to github. 

The feature has been added again. You can have a look on a release here:

https://github.com/mbeddr/mbeddr.core/releases/tag/nightly-557