### PR TITLE
mbeddr.doc: TemporaryFileName annotation

### DIFF
--- a/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc.gen_xhtml/languageModels/textGen.mps
+++ b/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc.gen_xhtml/languageModels/textGen.mps
@@ -6,10 +6,15 @@
   </languages>
   <imports>
     <import index="lsus" ref="r:25d6e7db-06a4-44ee-83aa-8c5bf17f3b3a(com.mbeddr.doc.gen_xhtml.structure)" />
+    <import index="2c95" ref="r:5f7188a9-e7b4-4a2e-bef9-38d2cf379fdc(com.mbeddr.doc.structure)" />
     <import index="iuxj" ref="r:64db3a92-5968-4a73-b456-34504a2d97a6(jetbrains.mps.core.xml.structure)" implicit="true" />
+    <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1082485599095" name="jetbrains.mps.baseLanguage.structure.BlockStatement" flags="nn" index="9aQIb">
+        <child id="1082485599096" name="statements" index="9aQI4" />
+      </concept>
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
@@ -20,17 +25,33 @@
       <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
         <property id="1070475926801" name="value" index="Xl_RC" />
       </concept>
+      <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
+        <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
+        <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
+      </concept>
+      <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
+        <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
       <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
+        <child id="1082485599094" name="ifFalseStatement" index="9aQIa" />
         <child id="1068580123160" name="condition" index="3clFbw" />
         <child id="1068580123161" name="ifTrue" index="3clFbx" />
       </concept>
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
       </concept>
-      <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6" />
+      <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
+        <child id="1068581517676" name="expression" index="3cqZAk" />
+      </concept>
+      <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
+        <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
+      </concept>
+      <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
       <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
         <child id="1081773367579" name="rightExpression" index="3uHU7w" />
         <child id="1081773367580" name="leftExpression" index="3uHU7B" />
@@ -41,6 +62,7 @@
       <concept id="7166719696753421196" name="jetbrains.mps.lang.textGen.structure.EncodingLiteral" flags="ng" index="22Jior">
         <property id="7166719696753421197" name="encoding" index="22Jioq" />
       </concept>
+      <concept id="45307784116571022" name="jetbrains.mps.lang.textGen.structure.FilenameFunction" flags="ig" index="29tfMY" />
       <concept id="8931911391946696733" name="jetbrains.mps.lang.textGen.structure.ExtensionDeclaration" flags="in" index="9MYSb" />
       <concept id="1237305208784" name="jetbrains.mps.lang.textGen.structure.NewLineAppendPart" flags="ng" index="l8MVK" />
       <concept id="1237305334312" name="jetbrains.mps.lang.textGen.structure.NodeAppendPart" flags="ng" index="l9hG8">
@@ -59,6 +81,7 @@
       </concept>
       <concept id="1233670071145" name="jetbrains.mps.lang.textGen.structure.ConceptTextGenDeclaration" flags="ig" index="WtQ9Q">
         <reference id="1233670257997" name="conceptDeclaration" index="WuzLi" />
+        <child id="45307784116711884" name="filename" index="29tGrW" />
         <child id="1233749296504" name="textGenBlock" index="11c4hB" />
         <child id="7991274449437422201" name="extension" index="33IsuW" />
         <child id="1224137887853744062" name="encoding" index="19oSPi" />
@@ -70,6 +93,16 @@
       </concept>
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1172008320231" name="jetbrains.mps.lang.smodel.structure.Node_IsNotNullOperation" flags="nn" index="3x8VRR" />
+      <concept id="6407023681583036853" name="jetbrains.mps.lang.smodel.structure.NodeAttributeQualifier" flags="ng" index="3CFYIy">
+        <reference id="6407023681583036854" name="attributeConcept" index="3CFYIx" />
+      </concept>
+      <concept id="6407023681583031218" name="jetbrains.mps.lang.smodel.structure.AttributeAccess" flags="nn" index="3CFZ6_">
+        <child id="6407023681583036852" name="qualifier" index="3CFYIz" />
+      </concept>
+      <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
+        <reference id="1138405853777" name="concept" index="ehGHo" />
+      </concept>
       <concept id="1138056022639" name="jetbrains.mps.lang.smodel.structure.SPropertyAccess" flags="nn" index="3TrcHB">
         <reference id="1138056395725" name="property" index="3TsBF5" />
       </concept>
@@ -83,6 +116,9 @@
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
         <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
     </language>
     <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
@@ -117,6 +153,58 @@
     </node>
     <node concept="22Jior" id="QRmqzKlpqU" role="19oSPi">
       <property role="22Jioq" value="UTF-8" />
+    </node>
+    <node concept="29tfMY" id="4VYjeLHNKJu" role="29tGrW">
+      <node concept="3clFbS" id="4VYjeLHNKJv" role="2VODD2">
+        <node concept="3cpWs8" id="4VYjeLHNPyE" role="3cqZAp">
+          <node concept="3cpWsn" id="4VYjeLHNPyF" role="3cpWs9">
+            <property role="TrG5h" value="tempFileName" />
+            <node concept="3Tqbb2" id="4VYjeLHNPyB" role="1tU5fm">
+              <ref role="ehGHo" to="2c95:4VYjeLHNjIp" resolve="TemporaryFileName" />
+            </node>
+            <node concept="2OqwBi" id="4VYjeLHNPyG" role="33vP2m">
+              <node concept="117lpO" id="4VYjeLHNPyH" role="2Oq$k0" />
+              <node concept="3CFZ6_" id="4VYjeLHNPyI" role="2OqNvi">
+                <node concept="3CFYIy" id="4VYjeLHNPyJ" role="3CFYIz">
+                  <ref role="3CFYIx" to="2c95:4VYjeLHNjIp" resolve="TemporaryFileName" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="4VYjeLHNKWE" role="3cqZAp">
+          <node concept="2OqwBi" id="4VYjeLHNP1g" role="3clFbw">
+            <node concept="37vLTw" id="4VYjeLHNPyK" role="2Oq$k0">
+              <ref role="3cqZAo" node="4VYjeLHNPyF" resolve="tempFileName" />
+            </node>
+            <node concept="3x8VRR" id="4VYjeLHNPlV" role="2OqNvi" />
+          </node>
+          <node concept="3clFbS" id="4VYjeLHNKWG" role="3clFbx">
+            <node concept="3cpWs6" id="4VYjeLHNQlk" role="3cqZAp">
+              <node concept="2OqwBi" id="4VYjeLHNQRf" role="3cqZAk">
+                <node concept="37vLTw" id="4VYjeLHNQya" role="2Oq$k0">
+                  <ref role="3cqZAo" node="4VYjeLHNPyF" resolve="tempFileName" />
+                </node>
+                <node concept="3TrcHB" id="4VYjeLHNRch" role="2OqNvi">
+                  <ref role="3TsBF5" to="2c95:4VYjeLHNjIw" resolve="name" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="9aQIb" id="4VYjeLHNRpi" role="9aQIa">
+            <node concept="3clFbS" id="4VYjeLHNRpj" role="9aQI4">
+              <node concept="3cpWs6" id="4VYjeLHNRAc" role="3cqZAp">
+                <node concept="2OqwBi" id="4VYjeLHNSx2" role="3cqZAk">
+                  <node concept="117lpO" id="4VYjeLHNRNk" role="2Oq$k0" />
+                  <node concept="3TrcHB" id="4VYjeLHNSR_" role="2OqNvi">
+                    <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
     </node>
   </node>
   <node concept="WtQ9Q" id="QRmqzHVj9O">

--- a/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/generator/template/com/mbeddr/doc/generator/template/main@generator.mps
+++ b/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/generator/template/com/mbeddr/doc/generator/template/main@generator.mps
@@ -95,6 +95,7 @@
       <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
       <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
       <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
+      <concept id="1225271221393" name="jetbrains.mps.baseLanguage.structure.NPENotEqualsExpression" flags="nn" index="17QLQc" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
       </concept>
@@ -349,6 +350,7 @@
       <concept id="1143224127713" name="jetbrains.mps.lang.smodel.structure.Node_InsertPrevSiblingOperation" flags="nn" index="HtX7F">
         <child id="1143224127716" name="insertedNode" index="HtX7I" />
       </concept>
+      <concept id="1143234257716" name="jetbrains.mps.lang.smodel.structure.Node_GetModelOperation" flags="nn" index="I4A8Y" />
       <concept id="1145383075378" name="jetbrains.mps.lang.smodel.structure.SNodeListType" flags="in" index="2I9FWS">
         <reference id="1145383142433" name="elementConcept" index="2I9WkF" />
       </concept>
@@ -2201,166 +2203,184 @@
             <property role="TrG5h" value="sr" />
           </node>
           <node concept="3clFbS" id="4PBxP351wwX" role="2LFqv$">
-            <node concept="3cpWs8" id="4PBxP351xvz" role="3cqZAp">
-              <node concept="3cpWsn" id="4PBxP351xv$" role="3cpWs9">
-                <property role="TrG5h" value="nameOfReferencedSection" />
-                <node concept="17QB3L" id="4PBxP351xvy" role="1tU5fm" />
-                <node concept="2OqwBi" id="mQGf9iJMRS" role="33vP2m">
-                  <node concept="2OqwBi" id="4PBxP351xvA" role="2Oq$k0">
-                    <node concept="2GrUjf" id="4PBxP351xvB" role="2Oq$k0">
-                      <ref role="2Gs0qQ" node="4PBxP351wwT" resolve="sr" />
+            <node concept="3clFbJ" id="5FtAU1qDDCT" role="3cqZAp">
+              <node concept="3clFbS" id="5FtAU1qDDCV" role="3clFbx">
+                <node concept="3cpWs8" id="4PBxP351xvz" role="3cqZAp">
+                  <node concept="3cpWsn" id="4PBxP351xv$" role="3cpWs9">
+                    <property role="TrG5h" value="nameOfReferencedSection" />
+                    <node concept="17QB3L" id="4PBxP351xvy" role="1tU5fm" />
+                    <node concept="2OqwBi" id="mQGf9iJMRS" role="33vP2m">
+                      <node concept="2OqwBi" id="4PBxP351xvA" role="2Oq$k0">
+                        <node concept="2GrUjf" id="4PBxP351xvB" role="2Oq$k0">
+                          <ref role="2Gs0qQ" node="4PBxP351wwT" resolve="sr" />
+                        </node>
+                        <node concept="3TrEf2" id="mQGf9iJMcY" role="2OqNvi">
+                          <ref role="3Tt5mk" to="2c95:2TZO3DbvhAJ" resolve="target" />
+                        </node>
+                      </node>
+                      <node concept="3TrcHB" id="mQGf9iJNQ1" role="2OqNvi">
+                        <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                      </node>
                     </node>
-                    <node concept="3TrEf2" id="mQGf9iJMcY" role="2OqNvi">
-                      <ref role="3Tt5mk" to="2c95:2TZO3DbvhAJ" resolve="target" />
-                    </node>
-                  </node>
-                  <node concept="3TrcHB" id="mQGf9iJNQ1" role="2OqNvi">
-                    <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
                   </node>
                 </node>
-              </node>
-            </node>
-            <node concept="3cpWs8" id="mQGf9iJPqk" role="3cqZAp">
-              <node concept="3cpWsn" id="mQGf9iJPql" role="3cpWs9">
-                <property role="TrG5h" value="nameOfReferencedDoc" />
-                <node concept="17QB3L" id="mQGf9iJPqm" role="1tU5fm" />
-                <node concept="2OqwBi" id="mQGf9iJPqn" role="33vP2m">
-                  <node concept="2OqwBi" id="mQGf9iJQ3w" role="2Oq$k0">
-                    <node concept="2OqwBi" id="mQGf9iJPqo" role="2Oq$k0">
-                      <node concept="2GrUjf" id="mQGf9iJPqp" role="2Oq$k0">
+                <node concept="3cpWs8" id="mQGf9iJPqk" role="3cqZAp">
+                  <node concept="3cpWsn" id="mQGf9iJPql" role="3cpWs9">
+                    <property role="TrG5h" value="nameOfReferencedDoc" />
+                    <node concept="17QB3L" id="mQGf9iJPqm" role="1tU5fm" />
+                    <node concept="2OqwBi" id="mQGf9iJPqn" role="33vP2m">
+                      <node concept="2OqwBi" id="mQGf9iJQ3w" role="2Oq$k0">
+                        <node concept="2OqwBi" id="mQGf9iJPqo" role="2Oq$k0">
+                          <node concept="2GrUjf" id="mQGf9iJPqp" role="2Oq$k0">
+                            <ref role="2Gs0qQ" node="4PBxP351wwT" resolve="sr" />
+                          </node>
+                          <node concept="3TrEf2" id="mQGf9iJPqq" role="2OqNvi">
+                            <ref role="3Tt5mk" to="2c95:2TZO3DbvhAJ" resolve="target" />
+                          </node>
+                        </node>
+                        <node concept="2Xjw5R" id="mQGf9iJR5C" role="2OqNvi">
+                          <node concept="1xMEDy" id="mQGf9iJR5E" role="1xVPHs">
+                            <node concept="chp4Y" id="mQGf9iJR7Y" role="ri$Ld">
+                              <ref role="cht4Q" to="2c95:2TZO3DbuxwK" resolve="Document" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3TrcHB" id="mQGf9iJPqr" role="2OqNvi">
+                        <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3cpWs8" id="4PBxP351IOY" role="3cqZAp">
+                  <node concept="3cpWsn" id="4PBxP351IOZ" role="3cpWs9">
+                    <property role="TrG5h" value="doc" />
+                    <node concept="3Tqbb2" id="4PBxP351IOW" role="1tU5fm">
+                      <ref role="ehGHo" to="2c95:2TZO3DbuxwK" resolve="Document" />
+                    </node>
+                    <node concept="2OqwBi" id="4PBxP351IP0" role="33vP2m">
+                      <node concept="2OqwBi" id="4PBxP351IP1" role="2Oq$k0">
+                        <node concept="1Q6Npb" id="4PBxP351IP2" role="2Oq$k0" />
+                        <node concept="2RRcyG" id="4PBxP351IP3" role="2OqNvi">
+                          <ref role="2RRcyH" to="2c95:2TZO3DbuxwK" resolve="Document" />
+                        </node>
+                      </node>
+                      <node concept="1z4cxt" id="4PBxP351IP4" role="2OqNvi">
+                        <node concept="1bVj0M" id="4PBxP351IP5" role="23t8la">
+                          <node concept="3clFbS" id="4PBxP351IP6" role="1bW5cS">
+                            <node concept="3clFbF" id="4PBxP351IP7" role="3cqZAp">
+                              <node concept="2OqwBi" id="4PBxP351IP8" role="3clFbG">
+                                <node concept="2OqwBi" id="4PBxP351IP9" role="2Oq$k0">
+                                  <node concept="37vLTw" id="4PBxP351IPa" role="2Oq$k0">
+                                    <ref role="3cqZAo" node="4PBxP351IPe" resolve="it" />
+                                  </node>
+                                  <node concept="3TrcHB" id="4PBxP351IPb" role="2OqNvi">
+                                    <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                                  </node>
+                                </node>
+                                <node concept="liA8E" id="4PBxP351IPc" role="2OqNvi">
+                                  <ref role="37wK5l" to="wyt6:~String.equals(java.lang.Object):boolean" resolve="equals" />
+                                  <node concept="37vLTw" id="mQGf9iJRde" role="37wK5m">
+                                    <ref role="3cqZAo" node="mQGf9iJPql" resolve="nameOfReferencedDoc" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="Rh6nW" id="4PBxP351IPe" role="1bW2Oz">
+                            <property role="TrG5h" value="it" />
+                            <node concept="2jxLKc" id="4PBxP351IPf" role="1tU5fm" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3cpWs8" id="mQGf9iK4XI" role="3cqZAp">
+                  <node concept="3cpWsn" id="mQGf9iK4XJ" role="3cpWs9">
+                    <property role="TrG5h" value="sec" />
+                    <node concept="3Tqbb2" id="mQGf9iK4WM" role="1tU5fm">
+                      <ref role="ehGHo" to="2c95:2TZO3Dbv6Ju" resolve="AbstractSection" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbF" id="mQGf9iK61c" role="3cqZAp">
+                  <node concept="37vLTI" id="mQGf9iK61e" role="3clFbG">
+                    <node concept="2OqwBi" id="mQGf9iK4XK" role="37vLTx">
+                      <node concept="2OqwBi" id="mQGf9iK4XL" role="2Oq$k0">
+                        <node concept="37vLTw" id="mQGf9iK4XM" role="2Oq$k0">
+                          <ref role="3cqZAo" node="4PBxP351IOZ" resolve="doc" />
+                        </node>
+                        <node concept="2Rf3mk" id="mQGf9iK4XN" role="2OqNvi">
+                          <node concept="1xMEDy" id="mQGf9iK4XO" role="1xVPHs">
+                            <node concept="chp4Y" id="mQGf9iK4XP" role="ri$Ld">
+                              <ref role="cht4Q" to="2c95:2TZO3Dbv6Ju" resolve="AbstractSection" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="1z4cxt" id="mQGf9iK4XQ" role="2OqNvi">
+                        <node concept="1bVj0M" id="mQGf9iK4XR" role="23t8la">
+                          <node concept="3clFbS" id="mQGf9iK4XS" role="1bW5cS">
+                            <node concept="3clFbF" id="mQGf9iK4XT" role="3cqZAp">
+                              <node concept="2OqwBi" id="mQGf9iK4XU" role="3clFbG">
+                                <node concept="2OqwBi" id="mQGf9iK4XV" role="2Oq$k0">
+                                  <node concept="37vLTw" id="mQGf9iK4XW" role="2Oq$k0">
+                                    <ref role="3cqZAo" node="mQGf9iK4Y0" resolve="it" />
+                                  </node>
+                                  <node concept="3TrcHB" id="mQGf9iK4XX" role="2OqNvi">
+                                    <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                                  </node>
+                                </node>
+                                <node concept="liA8E" id="mQGf9iK4XY" role="2OqNvi">
+                                  <ref role="37wK5l" to="wyt6:~String.equals(java.lang.Object):boolean" resolve="equals" />
+                                  <node concept="37vLTw" id="mQGf9iK4XZ" role="37wK5m">
+                                    <ref role="3cqZAo" node="4PBxP351xv$" resolve="nameOfReferencedSection" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="Rh6nW" id="mQGf9iK4Y0" role="1bW2Oz">
+                            <property role="TrG5h" value="it" />
+                            <node concept="2jxLKc" id="mQGf9iK4Y1" role="1tU5fm" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="37vLTw" id="mQGf9iK61i" role="37vLTJ">
+                      <ref role="3cqZAo" node="mQGf9iK4XJ" resolve="sec" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbF" id="4PBxP351JdE" role="3cqZAp">
+                  <node concept="37vLTI" id="4PBxP351JYv" role="3clFbG">
+                    <node concept="37vLTw" id="mQGf9iK5Ye" role="37vLTx">
+                      <ref role="3cqZAo" node="mQGf9iK4XJ" resolve="sec" />
+                    </node>
+                    <node concept="2OqwBi" id="4PBxP351JmY" role="37vLTJ">
+                      <node concept="2GrUjf" id="4PBxP351JdC" role="2Oq$k0">
                         <ref role="2Gs0qQ" node="4PBxP351wwT" resolve="sr" />
                       </node>
-                      <node concept="3TrEf2" id="mQGf9iJPqq" role="2OqNvi">
+                      <node concept="3TrEf2" id="mQGf9iJRRW" role="2OqNvi">
                         <ref role="3Tt5mk" to="2c95:2TZO3DbvhAJ" resolve="target" />
                       </node>
                     </node>
-                    <node concept="2Xjw5R" id="mQGf9iJR5C" role="2OqNvi">
-                      <node concept="1xMEDy" id="mQGf9iJR5E" role="1xVPHs">
-                        <node concept="chp4Y" id="mQGf9iJR7Y" role="ri$Ld">
-                          <ref role="cht4Q" to="2c95:2TZO3DbuxwK" resolve="Document" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="3TrcHB" id="mQGf9iJPqr" role="2OqNvi">
-                    <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
                   </node>
                 </node>
               </node>
-            </node>
-            <node concept="3cpWs8" id="4PBxP351IOY" role="3cqZAp">
-              <node concept="3cpWsn" id="4PBxP351IOZ" role="3cpWs9">
-                <property role="TrG5h" value="doc" />
-                <node concept="3Tqbb2" id="4PBxP351IOW" role="1tU5fm">
-                  <ref role="ehGHo" to="2c95:2TZO3DbuxwK" resolve="Document" />
-                </node>
-                <node concept="2OqwBi" id="4PBxP351IP0" role="33vP2m">
-                  <node concept="2OqwBi" id="4PBxP351IP1" role="2Oq$k0">
-                    <node concept="1Q6Npb" id="4PBxP351IP2" role="2Oq$k0" />
-                    <node concept="2RRcyG" id="4PBxP351IP3" role="2OqNvi">
-                      <ref role="2RRcyH" to="2c95:2TZO3DbuxwK" resolve="Document" />
+              <node concept="17QLQc" id="5FtAU1qDLn8" role="3clFbw">
+                <node concept="1Q6Npb" id="5FtAU1qDLDD" role="3uHU7w" />
+                <node concept="2OqwBi" id="5FtAU1qDGkv" role="3uHU7B">
+                  <node concept="2OqwBi" id="5FtAU1qDDSC" role="2Oq$k0">
+                    <node concept="2GrUjf" id="5FtAU1qDDGT" role="2Oq$k0">
+                      <ref role="2Gs0qQ" node="4PBxP351wwT" resolve="sr" />
+                    </node>
+                    <node concept="3TrEf2" id="5FtAU1qDEoF" role="2OqNvi">
+                      <ref role="3Tt5mk" to="2c95:2TZO3DbvhAJ" resolve="target" />
                     </node>
                   </node>
-                  <node concept="1z4cxt" id="4PBxP351IP4" role="2OqNvi">
-                    <node concept="1bVj0M" id="4PBxP351IP5" role="23t8la">
-                      <node concept="3clFbS" id="4PBxP351IP6" role="1bW5cS">
-                        <node concept="3clFbF" id="4PBxP351IP7" role="3cqZAp">
-                          <node concept="2OqwBi" id="4PBxP351IP8" role="3clFbG">
-                            <node concept="2OqwBi" id="4PBxP351IP9" role="2Oq$k0">
-                              <node concept="37vLTw" id="4PBxP351IPa" role="2Oq$k0">
-                                <ref role="3cqZAo" node="4PBxP351IPe" resolve="it" />
-                              </node>
-                              <node concept="3TrcHB" id="4PBxP351IPb" role="2OqNvi">
-                                <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
-                              </node>
-                            </node>
-                            <node concept="liA8E" id="4PBxP351IPc" role="2OqNvi">
-                              <ref role="37wK5l" to="wyt6:~String.equals(java.lang.Object):boolean" resolve="equals" />
-                              <node concept="37vLTw" id="mQGf9iJRde" role="37wK5m">
-                                <ref role="3cqZAo" node="mQGf9iJPql" resolve="nameOfReferencedDoc" />
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="Rh6nW" id="4PBxP351IPe" role="1bW2Oz">
-                        <property role="TrG5h" value="it" />
-                        <node concept="2jxLKc" id="4PBxP351IPf" role="1tU5fm" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3cpWs8" id="mQGf9iK4XI" role="3cqZAp">
-              <node concept="3cpWsn" id="mQGf9iK4XJ" role="3cpWs9">
-                <property role="TrG5h" value="sec" />
-                <node concept="3Tqbb2" id="mQGf9iK4WM" role="1tU5fm">
-                  <ref role="ehGHo" to="2c95:2TZO3Dbv6Ju" resolve="AbstractSection" />
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbF" id="mQGf9iK61c" role="3cqZAp">
-              <node concept="37vLTI" id="mQGf9iK61e" role="3clFbG">
-                <node concept="2OqwBi" id="mQGf9iK4XK" role="37vLTx">
-                  <node concept="2OqwBi" id="mQGf9iK4XL" role="2Oq$k0">
-                    <node concept="37vLTw" id="mQGf9iK4XM" role="2Oq$k0">
-                      <ref role="3cqZAo" node="4PBxP351IOZ" resolve="doc" />
-                    </node>
-                    <node concept="2Rf3mk" id="mQGf9iK4XN" role="2OqNvi">
-                      <node concept="1xMEDy" id="mQGf9iK4XO" role="1xVPHs">
-                        <node concept="chp4Y" id="mQGf9iK4XP" role="ri$Ld">
-                          <ref role="cht4Q" to="2c95:2TZO3Dbv6Ju" resolve="AbstractSection" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="1z4cxt" id="mQGf9iK4XQ" role="2OqNvi">
-                    <node concept="1bVj0M" id="mQGf9iK4XR" role="23t8la">
-                      <node concept="3clFbS" id="mQGf9iK4XS" role="1bW5cS">
-                        <node concept="3clFbF" id="mQGf9iK4XT" role="3cqZAp">
-                          <node concept="2OqwBi" id="mQGf9iK4XU" role="3clFbG">
-                            <node concept="2OqwBi" id="mQGf9iK4XV" role="2Oq$k0">
-                              <node concept="37vLTw" id="mQGf9iK4XW" role="2Oq$k0">
-                                <ref role="3cqZAo" node="mQGf9iK4Y0" resolve="it" />
-                              </node>
-                              <node concept="3TrcHB" id="mQGf9iK4XX" role="2OqNvi">
-                                <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
-                              </node>
-                            </node>
-                            <node concept="liA8E" id="mQGf9iK4XY" role="2OqNvi">
-                              <ref role="37wK5l" to="wyt6:~String.equals(java.lang.Object):boolean" resolve="equals" />
-                              <node concept="37vLTw" id="mQGf9iK4XZ" role="37wK5m">
-                                <ref role="3cqZAo" node="4PBxP351xv$" resolve="nameOfReferencedSection" />
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="Rh6nW" id="mQGf9iK4Y0" role="1bW2Oz">
-                        <property role="TrG5h" value="it" />
-                        <node concept="2jxLKc" id="mQGf9iK4Y1" role="1tU5fm" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="37vLTw" id="mQGf9iK61i" role="37vLTJ">
-                  <ref role="3cqZAo" node="mQGf9iK4XJ" resolve="sec" />
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbF" id="4PBxP351JdE" role="3cqZAp">
-              <node concept="37vLTI" id="4PBxP351JYv" role="3clFbG">
-                <node concept="37vLTw" id="mQGf9iK5Ye" role="37vLTx">
-                  <ref role="3cqZAo" node="mQGf9iK4XJ" resolve="sec" />
-                </node>
-                <node concept="2OqwBi" id="4PBxP351JmY" role="37vLTJ">
-                  <node concept="2GrUjf" id="4PBxP351JdC" role="2Oq$k0">
-                    <ref role="2Gs0qQ" node="4PBxP351wwT" resolve="sr" />
-                  </node>
-                  <node concept="3TrEf2" id="mQGf9iJRRW" role="2OqNvi">
-                    <ref role="3Tt5mk" to="2c95:2TZO3DbvhAJ" resolve="target" />
-                  </node>
+                  <node concept="I4A8Y" id="5FtAU1qDGZV" role="2OqNvi" />
                 </node>
               </node>
             </node>
@@ -2385,81 +2405,99 @@
             <property role="TrG5h" value="dr" />
           </node>
           <node concept="3clFbS" id="mQGf9iJKl2" role="2LFqv$">
-            <node concept="3cpWs8" id="mQGf9iJKl3" role="3cqZAp">
-              <node concept="3cpWsn" id="mQGf9iJKl4" role="3cpWs9">
-                <property role="TrG5h" value="nameOfReferencedDoc" />
-                <node concept="17QB3L" id="mQGf9iJKl5" role="1tU5fm" />
-                <node concept="2OqwBi" id="mQGf9iJKl6" role="33vP2m">
-                  <node concept="2OqwBi" id="mQGf9iJKl7" role="2Oq$k0">
-                    <node concept="2GrUjf" id="mQGf9iJKl8" role="2Oq$k0">
-                      <ref role="2Gs0qQ" node="mQGf9iJKl1" resolve="dr" />
+            <node concept="3clFbJ" id="5FtAU1qDO_R" role="3cqZAp">
+              <node concept="3clFbS" id="5FtAU1qDO_T" role="3clFbx">
+                <node concept="3cpWs8" id="mQGf9iJKl3" role="3cqZAp">
+                  <node concept="3cpWsn" id="mQGf9iJKl4" role="3cpWs9">
+                    <property role="TrG5h" value="nameOfReferencedDoc" />
+                    <node concept="17QB3L" id="mQGf9iJKl5" role="1tU5fm" />
+                    <node concept="2OqwBi" id="mQGf9iJKl6" role="33vP2m">
+                      <node concept="2OqwBi" id="mQGf9iJKl7" role="2Oq$k0">
+                        <node concept="2GrUjf" id="mQGf9iJKl8" role="2Oq$k0">
+                          <ref role="2Gs0qQ" node="mQGf9iJKl1" resolve="dr" />
+                        </node>
+                        <node concept="3TrEf2" id="mQGf9iJKl9" role="2OqNvi">
+                          <ref role="3Tt5mk" to="2c95:2TZO3DbvI5E" resolve="doc" />
+                        </node>
+                      </node>
+                      <node concept="3TrcHB" id="mQGf9iJKla" role="2OqNvi">
+                        <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                      </node>
                     </node>
-                    <node concept="3TrEf2" id="mQGf9iJKl9" role="2OqNvi">
-                      <ref role="3Tt5mk" to="2c95:2TZO3DbvI5E" resolve="doc" />
-                    </node>
-                  </node>
-                  <node concept="3TrcHB" id="mQGf9iJKla" role="2OqNvi">
-                    <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
                   </node>
                 </node>
-              </node>
-            </node>
-            <node concept="3cpWs8" id="mQGf9iJKlb" role="3cqZAp">
-              <node concept="3cpWsn" id="mQGf9iJKlc" role="3cpWs9">
-                <property role="TrG5h" value="doc" />
-                <node concept="3Tqbb2" id="mQGf9iJKld" role="1tU5fm">
-                  <ref role="ehGHo" to="2c95:2TZO3DbuxwK" resolve="Document" />
-                </node>
-                <node concept="2OqwBi" id="mQGf9iJKle" role="33vP2m">
-                  <node concept="2OqwBi" id="mQGf9iJKlf" role="2Oq$k0">
-                    <node concept="1Q6Npb" id="mQGf9iJKlg" role="2Oq$k0" />
-                    <node concept="2RRcyG" id="mQGf9iJKlh" role="2OqNvi">
-                      <ref role="2RRcyH" to="2c95:2TZO3DbuxwK" resolve="Document" />
+                <node concept="3cpWs8" id="mQGf9iJKlb" role="3cqZAp">
+                  <node concept="3cpWsn" id="mQGf9iJKlc" role="3cpWs9">
+                    <property role="TrG5h" value="doc" />
+                    <node concept="3Tqbb2" id="mQGf9iJKld" role="1tU5fm">
+                      <ref role="ehGHo" to="2c95:2TZO3DbuxwK" resolve="Document" />
                     </node>
-                  </node>
-                  <node concept="1z4cxt" id="mQGf9iJKli" role="2OqNvi">
-                    <node concept="1bVj0M" id="mQGf9iJKlj" role="23t8la">
-                      <node concept="3clFbS" id="mQGf9iJKlk" role="1bW5cS">
-                        <node concept="3clFbF" id="mQGf9iJKll" role="3cqZAp">
-                          <node concept="2OqwBi" id="mQGf9iJKlm" role="3clFbG">
-                            <node concept="2OqwBi" id="mQGf9iJKln" role="2Oq$k0">
-                              <node concept="37vLTw" id="mQGf9iJKlo" role="2Oq$k0">
-                                <ref role="3cqZAo" node="mQGf9iJKls" resolve="it" />
-                              </node>
-                              <node concept="3TrcHB" id="mQGf9iJKlp" role="2OqNvi">
-                                <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
-                              </node>
-                            </node>
-                            <node concept="liA8E" id="mQGf9iJKlq" role="2OqNvi">
-                              <ref role="37wK5l" to="wyt6:~String.equals(java.lang.Object):boolean" resolve="equals" />
-                              <node concept="37vLTw" id="mQGf9iJKlr" role="37wK5m">
-                                <ref role="3cqZAo" node="mQGf9iJKl4" resolve="nameOfReferencedDoc" />
+                    <node concept="2OqwBi" id="mQGf9iJKle" role="33vP2m">
+                      <node concept="2OqwBi" id="mQGf9iJKlf" role="2Oq$k0">
+                        <node concept="1Q6Npb" id="mQGf9iJKlg" role="2Oq$k0" />
+                        <node concept="2RRcyG" id="mQGf9iJKlh" role="2OqNvi">
+                          <ref role="2RRcyH" to="2c95:2TZO3DbuxwK" resolve="Document" />
+                        </node>
+                      </node>
+                      <node concept="1z4cxt" id="mQGf9iJKli" role="2OqNvi">
+                        <node concept="1bVj0M" id="mQGf9iJKlj" role="23t8la">
+                          <node concept="3clFbS" id="mQGf9iJKlk" role="1bW5cS">
+                            <node concept="3clFbF" id="mQGf9iJKll" role="3cqZAp">
+                              <node concept="2OqwBi" id="mQGf9iJKlm" role="3clFbG">
+                                <node concept="2OqwBi" id="mQGf9iJKln" role="2Oq$k0">
+                                  <node concept="37vLTw" id="mQGf9iJKlo" role="2Oq$k0">
+                                    <ref role="3cqZAo" node="mQGf9iJKls" resolve="it" />
+                                  </node>
+                                  <node concept="3TrcHB" id="mQGf9iJKlp" role="2OqNvi">
+                                    <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                                  </node>
+                                </node>
+                                <node concept="liA8E" id="mQGf9iJKlq" role="2OqNvi">
+                                  <ref role="37wK5l" to="wyt6:~String.equals(java.lang.Object):boolean" resolve="equals" />
+                                  <node concept="37vLTw" id="mQGf9iJKlr" role="37wK5m">
+                                    <ref role="3cqZAo" node="mQGf9iJKl4" resolve="nameOfReferencedDoc" />
+                                  </node>
+                                </node>
                               </node>
                             </node>
                           </node>
+                          <node concept="Rh6nW" id="mQGf9iJKls" role="1bW2Oz">
+                            <property role="TrG5h" value="it" />
+                            <node concept="2jxLKc" id="mQGf9iJKlt" role="1tU5fm" />
+                          </node>
                         </node>
                       </node>
-                      <node concept="Rh6nW" id="mQGf9iJKls" role="1bW2Oz">
-                        <property role="TrG5h" value="it" />
-                        <node concept="2jxLKc" id="mQGf9iJKlt" role="1tU5fm" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbF" id="mQGf9iJKlu" role="3cqZAp">
+                  <node concept="37vLTI" id="mQGf9iJKlv" role="3clFbG">
+                    <node concept="37vLTw" id="mQGf9iJKlw" role="37vLTx">
+                      <ref role="3cqZAo" node="mQGf9iJKlc" resolve="doc" />
+                    </node>
+                    <node concept="2OqwBi" id="mQGf9iJKlx" role="37vLTJ">
+                      <node concept="2GrUjf" id="mQGf9iJKly" role="2Oq$k0">
+                        <ref role="2Gs0qQ" node="mQGf9iJKl1" resolve="dr" />
+                      </node>
+                      <node concept="3TrEf2" id="mQGf9iJKlz" role="2OqNvi">
+                        <ref role="3Tt5mk" to="2c95:2TZO3DbvI5E" resolve="doc" />
                       </node>
                     </node>
                   </node>
                 </node>
               </node>
-            </node>
-            <node concept="3clFbF" id="mQGf9iJKlu" role="3cqZAp">
-              <node concept="37vLTI" id="mQGf9iJKlv" role="3clFbG">
-                <node concept="37vLTw" id="mQGf9iJKlw" role="37vLTx">
-                  <ref role="3cqZAo" node="mQGf9iJKlc" resolve="doc" />
-                </node>
-                <node concept="2OqwBi" id="mQGf9iJKlx" role="37vLTJ">
-                  <node concept="2GrUjf" id="mQGf9iJKly" role="2Oq$k0">
-                    <ref role="2Gs0qQ" node="mQGf9iJKl1" resolve="dr" />
+              <node concept="17QLQc" id="5FtAU1qDSP_" role="3clFbw">
+                <node concept="1Q6Npb" id="5FtAU1qDT3$" role="3uHU7w" />
+                <node concept="2OqwBi" id="5FtAU1qDPpW" role="3uHU7B">
+                  <node concept="2OqwBi" id="5FtAU1qDOKD" role="2Oq$k0">
+                    <node concept="2GrUjf" id="5FtAU1qDOC2" role="2Oq$k0">
+                      <ref role="2Gs0qQ" node="mQGf9iJKl1" resolve="dr" />
+                    </node>
+                    <node concept="3TrEf2" id="5FtAU1qDP6A" role="2OqNvi">
+                      <ref role="3Tt5mk" to="2c95:2TZO3DbvI5E" resolve="doc" />
+                    </node>
                   </node>
-                  <node concept="3TrEf2" id="mQGf9iJKlz" role="2OqNvi">
-                    <ref role="3Tt5mk" to="2c95:2TZO3DbvI5E" resolve="doc" />
-                  </node>
+                  <node concept="I4A8Y" id="5FtAU1qDPOQ" role="2OqNvi" />
                 </node>
               </node>
             </node>

--- a/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/generator/template/com/mbeddr/doc/generator/template/main@generator.mps
+++ b/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/generator/template/com/mbeddr/doc/generator/template/main@generator.mps
@@ -118,6 +118,9 @@
         <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
       </concept>
       <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
+      <concept id="1081516740877" name="jetbrains.mps.baseLanguage.structure.NotExpression" flags="nn" index="3fqX7Q">
+        <child id="1081516765348" name="expression" index="3fr31v" />
+      </concept>
       <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
@@ -442,6 +445,7 @@
       <concept id="1202120902084" name="jetbrains.mps.baseLanguage.collections.structure.WhereOperation" flags="nn" index="3zZkjj" />
       <concept id="1202128969694" name="jetbrains.mps.baseLanguage.collections.structure.SelectOperation" flags="nn" index="3$u5V9" />
       <concept id="1184963466173" name="jetbrains.mps.baseLanguage.collections.structure.ToArrayOperation" flags="nn" index="3_kTaI" />
+      <concept id="1172254888721" name="jetbrains.mps.baseLanguage.collections.structure.ContainsOperation" flags="nn" index="3JPx81" />
     </language>
   </registry>
   <node concept="bUwia" id="3RseghId8Of">
@@ -1383,7 +1387,9 @@
                               <node concept="37vLTw" id="6RvWQYjPPHz" role="37wK5m">
                                 <ref role="3cqZAo" node="49PUF$HTiTB" resolve="m" />
                               </node>
-                              <node concept="1Q6Npb" id="6RvWQYjPPV_" role="37wK5m" />
+                              <node concept="2GrUjf" id="5mrX3UfrVXZ" role="37wK5m">
+                                <ref role="2Gs0qQ" node="49PUF$HTi2y" resolve="doc" />
+                              </node>
                             </node>
                           </node>
                         </node>
@@ -2122,11 +2128,40 @@
             <node concept="2OqwBi" id="4PBxP3515Jk" role="33vP2m">
               <node concept="1iwH7S" id="4PBxP3515Jl" role="2Oq$k0" />
               <node concept="2QPPRi" id="4PBxP3515Jm" role="2OqNvi">
-                <node concept="2OqwBi" id="4PBxP3515Jn" role="2QPDDZ">
-                  <node concept="37vLTw" id="mQGf9iJv3o" role="2Oq$k0">
-                    <ref role="3cqZAo" node="mQGf9iJ7YL" resolve="dependentDocuments" />
+                <node concept="2OqwBi" id="5mrX3Ufo_8o" role="2QPDDZ">
+                  <node concept="2OqwBi" id="4PBxP3515Jn" role="2Oq$k0">
+                    <node concept="37vLTw" id="mQGf9iJv3o" role="2Oq$k0">
+                      <ref role="3cqZAo" node="mQGf9iJ7YL" resolve="dependentDocuments" />
+                    </node>
+                    <node concept="3zZkjj" id="5mrX3Ufoof8" role="2OqNvi">
+                      <node concept="1bVj0M" id="5mrX3Ufoofa" role="23t8la">
+                        <node concept="3clFbS" id="5mrX3Ufoofb" role="1bW5cS">
+                          <node concept="3clFbF" id="5mrX3UforGw" role="3cqZAp">
+                            <node concept="3fqX7Q" id="5mrX3Ufo$Ol" role="3clFbG">
+                              <node concept="2OqwBi" id="5mrX3Ufo$On" role="3fr31v">
+                                <node concept="2OqwBi" id="5mrX3Ufo$Oo" role="2Oq$k0">
+                                  <node concept="1Q6Npb" id="5mrX3Ufo$Op" role="2Oq$k0" />
+                                  <node concept="2RRcyG" id="5mrX3Ufo$Oq" role="2OqNvi">
+                                    <ref role="2RRcyH" to="2c95:2TZO3DbuxwK" resolve="Document" />
+                                  </node>
+                                </node>
+                                <node concept="3JPx81" id="5mrX3Ufo$Or" role="2OqNvi">
+                                  <node concept="37vLTw" id="5mrX3Ufo$Os" role="25WWJ7">
+                                    <ref role="3cqZAo" node="5mrX3Ufoofc" resolve="it" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="Rh6nW" id="5mrX3Ufoofc" role="1bW2Oz">
+                          <property role="TrG5h" value="it" />
+                          <node concept="2jxLKc" id="5mrX3Ufoofd" role="1tU5fm" />
+                        </node>
+                      </node>
+                    </node>
                   </node>
-                  <node concept="ANE8D" id="4PBxP3515Jp" role="2OqNvi" />
+                  <node concept="ANE8D" id="5mrX3Ufo_pW" role="2OqNvi" />
                 </node>
               </node>
             </node>

--- a/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/languageModels/plugin.mps
+++ b/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/languageModels/plugin.mps
@@ -89,6 +89,7 @@
         <child id="1068498886297" name="rValue" index="37vLTx" />
         <child id="1068498886295" name="lValue" index="37vLTJ" />
       </concept>
+      <concept id="1153417849900" name="jetbrains.mps.baseLanguage.structure.GreaterThanOrEqualsExpression" flags="nn" index="2d3UOw" />
       <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
       <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="ng" index="2tJIrI" />
@@ -132,6 +133,7 @@
         <reference id="1144433057691" name="classifier" index="1PxDUh" />
       </concept>
       <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
+      <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
       <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
       <concept id="1070534934090" name="jetbrains.mps.baseLanguage.structure.CastExpression" flags="nn" index="10QFUN">
         <child id="1070534934091" name="type" index="10QFUM" />
@@ -217,9 +219,17 @@
       <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
       </concept>
+      <concept id="1163668896201" name="jetbrains.mps.baseLanguage.structure.TernaryOperatorExpression" flags="nn" index="3K4zz7">
+        <child id="1163668914799" name="condition" index="3K4Cdx" />
+        <child id="1163668922816" name="ifTrue" index="3K4E3e" />
+        <child id="1163668934364" name="ifFalse" index="3K4GZi" />
+      </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
       <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
       <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
+      <concept id="1200397529627" name="jetbrains.mps.baseLanguage.structure.CharConstant" flags="nn" index="1Xhbcc">
+        <property id="1200397540847" name="charConstant" index="1XhdNS" />
+      </concept>
     </language>
     <language id="63650c59-16c8-498a-99c8-005c7ee9515d" name="jetbrains.mps.lang.access">
       <concept id="8974276187400348173" name="jetbrains.mps.lang.access.structure.CommandClosureLiteral" flags="nn" index="1QHqEC" />
@@ -282,6 +292,10 @@
       <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
         <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
       </concept>
+      <concept id="2396822768958367367" name="jetbrains.mps.lang.smodel.structure.AbstractTypeCastExpression" flags="nn" index="$5XWr">
+        <child id="6733348108486823193" name="leftExpression" index="1m5AlR" />
+        <child id="3906496115198199033" name="conceptArgument" index="3oSUPX" />
+      </concept>
       <concept id="1143226024141" name="jetbrains.mps.lang.smodel.structure.SModelType" flags="in" index="H_c77" />
       <concept id="1143234257716" name="jetbrains.mps.lang.smodel.structure.Node_GetModelOperation" flags="nn" index="I4A8Y" />
       <concept id="1145404486709" name="jetbrains.mps.lang.smodel.structure.SemanticDowncastExpression" flags="nn" index="2JrnkZ">
@@ -294,6 +308,7 @@
         <property id="4040588429969021683" name="moduleId" index="3rM5sR" />
       </concept>
       <concept id="4040588429969069898" name="jetbrains.mps.lang.smodel.structure.LanguageReferenceExpression" flags="nn" index="3rNLEe" />
+      <concept id="1171999116870" name="jetbrains.mps.lang.smodel.structure.Node_IsNullOperation" flags="nn" index="3w_OXm" />
       <concept id="1172008320231" name="jetbrains.mps.lang.smodel.structure.Node_IsNotNullOperation" flags="nn" index="3x8VRR" />
       <concept id="6407023681583036853" name="jetbrains.mps.lang.smodel.structure.NodeAttributeQualifier" flags="ng" index="3CFYIy">
         <reference id="6407023681583036854" name="attributeConcept" index="3CFYIx" />
@@ -301,6 +316,7 @@
       <concept id="6407023681583031218" name="jetbrains.mps.lang.smodel.structure.AttributeAccess" flags="nn" index="3CFZ6_">
         <child id="6407023681583036852" name="qualifier" index="3CFYIz" />
       </concept>
+      <concept id="1140137987495" name="jetbrains.mps.lang.smodel.structure.SNodeTypeCastExpression" flags="nn" index="1PxgMI" />
       <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2" />
       <concept id="1138056022639" name="jetbrains.mps.lang.smodel.structure.SPropertyAccess" flags="nn" index="3TrcHB">
         <reference id="1138056395725" name="property" index="3TsBF5" />
@@ -1080,15 +1096,26 @@
                               <node concept="3uibUv" id="49PUF$HQsjm" role="1tU5fm">
                                 <ref role="3uigEE" to="eoo2:~Path" resolve="Path" />
                               </node>
-                              <node concept="2YIFZM" id="49PUF$HQsjE" role="33vP2m">
+                            </node>
+                          </node>
+                          <node concept="3clFbF" id="5FtAU1q7pmm" role="3cqZAp">
+                            <node concept="37vLTI" id="5FtAU1q7pmn" role="3clFbG">
+                              <node concept="2YIFZM" id="5FtAU1q7pmo" role="37vLTx">
                                 <ref role="37wK5l" to="eoo2:~Paths.get(java.lang.String,java.lang.String...):java.nio.file.Path" resolve="get" />
                                 <ref role="1Pybhc" to="eoo2:~Paths" resolve="Paths" />
-                                <node concept="37vLTw" id="49PUF$HQsjF" role="37wK5m">
+                                <node concept="37vLTw" id="5FtAU1q7pmp" role="37wK5m">
                                   <ref role="3cqZAo" node="49PUF$HQmMF" resolve="location" />
                                 </node>
-                                <node concept="37vLTw" id="49PUF$HQsjG" role="37wK5m">
-                                  <ref role="3cqZAo" node="2cjkfC8t4VO" resolve="fileName" />
+                                <node concept="2YIFZM" id="5FtAU1q8Poq" role="37wK5m">
+                                  <ref role="37wK5l" node="5FtAU1q8N6h" resolve="getToFileName" />
+                                  <ref role="1Pybhc" node="6RvWQYjPIDF" resolve="GenerationHelper" />
+                                  <node concept="2GrUjf" id="5FtAU1q8Pwj" role="37wK5m">
+                                    <ref role="2Gs0qQ" node="49PUF$HPUgf" resolve="unit" />
+                                  </node>
                                 </node>
+                              </node>
+                              <node concept="37vLTw" id="5FtAU1q7pmr" role="37vLTJ">
+                                <ref role="3cqZAo" node="49PUF$HQsjD" resolve="reallocation" />
                               </node>
                             </node>
                           </node>
@@ -1350,27 +1377,35 @@
         <node concept="3clFbF" id="5mrX3UfrYCF" role="3cqZAp">
           <node concept="2OqwBi" id="5mrX3UfrYCH" role="3clFbG">
             <node concept="2OqwBi" id="5mrX3UfrZkC" role="2Oq$k0">
-              <node concept="2OqwBi" id="5mrX3UfrYCI" role="2Oq$k0">
-                <node concept="2OqwBi" id="5mrX3UfrYCJ" role="2Oq$k0">
-                  <node concept="2OqwBi" id="5mrX3UfrYCK" role="2Oq$k0">
-                    <node concept="2JrnkZ" id="5mrX3UfrYCL" role="2Oq$k0">
-                      <node concept="2OqwBi" id="5mrX3UfrYCM" role="2JrQYb">
-                        <node concept="37vLTw" id="5mrX3UfrYCN" role="2Oq$k0">
-                          <ref role="3cqZAo" node="5mrX3UfrYC8" resolve="node" />
+              <node concept="2OqwBi" id="5FtAU1q6szo" role="2Oq$k0">
+                <node concept="2OqwBi" id="5mrX3UfrYCI" role="2Oq$k0">
+                  <node concept="2OqwBi" id="5mrX3UfrYCJ" role="2Oq$k0">
+                    <node concept="2OqwBi" id="5mrX3UfrYCK" role="2Oq$k0">
+                      <node concept="2JrnkZ" id="5mrX3UfrYCL" role="2Oq$k0">
+                        <node concept="2OqwBi" id="5mrX3UfrYCM" role="2JrQYb">
+                          <node concept="37vLTw" id="5mrX3UfrYCN" role="2Oq$k0">
+                            <ref role="3cqZAo" node="5mrX3UfrYC8" resolve="node" />
+                          </node>
+                          <node concept="I4A8Y" id="5mrX3UfrYCO" role="2OqNvi" />
                         </node>
-                        <node concept="I4A8Y" id="5mrX3UfrYCO" role="2OqNvi" />
+                      </node>
+                      <node concept="liA8E" id="5mrX3UfrYCP" role="2OqNvi">
+                        <ref role="37wK5l" to="mhbf:~SModel.getReference():org.jetbrains.mps.openapi.model.SModelReference" resolve="getReference" />
                       </node>
                     </node>
-                    <node concept="liA8E" id="5mrX3UfrYCP" role="2OqNvi">
-                      <ref role="37wK5l" to="mhbf:~SModel.getReference():org.jetbrains.mps.openapi.model.SModelReference" resolve="getReference" />
+                    <node concept="liA8E" id="5mrX3UfrYCQ" role="2OqNvi">
+                      <ref role="37wK5l" to="mhbf:~SModelReference.getName():org.jetbrains.mps.openapi.model.SModelName" resolve="getName" />
                     </node>
                   </node>
-                  <node concept="liA8E" id="5mrX3UfrYCQ" role="2OqNvi">
-                    <ref role="37wK5l" to="mhbf:~SModelReference.getName():org.jetbrains.mps.openapi.model.SModelName" resolve="getName" />
+                  <node concept="liA8E" id="5mrX3UfrYCR" role="2OqNvi">
+                    <ref role="37wK5l" to="mhbf:~SModelName.getLongName():java.lang.String" resolve="getLongName" />
                   </node>
                 </node>
-                <node concept="liA8E" id="5mrX3UfrYCR" role="2OqNvi">
-                  <ref role="37wK5l" to="mhbf:~SModelName.getLongName():java.lang.String" resolve="getLongName" />
+                <node concept="liA8E" id="5FtAU1q6t49" role="2OqNvi">
+                  <ref role="37wK5l" to="wyt6:~String.concat(java.lang.String):java.lang.String" resolve="concat" />
+                  <node concept="Xl_RD" id="5FtAU1q6tgy" role="37wK5m">
+                    <property role="Xl_RC" value="/" />
+                  </node>
                 </node>
               </node>
               <node concept="liA8E" id="5mrX3Ufs0_G" role="2OqNvi">
@@ -1403,6 +1438,199 @@
         <property role="TrG5h" value="node" />
         <node concept="3Tqbb2" id="5mrX3UfrYC7" role="1tU5fm" />
       </node>
+    </node>
+    <node concept="2tJIrI" id="5FtAU1q8MNT" role="jymVt" />
+    <node concept="2YIFZL" id="5FtAU1q8N6h" role="jymVt">
+      <property role="TrG5h" value="getToFileName" />
+      <property role="od$2w" value="false" />
+      <property role="DiZV1" value="false" />
+      <property role="2aFKle" value="false" />
+      <node concept="3clFbS" id="5FtAU1q8N6k" role="3clF47">
+        <node concept="3cpWs8" id="5FtAU1q8O6Q" role="3cqZAp">
+          <node concept="3cpWsn" id="5FtAU1q8O6R" role="3cpWs9">
+            <property role="TrG5h" value="startNode" />
+            <node concept="3Tqbb2" id="5FtAU1q8Oho" role="1tU5fm" />
+            <node concept="2OqwBi" id="5FtAU1q8O6S" role="33vP2m">
+              <node concept="37vLTw" id="5FtAU1q8O6T" role="2Oq$k0">
+                <ref role="3cqZAo" node="5FtAU1q8NcE" resolve="unit" />
+              </node>
+              <node concept="liA8E" id="5FtAU1q8O6U" role="2OqNvi">
+                <ref role="37wK5l" to="ao3:~TextUnit.getStartNode():org.jetbrains.mps.openapi.model.SNode" resolve="getStartNode" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="5FtAU1q8R3Z" role="3cqZAp">
+          <node concept="3clFbS" id="5FtAU1q8R41" role="3clFbx">
+            <node concept="3cpWs6" id="5FtAU1q8S_M" role="3cqZAp">
+              <node concept="2OqwBi" id="5FtAU1q8Roo" role="3cqZAk">
+                <node concept="37vLTw" id="5FtAU1q8Rh8" role="2Oq$k0">
+                  <ref role="3cqZAo" node="5FtAU1q8NcE" resolve="unit" />
+                </node>
+                <node concept="liA8E" id="5FtAU1q8Rvv" role="2OqNvi">
+                  <ref role="37wK5l" to="ao3:~TextUnit.getFileName():java.lang.String" resolve="getFileName" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="5FtAU1q8Sfk" role="3clFbw">
+            <node concept="2OqwBi" id="5FtAU1q8RTn" role="2Oq$k0">
+              <node concept="37vLTw" id="5FtAU1q8R6s" role="2Oq$k0">
+                <ref role="3cqZAo" node="5FtAU1q8O6R" resolve="startNode" />
+              </node>
+              <node concept="3CFZ6_" id="5FtAU1q8S1$" role="2OqNvi">
+                <node concept="3CFYIy" id="5FtAU1q8S54" role="3CFYIz">
+                  <ref role="3CFYIx" to="2c95:4VYjeLHNjIp" resolve="TemporaryFileName" />
+                </node>
+              </node>
+            </node>
+            <node concept="3w_OXm" id="5FtAU1q8Svo" role="2OqNvi" />
+          </node>
+          <node concept="9aQIb" id="5FtAU1q8SOn" role="9aQIa">
+            <node concept="3clFbS" id="5FtAU1q8SOo" role="9aQI4">
+              <node concept="3cpWs6" id="5FtAU1q8Tb4" role="3cqZAp">
+                <node concept="2OqwBi" id="5FtAU1q8VhD" role="3cqZAk">
+                  <node concept="2OqwBi" id="5FtAU1q8Uuu" role="2Oq$k0">
+                    <node concept="1PxgMI" id="5FtAU1q8U53" role="2Oq$k0">
+                      <node concept="chp4Y" id="5FtAU1q8Uez" role="3oSUPX">
+                        <ref role="cht4Q" to="tpck:h0TrEE$" resolve="INamedConcept" />
+                      </node>
+                      <node concept="37vLTw" id="5FtAU1q8Tph" role="1m5AlR">
+                        <ref role="3cqZAo" node="5FtAU1q8O6R" resolve="startNode" />
+                      </node>
+                    </node>
+                    <node concept="3TrcHB" id="5FtAU1q8ULE" role="2OqNvi">
+                      <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="5FtAU1q8VN4" role="2OqNvi">
+                    <ref role="37wK5l" to="wyt6:~String.concat(java.lang.String):java.lang.String" resolve="concat" />
+                    <node concept="1rXfSq" id="5FtAU1q8W28" role="37wK5m">
+                      <ref role="37wK5l" node="2CDpSNwE2jp" resolve="getExtensionWithDot" />
+                      <node concept="2OqwBi" id="5FtAU1q8Wuv" role="37wK5m">
+                        <node concept="37vLTw" id="5FtAU1q8Whe" role="2Oq$k0">
+                          <ref role="3cqZAo" node="5FtAU1q8NcE" resolve="unit" />
+                        </node>
+                        <node concept="liA8E" id="5FtAU1q8WL8" role="2OqNvi">
+                          <ref role="37wK5l" to="ao3:~TextUnit.getFileName():java.lang.String" resolve="getFileName" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="5FtAU1q8MW5" role="1B3o_S" />
+      <node concept="17QB3L" id="5FtAU1q8N67" role="3clF45" />
+      <node concept="37vLTG" id="5FtAU1q8NcE" role="3clF46">
+        <property role="TrG5h" value="unit" />
+        <node concept="3uibUv" id="5FtAU1q8NtA" role="1tU5fm">
+          <ref role="3uigEE" to="ao3:~TextUnit" resolve="TextUnit" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="5FtAU1q8E2P" role="jymVt" />
+    <node concept="2YIFZL" id="2CDpSNwE2jp" role="jymVt">
+      <property role="TrG5h" value="getExtensionWithDot" />
+      <node concept="17QB3L" id="2CDpSNwE2js" role="3clF45" />
+      <node concept="3clFbS" id="2CDpSNwE2jr" role="3clF47">
+        <node concept="3cpWs8" id="2CDpSNwE2jv" role="3cqZAp">
+          <node concept="3cpWsn" id="2CDpSNwE2jw" role="3cpWs9">
+            <property role="TrG5h" value="index" />
+            <node concept="10Oyi0" id="2CDpSNwE2jx" role="1tU5fm" />
+            <node concept="2OqwBi" id="2CDpSNwE2jy" role="33vP2m">
+              <node concept="37vLTw" id="2BHiRxgm9f1" role="2Oq$k0">
+                <ref role="3cqZAo" node="2CDpSNwE2jt" resolve="fileName" />
+              </node>
+              <node concept="liA8E" id="2CDpSNwE2j$" role="2OqNvi">
+                <ref role="37wK5l" to="wyt6:~String.lastIndexOf(int):int" resolve="lastIndexOf" />
+                <node concept="1Xhbcc" id="2CDpSNwE2j_" role="37wK5m">
+                  <property role="1XhdNS" value="." />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="2CDpSNwE2jA" role="3cqZAp">
+          <node concept="3clFbS" id="2CDpSNwE2jB" role="3clFbx">
+            <node concept="3clFbJ" id="2CDpSNwE2jC" role="3cqZAp">
+              <node concept="3clFbS" id="2CDpSNwE2jD" role="3clFbx">
+                <node concept="3clFbF" id="2CDpSNwE2jE" role="3cqZAp">
+                  <node concept="37vLTI" id="2CDpSNwE2jF" role="3clFbG">
+                    <node concept="37vLTw" id="3GM_nagT_WS" role="37vLTJ">
+                      <ref role="3cqZAo" node="2CDpSNwE2jw" resolve="index" />
+                    </node>
+                    <node concept="3cmrfG" id="2CDpSNwE2jH" role="37vLTx">
+                      <property role="3cmrfH" value="-1" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="2d3UOw" id="2CDpSNwE2jI" role="3clFbw">
+                <node concept="3cmrfG" id="2CDpSNwE2jJ" role="3uHU7w">
+                  <property role="3cmrfH" value="0" />
+                </node>
+                <node concept="2OqwBi" id="2CDpSNwE2jK" role="3uHU7B">
+                  <node concept="37vLTw" id="2BHiRxgmaAt" role="2Oq$k0">
+                    <ref role="3cqZAo" node="2CDpSNwE2jt" resolve="fileName" />
+                  </node>
+                  <node concept="liA8E" id="2CDpSNwE2jM" role="2OqNvi">
+                    <ref role="37wK5l" to="wyt6:~String.indexOf(int,int):int" resolve="indexOf" />
+                    <node concept="1Xhbcc" id="2CDpSNwE2jN" role="37wK5m">
+                      <property role="1XhdNS" value="/" />
+                    </node>
+                    <node concept="37vLTw" id="3GM_nagTtjL" role="37wK5m">
+                      <ref role="3cqZAo" node="2CDpSNwE2jw" resolve="index" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2d3UOw" id="2CDpSNwE2jP" role="3clFbw">
+            <node concept="37vLTw" id="3GM_nagT$Jk" role="3uHU7B">
+              <ref role="3cqZAo" node="2CDpSNwE2jw" resolve="index" />
+            </node>
+            <node concept="3cmrfG" id="2CDpSNwE2jR" role="3uHU7w">
+              <property role="3cmrfH" value="0" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="2CDpSNwE2k3" role="3cqZAp">
+          <node concept="3K4zz7" id="2CDpSNwE2kb" role="3cqZAk">
+            <node concept="Xl_RD" id="2CDpSNwE2kf" role="3K4E3e">
+              <property role="Xl_RC" value="" />
+            </node>
+            <node concept="2OqwBi" id="2CDpSNwE2k_" role="3K4GZi">
+              <node concept="37vLTw" id="2BHiRxgm8uK" role="2Oq$k0">
+                <ref role="3cqZAo" node="2CDpSNwE2jt" resolve="fileName" />
+              </node>
+              <node concept="liA8E" id="2CDpSNwE2IH" role="2OqNvi">
+                <ref role="37wK5l" to="wyt6:~String.substring(int):java.lang.String" resolve="substring" />
+                <node concept="37vLTw" id="3GM_nagTzcv" role="37wK5m">
+                  <ref role="3cqZAo" node="2CDpSNwE2jw" resolve="index" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbC" id="2CDpSNwE2k7" role="3K4Cdx">
+              <node concept="3cmrfG" id="2CDpSNwE2ka" role="3uHU7w">
+                <property role="3cmrfH" value="-1" />
+              </node>
+              <node concept="37vLTw" id="3GM_nagTvu9" role="3uHU7B">
+                <ref role="3cqZAo" node="2CDpSNwE2jw" resolve="index" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="2CDpSNwE2jt" role="3clF46">
+        <property role="TrG5h" value="fileName" />
+        <node concept="17QB3L" id="2CDpSNwE2ju" role="1tU5fm" />
+      </node>
+      <node concept="3Tm1VV" id="5FtAU1q8DAQ" role="1B3o_S" />
     </node>
     <node concept="2tJIrI" id="6RvWQYjPIEa" role="jymVt" />
     <node concept="3Tm1VV" id="6RvWQYjPIDG" role="1B3o_S" />

--- a/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/languageModels/plugin.mps
+++ b/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/languageModels/plugin.mps
@@ -1222,6 +1222,94 @@
   </node>
   <node concept="312cEu" id="6RvWQYjPIDF">
     <property role="TrG5h" value="GenerationHelper" />
+    <node concept="2tJIrI" id="5FtAU1qmVVj" role="jymVt" />
+    <node concept="2YIFZL" id="5FtAU1qmVmm" role="jymVt">
+      <property role="TrG5h" value="getOutputLocation" />
+      <property role="DiZV1" value="false" />
+      <property role="od$2w" value="false" />
+      <node concept="3clFbS" id="5FtAU1qmVmn" role="3clF47">
+        <node concept="3cpWs8" id="5FtAU1qmVmo" role="3cqZAp">
+          <node concept="3cpWsn" id="5FtAU1qmVmp" role="3cpWs9">
+            <property role="TrG5h" value="docGenRoot" />
+            <node concept="3uibUv" id="5FtAU1qmVmq" role="1tU5fm">
+              <ref role="3uigEE" to="guwi:~File" resolve="File" />
+            </node>
+            <node concept="1rXfSq" id="5FtAU1qmVmr" role="33vP2m">
+              <ref role="37wK5l" node="2DWJLXXzCiq" resolve="getDocGenFolder" />
+              <node concept="37vLTw" id="5FtAU1qmVms" role="37wK5m">
+                <ref role="3cqZAo" node="5FtAU1qmVm_" resolve="m" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="5FtAU1qmVmt" role="3cqZAp">
+          <node concept="3cpWsn" id="5FtAU1qmVmu" role="3cpWs9">
+            <property role="TrG5h" value="mdlOutputRootInGenFolder" />
+            <node concept="3uibUv" id="5FtAU1qmVmv" role="1tU5fm">
+              <ref role="3uigEE" to="guwi:~File" resolve="File" />
+            </node>
+            <node concept="2ShNRf" id="5FtAU1qmVmw" role="33vP2m">
+              <node concept="1pGfFk" id="5FtAU1qmVmx" role="2ShVmc">
+                <ref role="37wK5l" to="guwi:~File.&lt;init&gt;(java.io.File,java.lang.String)" resolve="File" />
+                <node concept="37vLTw" id="5FtAU1qmVmy" role="37wK5m">
+                  <ref role="3cqZAo" node="5FtAU1qmVmp" resolve="docGenRoot" />
+                </node>
+                <node concept="2OqwBi" id="6RvWQYjPIJJ" role="37wK5m">
+                  <node concept="2OqwBi" id="6RvWQYjPIJK" role="2Oq$k0">
+                    <node concept="2OqwBi" id="6RvWQYjPIJL" role="2Oq$k0">
+                      <node concept="2OqwBi" id="6RvWQYjPIJM" role="2Oq$k0">
+                        <node concept="2JrnkZ" id="49PUF$HTuNT" role="2Oq$k0">
+                          <node concept="37vLTw" id="6RvWQYjPMnf" role="2JrQYb">
+                            <ref role="3cqZAo" node="5FtAU1qmVmB" resolve="model" />
+                          </node>
+                        </node>
+                        <node concept="liA8E" id="6RvWQYjPIJN" role="2OqNvi">
+                          <ref role="37wK5l" to="mhbf:~SModel.getReference():org.jetbrains.mps.openapi.model.SModelReference" resolve="getReference" />
+                        </node>
+                      </node>
+                      <node concept="liA8E" id="6RvWQYjPIJO" role="2OqNvi">
+                        <ref role="37wK5l" to="mhbf:~SModelReference.getName():org.jetbrains.mps.openapi.model.SModelName" resolve="getName" />
+                      </node>
+                    </node>
+                    <node concept="liA8E" id="6RvWQYjPIJP" role="2OqNvi">
+                      <ref role="37wK5l" to="mhbf:~SModelName.getLongName():java.lang.String" resolve="getLongName" />
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="6RvWQYjPIJQ" role="2OqNvi">
+                    <ref role="37wK5l" to="wyt6:~String.replace(java.lang.CharSequence,java.lang.CharSequence):java.lang.String" resolve="replace" />
+                    <node concept="Xl_RD" id="6RvWQYjPIJR" role="37wK5m">
+                      <property role="Xl_RC" value="." />
+                    </node>
+                    <node concept="Xl_RD" id="6RvWQYjPIJS" role="37wK5m">
+                      <property role="Xl_RC" value="/" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="5FtAU1qmVmz" role="3cqZAp">
+          <node concept="37vLTw" id="5FtAU1qmVm$" role="3cqZAk">
+            <ref role="3cqZAo" node="5FtAU1qmVmu" resolve="mdlOutputRootInGenFolder" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="5FtAU1qmVm_" role="3clF46">
+        <property role="TrG5h" value="m" />
+        <node concept="3uibUv" id="5FtAU1qmVmA" role="1tU5fm">
+          <ref role="3uigEE" to="z1c3:~AbstractModule" resolve="AbstractModule" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="5FtAU1qmVmB" role="3clF46">
+        <property role="TrG5h" value="model" />
+        <node concept="H_c77" id="6RvWQYjPJo0" role="1tU5fm" />
+      </node>
+      <node concept="3uibUv" id="5FtAU1qmVmC" role="3clF45">
+        <ref role="3uigEE" to="guwi:~File" resolve="File" />
+      </node>
+      <node concept="3Tm1VV" id="5FtAU1qmVmD" role="1B3o_S" />
+    </node>
     <node concept="2tJIrI" id="6RvWQYjPIE5" role="jymVt" />
     <node concept="2YIFZL" id="6RvWQYjPOPp" role="jymVt">
       <property role="TrG5h" value="getOutputLocation" />

--- a/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/languageModels/plugin.mps
+++ b/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/languageModels/plugin.mps
@@ -149,6 +149,7 @@
       <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
       <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
       <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
+      <concept id="1225271408483" name="jetbrains.mps.baseLanguage.structure.IsNotEmptyOperation" flags="nn" index="17RvpY" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
       </concept>
@@ -179,6 +180,7 @@
       <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
         <property id="1068580320021" name="value" index="3cmrfH" />
       </concept>
+      <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
       <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
         <child id="1068581517676" name="expression" index="3cqZAk" />
       </concept>
@@ -1462,51 +1464,79 @@
       <property role="DiZV1" value="false" />
       <property role="2aFKle" value="false" />
       <node concept="3clFbS" id="5mrX3UfrYsU" role="3clF47">
-        <node concept="3clFbF" id="5mrX3UfrYCF" role="3cqZAp">
-          <node concept="2OqwBi" id="5mrX3UfrYCH" role="3clFbG">
-            <node concept="2OqwBi" id="5mrX3UfrZkC" role="2Oq$k0">
-              <node concept="2OqwBi" id="5FtAU1q6szo" role="2Oq$k0">
-                <node concept="2OqwBi" id="5mrX3UfrYCI" role="2Oq$k0">
-                  <node concept="2OqwBi" id="5mrX3UfrYCJ" role="2Oq$k0">
-                    <node concept="2OqwBi" id="5mrX3UfrYCK" role="2Oq$k0">
-                      <node concept="2JrnkZ" id="5mrX3UfrYCL" role="2Oq$k0">
-                        <node concept="2OqwBi" id="5mrX3UfrYCM" role="2JrQYb">
-                          <node concept="37vLTw" id="5mrX3UfrYCN" role="2Oq$k0">
-                            <ref role="3cqZAo" node="5mrX3UfrYC8" resolve="node" />
-                          </node>
-                          <node concept="I4A8Y" id="5mrX3UfrYCO" role="2OqNvi" />
-                        </node>
+        <node concept="3cpWs8" id="5FtAU1qq$T9" role="3cqZAp">
+          <node concept="3cpWsn" id="5FtAU1qq$Ta" role="3cpWs9">
+            <property role="TrG5h" value="location" />
+            <node concept="17QB3L" id="5FtAU1qqOYj" role="1tU5fm" />
+            <node concept="2OqwBi" id="5FtAU1qq$Tc" role="33vP2m">
+              <node concept="2OqwBi" id="5FtAU1qq$Td" role="2Oq$k0">
+                <node concept="2OqwBi" id="5FtAU1qq$Te" role="2Oq$k0">
+                  <node concept="2JrnkZ" id="5FtAU1qq$Tf" role="2Oq$k0">
+                    <node concept="2OqwBi" id="5FtAU1qq$Tg" role="2JrQYb">
+                      <node concept="37vLTw" id="5FtAU1qq$Th" role="2Oq$k0">
+                        <ref role="3cqZAo" node="5mrX3UfrYC8" resolve="node" />
                       </node>
-                      <node concept="liA8E" id="5mrX3UfrYCP" role="2OqNvi">
-                        <ref role="37wK5l" to="mhbf:~SModel.getReference():org.jetbrains.mps.openapi.model.SModelReference" resolve="getReference" />
-                      </node>
-                    </node>
-                    <node concept="liA8E" id="5mrX3UfrYCQ" role="2OqNvi">
-                      <ref role="37wK5l" to="mhbf:~SModelReference.getName():org.jetbrains.mps.openapi.model.SModelName" resolve="getName" />
+                      <node concept="I4A8Y" id="5FtAU1qq$Ti" role="2OqNvi" />
                     </node>
                   </node>
-                  <node concept="liA8E" id="5mrX3UfrYCR" role="2OqNvi">
-                    <ref role="37wK5l" to="mhbf:~SModelName.getLongName():java.lang.String" resolve="getLongName" />
+                  <node concept="liA8E" id="5FtAU1qq$Tj" role="2OqNvi">
+                    <ref role="37wK5l" to="mhbf:~SModel.getReference():org.jetbrains.mps.openapi.model.SModelReference" resolve="getReference" />
                   </node>
                 </node>
-                <node concept="liA8E" id="5FtAU1q6t49" role="2OqNvi">
-                  <ref role="37wK5l" to="wyt6:~String.concat(java.lang.String):java.lang.String" resolve="concat" />
-                  <node concept="Xl_RD" id="5FtAU1q6tgy" role="37wK5m">
-                    <property role="Xl_RC" value="/" />
+                <node concept="liA8E" id="5FtAU1qq$Tk" role="2OqNvi">
+                  <ref role="37wK5l" to="mhbf:~SModelReference.getName():org.jetbrains.mps.openapi.model.SModelName" resolve="getName" />
+                </node>
+              </node>
+              <node concept="liA8E" id="5FtAU1qq$Tl" role="2OqNvi">
+                <ref role="37wK5l" to="mhbf:~SModelName.getLongName():java.lang.String" resolve="getLongName" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="5FtAU1qqAwm" role="3cqZAp">
+          <node concept="3clFbS" id="5FtAU1qqAwo" role="3clFbx">
+            <node concept="3clFbF" id="5FtAU1qqDCn" role="3cqZAp">
+              <node concept="37vLTI" id="5FtAU1qqDUd" role="3clFbG">
+                <node concept="37vLTw" id="5FtAU1qqDCl" role="37vLTJ">
+                  <ref role="3cqZAo" node="5FtAU1qq$Ta" resolve="location" />
+                </node>
+                <node concept="3cpWs3" id="5FtAU1qqYRO" role="37vLTx">
+                  <node concept="3cpWs3" id="5FtAU1qr1CM" role="3uHU7B">
+                    <node concept="Xl_RD" id="5FtAU1qr1Jv" role="3uHU7w">
+                      <property role="Xl_RC" value="/" />
+                    </node>
+                    <node concept="37vLTw" id="5FtAU1qq$To" role="3uHU7B">
+                      <ref role="3cqZAo" node="5FtAU1qq$Ta" resolve="location" />
+                    </node>
+                  </node>
+                  <node concept="2OqwBi" id="5mrX3Ufs15p" role="3uHU7w">
+                    <node concept="37vLTw" id="5mrX3Ufs0PG" role="2Oq$k0">
+                      <ref role="3cqZAo" node="5mrX3UfrYC8" resolve="node" />
+                    </node>
+                    <node concept="3TrcHB" id="5mrX3Ufs1_b" role="2OqNvi">
+                      <ref role="3TsBF5" to="tpck:hnGE5uv" resolve="virtualPackage" />
+                    </node>
                   </node>
                 </node>
               </node>
-              <node concept="liA8E" id="5mrX3Ufs0_G" role="2OqNvi">
-                <ref role="37wK5l" to="wyt6:~String.concat(java.lang.String):java.lang.String" resolve="concat" />
-                <node concept="2OqwBi" id="5mrX3Ufs15p" role="37wK5m">
-                  <node concept="37vLTw" id="5mrX3Ufs0PG" role="2Oq$k0">
-                    <ref role="3cqZAo" node="5mrX3UfrYC8" resolve="node" />
-                  </node>
-                  <node concept="3TrcHB" id="5mrX3Ufs1_b" role="2OqNvi">
-                    <ref role="3TsBF5" to="tpck:hnGE5uv" resolve="virtualPackage" />
-                  </node>
-                </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="5FtAU1qqChz" role="3clFbw">
+            <node concept="2OqwBi" id="5FtAU1qqAVF" role="2Oq$k0">
+              <node concept="37vLTw" id="5FtAU1qqAFL" role="2Oq$k0">
+                <ref role="3cqZAo" node="5mrX3UfrYC8" resolve="node" />
               </node>
+              <node concept="3TrcHB" id="5FtAU1qqBlp" role="2OqNvi">
+                <ref role="3TsBF5" to="tpck:hnGE5uv" resolve="virtualPackage" />
+              </node>
+            </node>
+            <node concept="17RvpY" id="5FtAU1qqCM2" role="2OqNvi" />
+          </node>
+        </node>
+        <node concept="3cpWs6" id="5FtAU1qqEqY" role="3cqZAp">
+          <node concept="2OqwBi" id="5FtAU1qqZTa" role="3cqZAk">
+            <node concept="37vLTw" id="5FtAU1qqEyJ" role="2Oq$k0">
+              <ref role="3cqZAo" node="5FtAU1qq$Ta" resolve="location" />
             </node>
             <node concept="liA8E" id="5mrX3UfrYCS" role="2OqNvi">
               <ref role="37wK5l" to="wyt6:~String.replace(java.lang.CharSequence,java.lang.CharSequence):java.lang.String" resolve="replace" />

--- a/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/languageModels/plugin.mps
+++ b/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/languageModels/plugin.mps
@@ -31,6 +31,7 @@
     <import index="8oaq" ref="b0f8641f-bd77-4421-8425-30d9088a82f7/java:org.apache.commons.io(org.apache.commons/)" />
     <import index="qq03" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.ide.actions(MPS.Platform/)" implicit="true" />
     <import index="fy8e" ref="r:89c0fb70-0977-7777-a076-5906f9d8630f(jetbrains.mps.make.facets)" implicit="true" />
+    <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
   </imports>
   <registry>
     <language id="a247e09e-2435-45ba-b8d2-07e93feba96a" name="jetbrains.mps.baseLanguage.tuples">
@@ -217,6 +218,7 @@
         <child id="1178549979242" name="visibility" index="1B3o_S" />
       </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
+      <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
       <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
     </language>
     <language id="63650c59-16c8-498a-99c8-005c7ee9515d" name="jetbrains.mps.lang.access">
@@ -281,6 +283,7 @@
         <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
       </concept>
       <concept id="1143226024141" name="jetbrains.mps.lang.smodel.structure.SModelType" flags="in" index="H_c77" />
+      <concept id="1143234257716" name="jetbrains.mps.lang.smodel.structure.Node_GetModelOperation" flags="nn" index="I4A8Y" />
       <concept id="1145404486709" name="jetbrains.mps.lang.smodel.structure.SemanticDowncastExpression" flags="nn" index="2JrnkZ">
         <child id="1145404616321" name="leftExpression" index="2JrQYb" />
       </concept>
@@ -1224,35 +1227,10 @@
                 <node concept="37vLTw" id="49PUF$HTuNO" role="37wK5m">
                   <ref role="3cqZAo" node="49PUF$HTiTU" resolve="docGenRoot" />
                 </node>
-                <node concept="2OqwBi" id="6RvWQYjPIJJ" role="37wK5m">
-                  <node concept="2OqwBi" id="6RvWQYjPIJK" role="2Oq$k0">
-                    <node concept="2OqwBi" id="6RvWQYjPIJL" role="2Oq$k0">
-                      <node concept="2OqwBi" id="6RvWQYjPIJM" role="2Oq$k0">
-                        <node concept="2JrnkZ" id="49PUF$HTuNT" role="2Oq$k0">
-                          <node concept="37vLTw" id="6RvWQYjPMnf" role="2JrQYb">
-                            <ref role="3cqZAo" node="6RvWQYjPJeF" resolve="model" />
-                          </node>
-                        </node>
-                        <node concept="liA8E" id="6RvWQYjPIJN" role="2OqNvi">
-                          <ref role="37wK5l" to="mhbf:~SModel.getReference():org.jetbrains.mps.openapi.model.SModelReference" resolve="getReference" />
-                        </node>
-                      </node>
-                      <node concept="liA8E" id="6RvWQYjPIJO" role="2OqNvi">
-                        <ref role="37wK5l" to="mhbf:~SModelReference.getName():org.jetbrains.mps.openapi.model.SModelName" resolve="getName" />
-                      </node>
-                    </node>
-                    <node concept="liA8E" id="6RvWQYjPIJP" role="2OqNvi">
-                      <ref role="37wK5l" to="mhbf:~SModelName.getLongName():java.lang.String" resolve="getLongName" />
-                    </node>
-                  </node>
-                  <node concept="liA8E" id="6RvWQYjPIJQ" role="2OqNvi">
-                    <ref role="37wK5l" to="wyt6:~String.replace(java.lang.CharSequence,java.lang.CharSequence):java.lang.String" resolve="replace" />
-                    <node concept="Xl_RD" id="6RvWQYjPIJR" role="37wK5m">
-                      <property role="Xl_RC" value="." />
-                    </node>
-                    <node concept="Xl_RD" id="6RvWQYjPIJS" role="37wK5m">
-                      <property role="Xl_RC" value="/" />
-                    </node>
+                <node concept="1rXfSq" id="5mrX3Ufs3Dq" role="37wK5m">
+                  <ref role="37wK5l" node="5mrX3UfrYsR" resolve="getNodeRelativeLocation" />
+                  <node concept="37vLTw" id="5mrX3Ufs4eG" role="37wK5m">
+                    <ref role="3cqZAo" node="6RvWQYjPJeF" resolve="node" />
                   </node>
                 </node>
               </node>
@@ -1272,14 +1250,15 @@
         </node>
       </node>
       <node concept="37vLTG" id="6RvWQYjPJeF" role="3clF46">
-        <property role="TrG5h" value="model" />
-        <node concept="H_c77" id="6RvWQYjPJo0" role="1tU5fm" />
+        <property role="TrG5h" value="node" />
+        <node concept="3Tqbb2" id="5mrX3UfrXp3" role="1tU5fm" />
       </node>
       <node concept="3uibUv" id="6RvWQYjPOJD" role="3clF45">
         <ref role="3uigEE" to="guwi:~File" resolve="File" />
       </node>
       <node concept="3Tm1VV" id="6RvWQYjPII1" role="1B3o_S" />
     </node>
+    <node concept="2tJIrI" id="5mrX3UfrY3F" role="jymVt" />
     <node concept="2YIFZL" id="2DWJLXXzCiq" role="jymVt">
       <property role="TrG5h" value="getDocGenFolder" />
       <property role="od$2w" value="false" />
@@ -1359,6 +1338,70 @@
         <node concept="3uibUv" id="2DWJLXXzCre" role="1tU5fm">
           <ref role="3uigEE" to="z1c3:~AbstractModule" resolve="AbstractModule" />
         </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="5mrX3UfrY77" role="jymVt" />
+    <node concept="2YIFZL" id="5mrX3UfrYsR" role="jymVt">
+      <property role="TrG5h" value="getNodeRelativeLocation" />
+      <property role="od$2w" value="false" />
+      <property role="DiZV1" value="false" />
+      <property role="2aFKle" value="false" />
+      <node concept="3clFbS" id="5mrX3UfrYsU" role="3clF47">
+        <node concept="3clFbF" id="5mrX3UfrYCF" role="3cqZAp">
+          <node concept="2OqwBi" id="5mrX3UfrYCH" role="3clFbG">
+            <node concept="2OqwBi" id="5mrX3UfrZkC" role="2Oq$k0">
+              <node concept="2OqwBi" id="5mrX3UfrYCI" role="2Oq$k0">
+                <node concept="2OqwBi" id="5mrX3UfrYCJ" role="2Oq$k0">
+                  <node concept="2OqwBi" id="5mrX3UfrYCK" role="2Oq$k0">
+                    <node concept="2JrnkZ" id="5mrX3UfrYCL" role="2Oq$k0">
+                      <node concept="2OqwBi" id="5mrX3UfrYCM" role="2JrQYb">
+                        <node concept="37vLTw" id="5mrX3UfrYCN" role="2Oq$k0">
+                          <ref role="3cqZAo" node="5mrX3UfrYC8" resolve="node" />
+                        </node>
+                        <node concept="I4A8Y" id="5mrX3UfrYCO" role="2OqNvi" />
+                      </node>
+                    </node>
+                    <node concept="liA8E" id="5mrX3UfrYCP" role="2OqNvi">
+                      <ref role="37wK5l" to="mhbf:~SModel.getReference():org.jetbrains.mps.openapi.model.SModelReference" resolve="getReference" />
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="5mrX3UfrYCQ" role="2OqNvi">
+                    <ref role="37wK5l" to="mhbf:~SModelReference.getName():org.jetbrains.mps.openapi.model.SModelName" resolve="getName" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="5mrX3UfrYCR" role="2OqNvi">
+                  <ref role="37wK5l" to="mhbf:~SModelName.getLongName():java.lang.String" resolve="getLongName" />
+                </node>
+              </node>
+              <node concept="liA8E" id="5mrX3Ufs0_G" role="2OqNvi">
+                <ref role="37wK5l" to="wyt6:~String.concat(java.lang.String):java.lang.String" resolve="concat" />
+                <node concept="2OqwBi" id="5mrX3Ufs15p" role="37wK5m">
+                  <node concept="37vLTw" id="5mrX3Ufs0PG" role="2Oq$k0">
+                    <ref role="3cqZAo" node="5mrX3UfrYC8" resolve="node" />
+                  </node>
+                  <node concept="3TrcHB" id="5mrX3Ufs1_b" role="2OqNvi">
+                    <ref role="3TsBF5" to="tpck:hnGE5uv" resolve="virtualPackage" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="liA8E" id="5mrX3UfrYCS" role="2OqNvi">
+              <ref role="37wK5l" to="wyt6:~String.replace(java.lang.CharSequence,java.lang.CharSequence):java.lang.String" resolve="replace" />
+              <node concept="Xl_RD" id="5mrX3UfrYCT" role="37wK5m">
+                <property role="Xl_RC" value="." />
+              </node>
+              <node concept="Xl_RD" id="5mrX3UfrYCU" role="37wK5m">
+                <property role="Xl_RC" value="/" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm6S6" id="5mrX3UfrYhA" role="1B3o_S" />
+      <node concept="17QB3L" id="5mrX3UfrYsH" role="3clF45" />
+      <node concept="37vLTG" id="5mrX3UfrYC8" role="3clF46">
+        <property role="TrG5h" value="node" />
+        <node concept="3Tqbb2" id="5mrX3UfrYC7" role="1tU5fm" />
       </node>
     </node>
     <node concept="2tJIrI" id="6RvWQYjPIEa" role="jymVt" />

--- a/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/languageModels/structure.mps
+++ b/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/languageModels/structure.mps
@@ -1729,5 +1729,27 @@
       <ref role="20lvS9" node="2TZO3DbuxwK" resolve="Document" />
     </node>
   </node>
+  <node concept="1TIwiD" id="4VYjeLHNjIp">
+    <property role="EcuMT" value="5692071557381045145" />
+    <property role="TrG5h" value="TemporaryFileName" />
+    <ref role="1TJDcQ" to="tpck:2ULFgo8_XDk" resolve="NodeAttribute" />
+    <node concept="1TJgyi" id="4VYjeLHNjIw" role="1TKVEl">
+      <property role="IQ2nx" value="5692071557381045152" />
+      <property role="TrG5h" value="name" />
+      <ref role="AX2Wp" to="tpck:fKAOsGN" resolve="string" />
+    </node>
+    <node concept="M6xJ_" id="4VYjeLHNjIq" role="lGtFl">
+      <property role="Hh88m" value="tempFileName" />
+      <node concept="tn0Fv" id="4VYjeLHNjIu" role="HhnKV">
+        <property role="tnX3d" value="false" />
+      </node>
+      <node concept="trNpa" id="4VYjeLHNLKB" role="EQaZv">
+        <ref role="trN6q" to="tpck:gw2VY9q" resolve="BaseConcept" />
+      </node>
+    </node>
+    <node concept="t5JxF" id="4VYjeLHNXKZ" role="lGtFl">
+      <property role="t5JxN" value="Annotation can be use used to avoid documents naming conflicts. Annotated documents will be generated with name property from this annotation." />
+    </node>
+  </node>
 </model>
 


### PR DESCRIPTION
Added a new annotation that allows handling conflicting generated document file names.

During generation one can use the annotation to make sure all names are unique, when copying the documents to doc_gen folder the facet makes sure that the names are again replaced with the original file name (as there we keep the folder structure from the node).

Downstream projects have to implement its own logic for attaching the annotation as per default the framework doesn't do it.