### PR TITLE
smaller plugins in mpsutil

### DIFF
--- a/code/languages/com.mbeddr.build/solutions/com.mbeddr.platform/models/com/mbeddr/platform/build.mps
+++ b/code/languages/com.mbeddr.build/solutions/com.mbeddr.platform/models/com/mbeddr/platform/build.mps
@@ -532,6 +532,36 @@
         <ref role="m$f5T" node="3quoVcnOFk5" resolve="group.suppresswarning" />
       </node>
     </node>
+    <node concept="m$_wf" id="64SK4bcNyQW" role="3989C9">
+      <property role="m$_wk" value="com.mbeddr.mpsutil.editorsupport" />
+      <node concept="3_J27D" id="64SK4bcNyQX" role="m$_yQ">
+        <node concept="3Mxwew" id="64SK4bcNyQY" role="3MwsjC">
+          <property role="3MwjfP" value="com.mbeddr.mpsutil.editorsupport" />
+        </node>
+      </node>
+      <node concept="3_J27D" id="64SK4bcNyQZ" role="m_cZH">
+        <node concept="3Mxwew" id="64SK4bcNyR0" role="3MwsjC">
+          <property role="3MwjfP" value="com.mbeddr.mpsutil.editorsupport" />
+        </node>
+      </node>
+      <node concept="3_J27D" id="64SK4bcNyR1" role="m$_w8">
+        <node concept="3Mxwey" id="64SK4bcNyR2" role="3MwsjC">
+          <ref role="3Mxwex" node="2HHioL2Nii3" resolve="mbeddr.version" />
+        </node>
+      </node>
+      <node concept="m$_yC" id="64SK4bcNyR3" role="m$_yJ">
+        <ref role="m$_y1" to="ffeo:4k71ibbKLe8" resolve="jetbrains.mps.core" />
+      </node>
+      <node concept="m$_yC" id="64SK4bcNEcS" role="m$_yJ">
+        <ref role="m$_y1" to="90a9:2Xjt3l57iTJ" resolve="de.slisson.mps.hacks" />
+      </node>
+      <node concept="m$_yC" id="64SK4bcNGsF" role="m$_yJ">
+        <ref role="m$_y1" to="ffeo:4k71ibbLe59" resolve="com.intellij.modules.mps" />
+      </node>
+      <node concept="m$f5U" id="64SK4bcNBX9" role="m$_yh">
+        <ref role="m$f5T" node="3quoVcnPZaE" resolve="group.editor-support" />
+      </node>
+    </node>
     <node concept="m$_wf" id="7uZw0yZ2_Jq" role="3989C9">
       <property role="m$_wk" value="com.mbeddr.mpsutil" />
       <node concept="m$_yC" id="64SK4bcJIU1" role="m$_yJ">
@@ -564,9 +594,6 @@
       </node>
       <node concept="m$f5U" id="3quoVcnS5bT" role="m$_yh">
         <ref role="m$f5T" node="3quoVcnQoOk" resolve="group.lang-support" />
-      </node>
-      <node concept="m$f5U" id="3quoVcnS4ZU" role="m$_yh">
-        <ref role="m$f5T" node="3quoVcnPZaE" resolve="group.editor-support" />
       </node>
       <node concept="m$f5U" id="3quoVcnS51A" role="m$_yh">
         <ref role="m$f5T" node="3quoVcnQS0C" resolve="group.gen-support" />
@@ -705,6 +732,9 @@
       </node>
       <node concept="m$_yC" id="3lZeU8ehJeh" role="m$_yJ">
         <ref role="m$_y1" node="3lZeU8ehrPx" resolve="com.mbeddr.mpsutil.httpsupport" />
+      </node>
+      <node concept="m$_yC" id="64SK4bcNIGW" role="m$_yJ">
+        <ref role="m$_y1" node="64SK4bcNyQW" resolve="com.mbeddr.mpsutil.editorsupport" />
       </node>
       <node concept="3_J27D" id="7uZw0yZ2_Jx" role="m_cZH">
         <node concept="3Mxwew" id="7uZw0yZ2_Jy" role="3MwsjC">
@@ -1273,11 +1303,14 @@
       <node concept="m$f5U" id="5l4WPWBtj0o" role="m$_yh">
         <ref role="m$f5T" node="5l4WPWBt8tR" resolve="com.mbeddr.doc.devkit" />
       </node>
-      <node concept="m$_yC" id="6ucYLjokHyJ" role="m$_yJ">
-        <ref role="m$_y1" node="7uZw0yZ2_Jq" resolve="com.mbeddr.mpsutil" />
-      </node>
       <node concept="m$_yC" id="5A_Zlt6D3p_" role="m$_yJ">
         <ref role="m$_y1" to="90a9:29so9Vb$6Tj" resolve="de.slisson.mps.tables" />
+      </node>
+      <node concept="m$_yC" id="64SK4bcKi0o" role="m$_yJ">
+        <ref role="m$_y1" to="90a9:7szUFELHeHf" resolve="de.itemis.mps.editor.widgets" />
+      </node>
+      <node concept="m$_yC" id="64SK4bcNM6e" role="m$_yJ">
+        <ref role="m$_y1" node="64SK4bcNyQW" resolve="com.mbeddr.mpsutil.editorsupport" />
       </node>
       <node concept="3_J27D" id="7tNo_gxoK8o" role="m_cZH">
         <node concept="3Mxwew" id="7tNo_gxoK8p" role="3MwsjC">
@@ -15373,24 +15406,6 @@
           <node concept="3bR9La" id="36BjQjBL5YS" role="1SiIV1">
             <property role="3bR36h" value="false" />
             <ref role="3bR37D" node="2N1CSrzSJt4" resolve="com.mbeddr.mpsutil.plantuml.pluginSolution" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="1JQAezFYA01" role="3bR37C">
-          <node concept="3bR9La" id="1JQAezFYA02" role="1SiIV1">
-            <property role="3bR36h" value="false" />
-            <ref role="3bR37D" to="ffeo:7Kfy9QB6L8Y" resolve="jetbrains.mps.lang.project" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="79i$vAY6Rp7" role="3bR37C">
-          <node concept="3bR9La" id="79i$vAY6Rp8" role="1SiIV1">
-            <property role="3bR36h" value="false" />
-            <ref role="3bR37D" node="1qdZ14g6jVZ" resolve="com.mbeddr.mpsutil.margincell" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="3$$jtHg5w0g" role="3bR37C">
-          <node concept="3bR9La" id="3$$jtHg5w0h" role="1SiIV1">
-            <property role="3bR36h" value="false" />
-            <ref role="3bR37D" node="1YMM4SJ2m0" resolve="com.mbeddr.doc" />
           </node>
         </node>
         <node concept="1SiIV0" id="2DWJLXXAtVX" role="3bR37C">

--- a/code/languages/com.mbeddr.build/solutions/com.mbeddr.platform/models/com/mbeddr/platform/build.mps
+++ b/code/languages/com.mbeddr.build/solutions/com.mbeddr.platform/models/com/mbeddr/platform/build.mps
@@ -267,14 +267,17 @@
       <node concept="m$_yC" id="vOGyTeKxr6" role="m$_yJ">
         <ref role="m$_y1" to="ffeo:4k71ibbKLe8" resolve="jetbrains.mps.core" />
       </node>
-      <node concept="m$_yC" id="vOGyTeMzpM" role="m$_yJ">
-        <ref role="m$_y1" node="7uZw0yZ2_Jq" resolve="com.mbeddr.mpsutil" />
-      </node>
       <node concept="m$_yC" id="vOGyTeMA5D" role="m$_yJ">
         <ref role="m$_y1" node="Vtr7jyB0oM" resolve="com.mbeddr.mpsutil.filepicker" />
       </node>
       <node concept="m$_yC" id="5ZsrU$Jfnm_" role="m$_yJ">
         <ref role="m$_y1" node="5fGcQI8WTaQ" resolve="com.mbeddr.mpsutil.smodule" />
+      </node>
+      <node concept="m$_yC" id="64SK4bcNSkG" role="m$_yJ">
+        <ref role="m$_y1" to="90a9:4p3FRivDLPy" resolve="org.apache.commons" />
+      </node>
+      <node concept="m$_yC" id="64SK4bcNVGq" role="m$_yJ">
+        <ref role="m$_y1" node="DnqfiuSO_Q" resolve="com.mbeddr.mpsutil.compare" />
       </node>
     </node>
     <node concept="m$_wf" id="33r_JpZ6k_l" role="3989C9">
@@ -1318,7 +1321,7 @@
         </node>
       </node>
       <node concept="2iUeEo" id="7tNo_gxoK8t" role="2iVFfd">
-        <property role="2iUeEt" value="mbedrr" />
+        <property role="2iUeEt" value="mbeddr" />
         <property role="2iUeEu" value="http://mbeddr.com" />
       </node>
     </node>

--- a/code/languages/com.mbeddr.build/solutions/com.mbeddr.platform/models/com/mbeddr/platform/build.mps
+++ b/code/languages/com.mbeddr.build/solutions/com.mbeddr.platform/models/com/mbeddr/platform/build.mps
@@ -2,10 +2,10 @@
 <model ref="r:742f344d-4dc4-4862-992c-4bc94b094870(com.mbeddr.mpsutil.dev.build)">
   <persistence version="9" />
   <languages>
-    <use id="798100da-4f0a-421a-b991-71f8c50ce5d2" name="jetbrains.mps.build" version="0" />
-    <use id="0cf935df-4699-4e9c-a132-fa109541cba3" name="jetbrains.mps.build.mps" version="5" />
-    <use id="479c7a8c-02f9-43b5-9139-d910cb22f298" name="jetbrains.mps.core.xml" version="0" />
-    <use id="3600cb0a-44dd-4a5b-9968-22924406419e" name="jetbrains.mps.build.mps.tests" version="0" />
+    <use id="798100da-4f0a-421a-b991-71f8c50ce5d2" name="jetbrains.mps.build" version="-1" />
+    <use id="0cf935df-4699-4e9c-a132-fa109541cba3" name="jetbrains.mps.build.mps" version="-1" />
+    <use id="479c7a8c-02f9-43b5-9139-d910cb22f298" name="jetbrains.mps.core.xml" version="-1" />
+    <use id="3600cb0a-44dd-4a5b-9968-22924406419e" name="jetbrains.mps.build.mps.tests" version="-1" />
   </languages>
   <imports>
     <import index="ffeo" ref="r:874d959d-e3b4-4d04-b931-ca849af130dd(jetbrains.mps.ide.build)" />
@@ -155,9 +155,6 @@
       </concept>
       <concept id="6592112598314498926" name="jetbrains.mps.build.mps.structure.BuildMpsLayout_Plugin" flags="ng" index="m$_wl">
         <reference id="6592112598314801433" name="plugin" index="m_rDy" />
-      </concept>
-      <concept id="6592112598314499036" name="jetbrains.mps.build.mps.structure.BuildMps_IdeaPluginModule" flags="ng" index="m$_yB">
-        <reference id="6592112598314499037" name="target" index="m$_yA" />
       </concept>
       <concept id="6592112598314499027" name="jetbrains.mps.build.mps.structure.BuildMps_IdeaPluginDependency" flags="ng" index="m$_yC">
         <reference id="6592112598314499066" name="target" index="m$_y1" />
@@ -475,42 +472,6 @@
         <ref role="m$_y1" to="ffeo:4k71ibbKLe8" resolve="jetbrains.mps.core" />
       </node>
     </node>
-    <node concept="m$_wf" id="64SK4bcJmGP" role="3989C9">
-      <property role="m$_wk" value="com.mbeddr.mpsutil.plantuml" />
-      <node concept="3_J27D" id="64SK4bcJmGQ" role="m$_yQ">
-        <node concept="3Mxwew" id="64SK4bcJmGR" role="3MwsjC">
-          <property role="3MwjfP" value="com.mbeddr.mpsutil.plantuml" />
-        </node>
-      </node>
-      <node concept="3_J27D" id="64SK4bcJmGS" role="m_cZH">
-        <node concept="3Mxwew" id="64SK4bcJmGT" role="3MwsjC">
-          <property role="3MwjfP" value="com.mbeddr.mpsutil.plantuml" />
-        </node>
-      </node>
-      <node concept="3_J27D" id="64SK4bcJmGU" role="m$_w8">
-        <node concept="3Mxwey" id="64SK4bcJmGV" role="3MwsjC">
-          <ref role="3Mxwex" node="2HHioL2Nii3" resolve="mbeddr.version" />
-        </node>
-      </node>
-      <node concept="m$f5U" id="64SK4bcJwhC" role="m$_yh">
-        <ref role="m$f5T" node="3quoVcnL8hF" resolve="group.plantuml" />
-      </node>
-      <node concept="m$f5U" id="11w71XmfHEh" role="m$_yh">
-        <ref role="m$f5T" node="11w71XmfwQH" resolve="group.apis" />
-      </node>
-      <node concept="m$_yC" id="64SK4bcJmGX" role="m$_yJ">
-        <ref role="m$_y1" to="ffeo:4k71ibbKLe8" resolve="jetbrains.mps.core" />
-      </node>
-      <node concept="m$_yC" id="64SK4bcJyxn" role="m$_yJ">
-        <ref role="m$_y1" to="90a9:6860Y5_ZW8e" resolve="de.itemis.mps.utils" />
-      </node>
-      <node concept="m$_yC" id="64SK4bcJ_T5" role="m$_yJ">
-        <ref role="m$_y1" to="ffeo:5xhjlkpPhJu" resolve="jetbrains.mps.ide.httpsupport" />
-      </node>
-      <node concept="m$_yC" id="64SK4bcJC8W" role="m$_yJ">
-        <ref role="m$_y1" node="3lZeU8ehrPx" resolve="com.mbeddr.mpsutil.httpsupport" />
-      </node>
-    </node>
     <node concept="m$_wf" id="64SK4bcJTt6" role="3989C9">
       <property role="m$_wk" value="com.mbeddr.mpsutil.suppresswarning" />
       <node concept="3_J27D" id="64SK4bcJTt7" role="m$_yQ">
@@ -533,36 +494,6 @@
       </node>
       <node concept="m$f5U" id="64SK4bcJZF8" role="m$_yh">
         <ref role="m$f5T" node="3quoVcnOFk5" resolve="group.suppresswarning" />
-      </node>
-    </node>
-    <node concept="m$_wf" id="64SK4bcNyQW" role="3989C9">
-      <property role="m$_wk" value="com.mbeddr.mpsutil.editorsupport" />
-      <node concept="3_J27D" id="64SK4bcNyQX" role="m$_yQ">
-        <node concept="3Mxwew" id="64SK4bcNyQY" role="3MwsjC">
-          <property role="3MwjfP" value="com.mbeddr.mpsutil.editorsupport" />
-        </node>
-      </node>
-      <node concept="3_J27D" id="64SK4bcNyQZ" role="m_cZH">
-        <node concept="3Mxwew" id="64SK4bcNyR0" role="3MwsjC">
-          <property role="3MwjfP" value="com.mbeddr.mpsutil.editorsupport" />
-        </node>
-      </node>
-      <node concept="3_J27D" id="64SK4bcNyR1" role="m$_w8">
-        <node concept="3Mxwey" id="64SK4bcNyR2" role="3MwsjC">
-          <ref role="3Mxwex" node="2HHioL2Nii3" resolve="mbeddr.version" />
-        </node>
-      </node>
-      <node concept="m$_yC" id="64SK4bcNyR3" role="m$_yJ">
-        <ref role="m$_y1" to="ffeo:4k71ibbKLe8" resolve="jetbrains.mps.core" />
-      </node>
-      <node concept="m$_yC" id="64SK4bcNEcS" role="m$_yJ">
-        <ref role="m$_y1" to="90a9:2Xjt3l57iTJ" resolve="de.slisson.mps.hacks" />
-      </node>
-      <node concept="m$_yC" id="64SK4bcNGsF" role="m$_yJ">
-        <ref role="m$_y1" to="ffeo:4k71ibbLe59" resolve="com.intellij.modules.mps" />
-      </node>
-      <node concept="m$f5U" id="64SK4bcNBX9" role="m$_yh">
-        <ref role="m$f5T" node="3quoVcnPZaE" resolve="group.editor-support" />
       </node>
     </node>
     <node concept="m$_wf" id="64SK4bcO2rO" role="3989C9">
@@ -793,12 +724,6 @@
       <node concept="m$f5U" id="2AIoSLVXUQp" role="m$_yh">
         <ref role="m$f5T" node="2AIoSLVX$h0" resolve="group.licensemanager" />
       </node>
-      <node concept="m$f5U" id="7uOgiTayfm" role="m$_yh">
-        <ref role="m$f5T" node="7uOgiTa68Q" resolve="group.jfreechart" />
-      </node>
-      <node concept="m$f5U" id="2jlBy7bQIhH" role="m$_yh">
-        <ref role="m$f5T" node="2jlBy7bQlGk" resolve="group.treenotation" />
-      </node>
       <node concept="m$f5U" id="4kGsAe0vUjA" role="m$_yh">
         <ref role="m$f5T" node="4kGsAe0vxvm" resolve="com.mbeddr.mpsutil.resources" />
       </node>
@@ -870,6 +795,12 @@
       </node>
       <node concept="m$_yC" id="6rBfBe1XpxG" role="m$_yJ">
         <ref role="m$_y1" node="6rBfBe1XaAA" resolve="com.mbeddr.mpsutil.contextactions" />
+      </node>
+      <node concept="m$_yC" id="1Rj3F434EFj" role="m$_yJ">
+        <ref role="m$_y1" node="1Rj3F434oop" resolve="com.mbeddr.mpsutil.treenotations" />
+      </node>
+      <node concept="m$_yC" id="1Rj3F434X7F" role="m$_yJ">
+        <ref role="m$_y1" node="1Rj3F434M3n" resolve="com.mbeddr.mpsutil.jfreechart" />
       </node>
       <node concept="3_J27D" id="7uZw0yZ2_Jx" role="m_cZH">
         <node concept="3Mxwew" id="7uZw0yZ2_Jy" role="3MwsjC">
@@ -1148,42 +1079,6 @@
         </node>
       </node>
     </node>
-    <node concept="m$_wf" id="DnqfiuSO_Q" role="3989C9">
-      <property role="m$_wk" value="com.mbeddr.mpsutil.compare" />
-      <node concept="3_J27D" id="DnqfiuSO_R" role="m$_yQ">
-        <node concept="3Mxwew" id="DnqfiuSO_S" role="3MwsjC">
-          <property role="3MwjfP" value="com.mbeddr.mpsutil.compare" />
-        </node>
-      </node>
-      <node concept="3_J27D" id="DnqfiuSO_T" role="m$_w8">
-        <node concept="3Mxwey" id="DnqfiuSO_U" role="3MwsjC">
-          <ref role="3Mxwex" node="2HHioL2Nii3" resolve="mbeddr.version" />
-        </node>
-      </node>
-      <node concept="m$f5U" id="DnqfiuSV7R" role="m$_yh">
-        <ref role="m$f5T" node="3quoVcnOe7A" resolve="group.compare" />
-      </node>
-      <node concept="m$_yC" id="DnqfiuSO_W" role="m$_yJ">
-        <ref role="m$_y1" to="ffeo:4k71ibbKLe8" resolve="jetbrains.mps.core" />
-      </node>
-      <node concept="m$_yC" id="DnqfiuSO_X" role="m$_yJ">
-        <ref role="m$_y1" to="ffeo:4k71ibbLe59" resolve="com.intellij.modules.mps" />
-      </node>
-      <node concept="3_J27D" id="DnqfiuSOA1" role="m_cZH">
-        <node concept="3Mxwew" id="DnqfiuSOA2" role="3MwsjC">
-          <property role="3MwjfP" value="com.mbeddr.mpsutil.compare" />
-        </node>
-      </node>
-      <node concept="2iUeEo" id="DnqfiuSOA3" role="2iVFfd">
-        <property role="2iUeEt" value="mbeddr" />
-        <property role="2iUeEu" value="http://mbeddr.com/" />
-      </node>
-      <node concept="3_J27D" id="DnqfiuSOA4" role="3s6cr7">
-        <node concept="3Mxwew" id="DnqfiuSOA5" role="3MwsjC">
-          <property role="3MwjfP" value="Node comparator utilities from mbeddr.mpsutil" />
-        </node>
-      </node>
-    </node>
     <node concept="m$_wf" id="5fGcQI94fMR" role="3989C9">
       <property role="m$_wk" value="com.mbeddr.mpsutil.common" />
       <node concept="3_J27D" id="5fGcQI94fMS" role="m$_yQ">
@@ -1385,39 +1280,6 @@
       </node>
       <node concept="m$_yC" id="48qh2gYh69d" role="m$_yJ">
         <ref role="m$_y1" node="$bJ0jguQdg" resolve="com.mbeddr.platform" />
-      </node>
-    </node>
-    <node concept="m$_wf" id="58oUBCRFYnR" role="3989C9">
-      <property role="m$_wk" value="com.mbeddr.mpsutil.generatorfacade" />
-      <node concept="3_J27D" id="58oUBCRFYnS" role="m$_yQ">
-        <node concept="3Mxwew" id="58oUBCRFYnT" role="3MwsjC">
-          <property role="3MwjfP" value="com.mbeddr.mpsutil.generatorfacade" />
-        </node>
-      </node>
-      <node concept="3_J27D" id="58oUBCRFYnU" role="m$_w8">
-        <node concept="3Mxwey" id="58oUBCRFYnV" role="3MwsjC">
-          <ref role="3Mxwex" node="2HHioL2Nii3" resolve="mbeddr.version" />
-        </node>
-      </node>
-      <node concept="m$f5U" id="58oUBCRG3LE" role="m$_yh">
-        <ref role="m$f5T" node="58oUBCRFNM4" resolve="group.generatorfacade" />
-      </node>
-      <node concept="m$_yC" id="58oUBCRFYnX" role="m$_yJ">
-        <ref role="m$_y1" to="ffeo:4k71ibbKLe8" resolve="jetbrains.mps.core" />
-      </node>
-      <node concept="3_J27D" id="58oUBCRFYo1" role="m_cZH">
-        <node concept="3Mxwew" id="58oUBCRFYo2" role="3MwsjC">
-          <property role="3MwjfP" value="com.mbeddr.mpsutil.generatorfacade" />
-        </node>
-      </node>
-      <node concept="2iUeEo" id="58oUBCRFYo3" role="2iVFfd">
-        <property role="2iUeEt" value="mbeddr" />
-        <property role="2iUeEu" value="http://mbeddr.com" />
-      </node>
-      <node concept="3_J27D" id="58oUBCRG2U6" role="3s6cr7">
-        <node concept="3Mxwew" id="58oUBCRG2Ua" role="3MwsjC">
-          <property role="3MwjfP" value="Utilities to run the generator to do M2M transformations" />
-        </node>
       </node>
     </node>
     <node concept="m$_wf" id="7tNo_gxoK8h" role="3989C9">
@@ -2843,34 +2705,6 @@
         </node>
       </node>
     </node>
-    <node concept="m$_wf" id="4VgGsUqOKxx" role="3989C9">
-      <property role="m$_wk" value="com.mbeddr.mpsutil.buildassistent" />
-      <node concept="3_J27D" id="4VgGsUqOKx$" role="m$_yQ">
-        <node concept="3Mxwew" id="4VgGsUqOKx_" role="3MwsjC">
-          <property role="3MwjfP" value="com.mbeddr.mpsutil.buildassistent" />
-        </node>
-      </node>
-      <node concept="3_J27D" id="4VgGsUqOKxA" role="m$_w8">
-        <node concept="3Mxwey" id="4VgGsUqOKxB" role="3MwsjC">
-          <ref role="3Mxwex" node="2HHioL2Nii3" resolve="mbeddr.version" />
-        </node>
-      </node>
-      <node concept="m$_yB" id="4VgGsUqPdOp" role="m$_yh">
-        <ref role="m$_yA" node="4VgGsUqP22$" resolve="com.mbeddr.mpsutil.buildassistant" />
-      </node>
-      <node concept="3_J27D" id="4VgGsUqOKxF" role="m_cZH">
-        <node concept="3Mxwew" id="4VgGsUqOKxG" role="3MwsjC">
-          <property role="3MwjfP" value="com.mbeddr.mpsutil.buildassistent" />
-        </node>
-      </node>
-      <node concept="2iUeEo" id="4VgGsUqOKxH" role="2iVFfd">
-        <property role="2iUeEt" value="mbedrr" />
-        <property role="2iUeEu" value="http://mbeddr.com" />
-      </node>
-      <node concept="m$_yC" id="4VgGsUqPgrj" role="m$_yJ">
-        <ref role="m$_y1" to="ffeo:6EN03E8oSte" resolve="jetbrains.mps.ide.make" />
-      </node>
-    </node>
     <node concept="2G$12M" id="11w71XmfwQH" role="3989C9">
       <property role="TrG5h" value="group.apis" />
       <node concept="1E1JtA" id="11w71Xmfzpd" role="2G$12L">
@@ -2990,6 +2824,707 @@
         </node>
       </node>
     </node>
+    <node concept="2G$12M" id="3quoVcnL8hF" role="3989C9">
+      <property role="TrG5h" value="group.plantuml" />
+      <node concept="1E1JtA" id="2N1CSrzSJt4" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="com.mbeddr.mpsutil.plantuml.pluginSolution" />
+        <property role="3LESm3" value="c0488c1e-322f-4f38-92d4-5520a7ce96c1" />
+        <property role="2GAjPV" value="false" />
+        <node concept="3rtmxn" id="3xFG3bj5cV0" role="3bR31x">
+          <node concept="3LXTmp" id="3xFG3bj5cV1" role="3rtmxm">
+            <node concept="3qWCbU" id="3xFG3bj5cV2" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+            <node concept="398BVA" id="3xFG3bj5cV3" role="3LXTmr">
+              <ref role="398BVh" node="7uZw0yZ2_Lj" />
+              <node concept="2Ry0Ak" id="3xFG3bj5cV4" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="3xFG3bj5cV5" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mbeddr.mpsutil.plantuml" />
+                  <node concept="2Ry0Ak" id="3xFG3bj5cV6" role="2Ry0An">
+                    <property role="2Ry0Am" value="solutions" />
+                    <node concept="2Ry0Ak" id="3xFG3bj5cV7" role="2Ry0An">
+                      <property role="2Ry0Am" value="pluginSolution" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="398BVA" id="2N1CSrzSJt5" role="3LF7KH">
+          <ref role="398BVh" node="7uZw0yZ2_Lj" />
+          <node concept="2Ry0Ak" id="2N1CSrzSJt9" role="iGT6I">
+            <property role="2Ry0Am" value="solutions" />
+            <node concept="2Ry0Ak" id="2N1CSrzSJta" role="2Ry0An">
+              <property role="2Ry0Am" value="com.mbeddr.mpsutil.plantuml" />
+              <node concept="2Ry0Ak" id="2N1CSrzSLnI" role="2Ry0An">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="2N1CSrzSM1E" role="2Ry0An">
+                  <property role="2Ry0Am" value="pluginSolution" />
+                  <node concept="2Ry0Ak" id="2N1CSrzSMFA" role="2Ry0An">
+                    <property role="2Ry0Am" value="pluginSolution.msd" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2N1CSrzSN0A" role="3bR37C">
+          <node concept="3bR9La" id="2N1CSrzSN0B" role="1SiIV1">
+            <property role="3bR36h" value="false" />
+            <ref role="3bR37D" to="ffeo:1TaHNgiIbJb" resolve="MPS.Platform" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2N1CSrzSN0C" role="3bR37C">
+          <node concept="3bR9La" id="2N1CSrzSN0D" role="1SiIV1">
+            <property role="3bR36h" value="false" />
+            <ref role="3bR37D" to="ffeo:1TaHNgiIbJ$" resolve="jetbrains.mps.ide.editor" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2N1CSrzSN0E" role="3bR37C">
+          <node concept="3bR9La" id="2N1CSrzSN0F" role="1SiIV1">
+            <property role="3bR36h" value="false" />
+            <ref role="3bR37D" to="ffeo:1ia2VB5guYy" resolve="MPS.IDEA" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2N1CSrzSSYm" role="3bR37C">
+          <node concept="3bR9La" id="2N1CSrzSSYn" role="1SiIV1">
+            <property role="3bR36h" value="false" />
+            <ref role="3bR37D" node="2N1CSrzSKpi" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2N1CSrzSSYo" role="3bR37C">
+          <node concept="3bR9La" id="2N1CSrzSSYp" role="1SiIV1">
+            <property role="3bR36h" value="false" />
+            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2N1CSrzSSYF" role="3bR37C">
+          <node concept="1BurEX" id="2N1CSrzSSYG" role="1SiIV1">
+            <node concept="398BVA" id="2N1CSrzSSYq" role="1BurEY">
+              <ref role="398BVh" node="7uZw0yZ2_Lj" />
+              <node concept="2Ry0Ak" id="2N1CSrzSSYr" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="2N1CSrzSSYs" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mbeddr.mpsutil.plantuml" />
+                  <node concept="2Ry0Ak" id="2N1CSrzSSYt" role="2Ry0An">
+                    <property role="2Ry0Am" value="solutions" />
+                    <node concept="2Ry0Ak" id="2N1CSrzSSYu" role="2Ry0An">
+                      <property role="2Ry0Am" value="pluginSolution" />
+                      <node concept="2Ry0Ak" id="2N1CSrzSSYv" role="2Ry0An">
+                        <property role="2Ry0Am" value="lib" />
+                        <node concept="2Ry0Ak" id="2N1CSrzSSYw" role="2Ry0An">
+                          <property role="2Ry0Am" value="batik-anim.jar" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2N1CSrzSSYY" role="3bR37C">
+          <node concept="1BurEX" id="2N1CSrzSSYZ" role="1SiIV1">
+            <node concept="398BVA" id="2N1CSrzSSYH" role="1BurEY">
+              <ref role="398BVh" node="7uZw0yZ2_Lj" />
+              <node concept="2Ry0Ak" id="2N1CSrzSSYI" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="2N1CSrzSSYJ" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mbeddr.mpsutil.plantuml" />
+                  <node concept="2Ry0Ak" id="2N1CSrzSSYK" role="2Ry0An">
+                    <property role="2Ry0Am" value="solutions" />
+                    <node concept="2Ry0Ak" id="2N1CSrzSSYL" role="2Ry0An">
+                      <property role="2Ry0Am" value="pluginSolution" />
+                      <node concept="2Ry0Ak" id="2N1CSrzSSYM" role="2Ry0An">
+                        <property role="2Ry0Am" value="lib" />
+                        <node concept="2Ry0Ak" id="2N1CSrzSSYN" role="2Ry0An">
+                          <property role="2Ry0Am" value="batik-awt-util.jar" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2N1CSrzSSZh" role="3bR37C">
+          <node concept="1BurEX" id="2N1CSrzSSZi" role="1SiIV1">
+            <node concept="398BVA" id="2N1CSrzSSZ0" role="1BurEY">
+              <ref role="398BVh" node="7uZw0yZ2_Lj" />
+              <node concept="2Ry0Ak" id="2N1CSrzSSZ1" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="2N1CSrzSSZ2" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mbeddr.mpsutil.plantuml" />
+                  <node concept="2Ry0Ak" id="2N1CSrzSSZ3" role="2Ry0An">
+                    <property role="2Ry0Am" value="solutions" />
+                    <node concept="2Ry0Ak" id="2N1CSrzSSZ4" role="2Ry0An">
+                      <property role="2Ry0Am" value="pluginSolution" />
+                      <node concept="2Ry0Ak" id="2N1CSrzSSZ5" role="2Ry0An">
+                        <property role="2Ry0Am" value="lib" />
+                        <node concept="2Ry0Ak" id="2N1CSrzSSZ6" role="2Ry0An">
+                          <property role="2Ry0Am" value="batik-bridge.jar" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2N1CSrzSSZ$" role="3bR37C">
+          <node concept="1BurEX" id="2N1CSrzSSZ_" role="1SiIV1">
+            <node concept="398BVA" id="2N1CSrzSSZj" role="1BurEY">
+              <ref role="398BVh" node="7uZw0yZ2_Lj" />
+              <node concept="2Ry0Ak" id="2N1CSrzSSZk" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="2N1CSrzSSZl" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mbeddr.mpsutil.plantuml" />
+                  <node concept="2Ry0Ak" id="2N1CSrzSSZm" role="2Ry0An">
+                    <property role="2Ry0Am" value="solutions" />
+                    <node concept="2Ry0Ak" id="2N1CSrzSSZn" role="2Ry0An">
+                      <property role="2Ry0Am" value="pluginSolution" />
+                      <node concept="2Ry0Ak" id="2N1CSrzSSZo" role="2Ry0An">
+                        <property role="2Ry0Am" value="lib" />
+                        <node concept="2Ry0Ak" id="2N1CSrzSSZp" role="2Ry0An">
+                          <property role="2Ry0Am" value="batik-codec.jar" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2N1CSrzSSZR" role="3bR37C">
+          <node concept="1BurEX" id="2N1CSrzSSZS" role="1SiIV1">
+            <node concept="398BVA" id="2N1CSrzSSZA" role="1BurEY">
+              <ref role="398BVh" node="7uZw0yZ2_Lj" />
+              <node concept="2Ry0Ak" id="2N1CSrzSSZB" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="2N1CSrzSSZC" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mbeddr.mpsutil.plantuml" />
+                  <node concept="2Ry0Ak" id="2N1CSrzSSZD" role="2Ry0An">
+                    <property role="2Ry0Am" value="solutions" />
+                    <node concept="2Ry0Ak" id="2N1CSrzSSZE" role="2Ry0An">
+                      <property role="2Ry0Am" value="pluginSolution" />
+                      <node concept="2Ry0Ak" id="2N1CSrzSSZF" role="2Ry0An">
+                        <property role="2Ry0Am" value="lib" />
+                        <node concept="2Ry0Ak" id="2N1CSrzSSZG" role="2Ry0An">
+                          <property role="2Ry0Am" value="batik-css.jar" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2N1CSrzST0a" role="3bR37C">
+          <node concept="1BurEX" id="2N1CSrzST0b" role="1SiIV1">
+            <node concept="398BVA" id="2N1CSrzSSZT" role="1BurEY">
+              <ref role="398BVh" node="7uZw0yZ2_Lj" />
+              <node concept="2Ry0Ak" id="2N1CSrzSSZU" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="2N1CSrzSSZV" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mbeddr.mpsutil.plantuml" />
+                  <node concept="2Ry0Ak" id="2N1CSrzSSZW" role="2Ry0An">
+                    <property role="2Ry0Am" value="solutions" />
+                    <node concept="2Ry0Ak" id="2N1CSrzSSZX" role="2Ry0An">
+                      <property role="2Ry0Am" value="pluginSolution" />
+                      <node concept="2Ry0Ak" id="2N1CSrzSSZY" role="2Ry0An">
+                        <property role="2Ry0Am" value="lib" />
+                        <node concept="2Ry0Ak" id="2N1CSrzSSZZ" role="2Ry0An">
+                          <property role="2Ry0Am" value="batik-dom.jar" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2N1CSrzST0K" role="3bR37C">
+          <node concept="1BurEX" id="2N1CSrzST0L" role="1SiIV1">
+            <node concept="398BVA" id="2N1CSrzST0v" role="1BurEY">
+              <ref role="398BVh" node="7uZw0yZ2_Lj" />
+              <node concept="2Ry0Ak" id="2N1CSrzST0w" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="2N1CSrzST0x" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mbeddr.mpsutil.plantuml" />
+                  <node concept="2Ry0Ak" id="2N1CSrzST0y" role="2Ry0An">
+                    <property role="2Ry0Am" value="solutions" />
+                    <node concept="2Ry0Ak" id="2N1CSrzST0z" role="2Ry0An">
+                      <property role="2Ry0Am" value="pluginSolution" />
+                      <node concept="2Ry0Ak" id="2N1CSrzST0$" role="2Ry0An">
+                        <property role="2Ry0Am" value="lib" />
+                        <node concept="2Ry0Ak" id="2N1CSrzST0_" role="2Ry0An">
+                          <property role="2Ry0Am" value="batik-extension.jar" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2N1CSrzST13" role="3bR37C">
+          <node concept="1BurEX" id="2N1CSrzST14" role="1SiIV1">
+            <node concept="398BVA" id="2N1CSrzST0M" role="1BurEY">
+              <ref role="398BVh" node="7uZw0yZ2_Lj" />
+              <node concept="2Ry0Ak" id="2N1CSrzST0N" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="2N1CSrzST0O" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mbeddr.mpsutil.plantuml" />
+                  <node concept="2Ry0Ak" id="2N1CSrzST0P" role="2Ry0An">
+                    <property role="2Ry0Am" value="solutions" />
+                    <node concept="2Ry0Ak" id="2N1CSrzST0Q" role="2Ry0An">
+                      <property role="2Ry0Am" value="pluginSolution" />
+                      <node concept="2Ry0Ak" id="2N1CSrzST0R" role="2Ry0An">
+                        <property role="2Ry0Am" value="lib" />
+                        <node concept="2Ry0Ak" id="2N1CSrzST0S" role="2Ry0An">
+                          <property role="2Ry0Am" value="batik-gui-util.jar" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2N1CSrzST1m" role="3bR37C">
+          <node concept="1BurEX" id="2N1CSrzST1n" role="1SiIV1">
+            <node concept="398BVA" id="2N1CSrzST15" role="1BurEY">
+              <ref role="398BVh" node="7uZw0yZ2_Lj" />
+              <node concept="2Ry0Ak" id="2N1CSrzST16" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="2N1CSrzST17" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mbeddr.mpsutil.plantuml" />
+                  <node concept="2Ry0Ak" id="2N1CSrzST18" role="2Ry0An">
+                    <property role="2Ry0Am" value="solutions" />
+                    <node concept="2Ry0Ak" id="2N1CSrzST19" role="2Ry0An">
+                      <property role="2Ry0Am" value="pluginSolution" />
+                      <node concept="2Ry0Ak" id="2N1CSrzST1a" role="2Ry0An">
+                        <property role="2Ry0Am" value="lib" />
+                        <node concept="2Ry0Ak" id="2N1CSrzST1b" role="2Ry0An">
+                          <property role="2Ry0Am" value="batik-gvt.jar" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2N1CSrzST1D" role="3bR37C">
+          <node concept="1BurEX" id="2N1CSrzST1E" role="1SiIV1">
+            <node concept="398BVA" id="2N1CSrzST1o" role="1BurEY">
+              <ref role="398BVh" node="7uZw0yZ2_Lj" />
+              <node concept="2Ry0Ak" id="2N1CSrzST1p" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="2N1CSrzST1q" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mbeddr.mpsutil.plantuml" />
+                  <node concept="2Ry0Ak" id="2N1CSrzST1r" role="2Ry0An">
+                    <property role="2Ry0Am" value="solutions" />
+                    <node concept="2Ry0Ak" id="2N1CSrzST1s" role="2Ry0An">
+                      <property role="2Ry0Am" value="pluginSolution" />
+                      <node concept="2Ry0Ak" id="2N1CSrzST1t" role="2Ry0An">
+                        <property role="2Ry0Am" value="lib" />
+                        <node concept="2Ry0Ak" id="2N1CSrzST1u" role="2Ry0An">
+                          <property role="2Ry0Am" value="batik-parser.jar" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2N1CSrzST1W" role="3bR37C">
+          <node concept="1BurEX" id="2N1CSrzST1X" role="1SiIV1">
+            <node concept="398BVA" id="2N1CSrzST1F" role="1BurEY">
+              <ref role="398BVh" node="7uZw0yZ2_Lj" />
+              <node concept="2Ry0Ak" id="2N1CSrzST1G" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="2N1CSrzST1H" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mbeddr.mpsutil.plantuml" />
+                  <node concept="2Ry0Ak" id="2N1CSrzST1I" role="2Ry0An">
+                    <property role="2Ry0Am" value="solutions" />
+                    <node concept="2Ry0Ak" id="2N1CSrzST1J" role="2Ry0An">
+                      <property role="2Ry0Am" value="pluginSolution" />
+                      <node concept="2Ry0Ak" id="2N1CSrzST1K" role="2Ry0An">
+                        <property role="2Ry0Am" value="lib" />
+                        <node concept="2Ry0Ak" id="2N1CSrzST1L" role="2Ry0An">
+                          <property role="2Ry0Am" value="batik-script.jar" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2N1CSrzST2f" role="3bR37C">
+          <node concept="1BurEX" id="2N1CSrzST2g" role="1SiIV1">
+            <node concept="398BVA" id="2N1CSrzST1Y" role="1BurEY">
+              <ref role="398BVh" node="7uZw0yZ2_Lj" />
+              <node concept="2Ry0Ak" id="2N1CSrzST1Z" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="2N1CSrzST20" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mbeddr.mpsutil.plantuml" />
+                  <node concept="2Ry0Ak" id="2N1CSrzST21" role="2Ry0An">
+                    <property role="2Ry0Am" value="solutions" />
+                    <node concept="2Ry0Ak" id="2N1CSrzST22" role="2Ry0An">
+                      <property role="2Ry0Am" value="pluginSolution" />
+                      <node concept="2Ry0Ak" id="2N1CSrzST23" role="2Ry0An">
+                        <property role="2Ry0Am" value="lib" />
+                        <node concept="2Ry0Ak" id="2N1CSrzST24" role="2Ry0An">
+                          <property role="2Ry0Am" value="batik-svg-dom.jar" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2N1CSrzST2y" role="3bR37C">
+          <node concept="1BurEX" id="2N1CSrzST2z" role="1SiIV1">
+            <node concept="398BVA" id="2N1CSrzST2h" role="1BurEY">
+              <ref role="398BVh" node="7uZw0yZ2_Lj" />
+              <node concept="2Ry0Ak" id="2N1CSrzST2i" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="2N1CSrzST2j" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mbeddr.mpsutil.plantuml" />
+                  <node concept="2Ry0Ak" id="2N1CSrzST2k" role="2Ry0An">
+                    <property role="2Ry0Am" value="solutions" />
+                    <node concept="2Ry0Ak" id="2N1CSrzST2l" role="2Ry0An">
+                      <property role="2Ry0Am" value="pluginSolution" />
+                      <node concept="2Ry0Ak" id="2N1CSrzST2m" role="2Ry0An">
+                        <property role="2Ry0Am" value="lib" />
+                        <node concept="2Ry0Ak" id="2N1CSrzST2n" role="2Ry0An">
+                          <property role="2Ry0Am" value="batik-svggen.jar" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2N1CSrzST2P" role="3bR37C">
+          <node concept="1BurEX" id="2N1CSrzST2Q" role="1SiIV1">
+            <node concept="398BVA" id="2N1CSrzST2$" role="1BurEY">
+              <ref role="398BVh" node="7uZw0yZ2_Lj" />
+              <node concept="2Ry0Ak" id="2N1CSrzST2_" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="2N1CSrzST2A" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mbeddr.mpsutil.plantuml" />
+                  <node concept="2Ry0Ak" id="2N1CSrzST2B" role="2Ry0An">
+                    <property role="2Ry0Am" value="solutions" />
+                    <node concept="2Ry0Ak" id="2N1CSrzST2C" role="2Ry0An">
+                      <property role="2Ry0Am" value="pluginSolution" />
+                      <node concept="2Ry0Ak" id="2N1CSrzST2D" role="2Ry0An">
+                        <property role="2Ry0Am" value="lib" />
+                        <node concept="2Ry0Ak" id="2N1CSrzST2E" role="2Ry0An">
+                          <property role="2Ry0Am" value="batik-swing.jar" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2N1CSrzST38" role="3bR37C">
+          <node concept="1BurEX" id="2N1CSrzST39" role="1SiIV1">
+            <node concept="398BVA" id="2N1CSrzST2R" role="1BurEY">
+              <ref role="398BVh" node="7uZw0yZ2_Lj" />
+              <node concept="2Ry0Ak" id="2N1CSrzST2S" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="2N1CSrzST2T" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mbeddr.mpsutil.plantuml" />
+                  <node concept="2Ry0Ak" id="2N1CSrzST2U" role="2Ry0An">
+                    <property role="2Ry0Am" value="solutions" />
+                    <node concept="2Ry0Ak" id="2N1CSrzST2V" role="2Ry0An">
+                      <property role="2Ry0Am" value="pluginSolution" />
+                      <node concept="2Ry0Ak" id="2N1CSrzST2W" role="2Ry0An">
+                        <property role="2Ry0Am" value="lib" />
+                        <node concept="2Ry0Ak" id="2N1CSrzST2X" role="2Ry0An">
+                          <property role="2Ry0Am" value="batik-transcoder.jar" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2N1CSrzST3r" role="3bR37C">
+          <node concept="1BurEX" id="2N1CSrzST3s" role="1SiIV1">
+            <node concept="398BVA" id="2N1CSrzST3a" role="1BurEY">
+              <ref role="398BVh" node="7uZw0yZ2_Lj" />
+              <node concept="2Ry0Ak" id="2N1CSrzST3b" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="2N1CSrzST3c" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mbeddr.mpsutil.plantuml" />
+                  <node concept="2Ry0Ak" id="2N1CSrzST3d" role="2Ry0An">
+                    <property role="2Ry0Am" value="solutions" />
+                    <node concept="2Ry0Ak" id="2N1CSrzST3e" role="2Ry0An">
+                      <property role="2Ry0Am" value="pluginSolution" />
+                      <node concept="2Ry0Ak" id="2N1CSrzST3f" role="2Ry0An">
+                        <property role="2Ry0Am" value="lib" />
+                        <node concept="2Ry0Ak" id="2N1CSrzST3g" role="2Ry0An">
+                          <property role="2Ry0Am" value="batik-util.jar" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2N1CSrzST3I" role="3bR37C">
+          <node concept="1BurEX" id="2N1CSrzST3J" role="1SiIV1">
+            <node concept="398BVA" id="2N1CSrzST3t" role="1BurEY">
+              <ref role="398BVh" node="7uZw0yZ2_Lj" />
+              <node concept="2Ry0Ak" id="2N1CSrzST3u" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="2N1CSrzST3v" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mbeddr.mpsutil.plantuml" />
+                  <node concept="2Ry0Ak" id="2N1CSrzST3w" role="2Ry0An">
+                    <property role="2Ry0Am" value="solutions" />
+                    <node concept="2Ry0Ak" id="2N1CSrzST3x" role="2Ry0An">
+                      <property role="2Ry0Am" value="pluginSolution" />
+                      <node concept="2Ry0Ak" id="2N1CSrzST3y" role="2Ry0An">
+                        <property role="2Ry0Am" value="lib" />
+                        <node concept="2Ry0Ak" id="2N1CSrzST3z" role="2Ry0An">
+                          <property role="2Ry0Am" value="batik-xml.jar" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2N1CSrzST41" role="3bR37C">
+          <node concept="1BurEX" id="2N1CSrzST42" role="1SiIV1">
+            <node concept="398BVA" id="2N1CSrzST3K" role="1BurEY">
+              <ref role="398BVh" node="7uZw0yZ2_Lj" />
+              <node concept="2Ry0Ak" id="2N1CSrzST3L" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="2N1CSrzST3M" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mbeddr.mpsutil.plantuml" />
+                  <node concept="2Ry0Ak" id="2N1CSrzST3N" role="2Ry0An">
+                    <property role="2Ry0Am" value="solutions" />
+                    <node concept="2Ry0Ak" id="2N1CSrzST3O" role="2Ry0An">
+                      <property role="2Ry0Am" value="pluginSolution" />
+                      <node concept="2Ry0Ak" id="2N1CSrzST3P" role="2Ry0An">
+                        <property role="2Ry0Am" value="lib" />
+                        <node concept="2Ry0Ak" id="2N1CSrzST3Q" role="2Ry0An">
+                          <property role="2Ry0Am" value="batik.jar" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2N1CSrzST4k" role="3bR37C">
+          <node concept="1BurEX" id="2N1CSrzST4l" role="1SiIV1">
+            <node concept="398BVA" id="2N1CSrzST43" role="1BurEY">
+              <ref role="398BVh" node="7uZw0yZ2_Lj" />
+              <node concept="2Ry0Ak" id="2N1CSrzST44" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="2N1CSrzST45" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mbeddr.mpsutil.plantuml" />
+                  <node concept="2Ry0Ak" id="2N1CSrzST46" role="2Ry0An">
+                    <property role="2Ry0Am" value="solutions" />
+                    <node concept="2Ry0Ak" id="2N1CSrzST47" role="2Ry0An">
+                      <property role="2Ry0Am" value="pluginSolution" />
+                      <node concept="2Ry0Ak" id="2N1CSrzST48" role="2Ry0An">
+                        <property role="2Ry0Am" value="lib" />
+                        <node concept="2Ry0Ak" id="2N1CSrzST49" role="2Ry0An">
+                          <property role="2Ry0Am" value="js.jar" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2N1CSrzST4B" role="3bR37C">
+          <node concept="1BurEX" id="2N1CSrzST4C" role="1SiIV1">
+            <node concept="398BVA" id="2N1CSrzST4m" role="1BurEY">
+              <ref role="398BVh" node="7uZw0yZ2_Lj" />
+              <node concept="2Ry0Ak" id="2N1CSrzST4n" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="2N1CSrzST4o" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mbeddr.mpsutil.plantuml" />
+                  <node concept="2Ry0Ak" id="2N1CSrzST4p" role="2Ry0An">
+                    <property role="2Ry0Am" value="solutions" />
+                    <node concept="2Ry0Ak" id="2N1CSrzST4q" role="2Ry0An">
+                      <property role="2Ry0Am" value="pluginSolution" />
+                      <node concept="2Ry0Ak" id="2N1CSrzST4r" role="2Ry0An">
+                        <property role="2Ry0Am" value="lib" />
+                        <node concept="2Ry0Ak" id="2N1CSrzST4s" role="2Ry0An">
+                          <property role="2Ry0Am" value="plantuml.jar" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2N1CSrzST4U" role="3bR37C">
+          <node concept="1BurEX" id="2N1CSrzST4V" role="1SiIV1">
+            <node concept="398BVA" id="2N1CSrzST4D" role="1BurEY">
+              <ref role="398BVh" node="7uZw0yZ2_Lj" />
+              <node concept="2Ry0Ak" id="2N1CSrzST4E" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="2N1CSrzST4F" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mbeddr.mpsutil.plantuml" />
+                  <node concept="2Ry0Ak" id="2N1CSrzST4G" role="2Ry0An">
+                    <property role="2Ry0Am" value="solutions" />
+                    <node concept="2Ry0Ak" id="2N1CSrzST4H" role="2Ry0An">
+                      <property role="2Ry0Am" value="pluginSolution" />
+                      <node concept="2Ry0Ak" id="2N1CSrzST4I" role="2Ry0An">
+                        <property role="2Ry0Am" value="lib" />
+                        <node concept="2Ry0Ak" id="2N1CSrzST4J" role="2Ry0An">
+                          <property role="2Ry0Am" value="xalan-2.6.0.jar" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="4VgGsUqPhAU" role="3bR37C">
+          <node concept="3bR9La" id="4VgGsUqPhAV" role="1SiIV1">
+            <property role="3bR36h" value="false" />
+            <ref role="3bR37D" node="11w71Xmfzpd" />
+          </node>
+        </node>
+      </node>
+      <node concept="1E1JtD" id="2N1CSrzSKpi" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="com.mbeddr.mpsutil.plantuml.node" />
+        <property role="3LESm3" value="b4d28e19-7d2d-47e9-943e-3a41f97a0e52" />
+        <property role="2GAjPV" value="false" />
+        <node concept="3rtmxn" id="3xFG3bj5cMA" role="3bR31x">
+          <node concept="3LXTmp" id="3xFG3bj5cMB" role="3rtmxm">
+            <node concept="3qWCbU" id="3xFG3bj5cMC" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+            <node concept="398BVA" id="3xFG3bj5cMD" role="3LXTmr">
+              <ref role="398BVh" node="7uZw0yZ2_Lj" />
+              <node concept="2Ry0Ak" id="3xFG3bj5cME" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="3xFG3bj5cMF" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mbeddr.mpsutil.plantuml.node" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="398BVA" id="2N1CSrzSKpj" role="3LF7KH">
+          <ref role="398BVh" node="7uZw0yZ2_Lj" />
+          <node concept="2Ry0Ak" id="2N1CSrzSKpn" role="iGT6I">
+            <property role="2Ry0Am" value="languages" />
+            <node concept="2Ry0Ak" id="2N1CSrzSKpo" role="2Ry0An">
+              <property role="2Ry0Am" value="com.mbeddr.mpsutil.plantuml.node" />
+              <node concept="2Ry0Ak" id="2N1CSrzSO5$" role="2Ry0An">
+                <property role="2Ry0Am" value="com.mbeddr.mpsutil.plantuml.node.mpl" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1E0d5M" id="2N1CSrzSKpw" role="1E1XAP">
+          <ref role="1E0d5P" node="4Hbnsm4OhEo" />
+        </node>
+        <node concept="1SiIV0" id="2N1CSrzSOBy" role="3bR37C">
+          <node concept="3bR9La" id="2N1CSrzSOBz" role="1SiIV1">
+            <property role="3bR36h" value="false" />
+            <ref role="3bR37D" node="2N1CSrzsvbI" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2VC4eVYcgRz" role="3bR37C">
+          <node concept="3bR9La" id="2VC4eVYcgR$" role="1SiIV1">
+            <property role="3bR36h" value="false" />
+            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2lop6rS5AmA" role="3bR37C">
+          <node concept="3bR9La" id="2lop6rS5AmB" role="1SiIV1">
+            <property role="3bR36h" value="false" />
+            <ref role="3bR37D" to="ffeo:xSXmQZAqVi" resolve="jetbrains.mps.ide.httpsupport.runtime" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="m$_wf" id="64SK4bcJmGP" role="3989C9">
+      <property role="m$_wk" value="com.mbeddr.mpsutil.plantuml" />
+      <node concept="3_J27D" id="64SK4bcJmGQ" role="m$_yQ">
+        <node concept="3Mxwew" id="64SK4bcJmGR" role="3MwsjC">
+          <property role="3MwjfP" value="com.mbeddr.mpsutil.plantuml" />
+        </node>
+      </node>
+      <node concept="3_J27D" id="64SK4bcJmGS" role="m_cZH">
+        <node concept="3Mxwew" id="64SK4bcJmGT" role="3MwsjC">
+          <property role="3MwjfP" value="com.mbeddr.mpsutil.plantuml" />
+        </node>
+      </node>
+      <node concept="3_J27D" id="64SK4bcJmGU" role="m$_w8">
+        <node concept="3Mxwey" id="64SK4bcJmGV" role="3MwsjC">
+          <ref role="3Mxwex" node="2HHioL2Nii3" resolve="mbeddr.version" />
+        </node>
+      </node>
+      <node concept="m$f5U" id="64SK4bcJwhC" role="m$_yh">
+        <ref role="m$f5T" node="3quoVcnL8hF" resolve="group.plantuml" />
+      </node>
+      <node concept="m$f5U" id="11w71XmfHEh" role="m$_yh">
+        <ref role="m$f5T" node="11w71XmfwQH" resolve="group.apis" />
+      </node>
+      <node concept="m$_yC" id="64SK4bcJmGX" role="m$_yJ">
+        <ref role="m$_y1" to="ffeo:4k71ibbKLe8" resolve="jetbrains.mps.core" />
+      </node>
+      <node concept="m$_yC" id="64SK4bcJyxn" role="m$_yJ">
+        <ref role="m$_y1" to="90a9:6860Y5_ZW8e" resolve="de.itemis.mps.utils" />
+      </node>
+      <node concept="m$_yC" id="64SK4bcJ_T5" role="m$_yJ">
+        <ref role="m$_y1" to="ffeo:5xhjlkpPhJu" resolve="jetbrains.mps.ide.httpsupport" />
+      </node>
+      <node concept="m$_yC" id="64SK4bcJC8W" role="m$_yJ">
+        <ref role="m$_y1" node="3lZeU8ehrPx" resolve="com.mbeddr.mpsutil.httpsupport" />
+      </node>
+    </node>
     <node concept="2G$12M" id="4VgGsUqP22z" role="3989C9">
       <property role="TrG5h" value="group.build" />
       <node concept="1E1JtA" id="4VgGsUqP22$" role="2G$12L">
@@ -3085,6 +3620,34 @@
             <ref role="3bR37D" to="ffeo:307DWrMiIBc" resolve="jetbrains.mps.lang.generator.plan" />
           </node>
         </node>
+      </node>
+    </node>
+    <node concept="m$_wf" id="4VgGsUqOKxx" role="3989C9">
+      <property role="m$_wk" value="com.mbeddr.mpsutil.buildassistent" />
+      <node concept="3_J27D" id="4VgGsUqOKx$" role="m$_yQ">
+        <node concept="3Mxwew" id="4VgGsUqOKx_" role="3MwsjC">
+          <property role="3MwjfP" value="com.mbeddr.mpsutil.buildassistent" />
+        </node>
+      </node>
+      <node concept="3_J27D" id="4VgGsUqOKxA" role="m$_w8">
+        <node concept="3Mxwey" id="4VgGsUqOKxB" role="3MwsjC">
+          <ref role="3Mxwex" node="2HHioL2Nii3" resolve="mbeddr.version" />
+        </node>
+      </node>
+      <node concept="m$f5U" id="1Rj3F433TRP" role="m$_yh">
+        <ref role="m$f5T" node="4VgGsUqP22z" resolve="group.build" />
+      </node>
+      <node concept="3_J27D" id="4VgGsUqOKxF" role="m_cZH">
+        <node concept="3Mxwew" id="4VgGsUqOKxG" role="3MwsjC">
+          <property role="3MwjfP" value="com.mbeddr.mpsutil.buildassistent" />
+        </node>
+      </node>
+      <node concept="2iUeEo" id="4VgGsUqOKxH" role="2iVFfd">
+        <property role="2iUeEt" value="mbedrr" />
+        <property role="2iUeEu" value="http://mbeddr.com" />
+      </node>
+      <node concept="m$_yC" id="4VgGsUqPgrj" role="m$_yJ">
+        <ref role="m$_y1" to="ffeo:6EN03E8oSte" resolve="jetbrains.mps.ide.make" />
       </node>
     </node>
     <node concept="2G$12M" id="4sjR92JQf0t" role="3989C9">
@@ -5090,6 +5653,36 @@
         </node>
       </node>
     </node>
+    <node concept="m$_wf" id="64SK4bcNyQW" role="3989C9">
+      <property role="m$_wk" value="com.mbeddr.mpsutil.editorsupport" />
+      <node concept="3_J27D" id="64SK4bcNyQX" role="m$_yQ">
+        <node concept="3Mxwew" id="64SK4bcNyQY" role="3MwsjC">
+          <property role="3MwjfP" value="com.mbeddr.mpsutil.editorsupport" />
+        </node>
+      </node>
+      <node concept="3_J27D" id="64SK4bcNyQZ" role="m_cZH">
+        <node concept="3Mxwew" id="64SK4bcNyR0" role="3MwsjC">
+          <property role="3MwjfP" value="com.mbeddr.mpsutil.editorsupport" />
+        </node>
+      </node>
+      <node concept="3_J27D" id="64SK4bcNyR1" role="m$_w8">
+        <node concept="3Mxwey" id="64SK4bcNyR2" role="3MwsjC">
+          <ref role="3Mxwex" node="2HHioL2Nii3" resolve="mbeddr.version" />
+        </node>
+      </node>
+      <node concept="m$_yC" id="64SK4bcNyR3" role="m$_yJ">
+        <ref role="m$_y1" to="ffeo:4k71ibbKLe8" resolve="jetbrains.mps.core" />
+      </node>
+      <node concept="m$_yC" id="64SK4bcNEcS" role="m$_yJ">
+        <ref role="m$_y1" to="90a9:2Xjt3l57iTJ" resolve="de.slisson.mps.hacks" />
+      </node>
+      <node concept="m$_yC" id="64SK4bcNGsF" role="m$_yJ">
+        <ref role="m$_y1" to="ffeo:4k71ibbLe59" resolve="com.intellij.modules.mps" />
+      </node>
+      <node concept="m$f5U" id="64SK4bcNBX9" role="m$_yh">
+        <ref role="m$f5T" node="3quoVcnPZaE" resolve="group.editor-support" />
+      </node>
+    </node>
     <node concept="2G$12M" id="3quoVcnRts4" role="3989C9">
       <property role="TrG5h" value="group.baseLanguage" />
       <node concept="1E1JtA" id="3zYUNYHJ2S3" role="2G$12L">
@@ -6715,6 +7308,42 @@
             <property role="3bR36h" value="false" />
             <ref role="3bR37D" node="4oNjwzxq9X5" resolve="com.mbeddr.mpsutil.compare.pattern.runtime" />
           </node>
+        </node>
+      </node>
+    </node>
+    <node concept="m$_wf" id="DnqfiuSO_Q" role="3989C9">
+      <property role="m$_wk" value="com.mbeddr.mpsutil.compare" />
+      <node concept="3_J27D" id="DnqfiuSO_R" role="m$_yQ">
+        <node concept="3Mxwew" id="DnqfiuSO_S" role="3MwsjC">
+          <property role="3MwjfP" value="com.mbeddr.mpsutil.compare" />
+        </node>
+      </node>
+      <node concept="3_J27D" id="DnqfiuSO_T" role="m$_w8">
+        <node concept="3Mxwey" id="DnqfiuSO_U" role="3MwsjC">
+          <ref role="3Mxwex" node="2HHioL2Nii3" resolve="mbeddr.version" />
+        </node>
+      </node>
+      <node concept="m$f5U" id="DnqfiuSV7R" role="m$_yh">
+        <ref role="m$f5T" node="3quoVcnOe7A" resolve="group.compare" />
+      </node>
+      <node concept="m$_yC" id="DnqfiuSO_W" role="m$_yJ">
+        <ref role="m$_y1" to="ffeo:4k71ibbKLe8" resolve="jetbrains.mps.core" />
+      </node>
+      <node concept="m$_yC" id="DnqfiuSO_X" role="m$_yJ">
+        <ref role="m$_y1" to="ffeo:4k71ibbLe59" resolve="com.intellij.modules.mps" />
+      </node>
+      <node concept="3_J27D" id="DnqfiuSOA1" role="m_cZH">
+        <node concept="3Mxwew" id="DnqfiuSOA2" role="3MwsjC">
+          <property role="3MwjfP" value="com.mbeddr.mpsutil.compare" />
+        </node>
+      </node>
+      <node concept="2iUeEo" id="DnqfiuSOA3" role="2iVFfd">
+        <property role="2iUeEt" value="mbeddr" />
+        <property role="2iUeEu" value="http://mbeddr.com/" />
+      </node>
+      <node concept="3_J27D" id="DnqfiuSOA4" role="3s6cr7">
+        <node concept="3Mxwew" id="DnqfiuSOA5" role="3MwsjC">
+          <property role="3MwjfP" value="Node comparator utilities from mbeddr.mpsutil" />
         </node>
       </node>
     </node>
@@ -8408,671 +9037,6 @@
           <node concept="3bR9La" id="3NH93cznuFe" role="1SiIV1">
             <property role="3bR36h" value="false" />
             <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
-          </node>
-        </node>
-      </node>
-    </node>
-    <node concept="2G$12M" id="3quoVcnL8hF" role="3989C9">
-      <property role="TrG5h" value="group.plantuml" />
-      <node concept="1E1JtA" id="2N1CSrzSJt4" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="com.mbeddr.mpsutil.plantuml.pluginSolution" />
-        <property role="3LESm3" value="c0488c1e-322f-4f38-92d4-5520a7ce96c1" />
-        <property role="2GAjPV" value="false" />
-        <node concept="3rtmxn" id="3xFG3bj5cV0" role="3bR31x">
-          <node concept="3LXTmp" id="3xFG3bj5cV1" role="3rtmxm">
-            <node concept="3qWCbU" id="3xFG3bj5cV2" role="3LXTna">
-              <property role="3qWCbO" value="icons/**, resources/**" />
-            </node>
-            <node concept="398BVA" id="3xFG3bj5cV3" role="3LXTmr">
-              <ref role="398BVh" node="7uZw0yZ2_Lj" resolve="mpsutil" />
-              <node concept="2Ry0Ak" id="3xFG3bj5cV4" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="3xFG3bj5cV5" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mbeddr.mpsutil.plantuml" />
-                  <node concept="2Ry0Ak" id="3xFG3bj5cV6" role="2Ry0An">
-                    <property role="2Ry0Am" value="solutions" />
-                    <node concept="2Ry0Ak" id="3xFG3bj5cV7" role="2Ry0An">
-                      <property role="2Ry0Am" value="pluginSolution" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="398BVA" id="2N1CSrzSJt5" role="3LF7KH">
-          <ref role="398BVh" node="7uZw0yZ2_Lj" resolve="mpsutil" />
-          <node concept="2Ry0Ak" id="2N1CSrzSJt9" role="iGT6I">
-            <property role="2Ry0Am" value="solutions" />
-            <node concept="2Ry0Ak" id="2N1CSrzSJta" role="2Ry0An">
-              <property role="2Ry0Am" value="com.mbeddr.mpsutil.plantuml" />
-              <node concept="2Ry0Ak" id="2N1CSrzSLnI" role="2Ry0An">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2N1CSrzSM1E" role="2Ry0An">
-                  <property role="2Ry0Am" value="pluginSolution" />
-                  <node concept="2Ry0Ak" id="2N1CSrzSMFA" role="2Ry0An">
-                    <property role="2Ry0Am" value="pluginSolution.msd" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2N1CSrzSN0A" role="3bR37C">
-          <node concept="3bR9La" id="2N1CSrzSN0B" role="1SiIV1">
-            <property role="3bR36h" value="false" />
-            <ref role="3bR37D" to="ffeo:1TaHNgiIbJb" resolve="MPS.Platform" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2N1CSrzSN0C" role="3bR37C">
-          <node concept="3bR9La" id="2N1CSrzSN0D" role="1SiIV1">
-            <property role="3bR36h" value="false" />
-            <ref role="3bR37D" to="ffeo:1TaHNgiIbJ$" resolve="jetbrains.mps.ide.editor" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2N1CSrzSN0E" role="3bR37C">
-          <node concept="3bR9La" id="2N1CSrzSN0F" role="1SiIV1">
-            <property role="3bR36h" value="false" />
-            <ref role="3bR37D" to="ffeo:1ia2VB5guYy" resolve="MPS.IDEA" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2N1CSrzSSYm" role="3bR37C">
-          <node concept="3bR9La" id="2N1CSrzSSYn" role="1SiIV1">
-            <property role="3bR36h" value="false" />
-            <ref role="3bR37D" node="2N1CSrzSKpi" resolve="com.mbeddr.mpsutil.plantuml.node" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2N1CSrzSSYo" role="3bR37C">
-          <node concept="3bR9La" id="2N1CSrzSSYp" role="1SiIV1">
-            <property role="3bR36h" value="false" />
-            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2N1CSrzSSYF" role="3bR37C">
-          <node concept="1BurEX" id="2N1CSrzSSYG" role="1SiIV1">
-            <node concept="398BVA" id="2N1CSrzSSYq" role="1BurEY">
-              <ref role="398BVh" node="7uZw0yZ2_Lj" resolve="mpsutil" />
-              <node concept="2Ry0Ak" id="2N1CSrzSSYr" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2N1CSrzSSYs" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mbeddr.mpsutil.plantuml" />
-                  <node concept="2Ry0Ak" id="2N1CSrzSSYt" role="2Ry0An">
-                    <property role="2Ry0Am" value="solutions" />
-                    <node concept="2Ry0Ak" id="2N1CSrzSSYu" role="2Ry0An">
-                      <property role="2Ry0Am" value="pluginSolution" />
-                      <node concept="2Ry0Ak" id="2N1CSrzSSYv" role="2Ry0An">
-                        <property role="2Ry0Am" value="lib" />
-                        <node concept="2Ry0Ak" id="2N1CSrzSSYw" role="2Ry0An">
-                          <property role="2Ry0Am" value="batik-anim.jar" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2N1CSrzSSYY" role="3bR37C">
-          <node concept="1BurEX" id="2N1CSrzSSYZ" role="1SiIV1">
-            <node concept="398BVA" id="2N1CSrzSSYH" role="1BurEY">
-              <ref role="398BVh" node="7uZw0yZ2_Lj" resolve="mpsutil" />
-              <node concept="2Ry0Ak" id="2N1CSrzSSYI" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2N1CSrzSSYJ" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mbeddr.mpsutil.plantuml" />
-                  <node concept="2Ry0Ak" id="2N1CSrzSSYK" role="2Ry0An">
-                    <property role="2Ry0Am" value="solutions" />
-                    <node concept="2Ry0Ak" id="2N1CSrzSSYL" role="2Ry0An">
-                      <property role="2Ry0Am" value="pluginSolution" />
-                      <node concept="2Ry0Ak" id="2N1CSrzSSYM" role="2Ry0An">
-                        <property role="2Ry0Am" value="lib" />
-                        <node concept="2Ry0Ak" id="2N1CSrzSSYN" role="2Ry0An">
-                          <property role="2Ry0Am" value="batik-awt-util.jar" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2N1CSrzSSZh" role="3bR37C">
-          <node concept="1BurEX" id="2N1CSrzSSZi" role="1SiIV1">
-            <node concept="398BVA" id="2N1CSrzSSZ0" role="1BurEY">
-              <ref role="398BVh" node="7uZw0yZ2_Lj" resolve="mpsutil" />
-              <node concept="2Ry0Ak" id="2N1CSrzSSZ1" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2N1CSrzSSZ2" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mbeddr.mpsutil.plantuml" />
-                  <node concept="2Ry0Ak" id="2N1CSrzSSZ3" role="2Ry0An">
-                    <property role="2Ry0Am" value="solutions" />
-                    <node concept="2Ry0Ak" id="2N1CSrzSSZ4" role="2Ry0An">
-                      <property role="2Ry0Am" value="pluginSolution" />
-                      <node concept="2Ry0Ak" id="2N1CSrzSSZ5" role="2Ry0An">
-                        <property role="2Ry0Am" value="lib" />
-                        <node concept="2Ry0Ak" id="2N1CSrzSSZ6" role="2Ry0An">
-                          <property role="2Ry0Am" value="batik-bridge.jar" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2N1CSrzSSZ$" role="3bR37C">
-          <node concept="1BurEX" id="2N1CSrzSSZ_" role="1SiIV1">
-            <node concept="398BVA" id="2N1CSrzSSZj" role="1BurEY">
-              <ref role="398BVh" node="7uZw0yZ2_Lj" resolve="mpsutil" />
-              <node concept="2Ry0Ak" id="2N1CSrzSSZk" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2N1CSrzSSZl" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mbeddr.mpsutil.plantuml" />
-                  <node concept="2Ry0Ak" id="2N1CSrzSSZm" role="2Ry0An">
-                    <property role="2Ry0Am" value="solutions" />
-                    <node concept="2Ry0Ak" id="2N1CSrzSSZn" role="2Ry0An">
-                      <property role="2Ry0Am" value="pluginSolution" />
-                      <node concept="2Ry0Ak" id="2N1CSrzSSZo" role="2Ry0An">
-                        <property role="2Ry0Am" value="lib" />
-                        <node concept="2Ry0Ak" id="2N1CSrzSSZp" role="2Ry0An">
-                          <property role="2Ry0Am" value="batik-codec.jar" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2N1CSrzSSZR" role="3bR37C">
-          <node concept="1BurEX" id="2N1CSrzSSZS" role="1SiIV1">
-            <node concept="398BVA" id="2N1CSrzSSZA" role="1BurEY">
-              <ref role="398BVh" node="7uZw0yZ2_Lj" resolve="mpsutil" />
-              <node concept="2Ry0Ak" id="2N1CSrzSSZB" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2N1CSrzSSZC" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mbeddr.mpsutil.plantuml" />
-                  <node concept="2Ry0Ak" id="2N1CSrzSSZD" role="2Ry0An">
-                    <property role="2Ry0Am" value="solutions" />
-                    <node concept="2Ry0Ak" id="2N1CSrzSSZE" role="2Ry0An">
-                      <property role="2Ry0Am" value="pluginSolution" />
-                      <node concept="2Ry0Ak" id="2N1CSrzSSZF" role="2Ry0An">
-                        <property role="2Ry0Am" value="lib" />
-                        <node concept="2Ry0Ak" id="2N1CSrzSSZG" role="2Ry0An">
-                          <property role="2Ry0Am" value="batik-css.jar" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2N1CSrzST0a" role="3bR37C">
-          <node concept="1BurEX" id="2N1CSrzST0b" role="1SiIV1">
-            <node concept="398BVA" id="2N1CSrzSSZT" role="1BurEY">
-              <ref role="398BVh" node="7uZw0yZ2_Lj" resolve="mpsutil" />
-              <node concept="2Ry0Ak" id="2N1CSrzSSZU" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2N1CSrzSSZV" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mbeddr.mpsutil.plantuml" />
-                  <node concept="2Ry0Ak" id="2N1CSrzSSZW" role="2Ry0An">
-                    <property role="2Ry0Am" value="solutions" />
-                    <node concept="2Ry0Ak" id="2N1CSrzSSZX" role="2Ry0An">
-                      <property role="2Ry0Am" value="pluginSolution" />
-                      <node concept="2Ry0Ak" id="2N1CSrzSSZY" role="2Ry0An">
-                        <property role="2Ry0Am" value="lib" />
-                        <node concept="2Ry0Ak" id="2N1CSrzSSZZ" role="2Ry0An">
-                          <property role="2Ry0Am" value="batik-dom.jar" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2N1CSrzST0K" role="3bR37C">
-          <node concept="1BurEX" id="2N1CSrzST0L" role="1SiIV1">
-            <node concept="398BVA" id="2N1CSrzST0v" role="1BurEY">
-              <ref role="398BVh" node="7uZw0yZ2_Lj" resolve="mpsutil" />
-              <node concept="2Ry0Ak" id="2N1CSrzST0w" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2N1CSrzST0x" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mbeddr.mpsutil.plantuml" />
-                  <node concept="2Ry0Ak" id="2N1CSrzST0y" role="2Ry0An">
-                    <property role="2Ry0Am" value="solutions" />
-                    <node concept="2Ry0Ak" id="2N1CSrzST0z" role="2Ry0An">
-                      <property role="2Ry0Am" value="pluginSolution" />
-                      <node concept="2Ry0Ak" id="2N1CSrzST0$" role="2Ry0An">
-                        <property role="2Ry0Am" value="lib" />
-                        <node concept="2Ry0Ak" id="2N1CSrzST0_" role="2Ry0An">
-                          <property role="2Ry0Am" value="batik-extension.jar" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2N1CSrzST13" role="3bR37C">
-          <node concept="1BurEX" id="2N1CSrzST14" role="1SiIV1">
-            <node concept="398BVA" id="2N1CSrzST0M" role="1BurEY">
-              <ref role="398BVh" node="7uZw0yZ2_Lj" resolve="mpsutil" />
-              <node concept="2Ry0Ak" id="2N1CSrzST0N" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2N1CSrzST0O" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mbeddr.mpsutil.plantuml" />
-                  <node concept="2Ry0Ak" id="2N1CSrzST0P" role="2Ry0An">
-                    <property role="2Ry0Am" value="solutions" />
-                    <node concept="2Ry0Ak" id="2N1CSrzST0Q" role="2Ry0An">
-                      <property role="2Ry0Am" value="pluginSolution" />
-                      <node concept="2Ry0Ak" id="2N1CSrzST0R" role="2Ry0An">
-                        <property role="2Ry0Am" value="lib" />
-                        <node concept="2Ry0Ak" id="2N1CSrzST0S" role="2Ry0An">
-                          <property role="2Ry0Am" value="batik-gui-util.jar" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2N1CSrzST1m" role="3bR37C">
-          <node concept="1BurEX" id="2N1CSrzST1n" role="1SiIV1">
-            <node concept="398BVA" id="2N1CSrzST15" role="1BurEY">
-              <ref role="398BVh" node="7uZw0yZ2_Lj" resolve="mpsutil" />
-              <node concept="2Ry0Ak" id="2N1CSrzST16" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2N1CSrzST17" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mbeddr.mpsutil.plantuml" />
-                  <node concept="2Ry0Ak" id="2N1CSrzST18" role="2Ry0An">
-                    <property role="2Ry0Am" value="solutions" />
-                    <node concept="2Ry0Ak" id="2N1CSrzST19" role="2Ry0An">
-                      <property role="2Ry0Am" value="pluginSolution" />
-                      <node concept="2Ry0Ak" id="2N1CSrzST1a" role="2Ry0An">
-                        <property role="2Ry0Am" value="lib" />
-                        <node concept="2Ry0Ak" id="2N1CSrzST1b" role="2Ry0An">
-                          <property role="2Ry0Am" value="batik-gvt.jar" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2N1CSrzST1D" role="3bR37C">
-          <node concept="1BurEX" id="2N1CSrzST1E" role="1SiIV1">
-            <node concept="398BVA" id="2N1CSrzST1o" role="1BurEY">
-              <ref role="398BVh" node="7uZw0yZ2_Lj" resolve="mpsutil" />
-              <node concept="2Ry0Ak" id="2N1CSrzST1p" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2N1CSrzST1q" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mbeddr.mpsutil.plantuml" />
-                  <node concept="2Ry0Ak" id="2N1CSrzST1r" role="2Ry0An">
-                    <property role="2Ry0Am" value="solutions" />
-                    <node concept="2Ry0Ak" id="2N1CSrzST1s" role="2Ry0An">
-                      <property role="2Ry0Am" value="pluginSolution" />
-                      <node concept="2Ry0Ak" id="2N1CSrzST1t" role="2Ry0An">
-                        <property role="2Ry0Am" value="lib" />
-                        <node concept="2Ry0Ak" id="2N1CSrzST1u" role="2Ry0An">
-                          <property role="2Ry0Am" value="batik-parser.jar" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2N1CSrzST1W" role="3bR37C">
-          <node concept="1BurEX" id="2N1CSrzST1X" role="1SiIV1">
-            <node concept="398BVA" id="2N1CSrzST1F" role="1BurEY">
-              <ref role="398BVh" node="7uZw0yZ2_Lj" resolve="mpsutil" />
-              <node concept="2Ry0Ak" id="2N1CSrzST1G" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2N1CSrzST1H" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mbeddr.mpsutil.plantuml" />
-                  <node concept="2Ry0Ak" id="2N1CSrzST1I" role="2Ry0An">
-                    <property role="2Ry0Am" value="solutions" />
-                    <node concept="2Ry0Ak" id="2N1CSrzST1J" role="2Ry0An">
-                      <property role="2Ry0Am" value="pluginSolution" />
-                      <node concept="2Ry0Ak" id="2N1CSrzST1K" role="2Ry0An">
-                        <property role="2Ry0Am" value="lib" />
-                        <node concept="2Ry0Ak" id="2N1CSrzST1L" role="2Ry0An">
-                          <property role="2Ry0Am" value="batik-script.jar" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2N1CSrzST2f" role="3bR37C">
-          <node concept="1BurEX" id="2N1CSrzST2g" role="1SiIV1">
-            <node concept="398BVA" id="2N1CSrzST1Y" role="1BurEY">
-              <ref role="398BVh" node="7uZw0yZ2_Lj" resolve="mpsutil" />
-              <node concept="2Ry0Ak" id="2N1CSrzST1Z" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2N1CSrzST20" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mbeddr.mpsutil.plantuml" />
-                  <node concept="2Ry0Ak" id="2N1CSrzST21" role="2Ry0An">
-                    <property role="2Ry0Am" value="solutions" />
-                    <node concept="2Ry0Ak" id="2N1CSrzST22" role="2Ry0An">
-                      <property role="2Ry0Am" value="pluginSolution" />
-                      <node concept="2Ry0Ak" id="2N1CSrzST23" role="2Ry0An">
-                        <property role="2Ry0Am" value="lib" />
-                        <node concept="2Ry0Ak" id="2N1CSrzST24" role="2Ry0An">
-                          <property role="2Ry0Am" value="batik-svg-dom.jar" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2N1CSrzST2y" role="3bR37C">
-          <node concept="1BurEX" id="2N1CSrzST2z" role="1SiIV1">
-            <node concept="398BVA" id="2N1CSrzST2h" role="1BurEY">
-              <ref role="398BVh" node="7uZw0yZ2_Lj" resolve="mpsutil" />
-              <node concept="2Ry0Ak" id="2N1CSrzST2i" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2N1CSrzST2j" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mbeddr.mpsutil.plantuml" />
-                  <node concept="2Ry0Ak" id="2N1CSrzST2k" role="2Ry0An">
-                    <property role="2Ry0Am" value="solutions" />
-                    <node concept="2Ry0Ak" id="2N1CSrzST2l" role="2Ry0An">
-                      <property role="2Ry0Am" value="pluginSolution" />
-                      <node concept="2Ry0Ak" id="2N1CSrzST2m" role="2Ry0An">
-                        <property role="2Ry0Am" value="lib" />
-                        <node concept="2Ry0Ak" id="2N1CSrzST2n" role="2Ry0An">
-                          <property role="2Ry0Am" value="batik-svggen.jar" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2N1CSrzST2P" role="3bR37C">
-          <node concept="1BurEX" id="2N1CSrzST2Q" role="1SiIV1">
-            <node concept="398BVA" id="2N1CSrzST2$" role="1BurEY">
-              <ref role="398BVh" node="7uZw0yZ2_Lj" resolve="mpsutil" />
-              <node concept="2Ry0Ak" id="2N1CSrzST2_" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2N1CSrzST2A" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mbeddr.mpsutil.plantuml" />
-                  <node concept="2Ry0Ak" id="2N1CSrzST2B" role="2Ry0An">
-                    <property role="2Ry0Am" value="solutions" />
-                    <node concept="2Ry0Ak" id="2N1CSrzST2C" role="2Ry0An">
-                      <property role="2Ry0Am" value="pluginSolution" />
-                      <node concept="2Ry0Ak" id="2N1CSrzST2D" role="2Ry0An">
-                        <property role="2Ry0Am" value="lib" />
-                        <node concept="2Ry0Ak" id="2N1CSrzST2E" role="2Ry0An">
-                          <property role="2Ry0Am" value="batik-swing.jar" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2N1CSrzST38" role="3bR37C">
-          <node concept="1BurEX" id="2N1CSrzST39" role="1SiIV1">
-            <node concept="398BVA" id="2N1CSrzST2R" role="1BurEY">
-              <ref role="398BVh" node="7uZw0yZ2_Lj" resolve="mpsutil" />
-              <node concept="2Ry0Ak" id="2N1CSrzST2S" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2N1CSrzST2T" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mbeddr.mpsutil.plantuml" />
-                  <node concept="2Ry0Ak" id="2N1CSrzST2U" role="2Ry0An">
-                    <property role="2Ry0Am" value="solutions" />
-                    <node concept="2Ry0Ak" id="2N1CSrzST2V" role="2Ry0An">
-                      <property role="2Ry0Am" value="pluginSolution" />
-                      <node concept="2Ry0Ak" id="2N1CSrzST2W" role="2Ry0An">
-                        <property role="2Ry0Am" value="lib" />
-                        <node concept="2Ry0Ak" id="2N1CSrzST2X" role="2Ry0An">
-                          <property role="2Ry0Am" value="batik-transcoder.jar" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2N1CSrzST3r" role="3bR37C">
-          <node concept="1BurEX" id="2N1CSrzST3s" role="1SiIV1">
-            <node concept="398BVA" id="2N1CSrzST3a" role="1BurEY">
-              <ref role="398BVh" node="7uZw0yZ2_Lj" resolve="mpsutil" />
-              <node concept="2Ry0Ak" id="2N1CSrzST3b" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2N1CSrzST3c" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mbeddr.mpsutil.plantuml" />
-                  <node concept="2Ry0Ak" id="2N1CSrzST3d" role="2Ry0An">
-                    <property role="2Ry0Am" value="solutions" />
-                    <node concept="2Ry0Ak" id="2N1CSrzST3e" role="2Ry0An">
-                      <property role="2Ry0Am" value="pluginSolution" />
-                      <node concept="2Ry0Ak" id="2N1CSrzST3f" role="2Ry0An">
-                        <property role="2Ry0Am" value="lib" />
-                        <node concept="2Ry0Ak" id="2N1CSrzST3g" role="2Ry0An">
-                          <property role="2Ry0Am" value="batik-util.jar" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2N1CSrzST3I" role="3bR37C">
-          <node concept="1BurEX" id="2N1CSrzST3J" role="1SiIV1">
-            <node concept="398BVA" id="2N1CSrzST3t" role="1BurEY">
-              <ref role="398BVh" node="7uZw0yZ2_Lj" resolve="mpsutil" />
-              <node concept="2Ry0Ak" id="2N1CSrzST3u" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2N1CSrzST3v" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mbeddr.mpsutil.plantuml" />
-                  <node concept="2Ry0Ak" id="2N1CSrzST3w" role="2Ry0An">
-                    <property role="2Ry0Am" value="solutions" />
-                    <node concept="2Ry0Ak" id="2N1CSrzST3x" role="2Ry0An">
-                      <property role="2Ry0Am" value="pluginSolution" />
-                      <node concept="2Ry0Ak" id="2N1CSrzST3y" role="2Ry0An">
-                        <property role="2Ry0Am" value="lib" />
-                        <node concept="2Ry0Ak" id="2N1CSrzST3z" role="2Ry0An">
-                          <property role="2Ry0Am" value="batik-xml.jar" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2N1CSrzST41" role="3bR37C">
-          <node concept="1BurEX" id="2N1CSrzST42" role="1SiIV1">
-            <node concept="398BVA" id="2N1CSrzST3K" role="1BurEY">
-              <ref role="398BVh" node="7uZw0yZ2_Lj" resolve="mpsutil" />
-              <node concept="2Ry0Ak" id="2N1CSrzST3L" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2N1CSrzST3M" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mbeddr.mpsutil.plantuml" />
-                  <node concept="2Ry0Ak" id="2N1CSrzST3N" role="2Ry0An">
-                    <property role="2Ry0Am" value="solutions" />
-                    <node concept="2Ry0Ak" id="2N1CSrzST3O" role="2Ry0An">
-                      <property role="2Ry0Am" value="pluginSolution" />
-                      <node concept="2Ry0Ak" id="2N1CSrzST3P" role="2Ry0An">
-                        <property role="2Ry0Am" value="lib" />
-                        <node concept="2Ry0Ak" id="2N1CSrzST3Q" role="2Ry0An">
-                          <property role="2Ry0Am" value="batik.jar" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2N1CSrzST4k" role="3bR37C">
-          <node concept="1BurEX" id="2N1CSrzST4l" role="1SiIV1">
-            <node concept="398BVA" id="2N1CSrzST43" role="1BurEY">
-              <ref role="398BVh" node="7uZw0yZ2_Lj" resolve="mpsutil" />
-              <node concept="2Ry0Ak" id="2N1CSrzST44" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2N1CSrzST45" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mbeddr.mpsutil.plantuml" />
-                  <node concept="2Ry0Ak" id="2N1CSrzST46" role="2Ry0An">
-                    <property role="2Ry0Am" value="solutions" />
-                    <node concept="2Ry0Ak" id="2N1CSrzST47" role="2Ry0An">
-                      <property role="2Ry0Am" value="pluginSolution" />
-                      <node concept="2Ry0Ak" id="2N1CSrzST48" role="2Ry0An">
-                        <property role="2Ry0Am" value="lib" />
-                        <node concept="2Ry0Ak" id="2N1CSrzST49" role="2Ry0An">
-                          <property role="2Ry0Am" value="js.jar" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2N1CSrzST4B" role="3bR37C">
-          <node concept="1BurEX" id="2N1CSrzST4C" role="1SiIV1">
-            <node concept="398BVA" id="2N1CSrzST4m" role="1BurEY">
-              <ref role="398BVh" node="7uZw0yZ2_Lj" resolve="mpsutil" />
-              <node concept="2Ry0Ak" id="2N1CSrzST4n" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2N1CSrzST4o" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mbeddr.mpsutil.plantuml" />
-                  <node concept="2Ry0Ak" id="2N1CSrzST4p" role="2Ry0An">
-                    <property role="2Ry0Am" value="solutions" />
-                    <node concept="2Ry0Ak" id="2N1CSrzST4q" role="2Ry0An">
-                      <property role="2Ry0Am" value="pluginSolution" />
-                      <node concept="2Ry0Ak" id="2N1CSrzST4r" role="2Ry0An">
-                        <property role="2Ry0Am" value="lib" />
-                        <node concept="2Ry0Ak" id="2N1CSrzST4s" role="2Ry0An">
-                          <property role="2Ry0Am" value="plantuml.jar" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2N1CSrzST4U" role="3bR37C">
-          <node concept="1BurEX" id="2N1CSrzST4V" role="1SiIV1">
-            <node concept="398BVA" id="2N1CSrzST4D" role="1BurEY">
-              <ref role="398BVh" node="7uZw0yZ2_Lj" resolve="mpsutil" />
-              <node concept="2Ry0Ak" id="2N1CSrzST4E" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2N1CSrzST4F" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mbeddr.mpsutil.plantuml" />
-                  <node concept="2Ry0Ak" id="2N1CSrzST4G" role="2Ry0An">
-                    <property role="2Ry0Am" value="solutions" />
-                    <node concept="2Ry0Ak" id="2N1CSrzST4H" role="2Ry0An">
-                      <property role="2Ry0Am" value="pluginSolution" />
-                      <node concept="2Ry0Ak" id="2N1CSrzST4I" role="2Ry0An">
-                        <property role="2Ry0Am" value="lib" />
-                        <node concept="2Ry0Ak" id="2N1CSrzST4J" role="2Ry0An">
-                          <property role="2Ry0Am" value="xalan-2.6.0.jar" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="4VgGsUqPhAU" role="3bR37C">
-          <node concept="3bR9La" id="4VgGsUqPhAV" role="1SiIV1">
-            <property role="3bR36h" value="false" />
-            <ref role="3bR37D" node="11w71Xmfzpd" resolve="org.xml" />
-          </node>
-        </node>
-      </node>
-      <node concept="1E1JtD" id="2N1CSrzSKpi" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="com.mbeddr.mpsutil.plantuml.node" />
-        <property role="3LESm3" value="b4d28e19-7d2d-47e9-943e-3a41f97a0e52" />
-        <property role="2GAjPV" value="false" />
-        <node concept="3rtmxn" id="3xFG3bj5cMA" role="3bR31x">
-          <node concept="3LXTmp" id="3xFG3bj5cMB" role="3rtmxm">
-            <node concept="3qWCbU" id="3xFG3bj5cMC" role="3LXTna">
-              <property role="3qWCbO" value="icons/**, resources/**" />
-            </node>
-            <node concept="398BVA" id="3xFG3bj5cMD" role="3LXTmr">
-              <ref role="398BVh" node="7uZw0yZ2_Lj" resolve="mpsutil" />
-              <node concept="2Ry0Ak" id="3xFG3bj5cME" role="iGT6I">
-                <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="3xFG3bj5cMF" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mbeddr.mpsutil.plantuml.node" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="398BVA" id="2N1CSrzSKpj" role="3LF7KH">
-          <ref role="398BVh" node="7uZw0yZ2_Lj" resolve="mpsutil" />
-          <node concept="2Ry0Ak" id="2N1CSrzSKpn" role="iGT6I">
-            <property role="2Ry0Am" value="languages" />
-            <node concept="2Ry0Ak" id="2N1CSrzSKpo" role="2Ry0An">
-              <property role="2Ry0Am" value="com.mbeddr.mpsutil.plantuml.node" />
-              <node concept="2Ry0Ak" id="2N1CSrzSO5$" role="2Ry0An">
-                <property role="2Ry0Am" value="com.mbeddr.mpsutil.plantuml.node.mpl" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1E0d5M" id="2N1CSrzSKpw" role="1E1XAP">
-          <ref role="1E0d5P" node="4Hbnsm4OhEo" resolve="com.mbeddr.mpsutil.editor.querylist.runtime" />
-        </node>
-        <node concept="1SiIV0" id="2N1CSrzSOBy" role="3bR37C">
-          <node concept="3bR9La" id="2N1CSrzSOBz" role="1SiIV1">
-            <property role="3bR36h" value="false" />
-            <ref role="3bR37D" node="2N1CSrzsvbI" resolve="com.mbeddr.mpsutil.nodeaccess" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2VC4eVYcgRz" role="3bR37C">
-          <node concept="3bR9La" id="2VC4eVYcgR$" role="1SiIV1">
-            <property role="3bR36h" value="false" />
-            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2lop6rS5AmA" role="3bR37C">
-          <node concept="3bR9La" id="2lop6rS5AmB" role="1SiIV1">
-            <property role="3bR36h" value="false" />
-            <ref role="3bR37D" to="ffeo:xSXmQZAqVi" resolve="jetbrains.mps.ide.httpsupport.runtime" />
           </node>
         </node>
       </node>
@@ -16787,6 +16751,30 @@
         </node>
       </node>
     </node>
+    <node concept="m$_wf" id="1Rj3F434M3n" role="3989C9">
+      <property role="m$_wk" value="com.mbeddr.mpsutil.jfreechart" />
+      <node concept="3_J27D" id="1Rj3F434M3o" role="m$_yQ">
+        <node concept="3Mxwew" id="1Rj3F434M3p" role="3MwsjC">
+          <property role="3MwjfP" value="com.mbeddr.mpsutil.jfreechart" />
+        </node>
+      </node>
+      <node concept="3_J27D" id="1Rj3F434M3q" role="m_cZH">
+        <node concept="3Mxwew" id="1Rj3F434M3r" role="3MwsjC">
+          <property role="3MwjfP" value="com.mbeddr.mpsutil.jfreechart" />
+        </node>
+      </node>
+      <node concept="3_J27D" id="1Rj3F434M3s" role="m$_w8">
+        <node concept="3Mxwey" id="1Rj3F434M3t" role="3MwsjC">
+          <ref role="3Mxwex" node="2HHioL2Nii3" resolve="mbeddr.version" />
+        </node>
+      </node>
+      <node concept="m$f5U" id="1Rj3F434URE" role="m$_yh">
+        <ref role="m$f5T" node="7uOgiTa68Q" resolve="group.jfreechart" />
+      </node>
+      <node concept="m$_yC" id="1Rj3F434M3v" role="m$_yJ">
+        <ref role="m$_y1" to="ffeo:4k71ibbKLe8" resolve="jetbrains.mps.core" />
+      </node>
+    </node>
     <node concept="2G$12M" id="2jlBy7bQlGk" role="3989C9">
       <property role="TrG5h" value="group.treenotation" />
       <node concept="1E1JtA" id="2jlBy7bQp6P" role="2G$12L">
@@ -17010,6 +16998,30 @@
             </node>
           </node>
         </node>
+      </node>
+    </node>
+    <node concept="m$_wf" id="1Rj3F434oop" role="3989C9">
+      <property role="m$_wk" value="com.mbeddr.mpsutil.treenotations" />
+      <node concept="3_J27D" id="1Rj3F434oor" role="m$_yQ">
+        <node concept="3Mxwew" id="1Rj3F434xFf" role="3MwsjC">
+          <property role="3MwjfP" value="com.mbeddr.mpsutil.treenotations" />
+        </node>
+      </node>
+      <node concept="3_J27D" id="1Rj3F434oot" role="m_cZH">
+        <node concept="3Mxwew" id="1Rj3F434xFh" role="3MwsjC">
+          <property role="3MwjfP" value="com.mbeddr.mpsutil.treenotations" />
+        </node>
+      </node>
+      <node concept="3_J27D" id="1Rj3F434oov" role="m$_w8">
+        <node concept="3Mxwey" id="1Rj3F434yN6" role="3MwsjC">
+          <ref role="3Mxwex" node="2HHioL2Nii3" resolve="mbeddr.version" />
+        </node>
+      </node>
+      <node concept="m$f5U" id="1Rj3F434_2I" role="m$_yh">
+        <ref role="m$f5T" node="2jlBy7bQlGk" resolve="group.treenotation" />
+      </node>
+      <node concept="m$_yC" id="1Rj3F434FNu" role="m$_yJ">
+        <ref role="m$_y1" to="ffeo:4k71ibbKLe8" resolve="jetbrains.mps.core" />
       </node>
     </node>
     <node concept="2G$12M" id="5ovySaD2Vaa" role="3989C9">
@@ -17570,6 +17582,39 @@
             <property role="3bR36h" value="false" />
             <ref role="3bR37D" to="90a9:PE3B26QCrP" resolve="org.apache.commons" />
           </node>
+        </node>
+      </node>
+    </node>
+    <node concept="m$_wf" id="58oUBCRFYnR" role="3989C9">
+      <property role="m$_wk" value="com.mbeddr.mpsutil.generatorfacade" />
+      <node concept="3_J27D" id="58oUBCRFYnS" role="m$_yQ">
+        <node concept="3Mxwew" id="58oUBCRFYnT" role="3MwsjC">
+          <property role="3MwjfP" value="com.mbeddr.mpsutil.generatorfacade" />
+        </node>
+      </node>
+      <node concept="3_J27D" id="58oUBCRFYnU" role="m$_w8">
+        <node concept="3Mxwey" id="58oUBCRFYnV" role="3MwsjC">
+          <ref role="3Mxwex" node="2HHioL2Nii3" resolve="mbeddr.version" />
+        </node>
+      </node>
+      <node concept="m$f5U" id="58oUBCRG3LE" role="m$_yh">
+        <ref role="m$f5T" node="58oUBCRFNM4" resolve="group.generatorfacade" />
+      </node>
+      <node concept="m$_yC" id="58oUBCRFYnX" role="m$_yJ">
+        <ref role="m$_y1" to="ffeo:4k71ibbKLe8" resolve="jetbrains.mps.core" />
+      </node>
+      <node concept="3_J27D" id="58oUBCRFYo1" role="m_cZH">
+        <node concept="3Mxwew" id="58oUBCRFYo2" role="3MwsjC">
+          <property role="3MwjfP" value="com.mbeddr.mpsutil.generatorfacade" />
+        </node>
+      </node>
+      <node concept="2iUeEo" id="58oUBCRFYo3" role="2iVFfd">
+        <property role="2iUeEt" value="mbeddr" />
+        <property role="2iUeEu" value="http://mbeddr.com" />
+      </node>
+      <node concept="3_J27D" id="58oUBCRG2U6" role="3s6cr7">
+        <node concept="3Mxwew" id="58oUBCRG2Ua" role="3MwsjC">
+          <property role="3MwjfP" value="Utilities to run the generator to do M2M transformations" />
         </node>
       </node>
     </node>
@@ -18289,6 +18334,40 @@
       <node concept="m$_wl" id="6rBfBe1XyuT" role="39821P">
         <ref role="m_rDy" node="6rBfBe1XaAA" resolve="com.mbeddr.mpsutil.contextactions" />
       </node>
+      <node concept="m$_wl" id="1Rj3F4357qn" role="39821P">
+        <ref role="m_rDy" node="1Rj3F434oop" resolve="com.mbeddr.mpsutil.treenotations" />
+      </node>
+      <node concept="m$_wl" id="1Rj3F4350z$" role="39821P">
+        <ref role="m_rDy" node="1Rj3F434M3n" resolve="com.mbeddr.mpsutil.jfreechart" />
+        <node concept="398223" id="1Rj3F4353Z5" role="39821P">
+          <node concept="398223" id="7uOgiTaLEr" role="39821P">
+            <node concept="3_J27D" id="7uOgiTaLEs" role="Nbhlr">
+              <node concept="3Mxwew" id="7uOgiTaLEt" role="3MwsjC">
+                <property role="3MwjfP" value="jfreechart" />
+              </node>
+            </node>
+            <node concept="2HvfSZ" id="7uOgiTaLEu" role="39821P">
+              <node concept="398BVA" id="7uOgiTaLEv" role="2HvfZ0">
+                <ref role="398BVh" node="7uZw0yZ2_Lj" />
+                <node concept="2Ry0Ak" id="7uOgiTaLEw" role="iGT6I">
+                  <property role="2Ry0Am" value="solutions" />
+                  <node concept="2Ry0Ak" id="7uOgiTaLEx" role="2Ry0An">
+                    <property role="2Ry0Am" value="com.mbeddr.mpsutil.jfreechart.runtime" />
+                    <node concept="2Ry0Ak" id="7uOgiTaO8q" role="2Ry0An">
+                      <property role="2Ry0Am" value="lib" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3_J27D" id="1Rj3F4353Z6" role="Nbhlr">
+            <node concept="3Mxwew" id="1Rj3F4353Z9" role="3MwsjC">
+              <property role="3MwjfP" value="lib" />
+            </node>
+          </node>
+        </node>
+      </node>
       <node concept="m$_wl" id="58oUBCRG6v3" role="39821P">
         <ref role="m_rDy" node="58oUBCRFYnR" resolve="com.mbeddr.mpsutil.generatorfacade" />
       </node>
@@ -18365,27 +18444,6 @@
                   <node concept="2Ry0Ak" id="6L0JKBMPRza" role="2Ry0An">
                     <property role="2Ry0Am" value="com.mbeddr.mpsutil.datepicker.runtime" />
                     <node concept="2Ry0Ak" id="6L0JKBMXb9a" role="2Ry0An">
-                      <property role="2Ry0Am" value="lib" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="398223" id="7uOgiTaLEr" role="39821P">
-            <node concept="3_J27D" id="7uOgiTaLEs" role="Nbhlr">
-              <node concept="3Mxwew" id="7uOgiTaLEt" role="3MwsjC">
-                <property role="3MwjfP" value="jfreechart" />
-              </node>
-            </node>
-            <node concept="2HvfSZ" id="7uOgiTaLEu" role="39821P">
-              <node concept="398BVA" id="7uOgiTaLEv" role="2HvfZ0">
-                <ref role="398BVh" node="7uZw0yZ2_Lj" resolve="mpsutil" />
-                <node concept="2Ry0Ak" id="7uOgiTaLEw" role="iGT6I">
-                  <property role="2Ry0Am" value="solutions" />
-                  <node concept="2Ry0Ak" id="7uOgiTaLEx" role="2Ry0An">
-                    <property role="2Ry0Am" value="com.mbeddr.mpsutil.jfreechart.runtime" />
-                    <node concept="2Ry0Ak" id="7uOgiTaO8q" role="2Ry0An">
                       <property role="2Ry0Am" value="lib" />
                     </node>
                   </node>

--- a/code/languages/com.mbeddr.build/solutions/com.mbeddr.platform/models/com/mbeddr/platform/build.mps
+++ b/code/languages/com.mbeddr.build/solutions/com.mbeddr.platform/models/com/mbeddr/platform/build.mps
@@ -598,6 +598,102 @@
         <ref role="m$f5T" node="3quoVcnFQX5" resolve="group.projectview" />
       </node>
     </node>
+    <node concept="m$_wf" id="6rBfBe1WhKl" role="3989C9">
+      <property role="m$_wk" value="com.mbeddr.mpsutil.interpreter" />
+      <node concept="3_J27D" id="6rBfBe1WhKm" role="m$_yQ">
+        <node concept="3Mxwew" id="6rBfBe1WhKn" role="3MwsjC">
+          <property role="3MwjfP" value="com.mbeddr.mpsutil.interpreter" />
+        </node>
+      </node>
+      <node concept="3_J27D" id="6rBfBe1WhKo" role="m_cZH">
+        <node concept="3Mxwew" id="6rBfBe1WhKp" role="3MwsjC">
+          <property role="3MwjfP" value="com.mbeddr.mpsutil.interpreter" />
+        </node>
+      </node>
+      <node concept="3_J27D" id="6rBfBe1WhKq" role="m$_w8">
+        <node concept="3Mxwey" id="6rBfBe1WhKr" role="3MwsjC">
+          <ref role="3Mxwex" node="2HHioL2Nii3" resolve="mbeddr.version" />
+        </node>
+      </node>
+      <node concept="m$_yC" id="6rBfBe1WhKs" role="m$_yJ">
+        <ref role="m$_y1" to="ffeo:4k71ibbKLe8" resolve="jetbrains.mps.core" />
+      </node>
+      <node concept="m$_yC" id="6rBfBe1WhKt" role="m$_yJ">
+        <ref role="m$_y1" to="90a9:2Xjt3l57iTJ" resolve="de.slisson.mps.hacks" />
+      </node>
+      <node concept="m$_yC" id="6rBfBe1WhKu" role="m$_yJ">
+        <ref role="m$_y1" to="ffeo:4k71ibbLe59" resolve="com.intellij.modules.mps" />
+      </node>
+      <node concept="m$_yC" id="6rBfBe1WhKv" role="m$_yJ">
+        <ref role="m$_y1" to="90a9:4p3FRivDLPy" resolve="org.apache.commons" />
+      </node>
+      <node concept="m$_yC" id="6rBfBe1WsaJ" role="m$_yJ">
+        <ref role="m$_y1" to="90a9:1sO539bGQvt" resolve="de.slisson.mps.richtext" />
+      </node>
+      <node concept="m$_yC" id="6rBfBe1Wuqz" role="m$_yJ">
+        <ref role="m$_y1" node="5fGcQI94fMR" resolve="com.mbeddr.mpsutil.common" />
+      </node>
+      <node concept="m$f5U" id="6rBfBe1WpV0" role="m$_yh">
+        <ref role="m$f5T" node="3quoVcnN1e0" resolve="group.interpreter" />
+      </node>
+    </node>
+    <node concept="m$_wf" id="6rBfBe1WRMd" role="3989C9">
+      <property role="m$_wk" value="com.mbeddr.mpsutil.varscope" />
+      <node concept="3_J27D" id="6rBfBe1WRMe" role="m$_yQ">
+        <node concept="3Mxwew" id="6rBfBe1WRMf" role="3MwsjC">
+          <property role="3MwjfP" value="com.mbeddr.mpsutil.varscope" />
+        </node>
+      </node>
+      <node concept="3_J27D" id="6rBfBe1WRMg" role="m_cZH">
+        <node concept="3Mxwew" id="6rBfBe1WRMh" role="3MwsjC">
+          <property role="3MwjfP" value="com.mbeddr.mpsutil.varscope" />
+        </node>
+      </node>
+      <node concept="3_J27D" id="6rBfBe1WRMi" role="m$_w8">
+        <node concept="3Mxwey" id="6rBfBe1WRMj" role="3MwsjC">
+          <ref role="3Mxwex" node="2HHioL2Nii3" resolve="mbeddr.version" />
+        </node>
+      </node>
+      <node concept="m$f5U" id="6rBfBe1X2OW" role="m$_yh">
+        <ref role="m$f5T" node="5ovySaD2Vaa" resolve="group.varscope" />
+      </node>
+      <node concept="m$_yC" id="6rBfBe1X54_" role="m$_yJ">
+        <ref role="m$_y1" to="ffeo:4k71ibbKLe8" resolve="jetbrains.mps.core" />
+      </node>
+    </node>
+    <node concept="m$_wf" id="6rBfBe1XaAA" role="3989C9">
+      <property role="m$_wk" value="com.mbeddr.mpsutil.contextactions" />
+      <node concept="3_J27D" id="6rBfBe1XaAB" role="m$_yQ">
+        <node concept="3Mxwew" id="6rBfBe1XaAC" role="3MwsjC">
+          <property role="3MwjfP" value="com.mbeddr.mpsutil.contextactions" />
+        </node>
+      </node>
+      <node concept="3_J27D" id="6rBfBe1XaAD" role="m_cZH">
+        <node concept="3Mxwew" id="6rBfBe1XaAE" role="3MwsjC">
+          <property role="3MwjfP" value="com.mbeddr.mpsutil.contextactions" />
+        </node>
+      </node>
+      <node concept="3_J27D" id="6rBfBe1XaAF" role="m$_w8">
+        <node concept="3Mxwey" id="6rBfBe1XaAG" role="3MwsjC">
+          <ref role="3Mxwex" node="2HHioL2Nii3" resolve="mbeddr.version" />
+        </node>
+      </node>
+      <node concept="m$f5U" id="6rBfBe1Xfqb" role="m$_yh">
+        <ref role="m$f5T" node="3quoVcnQyPx" resolve="group.contextactions" />
+      </node>
+      <node concept="m$_yC" id="6rBfBe1XaAI" role="m$_yJ">
+        <ref role="m$_y1" to="ffeo:4k71ibbKLe8" resolve="jetbrains.mps.core" />
+      </node>
+      <node concept="m$_yC" id="6rBfBe1XhDR" role="m$_yJ">
+        <ref role="m$_y1" to="90a9:2Xjt3l57iTJ" resolve="de.slisson.mps.hacks" />
+      </node>
+      <node concept="m$_yC" id="6rBfBe1XjT_" role="m$_yJ">
+        <ref role="m$_y1" to="90a9:4p3FRivDLPy" resolve="org.apache.commons" />
+      </node>
+      <node concept="m$_yC" id="6rBfBe1Xm9l" role="m$_yJ">
+        <ref role="m$_y1" to="ffeo:4k71ibbLe59" resolve="com.intellij.modules.mps" />
+      </node>
+    </node>
     <node concept="m$_wf" id="7uZw0yZ2_Jq" role="3989C9">
       <property role="m$_wk" value="com.mbeddr.mpsutil" />
       <node concept="m$_yC" id="64SK4bcJIU1" role="m$_yJ">
@@ -646,9 +742,6 @@
       <node concept="m$f5U" id="3quoVcnS4VA" role="m$_yh">
         <ref role="m$f5T" node="3quoVcnF0zV" resolve="group.ccmenu" />
       </node>
-      <node concept="m$f5U" id="3quoVcnS4Wm" role="m$_yh">
-        <ref role="m$f5T" node="3quoVcnQyPx" resolve="group.contextactions" />
-      </node>
       <node concept="m$f5U" id="3quoVcnS4WI" role="m$_yh">
         <ref role="m$f5T" node="3quoVcnHJhB" resolve="group.datepicker" />
       </node>
@@ -658,8 +751,8 @@
       <node concept="m$f5U" id="3quoVcnS52a" role="m$_yh">
         <ref role="m$f5T" node="3quoVcnGSCe" resolve="group.globalgenerators" />
       </node>
-      <node concept="m$f5U" id="3quoVcnS5al" role="m$_yh">
-        <ref role="m$f5T" node="3quoVcnN1e0" resolve="group.interpreter" />
+      <node concept="m$f5U" id="6rBfBe1WN_k" role="m$_yh">
+        <ref role="m$f5T" node="6rBfBe1W$s6" resolve="group.interpreter-java" />
       </node>
       <node concept="m$f5U" id="6mJAQ2PgcmS" role="m$_yh">
         <ref role="m$f5T" node="3bCcKqaTTOY" resolve="group.incrementalcomputation" />
@@ -705,9 +798,6 @@
       </node>
       <node concept="m$f5U" id="2jlBy7bQIhH" role="m$_yh">
         <ref role="m$f5T" node="2jlBy7bQlGk" resolve="group.treenotation" />
-      </node>
-      <node concept="m$f5U" id="5ovySaD3gUa" role="m$_yh">
-        <ref role="m$f5T" node="5ovySaD2Vaa" resolve="group.varscope" />
       </node>
       <node concept="m$f5U" id="4kGsAe0vUjA" role="m$_yh">
         <ref role="m$f5T" node="4kGsAe0vxvm" resolve="com.mbeddr.mpsutil.resources" />
@@ -771,6 +861,15 @@
       </node>
       <node concept="m$_yC" id="64SK4bcOiM_" role="m$_yJ">
         <ref role="m$_y1" node="64SK4bcO2rO" resolve="com.mbeddr.mpsutil.projectview" />
+      </node>
+      <node concept="m$_yC" id="6rBfBe1WPPO" role="m$_yJ">
+        <ref role="m$_y1" node="6rBfBe1WhKl" resolve="com.mbeddr.mpsutil.interpreter" />
+      </node>
+      <node concept="m$_yC" id="6rBfBe1X8sS" role="m$_yJ">
+        <ref role="m$_y1" node="6rBfBe1WRMd" resolve="com.mbeddr.mpsutil.varscope" />
+      </node>
+      <node concept="m$_yC" id="6rBfBe1XpxG" role="m$_yJ">
+        <ref role="m$_y1" node="6rBfBe1XaAA" resolve="com.mbeddr.mpsutil.contextactions" />
       </node>
       <node concept="3_J27D" id="7uZw0yZ2_Jx" role="m_cZH">
         <node concept="3Mxwew" id="7uZw0yZ2_Jy" role="3MwsjC">
@@ -7485,6 +7584,9 @@
           </node>
         </node>
       </node>
+    </node>
+    <node concept="2G$12M" id="6rBfBe1W$s6" role="3989C9">
+      <property role="TrG5h" value="group.interpreter-java" />
       <node concept="1E1JtA" id="15E$Thf$Je7" role="2G$12L">
         <property role="BnDLt" value="true" />
         <property role="TrG5h" value="com.mbeddr.mpsutil.javainterpreter" />
@@ -18177,6 +18279,15 @@
       </node>
       <node concept="m$_wl" id="64SK4bcOKUz" role="39821P">
         <ref role="m_rDy" node="64SK4bcO2rO" resolve="com.mbeddr.mpsutil.projectview" />
+      </node>
+      <node concept="m$_wl" id="6rBfBe1XsD$" role="39821P">
+        <ref role="m_rDy" node="6rBfBe1WhKl" resolve="com.mbeddr.mpsutil.interpreter" />
+      </node>
+      <node concept="m$_wl" id="6rBfBe1Xw87" role="39821P">
+        <ref role="m_rDy" node="6rBfBe1WRMd" resolve="com.mbeddr.mpsutil.varscope" />
+      </node>
+      <node concept="m$_wl" id="6rBfBe1XyuT" role="39821P">
+        <ref role="m_rDy" node="6rBfBe1XaAA" resolve="com.mbeddr.mpsutil.contextactions" />
       </node>
       <node concept="m$_wl" id="58oUBCRG6v3" role="39821P">
         <ref role="m_rDy" node="58oUBCRFYnR" resolve="com.mbeddr.mpsutil.generatorfacade" />

--- a/code/languages/com.mbeddr.build/solutions/com.mbeddr.platform/models/com/mbeddr/platform/build.mps
+++ b/code/languages/com.mbeddr.build/solutions/com.mbeddr.platform/models/com/mbeddr/platform/build.mps
@@ -565,6 +565,39 @@
         <ref role="m$f5T" node="3quoVcnPZaE" resolve="group.editor-support" />
       </node>
     </node>
+    <node concept="m$_wf" id="64SK4bcO2rO" role="3989C9">
+      <property role="m$_wk" value="com.mbeddr.mpsutil.projectview" />
+      <node concept="3_J27D" id="64SK4bcO2rP" role="m$_yQ">
+        <node concept="3Mxwew" id="64SK4bcO2rQ" role="3MwsjC">
+          <property role="3MwjfP" value="com.mbeddr.mpsutil.projectview" />
+        </node>
+      </node>
+      <node concept="3_J27D" id="64SK4bcO2rR" role="m_cZH">
+        <node concept="3Mxwew" id="64SK4bcO2rS" role="3MwsjC">
+          <property role="3MwjfP" value="com.mbeddr.mpsutil.projectview" />
+        </node>
+      </node>
+      <node concept="3_J27D" id="64SK4bcO2rT" role="m$_w8">
+        <node concept="3Mxwey" id="64SK4bcO2rU" role="3MwsjC">
+          <ref role="3Mxwex" node="2HHioL2Nii3" resolve="mbeddr.version" />
+        </node>
+      </node>
+      <node concept="m$_yC" id="64SK4bcO2rV" role="m$_yJ">
+        <ref role="m$_y1" to="ffeo:4k71ibbKLe8" resolve="jetbrains.mps.core" />
+      </node>
+      <node concept="m$_yC" id="64SK4bcO2rW" role="m$_yJ">
+        <ref role="m$_y1" to="90a9:2Xjt3l57iTJ" resolve="de.slisson.mps.hacks" />
+      </node>
+      <node concept="m$_yC" id="64SK4bcO2rX" role="m$_yJ">
+        <ref role="m$_y1" to="ffeo:4k71ibbLe59" resolve="com.intellij.modules.mps" />
+      </node>
+      <node concept="m$_yC" id="64SK4bcOfpl" role="m$_yJ">
+        <ref role="m$_y1" to="90a9:4p3FRivDLPy" resolve="org.apache.commons" />
+      </node>
+      <node concept="m$f5U" id="64SK4bcOd9y" role="m$_yh">
+        <ref role="m$f5T" node="3quoVcnFQX5" resolve="group.projectview" />
+      </node>
+    </node>
     <node concept="m$_wf" id="7uZw0yZ2_Jq" role="3989C9">
       <property role="m$_wk" value="com.mbeddr.mpsutil" />
       <node concept="m$_yC" id="64SK4bcJIU1" role="m$_yJ">
@@ -648,9 +681,6 @@
       </node>
       <node concept="m$f5U" id="3quoVcnS5k$" role="m$_yh">
         <ref role="m$f5T" node="3quoVcnI9Jv" resolve="group.preferenceform" />
-      </node>
-      <node concept="m$f5U" id="3quoVcnS5tL" role="m$_yh">
-        <ref role="m$f5T" node="3quoVcnFQX5" resolve="group.projectview" />
       </node>
       <node concept="m$f5U" id="3quoVcnS5uV" role="m$_yh">
         <ref role="m$f5T" node="3quoVcnPcDz" resolve="group.rcp" />
@@ -739,6 +769,9 @@
       <node concept="m$_yC" id="64SK4bcNIGW" role="m$_yJ">
         <ref role="m$_y1" node="64SK4bcNyQW" resolve="com.mbeddr.mpsutil.editorsupport" />
       </node>
+      <node concept="m$_yC" id="64SK4bcOiM_" role="m$_yJ">
+        <ref role="m$_y1" node="64SK4bcO2rO" resolve="com.mbeddr.mpsutil.projectview" />
+      </node>
       <node concept="3_J27D" id="7uZw0yZ2_Jx" role="m_cZH">
         <node concept="3Mxwew" id="7uZw0yZ2_Jy" role="3MwsjC">
           <property role="3MwjfP" value="mbeddr.mpsutil" />
@@ -767,8 +800,14 @@
       <node concept="m$_yC" id="24ObHxTzV4Y" role="m$_yJ">
         <ref role="m$_y1" to="ffeo:4k71ibbKLe8" resolve="jetbrains.mps.core" />
       </node>
-      <node concept="m$_yC" id="24ObHxTzV4Z" role="m$_yJ">
-        <ref role="m$_y1" node="7uZw0yZ2_Jq" resolve="com.mbeddr.mpsutil" />
+      <node concept="m$_yC" id="64SK4bcOl2U" role="m$_yJ">
+        <ref role="m$_y1" node="64SK4bcO2rO" resolve="com.mbeddr.mpsutil.projectview" />
+      </node>
+      <node concept="m$_yC" id="64SK4bcNZ46" role="m$_yJ">
+        <ref role="m$_y1" to="ffeo:RJsmGEieyQ" resolve="jetbrains.mps.vcs" />
+      </node>
+      <node concept="m$_yC" id="64SK4bcO1jT" role="m$_yJ">
+        <ref role="m$_y1" to="90a9:2Xjt3l57iTJ" resolve="de.slisson.mps.hacks" />
       </node>
       <node concept="3_J27D" id="24ObHxTzV50" role="m_cZH">
         <node concept="3Mxwew" id="24ObHxTzV51" role="3MwsjC">
@@ -18042,44 +18081,49 @@
       <node concept="m$_wl" id="5fGcQI97F2C" role="39821P">
         <ref role="m_rDy" node="5fGcQI93Tz0" resolve="com.mbeddr.mpsutil.processwizard" />
       </node>
-      <node concept="m$_wl" id="58oUBCRG6v3" role="39821P">
-        <ref role="m_rDy" node="58oUBCRFYnR" resolve="com.mbeddr.mpsutil.generatorfacade" />
+      <node concept="m$_wl" id="64SK4bcOniE" role="39821P">
+        <ref role="m_rDy" node="64SK4bcNyQW" resolve="com.mbeddr.mpsutil.editorsupport" />
       </node>
-      <node concept="m$_wl" id="6hpTCZQe4Ro" role="39821P">
-        <ref role="m_rDy" node="6hpTCZQdXQX" resolve="com.mbeddr.mpsutil.editor.querylist" />
-      </node>
-      <node concept="m$_wl" id="3lZeU8ehKmj" role="39821P">
-        <ref role="m_rDy" node="3lZeU8ehrPx" resolve="com.mbeddr.mpsutil.httpsupport" />
-        <node concept="398223" id="3lZeU8ehQ1N" role="39821P">
-          <node concept="2HvfSZ" id="6ucYLjonLe2" role="39821P">
-            <node concept="398BVA" id="6ucYLjonLe3" role="2HvfZ0">
-              <ref role="398BVh" node="7uZw0yZ2_Lj" resolve="mpsutil" />
-              <node concept="2Ry0Ak" id="6ucYLjonLe4" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="6ucYLjonLe5" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mbeddr.mpsutil.httpsupport.rt" />
-                  <node concept="2Ry0Ak" id="6ucYLjonLe6" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
+      <node concept="m$_wl" id="64SK4bcOqRB" role="39821P">
+        <ref role="m_rDy" node="64SK4bcIqLW" resolve="com.mbeddr.mpsutil.jung" />
+        <node concept="398223" id="64SK4bcOuny" role="39821P">
+          <node concept="398223" id="2mU72gDysQA" role="39821P">
+            <node concept="3_J27D" id="2mU72gDysQB" role="Nbhlr">
+              <node concept="3Mxwew" id="2mU72gDysQC" role="3MwsjC">
+                <property role="3MwjfP" value="jung" />
+              </node>
+            </node>
+            <node concept="2HvfSZ" id="2mU72gDysQD" role="39821P">
+              <node concept="398BVA" id="2mU72gDysQE" role="2HvfZ0">
+                <ref role="398BVh" node="7uZw0yZ2_Lj" resolve="mpsutil" />
+                <node concept="2Ry0Ak" id="2mU72gDysQF" role="iGT6I">
+                  <property role="2Ry0Am" value="languages" />
+                  <node concept="2Ry0Ak" id="2mU72gDysQG" role="2Ry0An">
+                    <property role="2Ry0Am" value="com.mbeddr.mpsutil.jung" />
+                    <node concept="2Ry0Ak" id="2mU72gDysQH" role="2Ry0An">
+                      <property role="2Ry0Am" value="solutions" />
+                      <node concept="2Ry0Ak" id="2mU72gDysQI" role="2Ry0An">
+                        <property role="2Ry0Am" value="pluginSolution" />
+                        <node concept="2Ry0Ak" id="2mU72gDysQJ" role="2Ry0An">
+                          <property role="2Ry0Am" value="lib" />
+                        </node>
+                      </node>
+                    </node>
                   </node>
                 </node>
               </node>
             </node>
           </node>
-          <node concept="3_J27D" id="3lZeU8ehQ1O" role="Nbhlr">
-            <node concept="3Mxwew" id="3lZeU8ehR9E" role="3MwsjC">
+          <node concept="3_J27D" id="64SK4bcOunz" role="Nbhlr">
+            <node concept="3Mxwew" id="64SK4bcOvvr" role="3MwsjC">
               <property role="3MwjfP" value="lib" />
             </node>
           </node>
         </node>
       </node>
-      <node concept="m$_wl" id="6ucYLjol21$" role="39821P">
-        <ref role="m_rDy" node="7uZw0yZ2_Jq" resolve="com.mbeddr.mpsutil" />
-        <node concept="398223" id="6ucYLjonLdw" role="39821P">
-          <node concept="3_J27D" id="6ucYLjonLdx" role="Nbhlr">
-            <node concept="3Mxwew" id="6ucYLjonLdy" role="3MwsjC">
-              <property role="3MwjfP" value="lib" />
-            </node>
-          </node>
+      <node concept="m$_wl" id="64SK4bcO$6K" role="39821P">
+        <ref role="m_rDy" node="64SK4bcJmGP" resolve="com.mbeddr.mpsutil.plantuml" />
+        <node concept="398223" id="64SK4bcOAti" role="39821P">
           <node concept="2HvfSZ" id="11w71XmfIx2" role="39821P">
             <node concept="398BVA" id="11w71XmfIx3" role="2HvfZ0">
               <ref role="398BVh" node="7uZw0yZ2_Lj" resolve="mpsutil" />
@@ -18121,31 +18165,55 @@
               </node>
             </node>
           </node>
-          <node concept="398223" id="2mU72gDysQA" role="39821P">
-            <node concept="3_J27D" id="2mU72gDysQB" role="Nbhlr">
-              <node concept="3Mxwew" id="2mU72gDysQC" role="3MwsjC">
-                <property role="3MwjfP" value="jung" />
-              </node>
+          <node concept="3_J27D" id="64SK4bcOAtj" role="Nbhlr">
+            <node concept="3Mxwew" id="64SK4bcOB_b" role="3MwsjC">
+              <property role="3MwjfP" value="lib" />
             </node>
-            <node concept="2HvfSZ" id="2mU72gDysQD" role="39821P">
-              <node concept="398BVA" id="2mU72gDysQE" role="2HvfZ0">
-                <ref role="398BVh" node="7uZw0yZ2_Lj" resolve="mpsutil" />
-                <node concept="2Ry0Ak" id="2mU72gDysQF" role="iGT6I">
-                  <property role="2Ry0Am" value="languages" />
-                  <node concept="2Ry0Ak" id="2mU72gDysQG" role="2Ry0An">
-                    <property role="2Ry0Am" value="com.mbeddr.mpsutil.jung" />
-                    <node concept="2Ry0Ak" id="2mU72gDysQH" role="2Ry0An">
-                      <property role="2Ry0Am" value="solutions" />
-                      <node concept="2Ry0Ak" id="2mU72gDysQI" role="2Ry0An">
-                        <property role="2Ry0Am" value="pluginSolution" />
-                        <node concept="2Ry0Ak" id="2mU72gDysQJ" role="2Ry0An">
-                          <property role="2Ry0Am" value="lib" />
-                        </node>
-                      </node>
-                    </node>
+          </node>
+        </node>
+      </node>
+      <node concept="m$_wl" id="64SK4bcOF5o" role="39821P">
+        <ref role="m_rDy" node="64SK4bcJTt6" resolve="com.mbeddr.mpsutil.suppresswarning" />
+      </node>
+      <node concept="m$_wl" id="64SK4bcOKUz" role="39821P">
+        <ref role="m_rDy" node="64SK4bcO2rO" resolve="com.mbeddr.mpsutil.projectview" />
+      </node>
+      <node concept="m$_wl" id="58oUBCRG6v3" role="39821P">
+        <ref role="m_rDy" node="58oUBCRFYnR" resolve="com.mbeddr.mpsutil.generatorfacade" />
+      </node>
+      <node concept="m$_wl" id="6hpTCZQe4Ro" role="39821P">
+        <ref role="m_rDy" node="6hpTCZQdXQX" resolve="com.mbeddr.mpsutil.editor.querylist" />
+      </node>
+      <node concept="m$_wl" id="3lZeU8ehKmj" role="39821P">
+        <ref role="m_rDy" node="3lZeU8ehrPx" resolve="com.mbeddr.mpsutil.httpsupport" />
+        <node concept="398223" id="3lZeU8ehQ1N" role="39821P">
+          <node concept="2HvfSZ" id="6ucYLjonLe2" role="39821P">
+            <node concept="398BVA" id="6ucYLjonLe3" role="2HvfZ0">
+              <ref role="398BVh" node="7uZw0yZ2_Lj" resolve="mpsutil" />
+              <node concept="2Ry0Ak" id="6ucYLjonLe4" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="6ucYLjonLe5" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mbeddr.mpsutil.httpsupport.rt" />
+                  <node concept="2Ry0Ak" id="6ucYLjonLe6" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
                   </node>
                 </node>
               </node>
+            </node>
+          </node>
+          <node concept="3_J27D" id="3lZeU8ehQ1O" role="Nbhlr">
+            <node concept="3Mxwew" id="3lZeU8ehR9E" role="3MwsjC">
+              <property role="3MwjfP" value="lib" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="m$_wl" id="6ucYLjol21$" role="39821P">
+        <ref role="m_rDy" node="7uZw0yZ2_Jq" resolve="com.mbeddr.mpsutil" />
+        <node concept="398223" id="6ucYLjonLdw" role="39821P">
+          <node concept="3_J27D" id="6ucYLjonLdx" role="Nbhlr">
+            <node concept="3Mxwew" id="6ucYLjonLdy" role="3MwsjC">
+              <property role="3MwjfP" value="lib" />
             </node>
           </node>
           <node concept="398223" id="3$kl3LJXBTZ" role="39821P">

--- a/code/languages/com.mbeddr.build/solutions/com.mbeddr.platform/models/com/mbeddr/platform/build.mps
+++ b/code/languages/com.mbeddr.build/solutions/com.mbeddr.platform/models/com/mbeddr/platform/build.mps
@@ -2,10 +2,10 @@
 <model ref="r:742f344d-4dc4-4862-992c-4bc94b094870(com.mbeddr.mpsutil.dev.build)">
   <persistence version="9" />
   <languages>
-    <use id="798100da-4f0a-421a-b991-71f8c50ce5d2" name="jetbrains.mps.build" version="-1" />
-    <use id="0cf935df-4699-4e9c-a132-fa109541cba3" name="jetbrains.mps.build.mps" version="-1" />
-    <use id="479c7a8c-02f9-43b5-9139-d910cb22f298" name="jetbrains.mps.core.xml" version="-1" />
-    <use id="3600cb0a-44dd-4a5b-9968-22924406419e" name="jetbrains.mps.build.mps.tests" version="-1" />
+    <use id="798100da-4f0a-421a-b991-71f8c50ce5d2" name="jetbrains.mps.build" version="0" />
+    <use id="0cf935df-4699-4e9c-a132-fa109541cba3" name="jetbrains.mps.build.mps" version="5" />
+    <use id="479c7a8c-02f9-43b5-9139-d910cb22f298" name="jetbrains.mps.core.xml" version="0" />
+    <use id="3600cb0a-44dd-4a5b-9968-22924406419e" name="jetbrains.mps.build.mps.tests" version="0" />
   </languages>
   <imports>
     <import index="ffeo" ref="r:874d959d-e3b4-4d04-b931-ca849af130dd(jetbrains.mps.ide.build)" />
@@ -448,8 +448,101 @@
         <property role="2iUeEu" value="http://mbeddr.com" />
       </node>
     </node>
+    <node concept="m$_wf" id="64SK4bcIqLW" role="3989C9">
+      <property role="m$_wk" value="com.mbeddr.mpsutil.jung" />
+      <node concept="3_J27D" id="64SK4bcIqLY" role="m$_yQ">
+        <node concept="3Mxwew" id="64SK4bcIv$i" role="3MwsjC">
+          <property role="3MwjfP" value="com.mbeddr.mpsutil.jung" />
+        </node>
+      </node>
+      <node concept="3_J27D" id="64SK4bcIqM0" role="m_cZH">
+        <node concept="3Mxwew" id="64SK4bcIv$k" role="3MwsjC">
+          <property role="3MwjfP" value="com.mbeddr.mpsutil.jung" />
+        </node>
+      </node>
+      <node concept="3_J27D" id="64SK4bcIqM2" role="m$_w8">
+        <node concept="3Mxwey" id="64SK4bcIwG9" role="3MwsjC">
+          <ref role="3Mxwex" node="2HHioL2Nii3" resolve="mbeddr.version" />
+        </node>
+      </node>
+      <node concept="m$f5U" id="64SK4bcI$3A" role="m$_yh">
+        <ref role="m$f5T" node="3quoVcnKz3m" resolve="group.jung" />
+      </node>
+      <node concept="m$_yC" id="64SK4bcI_br" role="m$_yJ">
+        <ref role="m$_y1" to="ffeo:4k71ibbKLe8" resolve="jetbrains.mps.core" />
+      </node>
+    </node>
+    <node concept="m$_wf" id="64SK4bcJmGP" role="3989C9">
+      <property role="m$_wk" value="com.mbeddr.mpsutil.plantuml" />
+      <node concept="3_J27D" id="64SK4bcJmGQ" role="m$_yQ">
+        <node concept="3Mxwew" id="64SK4bcJmGR" role="3MwsjC">
+          <property role="3MwjfP" value="com.mbeddr.mpsutil.plantuml" />
+        </node>
+      </node>
+      <node concept="3_J27D" id="64SK4bcJmGS" role="m_cZH">
+        <node concept="3Mxwew" id="64SK4bcJmGT" role="3MwsjC">
+          <property role="3MwjfP" value="com.mbeddr.mpsutil.plantuml" />
+        </node>
+      </node>
+      <node concept="3_J27D" id="64SK4bcJmGU" role="m$_w8">
+        <node concept="3Mxwey" id="64SK4bcJmGV" role="3MwsjC">
+          <ref role="3Mxwex" node="2HHioL2Nii3" resolve="mbeddr.version" />
+        </node>
+      </node>
+      <node concept="m$f5U" id="64SK4bcJwhC" role="m$_yh">
+        <ref role="m$f5T" node="3quoVcnL8hF" resolve="group.plantuml" />
+      </node>
+      <node concept="m$f5U" id="11w71XmfHEh" role="m$_yh">
+        <ref role="m$f5T" node="11w71XmfwQH" resolve="group.apis" />
+      </node>
+      <node concept="m$_yC" id="64SK4bcJmGX" role="m$_yJ">
+        <ref role="m$_y1" to="ffeo:4k71ibbKLe8" resolve="jetbrains.mps.core" />
+      </node>
+      <node concept="m$_yC" id="64SK4bcJyxn" role="m$_yJ">
+        <ref role="m$_y1" to="90a9:6860Y5_ZW8e" resolve="de.itemis.mps.utils" />
+      </node>
+      <node concept="m$_yC" id="64SK4bcJ_T5" role="m$_yJ">
+        <ref role="m$_y1" to="ffeo:5xhjlkpPhJu" resolve="jetbrains.mps.ide.httpsupport" />
+      </node>
+      <node concept="m$_yC" id="64SK4bcJC8W" role="m$_yJ">
+        <ref role="m$_y1" node="3lZeU8ehrPx" resolve="com.mbeddr.mpsutil.httpsupport" />
+      </node>
+    </node>
+    <node concept="m$_wf" id="64SK4bcJTt6" role="3989C9">
+      <property role="m$_wk" value="com.mbeddr.mpsutil.suppresswarning" />
+      <node concept="3_J27D" id="64SK4bcJTt7" role="m$_yQ">
+        <node concept="3Mxwew" id="64SK4bcJTt8" role="3MwsjC">
+          <property role="3MwjfP" value="com.mbeddr.mpsutil.suppresswarning" />
+        </node>
+      </node>
+      <node concept="3_J27D" id="64SK4bcJTt9" role="m_cZH">
+        <node concept="3Mxwew" id="64SK4bcJTta" role="3MwsjC">
+          <property role="3MwjfP" value="com.mbeddr.mpsutil.suppresswarning" />
+        </node>
+      </node>
+      <node concept="3_J27D" id="64SK4bcJTtb" role="m$_w8">
+        <node concept="3Mxwey" id="64SK4bcJTtc" role="3MwsjC">
+          <ref role="3Mxwex" node="2HHioL2Nii3" resolve="mbeddr.version" />
+        </node>
+      </node>
+      <node concept="m$_yC" id="64SK4bcJTtf" role="m$_yJ">
+        <ref role="m$_y1" to="ffeo:4k71ibbKLe8" resolve="jetbrains.mps.core" />
+      </node>
+      <node concept="m$f5U" id="64SK4bcJZF8" role="m$_yh">
+        <ref role="m$f5T" node="3quoVcnOFk5" resolve="group.suppresswarning" />
+      </node>
+    </node>
     <node concept="m$_wf" id="7uZw0yZ2_Jq" role="3989C9">
       <property role="m$_wk" value="com.mbeddr.mpsutil" />
+      <node concept="m$_yC" id="64SK4bcJIU1" role="m$_yJ">
+        <ref role="m$_y1" node="64SK4bcJmGP" resolve="com.mbeddr.mpsutil.plantuml" />
+      </node>
+      <node concept="m$_yC" id="64SK4bcICzH" role="m$_yJ">
+        <ref role="m$_y1" node="64SK4bcIqLW" resolve="com.mbeddr.mpsutil.jung" />
+      </node>
+      <node concept="m$_yC" id="64SK4bcK4c6" role="m$_yJ">
+        <ref role="m$_y1" node="64SK4bcJTt6" resolve="com.mbeddr.mpsutil.suppresswarning" />
+      </node>
       <node concept="m$_yC" id="70BL6LoGNLc" role="m$_yJ">
         <ref role="m$_y1" to="ffeo:5CFKsRWRuFN" resolve="jetbrains.mps.debugger.api" />
       </node>
@@ -465,9 +558,6 @@
       </node>
       <node concept="m$f5U" id="4sjR92KlXUh" role="m$_yh">
         <ref role="m$f5T" node="4sjR92JQf0t" resolve="group.dataflow" />
-      </node>
-      <node concept="m$f5U" id="11w71XmfHEh" role="m$_yh">
-        <ref role="m$f5T" node="11w71XmfwQH" resolve="group.apis" />
       </node>
       <node concept="m$f5U" id="5l4WPWBsMzR" role="m$_yh">
         <ref role="m$f5T" node="5l4WPWBsBct" resolve="group.commenting.devkit" />
@@ -511,9 +601,6 @@
       <node concept="m$f5U" id="6mJAQ2PgcmS" role="m$_yh">
         <ref role="m$f5T" node="3bCcKqaTTOY" resolve="group.incrementalcomputation" />
       </node>
-      <node concept="m$f5U" id="3quoVcnS5b7" role="m$_yh">
-        <ref role="m$f5T" node="3quoVcnKz3m" resolve="group.jung" />
-      </node>
       <node concept="m$f5U" id="70AMzaWK1Ni" role="m$_yh">
         <ref role="m$f5T" node="5BXRi0X27hr" resolve="group.graphstream" />
       </node>
@@ -543,9 +630,6 @@
       </node>
       <node concept="m$f5U" id="3quoVcnS5yp" role="m$_yh">
         <ref role="m$f5T" node="3quoVcnJkAK" resolve="group.spreferences" />
-      </node>
-      <node concept="m$f5U" id="3quoVcnS5zz" role="m$_yh">
-        <ref role="m$f5T" node="3quoVcnOFk5" resolve="group.suppresswarning" />
       </node>
       <node concept="m$f5U" id="3quoVcnS5EJ" role="m$_yh">
         <ref role="m$f5T" node="3quoVcnFw2G" resolve="group.userstyles" />
@@ -1058,8 +1142,29 @@
       <node concept="m$_yC" id="$bJ0jguQdm" role="m$_yJ">
         <ref role="m$_y1" to="ffeo:4k71ibbKLe8" resolve="jetbrains.mps.core" />
       </node>
-      <node concept="m$_yC" id="$bJ0jguQdn" role="m$_yJ">
-        <ref role="m$_y1" node="7uZw0yZ2_Jq" resolve="com.mbeddr.mpsutil" />
+      <node concept="m$_yC" id="64SK4bcIaK4" role="m$_yJ">
+        <ref role="m$_y1" to="90a9:1sO539bGQvt" resolve="de.slisson.mps.richtext" />
+      </node>
+      <node concept="m$_yC" id="64SK4bcIcZU" role="m$_yJ">
+        <ref role="m$_y1" to="90a9:7klUZA6XM5S" resolve="de.slisson.mps.conditionalEditor" />
+      </node>
+      <node concept="m$_yC" id="64SK4bcIgn_" role="m$_yJ">
+        <ref role="m$_y1" to="90a9:4p3FRivDLPy" resolve="org.apache.commons" />
+      </node>
+      <node concept="m$_yC" id="64SK4bcIiBv" role="m$_yJ">
+        <ref role="m$_y1" node="3lZeU8ehrPx" resolve="com.mbeddr.mpsutil.httpsupport" />
+      </node>
+      <node concept="m$_yC" id="64SK4bcIkRr" role="m$_yJ">
+        <ref role="m$_y1" to="90a9:2NyZxKpUXYJ" resolve="de.itemis.mps.blutil" />
+      </node>
+      <node concept="m$_yC" id="64SK4bcK6sD" role="m$_yJ">
+        <ref role="m$_y1" node="64SK4bcJTt6" resolve="com.mbeddr.mpsutil.suppresswarning" />
+      </node>
+      <node concept="m$_yC" id="64SK4bcJLaw" role="m$_yJ">
+        <ref role="m$_y1" node="64SK4bcJmGP" resolve="com.mbeddr.mpsutil.plantuml" />
+      </node>
+      <node concept="m$_yC" id="64SK4bcIENJ" role="m$_yJ">
+        <ref role="m$_y1" node="64SK4bcIqLW" resolve="com.mbeddr.mpsutil.jung" />
       </node>
       <node concept="m$_yC" id="Vtr7jyBh9l" role="m$_yJ">
         <ref role="m$_y1" node="Vtr7jyB0oM" resolve="com.mbeddr.mpsutil.filepicker" />
@@ -1146,7 +1251,7 @@
     </node>
     <node concept="m$_wf" id="7tNo_gxoK8h" role="3989C9">
       <property role="m$_wk" value="com.mbeddr.doc" />
-      <node concept="m$_yC" id="5fGcQI99y$D" role="m$_yJ">
+      <node concept="m$_yC" id="64SK4bcK9OL" role="m$_yJ">
         <ref role="m$_y1" node="$bJ0jguQdg" resolve="com.mbeddr.platform" />
       </node>
       <node concept="m$_yC" id="5fGcQI99wPx" role="m$_yJ">
@@ -3663,16 +3768,16 @@
             <ref role="3bR37D" to="ffeo:1TaHNgiIbJ$" resolve="jetbrains.mps.ide.editor" />
           </node>
         </node>
-        <node concept="1yeLz9" id="5HhTKhg$tap" role="1TViLv">
-          <property role="TrG5h" value="com.mbeddr.mpsutil.conceptdiagram#6068210057811478803" />
-          <property role="3LESm3" value="93d07035-b779-4c5e-b375-11d6ac076571" />
-          <property role="2GAjPV" value="false" />
-        </node>
         <node concept="1SiIV0" id="qKMpfEH3Ta" role="3bR37C">
           <node concept="3bR9La" id="qKMpfEH3Tb" role="1SiIV1">
             <property role="3bR36h" value="false" />
             <ref role="3bR37D" to="ffeo:7Kfy9QB6L9O" resolve="jetbrains.mps.lang.smodel" />
           </node>
+        </node>
+        <node concept="1yeLz9" id="5HhTKhg$tap" role="1TViLv">
+          <property role="TrG5h" value="com.mbeddr.mpsutil.conceptdiagram#6068210057811478803" />
+          <property role="3LESm3" value="93d07035-b779-4c5e-b375-11d6ac076571" />
+          <property role="2GAjPV" value="false" />
         </node>
       </node>
       <node concept="1E1JtD" id="5HhTKhg$v8P" role="2G$12L">
@@ -14817,23 +14922,6 @@
             <ref role="1Busuk" to="90a9:1sO539bGQvB" resolve="de.slisson.mps.richtext" />
           </node>
         </node>
-        <node concept="1SiIV0" id="6SQk4GjQ1tA" role="3bR37C">
-          <node concept="3bR9La" id="6SQk4GjQ1tB" role="1SiIV1">
-            <property role="3bR36h" value="false" />
-            <ref role="3bR37D" node="61Pvu7KHtlo" resolve="com.mbeddr.mpsutil.breadcrumb" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="6SQk4GjQ1tC" role="3bR37C">
-          <node concept="1Busua" id="6SQk4GjQ1tD" role="1SiIV1">
-            <ref role="1Busuk" node="61Pvu7KHtlo" resolve="com.mbeddr.mpsutil.breadcrumb" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2PO6OhSw_Mv" role="3bR37C">
-          <node concept="3bR9La" id="2PO6OhSw_Mw" role="1SiIV1">
-            <property role="3bR36h" value="false" />
-            <ref role="3bR37D" node="61Pvu7KHlD1" resolve="com.mbeddr.mpsutil.breadcrumb.runtime" />
-          </node>
-        </node>
         <node concept="1SiIV0" id="3soxMz$rkWc" role="3bR37C">
           <node concept="3bR9La" id="3soxMz$rkWd" role="1SiIV1">
             <property role="3bR36h" value="false" />
@@ -14927,8 +15015,8 @@
             <ref role="3bR37D" to="90a9:6860Y5A00Lp" resolve="com.mbeddr.mpsutil.serializer.xml" />
           </node>
         </node>
-        <node concept="1SiIV0" id="1iNy2ibya1H" role="3bR37C">
-          <node concept="3bR9La" id="1iNy2ibya1I" role="1SiIV1">
+        <node concept="1SiIV0" id="64SK4bcJgMo" role="3bR37C">
+          <node concept="3bR9La" id="64SK4bcJgMp" role="1SiIV1">
             <property role="3bR36h" value="false" />
             <ref role="3bR37D" to="ffeo:5cCcm$KATVz" resolve="jetbrains.mps.lang.migration.runtime" />
           </node>
@@ -17947,7 +18035,7 @@
         <node concept="398223" id="3lZeU8ehQ1N" role="39821P">
           <node concept="2HvfSZ" id="6ucYLjonLe2" role="39821P">
             <node concept="398BVA" id="6ucYLjonLe3" role="2HvfZ0">
-              <ref role="398BVh" node="7uZw0yZ2_Lj" />
+              <ref role="398BVh" node="7uZw0yZ2_Lj" resolve="mpsutil" />
               <node concept="2Ry0Ak" id="6ucYLjonLe4" role="iGT6I">
                 <property role="2Ry0Am" value="solutions" />
                 <node concept="2Ry0Ak" id="6ucYLjonLe5" role="2Ry0An">

--- a/code/languages/com.mbeddr.build/solutions/com.mbeddr.platform/models/com/mbeddr/platform/build.mps
+++ b/code/languages/com.mbeddr.build/solutions/com.mbeddr.platform/models/com/mbeddr/platform/build.mps
@@ -715,9 +715,6 @@
       <node concept="m$f5U" id="3quoVcnS5yp" role="m$_yh">
         <ref role="m$f5T" node="3quoVcnJkAK" resolve="group.spreferences" />
       </node>
-      <node concept="m$f5U" id="3quoVcnS5EJ" role="m$_yh">
-        <ref role="m$f5T" node="3quoVcnFw2G" resolve="group.userstyles" />
-      </node>
       <node concept="m$f5U" id="4gGXGcLW04l" role="m$_yh">
         <ref role="m$f5T" node="4gGXGcLV$l$" resolve="group.multilingual" />
       </node>
@@ -741,9 +738,6 @@
       </node>
       <node concept="m$f5U" id="yLGIkBgrHd" role="m$_yh">
         <ref role="m$f5T" node="yLGIkBgeKP" resolve="group.toolrunner" />
-      </node>
-      <node concept="m$f5U" id="6o5cjw5gP$D" role="m$_yh">
-        <ref role="m$f5T" node="6o5cjw5gxJq" resolve="group.json" />
       </node>
       <node concept="m$_yC" id="7uZw0yZ2_Jw" role="m$_yJ">
         <ref role="m$_y1" to="ffeo:4k71ibbKLe8" resolve="jetbrains.mps.core" />
@@ -801,6 +795,12 @@
       </node>
       <node concept="m$_yC" id="1Rj3F434X7F" role="m$_yJ">
         <ref role="m$_y1" node="1Rj3F434M3n" resolve="com.mbeddr.mpsutil.jfreechart" />
+      </node>
+      <node concept="m$_yC" id="NMVW79ydCR" role="m$_yJ">
+        <ref role="m$_y1" node="NMVW79y25x" resolve="com.mbeddr.mpsutil.json" />
+      </node>
+      <node concept="m$_yC" id="NMVW79ysTx" role="m$_yJ">
+        <ref role="m$_y1" node="NMVW79yitG" resolve="com.mbeddr.mpsutil.userstyles" />
       </node>
       <node concept="3_J27D" id="7uZw0yZ2_Jx" role="m_cZH">
         <node concept="3Mxwew" id="7uZw0yZ2_Jy" role="3MwsjC">
@@ -13391,6 +13391,37 @@
         </node>
       </node>
     </node>
+    <node concept="m$_wf" id="NMVW79yitG" role="3989C9">
+      <property role="m$_wk" value="com.mbeddr.mpsutil.userstyles" />
+      <node concept="3_J27D" id="NMVW79yitH" role="m$_yQ">
+        <node concept="3Mxwew" id="NMVW79yitI" role="3MwsjC">
+          <property role="3MwjfP" value="com.mbeddr.mpsutil.userstyles" />
+        </node>
+      </node>
+      <node concept="3_J27D" id="NMVW79yitJ" role="m$_w8">
+        <node concept="3Mxwey" id="NMVW79yitK" role="3MwsjC">
+          <ref role="3Mxwex" node="2HHioL2Nii3" resolve="mbeddr.version" />
+        </node>
+      </node>
+      <node concept="m$f5U" id="NMVW79yopL" role="m$_yh">
+        <ref role="m$f5T" node="3quoVcnFw2G" resolve="group.userstyles" />
+      </node>
+      <node concept="m$_yC" id="NMVW79yitM" role="m$_yJ">
+        <ref role="m$_y1" to="ffeo:4k71ibbKLe8" resolve="jetbrains.mps.core" />
+      </node>
+      <node concept="m$_yC" id="NMVW79yqDt" role="m$_yJ">
+        <ref role="m$_y1" to="ffeo:5HVSRHdVm9a" resolve="jetbrains.mps.build" />
+      </node>
+      <node concept="3_J27D" id="NMVW79yitN" role="m_cZH">
+        <node concept="3Mxwew" id="NMVW79yitO" role="3MwsjC">
+          <property role="3MwjfP" value="com.mbeddr.mpsutil.userstyles" />
+        </node>
+      </node>
+      <node concept="2iUeEo" id="NMVW79yitP" role="2iVFfd">
+        <property role="2iUeEt" value="mbeddr" />
+        <property role="2iUeEu" value="http://mbeddr.com" />
+      </node>
+    </node>
     <node concept="2G$12M" id="3quoVcnFk6j" role="3989C9">
       <property role="TrG5h" value="group.actionsfilter.lang" />
       <node concept="1E1JtD" id="5FJiYrlP3bT" role="2G$12L">
@@ -17813,6 +17844,34 @@
         </node>
       </node>
     </node>
+    <node concept="m$_wf" id="NMVW79y25x" role="3989C9">
+      <property role="m$_wk" value="com.mbeddr.mpsutil.json" />
+      <node concept="3_J27D" id="NMVW79y25y" role="m$_yQ">
+        <node concept="3Mxwew" id="NMVW79y25z" role="3MwsjC">
+          <property role="3MwjfP" value="com.mbeddr.mpsutil.json" />
+        </node>
+      </node>
+      <node concept="3_J27D" id="NMVW79y25$" role="m$_w8">
+        <node concept="3Mxwey" id="NMVW79y25_" role="3MwsjC">
+          <ref role="3Mxwex" node="2HHioL2Nii3" resolve="mbeddr.version" />
+        </node>
+      </node>
+      <node concept="m$f5U" id="NMVW79yboP" role="m$_yh">
+        <ref role="m$f5T" node="6o5cjw5gxJq" resolve="group.json" />
+      </node>
+      <node concept="m$_yC" id="NMVW79y25B" role="m$_yJ">
+        <ref role="m$_y1" to="ffeo:4k71ibbKLe8" resolve="jetbrains.mps.core" />
+      </node>
+      <node concept="3_J27D" id="NMVW79y25C" role="m_cZH">
+        <node concept="3Mxwew" id="NMVW79y25D" role="3MwsjC">
+          <property role="3MwjfP" value="com.mbeddr.mpsutil.json" />
+        </node>
+      </node>
+      <node concept="2iUeEo" id="NMVW79y25E" role="2iVFfd">
+        <property role="2iUeEt" value="mbeddr" />
+        <property role="2iUeEu" value="http://mbeddr.com" />
+      </node>
+    </node>
     <node concept="2G$12M" id="48qh2gYg815" role="3989C9">
       <property role="TrG5h" value="com.mbeddr.core.codereview" />
       <node concept="1E1JtD" id="48qh2gYgjRX" role="2G$12L">
@@ -18373,6 +18432,12 @@
       </node>
       <node concept="m$_wl" id="6hpTCZQe4Ro" role="39821P">
         <ref role="m_rDy" node="6hpTCZQdXQX" resolve="com.mbeddr.mpsutil.editor.querylist" />
+      </node>
+      <node concept="m$_wl" id="NMVW79yva0" role="39821P">
+        <ref role="m_rDy" node="NMVW79y25x" resolve="com.mbeddr.mpsutil.json" />
+      </node>
+      <node concept="m$_wl" id="NMVW79yxti" role="39821P">
+        <ref role="m_rDy" node="NMVW79yitG" resolve="com.mbeddr.mpsutil.userstyles" />
       </node>
       <node concept="m$_wl" id="3lZeU8ehKmj" role="39821P">
         <ref role="m_rDy" node="3lZeU8ehrPx" resolve="com.mbeddr.mpsutil.httpsupport" />

--- a/code/languages/com.mbeddr.core/languages/com.mbeddr.core.base/base.mpl
+++ b/code/languages/com.mbeddr.core/languages/com.mbeddr.core.base/base.mpl
@@ -45,7 +45,6 @@
         <module reference="d4280a54-f6df-4383-aa41-d1b2bffa7eb1(com.mbeddr.core.base)" version="3" />
         <module reference="2764de2d-de8a-48ff-9db3-f78342da5c1a(com.mbeddr.core.base#8626086128958648025)" version="0" />
         <module reference="63e0e566-5131-447e-90e3-12ea330e1a00(com.mbeddr.mpsutil.blutil)" version="0" />
-        <module reference="a482b416-d0c9-473f-8f67-725ed642b3f3(com.mbeddr.mpsutil.breadcrumb)" version="0" />
         <module reference="d3a0fd26-445a-466c-900e-10444ddfed52(com.mbeddr.mpsutil.filepicker)" version="0" />
         <module reference="d09a16fb-1d68-4a92-a5a4-20b4b2f86a62(com.mbeddr.mpsutil.jung)" version="0" />
         <module reference="b4d28e19-7d2d-47e9-943e-3a41f97a0e52(com.mbeddr.mpsutil.plantuml.node)" version="0" />
@@ -68,12 +67,10 @@
   </generators>
   <sourcePath />
   <dependencies>
-    <dependency reexport="false">a482b416-d0c9-473f-8f67-725ed642b3f3(com.mbeddr.mpsutil.breadcrumb)</dependency>
     <dependency reexport="false">8d29d73f-ed99-4652-ae0a-083cdfe53c34(jetbrains.mps.ide.platform)</dependency>
     <dependency reexport="false">742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)</dependency>
     <dependency reexport="false">1338ba73-5059-479b-a929-de86597a62b8(com.mbeddr.mpsutil.jung.pluginSolution)</dependency>
     <dependency reexport="false">1ed103c3-3aa6-49b7-9c21-6765ee11f224(MPS.Editor)</dependency>
-    <dependency reexport="false">fd28f7ed-d277-425b-a282-684ac4cbead6(com.mbeddr.mpsutil.breadcrumb.runtime)</dependency>
     <dependency reexport="false">498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)</dependency>
     <dependency reexport="false">b4d28e19-7d2d-47e9-943e-3a41f97a0e52(com.mbeddr.mpsutil.plantuml.node)</dependency>
     <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
@@ -159,8 +156,6 @@
     <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
     <module reference="d4280a54-f6df-4383-aa41-d1b2bffa7eb1(com.mbeddr.core.base)" version="3" />
     <module reference="63e0e566-5131-447e-90e3-12ea330e1a00(com.mbeddr.mpsutil.blutil)" version="0" />
-    <module reference="a482b416-d0c9-473f-8f67-725ed642b3f3(com.mbeddr.mpsutil.breadcrumb)" version="0" />
-    <module reference="fd28f7ed-d277-425b-a282-684ac4cbead6(com.mbeddr.mpsutil.breadcrumb.runtime)" version="0" />
     <module reference="c7a315e6-1d93-4186-85bc-2dfafd1ccc21(com.mbeddr.mpsutil.common)" version="0" />
     <module reference="d3a0fd26-445a-466c-900e-10444ddfed52(com.mbeddr.mpsutil.filepicker)" version="0" />
     <module reference="d09a16fb-1d68-4a92-a5a4-20b4b2f86a62(com.mbeddr.mpsutil.jung)" version="0" />
@@ -195,7 +190,6 @@
   <extendedLanguages>
     <extendedLanguage>92d2ea16-5a42-4fdf-a676-c7604efe3504(de.slisson.mps.richtext)</extendedLanguage>
     <extendedLanguage>ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)</extendedLanguage>
-    <extendedLanguage>a482b416-d0c9-473f-8f67-725ed642b3f3(com.mbeddr.mpsutil.breadcrumb)</extendedLanguage>
     <extendedLanguage>d09a16fb-1d68-4a92-a5a4-20b4b2f86a62(com.mbeddr.mpsutil.jung)</extendedLanguage>
     <extendedLanguage>b4d28e19-7d2d-47e9-943e-3a41f97a0e52(com.mbeddr.mpsutil.plantuml.node)</extendedLanguage>
     <extendedLanguage>63e0e566-5131-447e-90e3-12ea330e1a00(com.mbeddr.mpsutil.blutil)</extendedLanguage>

--- a/code/languages/com.mbeddr.core/languages/com.mbeddr.core.base/languageModels/behavior.mps
+++ b/code/languages/com.mbeddr.core/languages/com.mbeddr.core.base/languageModels/behavior.mps
@@ -20,10 +20,8 @@
     <import index="kwxp" ref="b4d28e19-7d2d-47e9-943e-3a41f97a0e52/r:4903509f-5416-46ff-9a8b-44b5a178b568(com.mbeddr.mpsutil.plantuml.node/com.mbeddr.mpsutil.plantuml.node.structure)" />
     <import index="grvc" ref="b4d28e19-7d2d-47e9-943e-3a41f97a0e52/r:e4b7e230-de2a-46ac-9f53-996b361d25ef(com.mbeddr.mpsutil.plantuml.node/com.mbeddr.mpsutil.plantuml.node.behavior)" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" />
-    <import index="u8e7" ref="r:4acb4e42-0ef5-487c-a21d-496738d115a6(com.mbeddr.mpsutil.breadcrumb.behavior)" />
     <import index="dxuu" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:javax.swing(JDK/)" />
     <import index="xnls" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.ide.icons(MPS.Platform/)" />
-    <import index="jqcv" ref="r:3b5e5c58-5a2a-44f7-840e-bf72f3bd68f2(com.mbeddr.mpsutil.breadcrumb.runtime.plugin)" />
     <import index="jgjw" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.security(JDK/)" />
     <import index="z1c3" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.project(MPS.Core/)" />
     <import index="kz9k" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.navigation(MPS.Editor/)" />
@@ -593,6 +591,7 @@
       <concept id="1235566554328" name="jetbrains.mps.baseLanguage.collections.structure.AnyOperation" flags="nn" index="2HwmR7" />
       <concept id="1235566831861" name="jetbrains.mps.baseLanguage.collections.structure.AllOperation" flags="nn" index="2HxqBE" />
       <concept id="1237721394592" name="jetbrains.mps.baseLanguage.collections.structure.AbstractContainerCreator" flags="nn" index="HWqM0">
+        <child id="1237721435808" name="initValue" index="HW$Y0" />
         <child id="1237721435807" name="elementType" index="HW$YZ" />
       </concept>
       <concept id="1227008614712" name="jetbrains.mps.baseLanguage.collections.structure.LinkedListCreator" flags="nn" index="2Jqq0_" />
@@ -607,6 +606,7 @@
       <concept id="1160600644654" name="jetbrains.mps.baseLanguage.collections.structure.ListCreatorWithInit" flags="nn" index="Tc6Ow" />
       <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="nn" index="TSZUe" />
       <concept id="1160666733551" name="jetbrains.mps.baseLanguage.collections.structure.AddAllElementsOperation" flags="nn" index="X8dFx" />
+      <concept id="1240217271293" name="jetbrains.mps.baseLanguage.collections.structure.LinkedHashSetCreator" flags="nn" index="32HrFt" />
       <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="nn" index="34oBXx" />
       <concept id="1175845471038" name="jetbrains.mps.baseLanguage.collections.structure.ReverseOperation" flags="nn" index="35Qw8J" />
       <concept id="3055999550620853964" name="jetbrains.mps.baseLanguage.collections.structure.RemoveWhereOperation" flags="nn" index="1aUR6E" />
@@ -4260,9 +4260,6 @@
       <property role="13i0it" value="true" />
       <property role="TrG5h" value="getIDEDisplayString" />
       <property role="2Ki8OM" value="false" />
-      <node concept="3Tm1VV" id="IviauXb0h" role="1B3o_S" />
-      <node concept="17QB3L" id="IviauXb9z" role="3clF45" />
-      <node concept="3clFbS" id="IviauXb0j" role="3clF47" />
       <node concept="P$JXv" id="3O27jEAbHZi" role="lGtFl">
         <node concept="TZ5HA" id="3O27jEAbHZj" role="TZ5H$">
           <node concept="1dT_AC" id="3O27jEAbHZk" role="1dT_Ay">
@@ -4271,14 +4268,14 @@
         </node>
         <node concept="x79VA" id="3O27jEAbHZl" role="3nqlJM" />
       </node>
+      <node concept="3Tm1VV" id="IviauXb0h" role="1B3o_S" />
+      <node concept="17QB3L" id="IviauXb9z" role="3clF45" />
+      <node concept="3clFbS" id="IviauXb0j" role="3clF47" />
     </node>
     <node concept="13i0hz" id="1uL8CIs6rGR" role="13h7CS">
       <property role="13i0iv" value="true" />
       <property role="13i0it" value="true" />
       <property role="TrG5h" value="getSortOrder" />
-      <node concept="3Tm1VV" id="1uL8CIs6rLA" role="1B3o_S" />
-      <node concept="10Oyi0" id="1uL8CIs6rUS" role="3clF45" />
-      <node concept="3clFbS" id="1uL8CIs6rLC" role="3clF47" />
       <node concept="P$JXv" id="3O27jEAbHZA" role="lGtFl">
         <node concept="TZ5HA" id="3O27jEAbHZB" role="TZ5H$">
           <node concept="1dT_AC" id="3O27jEAbHZC" role="1dT_Ay">
@@ -4287,14 +4284,14 @@
         </node>
         <node concept="x79VA" id="3O27jEAbHZD" role="3nqlJM" />
       </node>
+      <node concept="3Tm1VV" id="1uL8CIs6rLA" role="1B3o_S" />
+      <node concept="10Oyi0" id="1uL8CIs6rUS" role="3clF45" />
+      <node concept="3clFbS" id="1uL8CIs6rLC" role="3clF47" />
     </node>
     <node concept="13i0hz" id="1uL8CIsKxiy" role="13h7CS">
       <property role="13i0iv" value="true" />
       <property role="13i0it" value="true" />
       <property role="TrG5h" value="getCategory" />
-      <node concept="3Tm1VV" id="1uL8CIsKxiz" role="1B3o_S" />
-      <node concept="17QB3L" id="1uL8CIsKxIg" role="3clF45" />
-      <node concept="3clFbS" id="1uL8CIsKxi_" role="3clF47" />
       <node concept="P$JXv" id="3O27jEAbHZU" role="lGtFl">
         <node concept="TZ5HA" id="3O27jEAbHZV" role="TZ5H$">
           <node concept="1dT_AC" id="3O27jEAbHZW" role="1dT_Ay">
@@ -4308,6 +4305,9 @@
         </node>
         <node concept="x79VA" id="3O27jEAbHZX" role="3nqlJM" />
       </node>
+      <node concept="3Tm1VV" id="1uL8CIsKxiz" role="1B3o_S" />
+      <node concept="17QB3L" id="1uL8CIsKxIg" role="3clF45" />
+      <node concept="3clFbS" id="1uL8CIsKxi_" role="3clF47" />
     </node>
     <node concept="13hLZK" id="IviauXa$k" role="13h7CW">
       <node concept="3clFbS" id="IviauXa$l" role="2VODD2" />
@@ -18207,59 +18207,6 @@
     <node concept="13hLZK" id="6SQk4GjJGHy" role="13h7CW">
       <node concept="3clFbS" id="6SQk4GjJGHz" role="2VODD2" />
     </node>
-    <node concept="13i0hz" id="6SQk4GjJGIn" role="13h7CS">
-      <property role="13i0iv" value="false" />
-      <property role="13i0it" value="false" />
-      <property role="TrG5h" value="getBreadcrumbText" />
-      <ref role="13i0hy" to="u8e7:3JrMqIyfmQ4" resolve="getBreadcrumbText" />
-      <node concept="3Tm1VV" id="6SQk4GjJGIo" role="1B3o_S" />
-      <node concept="3clFbS" id="6SQk4GjJGIv" role="3clF47">
-        <node concept="3clFbF" id="6SQk4GjJTEq" role="3cqZAp">
-          <node concept="2OqwBi" id="6SQk4GjJTHc" role="3clFbG">
-            <node concept="13iPFW" id="6SQk4GjJTEl" role="2Oq$k0" />
-            <node concept="2qgKlT" id="6SQk4GjVrOh" role="2OqNvi">
-              <ref role="37wK5l" node="6SQk4GjV1MZ" resolve="getHierarchicalStructureName" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="17QB3L" id="6SQk4GjJGIw" role="3clF45" />
-    </node>
-    <node concept="13i0hz" id="6SQk4GjJGI_" role="13h7CS">
-      <property role="13i0iv" value="false" />
-      <property role="13i0it" value="false" />
-      <property role="TrG5h" value="getBreadcrumbIcon" />
-      <ref role="13i0hy" to="u8e7:4lLcfuhLhmo" resolve="getBreadcrumbIcon" />
-      <node concept="3Tm1VV" id="6SQk4GjJGIA" role="1B3o_S" />
-      <node concept="3clFbS" id="6SQk4GjJGIF" role="3clF47">
-        <node concept="3clFbF" id="6SQk4GjVrQi" role="3cqZAp">
-          <node concept="2OqwBi" id="6SQk4GjVrTY" role="3clFbG">
-            <node concept="13iPFW" id="6SQk4GjVrQe" role="2Oq$k0" />
-            <node concept="2qgKlT" id="6SQk4GjVsme" role="2OqNvi">
-              <ref role="37wK5l" node="6SQk4GjV1Yp" resolve="getHierarchicalStructureIcon" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3uibUv" id="6SQk4GjJGIG" role="3clF45">
-        <ref role="3uigEE" to="dxuu:~Icon" resolve="Icon" />
-      </node>
-    </node>
-    <node concept="13i0hz" id="1pmorAaw7Cb" role="13h7CS">
-      <property role="13i0iv" value="false" />
-      <property role="13i0it" value="false" />
-      <property role="TrG5h" value="showInBreadcrumb" />
-      <ref role="13i0hy" to="u8e7:1pmorAautNF" resolve="showInBreadcrumb" />
-      <node concept="3Tm1VV" id="1pmorAaw7Cc" role="1B3o_S" />
-      <node concept="3clFbS" id="1pmorAaw7Ch" role="3clF47">
-        <node concept="3clFbF" id="1pmorAaw7FZ" role="3cqZAp">
-          <node concept="BsUDl" id="3$xysz6OSQq" role="3clFbG">
-            <ref role="37wK5l" node="1pmorAatV7O" resolve="showInHierchicalStructure" />
-          </node>
-        </node>
-      </node>
-      <node concept="10P_77" id="1pmorAaw7Ci" role="3clF45" />
-    </node>
   </node>
   <node concept="13h7C7" id="6SQk4GjUJSp">
     <property role="3GE5qa" value="tree.hierarchicalstructure" />
@@ -18536,8 +18483,8 @@
       <node concept="3clFbS" id="6SQk4GjV1Ys" role="3clF47">
         <node concept="3clFbF" id="1pmorAaw7mw" role="3cqZAp">
           <node concept="2YIFZM" id="1pmorAaw7sW" role="3clFbG">
-            <ref role="37wK5l" to="jqcv:1pmorAauK8j" resolve="getIconForIfNotDefault" />
-            <ref role="1Pybhc" to="jqcv:1pmorAauvn_" resolve="FilteredIconManager" />
+            <ref role="37wK5l" node="1pmorAauK8j" resolve="getIconForIfNotDefault" />
+            <ref role="1Pybhc" node="1pmorAauvn_" resolve="FilteredIconManager" />
             <node concept="13iPFW" id="1pmorAaw7tg" role="37wK5m" />
           </node>
         </node>
@@ -23715,6 +23662,96 @@
     <node concept="13hLZK" id="4yaQL1YaUN6" role="13h7CW">
       <node concept="3clFbS" id="4yaQL1YaUN7" role="2VODD2" />
     </node>
+  </node>
+  <node concept="312cEu" id="1pmorAauvn_">
+    <property role="TrG5h" value="FilteredIconManager" />
+    <property role="3GE5qa" value="common" />
+    <node concept="Wx3nA" id="1pmorAauLb1" role="jymVt">
+      <property role="2dlcS1" value="false" />
+      <property role="2dld4O" value="false" />
+      <property role="TrG5h" value="DEFAULT_ICONS" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm6S6" id="1pmorAauKNr" role="1B3o_S" />
+      <node concept="2hMVRd" id="1pmorAauL4D" role="1tU5fm">
+        <node concept="3uibUv" id="1pmorAauLaB" role="2hN53Y">
+          <ref role="3uigEE" to="dxuu:~Icon" resolve="Icon" />
+        </node>
+      </node>
+      <node concept="2ShNRf" id="1pmorAauL_p" role="33vP2m">
+        <node concept="32HrFt" id="1pmorAauL_m" role="2ShVmc">
+          <node concept="3uibUv" id="1pmorAauL_n" role="HW$YZ">
+            <ref role="3uigEE" to="dxuu:~Icon" resolve="Icon" />
+          </node>
+          <node concept="10M0yZ" id="1pmorAauLB$" role="HW$Y0">
+            <ref role="1PxDUh" to="xnls:~IdeIcons" resolve="IdeIcons" />
+            <ref role="3cqZAo" to="xnls:~IdeIcons.DEFAULT_ICON" resolve="DEFAULT_ICON" />
+          </node>
+          <node concept="10M0yZ" id="1pmorAauLDV" role="HW$Y0">
+            <ref role="1PxDUh" to="xnls:~IdeIcons" resolve="IdeIcons" />
+            <ref role="3cqZAo" to="xnls:~IdeIcons.DEFAULT_ROOT_ICON" resolve="DEFAULT_ROOT_ICON" />
+          </node>
+          <node concept="10M0yZ" id="1pmorAauLGw" role="HW$Y0">
+            <ref role="3cqZAo" to="xnls:~IdeIcons.DEFAULT_NODE_ICON" resolve="DEFAULT_NODE_ICON" />
+            <ref role="1PxDUh" to="xnls:~IdeIcons" resolve="IdeIcons" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="1pmorAav8i$" role="jymVt" />
+    <node concept="2YIFZL" id="1pmorAauK8j" role="jymVt">
+      <property role="TrG5h" value="getIconForIfNotDefault" />
+      <property role="IEkAT" value="false" />
+      <property role="DiZV1" value="false" />
+      <property role="od$2w" value="false" />
+      <node concept="3clFbS" id="1pmorAauIrt" role="3clF47">
+        <node concept="3cpWs8" id="5DkixGo8c74" role="3cqZAp">
+          <node concept="3cpWsn" id="5DkixGo8c75" role="3cpWs9">
+            <property role="TrG5h" value="result" />
+            <node concept="3uibUv" id="5DkixGo8c73" role="1tU5fm">
+              <ref role="3uigEE" to="dxuu:~Icon" resolve="Icon" />
+            </node>
+            <node concept="2YIFZM" id="5DkixGo8c76" role="33vP2m">
+              <ref role="1Pybhc" to="xnls:~IconManager" resolve="IconManager" />
+              <ref role="37wK5l" to="xnls:~IconManager.getIconFor(org.jetbrains.mps.openapi.model.SNode):javax.swing.Icon" resolve="getIconFor" />
+              <node concept="37vLTw" id="1pmorAav7Mg" role="37wK5m">
+                <ref role="3cqZAo" node="1pmorAauK7R" resolve="node" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="5DkixGo8g8X" role="3cqZAp">
+          <node concept="3clFbS" id="5DkixGo8g90" role="3clFbx">
+            <node concept="3cpWs6" id="5DkixGo8hJo" role="3cqZAp">
+              <node concept="10Nm6u" id="5DkixGo8hNZ" role="3cqZAk" />
+            </node>
+          </node>
+          <node concept="2OqwBi" id="1pmorAav4Oz" role="3clFbw">
+            <node concept="37vLTw" id="64SK4bcJ9g0" role="2Oq$k0">
+              <ref role="3cqZAo" node="1pmorAauLb1" resolve="DEFAULT_ICONS" />
+            </node>
+            <node concept="3JPx81" id="1pmorAav8fg" role="2OqNvi">
+              <node concept="37vLTw" id="1pmorAav8gX" role="25WWJ7">
+                <ref role="3cqZAo" node="5DkixGo8c75" resolve="result" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="6SQk4GjV20d" role="3cqZAp">
+          <node concept="37vLTw" id="5DkixGo8c78" role="3clFbG">
+            <ref role="3cqZAo" node="5DkixGo8c75" resolve="result" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="1pmorAauK7R" role="3clF46">
+        <property role="TrG5h" value="node" />
+        <node concept="3Tqbb2" id="1pmorAauK7Q" role="1tU5fm" />
+      </node>
+      <node concept="3uibUv" id="1pmorAauIra" role="3clF45">
+        <ref role="3uigEE" to="dxuu:~Icon" resolve="Icon" />
+      </node>
+      <node concept="3Tm1VV" id="1pmorAauK8a" role="1B3o_S" />
+    </node>
+    <node concept="3Tm1VV" id="1pmorAauvnA" role="1B3o_S" />
   </node>
 </model>
 

--- a/code/languages/com.mbeddr.core/languages/com.mbeddr.core.base/languageModels/editor.mps
+++ b/code/languages/com.mbeddr.core/languages/com.mbeddr.core.base/languageModels/editor.mps
@@ -2,22 +2,22 @@
 <model ref="r:1784e088-20fd-4fdb-96b8-bc57f0056d94(com.mbeddr.core.base.editor)">
   <persistence version="9" />
   <languages>
-    <use id="63650c59-16c8-498a-99c8-005c7ee9515d" name="jetbrains.mps.lang.access" version="0" />
-    <use id="13744753-c81f-424a-9c1b-cf8943bf4e86" name="jetbrains.mps.lang.sharedConcepts" version="0" />
-    <use id="f89904fb-9486-43a1-865e-5ad0375a8a88" name="de.itemis.mps.editor.bool" version="0" />
-    <use id="120e1c9d-4e27-4478-b2af-b2c3bd3850b0" name="com.mbeddr.mpsutil.editor.querylist" version="0" />
-    <use id="774bf8a0-62e5-41e1-af63-f4812e60e48b" name="jetbrains.mps.baseLanguage.checkedDots" version="0" />
-    <use id="a0ab8c10-c118-4755-ba27-3853435cf524" name="de.itemis.mps.tooltips" version="0" />
-    <use id="52733268-be24-4f5f-ab84-a73b7c0c03b0" name="de.slisson.mps.richtext.customcell" version="0" />
-    <use id="a247e09e-2435-45ba-b8d2-07e93feba96a" name="jetbrains.mps.baseLanguage.tuples" version="0" />
-    <use id="23f985f2-965f-4af1-aee8-a32677429514" name="com.mbeddr.mpsutil.multilingual.common" version="0" />
-    <use id="b8bb702e-43ed-4090-a902-d180d3e5f292" name="de.slisson.mps.conditionalEditor" version="0" />
-    <use id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core" version="1" />
-    <use id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc" version="2" />
-    <use id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor" version="11" />
-    <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="5" />
-    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="8" />
-    <use id="1919c723-b60b-4592-9318-9ce96d91da44" name="de.itemis.mps.editor.celllayout" version="0" />
+    <use id="63650c59-16c8-498a-99c8-005c7ee9515d" name="jetbrains.mps.lang.access" version="-1" />
+    <use id="13744753-c81f-424a-9c1b-cf8943bf4e86" name="jetbrains.mps.lang.sharedConcepts" version="-1" />
+    <use id="f89904fb-9486-43a1-865e-5ad0375a8a88" name="de.itemis.mps.editor.bool" version="-1" />
+    <use id="120e1c9d-4e27-4478-b2af-b2c3bd3850b0" name="com.mbeddr.mpsutil.editor.querylist" version="-1" />
+    <use id="774bf8a0-62e5-41e1-af63-f4812e60e48b" name="jetbrains.mps.baseLanguage.checkedDots" version="-1" />
+    <use id="a0ab8c10-c118-4755-ba27-3853435cf524" name="de.itemis.mps.tooltips" version="-1" />
+    <use id="52733268-be24-4f5f-ab84-a73b7c0c03b0" name="de.slisson.mps.richtext.customcell" version="-1" />
+    <use id="a247e09e-2435-45ba-b8d2-07e93feba96a" name="jetbrains.mps.baseLanguage.tuples" version="-1" />
+    <use id="23f985f2-965f-4af1-aee8-a32677429514" name="com.mbeddr.mpsutil.multilingual.common" version="-1" />
+    <use id="b8bb702e-43ed-4090-a902-d180d3e5f292" name="de.slisson.mps.conditionalEditor" version="-1" />
+    <use id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core" version="-1" />
+    <use id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc" version="-1" />
+    <use id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor" version="-1" />
+    <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="-1" />
+    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="-1" />
+    <use id="1919c723-b60b-4592-9318-9ce96d91da44" name="de.itemis.mps.editor.celllayout" version="-1" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
@@ -44,7 +44,6 @@
     <import index="zwau" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor.hintsSettings(MPS.Editor/)" />
     <import index="iwf0" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.descriptor(MPS.Editor/)" />
     <import index="jan3" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt.image(JDK/)" />
-    <import index="kz9k" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.navigation(MPS.Editor/)" />
     <import index="z1c3" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.project(MPS.Core/)" />
     <import index="cj4x" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor(MPS.Editor/)" />
     <import index="lwvz" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.selection(MPS.Editor/)" />
@@ -53,15 +52,11 @@
     <import index="fbzs" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt.geom(JDK/)" />
     <import index="22ra" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.update(MPS.Editor/)" />
     <import index="mhbf" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.model(MPS.OpenAPI/)" />
-    <import index="dqn8" ref="r:6f177fc3-8a05-4826-8d08-fd8676623247(com.mbeddr.mpsutil.suppresswarning.behavior)" />
-    <import index="bdcd" ref="r:d5deda81-7a35-4c2b-bda1-1fdc1db99e3b(com.mbeddr.mpsutil.suppresswarning.structure)" />
     <import index="mhfm" ref="3f233e7f-b8a6-46d2-a57f-795d56775243/java:org.jetbrains.annotations(Annotations/)" />
     <import index="mc8f" ref="r:02240f59-d215-4642-b459-56f9f2ccb58d(de.itemis.mps.editor.celllayout.runtime.cells)" />
     <import index="z0fb" ref="r:0b928dd6-dd7e-45a8-b309-a2e315b7877a(de.itemis.mps.editor.celllayout.styles.editor)" />
     <import index="wcxw" ref="r:b9f36c08-4a75-4513-9277-a390d3426e0f(jetbrains.mps.editor.runtime.impl.cellActions)" />
     <import index="hox0" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.style(MPS.Editor/)" />
-    <import index="oqcp" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:javax.imageio(JDK/)" />
-    <import index="7a0s" ref="r:2af017c2-293f-4ebb-99f3-81e353b3d6e6(jetbrains.mps.editor.runtime)" />
     <import index="q4oi" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor.cellActions(MPS.Editor/)" />
     <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" implicit="true" />
   </imports>
@@ -870,9 +865,6 @@
     <node concept="3EZMnI" id="3m8H$lmFM6t" role="2wV5jI">
       <node concept="3EZMnI" id="5gTlpakxgl3" role="3EZMnx">
         <ref role="1ERwB7" node="3m8H$lmIlF8" resolve="deleteElementDocumentation" />
-        <node concept="VPM3Z" id="5gTlpakxgl4" role="3F10Kt">
-          <property role="VOm3f" value="true" />
-        </node>
         <node concept="1QoScp" id="5hKIe0aPqzo" role="3EZMnx">
           <property role="1QpmdY" value="true" />
           <node concept="pkWqt" id="5hKIe0aPqzr" role="3e4ffs">
@@ -906,16 +898,18 @@
             <ref role="1k5W1q" node="2CEi94dprSJ" resolve="TextComment" />
           </node>
         </node>
+        <node concept="VPM3Z" id="5gTlpakxgl4" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
         <node concept="3EZMnI" id="70aAUsacPz9" role="3EZMnx">
           <property role="S$Qs1" value="true" />
           <node concept="2iRkQZ" id="70aAUsacPza" role="2iSdaV" />
           <node concept="3F1sOY" id="3wX8xlocqUq" role="3EZMnx">
             <ref role="1NtTu8" to="vs0r:3wX8xlocnjN" resolve="text" />
-            <ref role="1k5W1q" node="2CEi94dprSJ" resolve="TextComment" />
             <ref role="1ERwB7" node="7zJMcSxj$uX" resolve="preventDeletion" />
+            <ref role="1k5W1q" node="2CEi94dprSJ" resolve="TextComment" />
           </node>
         </node>
-        <node concept="2iRfu4" id="7sHl0myfC36" role="2iSdaV" />
         <node concept="3EZMnI" id="1lmGFD6Gd20" role="3EZMnx">
           <node concept="2iRkQZ" id="1lmGFD6Gd21" role="2iSdaV" />
           <node concept="3F0ifn" id="1lmGFD6JVhF" role="3EZMnx">
@@ -949,6 +943,7 @@
             </node>
           </node>
         </node>
+        <node concept="2iRfu4" id="7sHl0myfC36" role="2iSdaV" />
       </node>
       <node concept="2SsqMj" id="3m8H$lmFM6D" role="3EZMnx">
         <node concept="pVoyu" id="3vl9z2f8Ng9" role="3F10Kt">

--- a/code/languages/com.mbeddr.core/languages/com.mbeddr.core.base/languageModels/structure.mps
+++ b/code/languages/com.mbeddr.core/languages/com.mbeddr.core.base/languageModels/structure.mps
@@ -15,7 +15,6 @@
   <imports>
     <import index="87nw" ref="r:ca2ab6bb-f6e7-4c0f-a88c-b78b9b31fff3(de.slisson.mps.richtext.structure)" />
     <import index="kwxp" ref="b4d28e19-7d2d-47e9-943e-3a41f97a0e52/r:4903509f-5416-46ff-9a8b-44b5a178b568(com.mbeddr.mpsutil.plantuml.node/com.mbeddr.mpsutil.plantuml.node.structure)" />
-    <import index="570t" ref="r:f06c514c-4b4c-4bfc-ad27-ef90a5bd8ded(com.mbeddr.mpsutil.breadcrumb.structure)" />
     <import index="68mc" ref="r:2a10821d-612f-4a73-b7b0-ed6b57106321(com.mbeddr.mpsutil.filepicker.structure)" />
     <import index="10jo" ref="d09a16fb-1d68-4a92-a5a4-20b4b2f86a62/r:6e32694b-6dd1-4530-b48f-4e3bf97b2744(com.mbeddr.mpsutil.jung/com.mbeddr.mpsutil.jung.structure)" />
     <import index="hba4" ref="63e0e566-5131-447e-90e3-12ea330e1a00/r:f5bd2ad9-cd54-4408-b815-07f9f306f074(com.mbeddr.mpsutil.blutil/com.mbeddr.mpsutil.blutil.structure)" />
@@ -1615,9 +1614,6 @@
     <property role="EcuMT" value="7941623276298081733" />
     <node concept="PrWs8" id="6SQk4GjInaQ" role="PrDN$">
       <ref role="PrY4T" node="6SQk4GjV1Md" resolve="IHierarchicalStructureBase" />
-    </node>
-    <node concept="PrWs8" id="6SQk4GjJG$Z" role="PrDN$">
-      <ref role="PrY4T" to="570t:3JrMqIyfmMY" resolve="IBreadcrumb" />
     </node>
   </node>
   <node concept="PlHQZ" id="6SQk4GjUJRB">

--- a/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/doc.mpl
+++ b/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/doc.mpl
@@ -146,15 +146,11 @@
     <dependency reexport="false">c0488c1e-322f-4f38-92d4-5520a7ce96c1(com.mbeddr.mpsutil.plantuml.pluginSolution)</dependency>
     <dependency reexport="false">c1c2a88a-323c-4605-a37d-9ab77a2ccbd2(com.mbeddr.mpsutil.suppresswarning)</dependency>
     <dependency reexport="false">24c96a96-b7a1-4f30-82da-0f8e279a2661(de.itemis.mps.editor.celllayout.styles)</dependency>
-    <dependency reexport="false">86ef8290-12bb-4ca7-947f-093788f263a9(jetbrains.mps.lang.project)</dependency>
     <dependency reexport="true">7866978e-a0f0-4cc7-81bc-4d213d9375e1(jetbrains.mps.lang.smodel)</dependency>
     <dependency reexport="true">5c13c612-0f7b-4f0a-ab8b-565186b418de(de.itemis.mps.mouselistener.runtime)</dependency>
-    <dependency reexport="false">92f195b6-a209-4804-ad65-f5248ecd5873(com.mbeddr.mpsutil.margincell)</dependency>
-    <dependency reexport="false">2374bc90-7e37-41f1-a9c4-c2e35194c36a(com.mbeddr.doc)</dependency>
     <dependency reexport="false">df9d410f-2ebb-43f7-893a-483a4f085250(jetbrains.mps.smodel.resources)</dependency>
   </dependencies>
   <languageVersions>
-    <language slang="l:63e0e566-5131-447e-90e3-12ea330e1a00:com.mbeddr.mpsutil.blutil" version="1" />
     <language slang="l:53a2e8ff-4795-41ec-949d-d5c6bc4895de:com.mbeddr.mpsutil.breadcrumb.editor" version="0" />
     <language slang="l:120e1c9d-4e27-4478-b2af-b2c3bd3850b0:com.mbeddr.mpsutil.editor.querylist" version="0" />
     <language slang="l:b33d119e-196d-4497-977c-5c167b21fe33:com.mbeddr.mpsutil.framecell" version="0" />
@@ -163,7 +159,6 @@
     <language slang="l:f89904fb-9486-43a1-865e-5ad0375a8a88:de.itemis.mps.editor.bool" version="0" />
     <language slang="l:a0ab8c10-c118-4755-ba27-3853435cf524:de.itemis.mps.tooltips" version="0" />
     <language slang="l:b8bb702e-43ed-4090-a902-d180d3e5f292:de.slisson.mps.conditionalEditor" version="0" />
-    <language slang="l:654422bf-e75f-44dc-936d-188890a746ce:de.slisson.mps.reflection" version="0" />
     <language slang="l:52733268-be24-4f5f-ab84-a73b7c0c03b0:de.slisson.mps.richtext.customcell" version="0" />
     <language slang="l:7e450f4e-1ac3-41ef-a851-4598161bdb94:de.slisson.mps.tables" version="0" />
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="5" />
@@ -220,12 +215,10 @@
     <module reference="9e24fcdc-a232-4d24-8c95-1f525946191a(com.mbeddr.core.base.pluginSolution)" version="0" />
     <module reference="2374bc90-7e37-41f1-a9c4-c2e35194c36a(com.mbeddr.doc)" version="0" />
     <module reference="63e0e566-5131-447e-90e3-12ea330e1a00(com.mbeddr.mpsutil.blutil)" version="0" />
-    <module reference="a482b416-d0c9-473f-8f67-725ed642b3f3(com.mbeddr.mpsutil.breadcrumb)" version="0" />
     <module reference="d3a0fd26-445a-466c-900e-10444ddfed52(com.mbeddr.mpsutil.filepicker)" version="0" />
     <module reference="b33d119e-196d-4497-977c-5c167b21fe33(com.mbeddr.mpsutil.framecell)" version="0" />
     <module reference="04e1f940-330e-483b-9a6a-1648b396a81c(com.mbeddr.mpsutil.hyperlink)" version="0" />
     <module reference="d09a16fb-1d68-4a92-a5a4-20b4b2f86a62(com.mbeddr.mpsutil.jung)" version="0" />
-    <module reference="92f195b6-a209-4804-ad65-f5248ecd5873(com.mbeddr.mpsutil.margincell)" version="0" />
     <module reference="b4d28e19-7d2d-47e9-943e-3a41f97a0e52(com.mbeddr.mpsutil.plantuml.node)" version="0" />
     <module reference="c0488c1e-322f-4f38-92d4-5520a7ce96c1(com.mbeddr.mpsutil.plantuml.pluginSolution)" version="0" />
     <module reference="c1c2a88a-323c-4605-a37d-9ab77a2ccbd2(com.mbeddr.mpsutil.suppresswarning)" version="0" />
@@ -246,7 +239,6 @@
     <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
     <module reference="a9e4c532-c5f5-4bb7-99ef-42abb73bbb70(jetbrains.mps.lang.descriptor.aspects)" version="0" />
     <module reference="18bc6592-03a6-4e29-a83a-7ff23bde13ba(jetbrains.mps.lang.editor)" version="0" />
-    <module reference="86ef8290-12bb-4ca7-947f-093788f263a9(jetbrains.mps.lang.project)" version="0" />
     <module reference="d7eb0a2a-bd50-4576-beae-e4a89db35f20(jetbrains.mps.lang.scopes.runtime)" version="0" />
     <module reference="7866978e-a0f0-4cc7-81bc-4d213d9375e1(jetbrains.mps.lang.smodel)" version="1" />
     <module reference="c72da2b9-7cce-4447-8389-f407dc1158b7(jetbrains.mps.lang.structure)" version="0" />

--- a/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/generator/template/com/mbeddr/doc/generator/template/main@generator.mps
+++ b/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/generator/template/com/mbeddr/doc/generator/template/main@generator.mps
@@ -16,16 +16,12 @@
     <import index="2c95" ref="r:5f7188a9-e7b4-4a2e-bef9-38d2cf379fdc(com.mbeddr.doc.structure)" />
     <import index="87nw" ref="r:ca2ab6bb-f6e7-4c0f-a88c-b78b9b31fff3(de.slisson.mps.richtext.structure)" />
     <import index="4gky" ref="r:e1dfab1d-c7a7-43e7-9f26-028afd483e82(com.mbeddr.doc.behavior)" />
-    <import index="hwgx" ref="r:fd2980c8-676c-4b19-b524-18c70e02f8b7(com.mbeddr.core.base.behavior)" />
     <import index="guwi" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.io(JDK/)" />
     <import index="vs0r" ref="r:f7764ca4-8c75-4049-922b-08516400a727(com.mbeddr.core.base.structure)" />
     <import index="grvc" ref="b4d28e19-7d2d-47e9-943e-3a41f97a0e52/r:e4b7e230-de2a-46ac-9f53-996b361d25ef(com.mbeddr.mpsutil.plantuml.node/com.mbeddr.mpsutil.plantuml.node.behavior)" />
-    <import index="w1kc" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel(MPS.Core/)" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" />
     <import index="81o" ref="c0488c1e-322f-4f38-92d4-5520a7ce96c1/java:net.sourceforge.plantuml(com.mbeddr.mpsutil.plantuml.pluginSolution/)" />
     <import index="tpc2" ref="r:00000000-0000-4000-0000-011c8959029e(jetbrains.mps.lang.editor.structure)" />
-    <import index="r4b4" ref="r:1784e088-20fd-4fdb-96b8-bc57f0056d94(com.mbeddr.core.base.editor)" />
-    <import index="i51s" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.lang.smodel.generator.smodelAdapter(MPS.Core/)" />
     <import index="z1c3" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.project(MPS.Core/)" />
     <import index="lui2" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.module(MPS.OpenAPI/)" />
     <import index="mhbf" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.model(MPS.OpenAPI/)" />

--- a/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/languageModels/actions.mps
+++ b/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/languageModels/actions.mps
@@ -3,12 +3,8 @@
   <persistence version="9" />
   <languages>
     <use id="aee9cad2-acd4-4608-aef2-0004f6a1cdbd" name="jetbrains.mps.lang.actions" version="4" />
-    <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
-  <imports>
-    <import index="2c95" ref="r:5f7188a9-e7b4-4a2e-bef9-38d2cf379fdc(com.mbeddr.doc.structure)" />
-    <import index="z726" ref="r:6b7eb85f-64d8-4de6-8906-0e18804729df(com.mbeddr.doc.editor)" />
-  </imports>
+  <imports />
   <registry />
 </model>
 

--- a/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/languageModels/behavior.mps
+++ b/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/languageModels/behavior.mps
@@ -3,7 +3,6 @@
   <persistence version="9" />
   <languages>
     <use id="af65afd8-f0dd-4942-87d9-63a55f2a9db1" name="jetbrains.mps.lang.behavior" version="1" />
-    <use id="63e0e566-5131-447e-90e3-12ea330e1a00" name="com.mbeddr.mpsutil.blutil" version="-1" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
@@ -14,8 +13,6 @@
     <import index="87nw" ref="r:ca2ab6bb-f6e7-4c0f-a88c-b78b9b31fff3(de.slisson.mps.richtext.structure)" />
     <import index="vs0r" ref="r:f7764ca4-8c75-4049-922b-08516400a727(com.mbeddr.core.base.structure)" />
     <import index="grvc" ref="b4d28e19-7d2d-47e9-943e-3a41f97a0e52/r:e4b7e230-de2a-46ac-9f53-996b361d25ef(com.mbeddr.mpsutil.plantuml.node/com.mbeddr.mpsutil.plantuml.node.behavior)" />
-    <import index="u8e7" ref="r:4acb4e42-0ef5-487c-a21d-496738d115a6(com.mbeddr.mpsutil.breadcrumb.behavior)" />
-    <import index="tpce" ref="r:00000000-0000-4000-0000-011c89590292(jetbrains.mps.lang.structure.structure)" />
     <import index="guwi" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.io(JDK/)" />
     <import index="cj4x" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor(MPS.Editor/)" />
     <import index="f4zo" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.cells(MPS.Editor/)" />
@@ -399,21 +396,6 @@
         </node>
       </node>
     </node>
-    <node concept="13i0hz" id="2W7DBH1CpS3" role="13h7CS">
-      <property role="13i0iv" value="false" />
-      <property role="13i0it" value="false" />
-      <property role="TrG5h" value="showInBreadcrumb" />
-      <ref role="13i0hy" to="u8e7:1pmorAautNF" resolve="showInBreadcrumb" />
-      <node concept="3Tm1VV" id="2W7DBH1CpS4" role="1B3o_S" />
-      <node concept="3clFbS" id="2W7DBH1CpS9" role="3clF47">
-        <node concept="3clFbF" id="2W7DBH1CrZ8" role="3cqZAp">
-          <node concept="3clFbT" id="2W7DBH1CrZ7" role="3clFbG">
-            <property role="3clFbU" value="false" />
-          </node>
-        </node>
-      </node>
-      <node concept="10P_77" id="2W7DBH1CpSa" role="3clF45" />
-    </node>
   </node>
   <node concept="13h7C7" id="2TZO3Dbvd_K">
     <property role="3GE5qa" value="paragraphs" />
@@ -756,21 +738,6 @@
       </node>
       <node concept="10P_77" id="3il$LAnWBYe" role="3clF45" />
       <node concept="3Tm1VV" id="3il$LAnWBYf" role="1B3o_S" />
-    </node>
-    <node concept="13i0hz" id="1o2NPvZtAES" role="13h7CS">
-      <property role="13i0iv" value="false" />
-      <property role="13i0it" value="false" />
-      <property role="TrG5h" value="showInBreadcrumb" />
-      <ref role="13i0hy" to="u8e7:1pmorAautNF" resolve="showInBreadcrumb" />
-      <node concept="3Tm1VV" id="1o2NPvZtAET" role="1B3o_S" />
-      <node concept="3clFbS" id="1o2NPvZtAEY" role="3clF47">
-        <node concept="3clFbF" id="1o2NPvZtC11" role="3cqZAp">
-          <node concept="3clFbT" id="1o2NPvZtC10" role="3clFbG">
-            <property role="3clFbU" value="false" />
-          </node>
-        </node>
-      </node>
-      <node concept="10P_77" id="1o2NPvZtAEZ" role="3clF45" />
     </node>
   </node>
   <node concept="13h7C7" id="2TZO3DbvK_h">
@@ -2373,24 +2340,6 @@
           </node>
         </node>
       </node>
-    </node>
-    <node concept="13i0hz" id="2FK2lSA6Vnf" role="13h7CS">
-      <property role="13i0iv" value="false" />
-      <property role="13i0it" value="false" />
-      <property role="TrG5h" value="getBreadcrumbText" />
-      <ref role="13i0hy" to="u8e7:3JrMqIyfmQ4" resolve="getBreadcrumbText" />
-      <node concept="3Tm1VV" id="2FK2lSA6Vng" role="1B3o_S" />
-      <node concept="3clFbS" id="2FK2lSA6Vnn" role="3clF47">
-        <node concept="3clFbF" id="5wmuVxvF2lo" role="3cqZAp">
-          <node concept="2OqwBi" id="5wmuVxvF2ts" role="3clFbG">
-            <node concept="13iPFW" id="5wmuVxvF2ln" role="2Oq$k0" />
-            <node concept="2qgKlT" id="5wmuVxvF3hW" role="2OqNvi">
-              <ref role="37wK5l" node="5wmuVxvF0fD" resolve="getIndexedText" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="17QB3L" id="2FK2lSA6Vno" role="3clF45" />
     </node>
   </node>
   <node concept="13h7C7" id="5yxqZJwzdPm">
@@ -7456,24 +7405,6 @@
     <ref role="13h7C2" to="2c95:3DAECxG6nQE" resolve="Chapter" />
     <node concept="13hLZK" id="aiIotWBg4P" role="13h7CW">
       <node concept="3clFbS" id="aiIotWBg4Q" role="2VODD2" />
-    </node>
-    <node concept="13i0hz" id="aiIotWBg4R" role="13h7CS">
-      <property role="13i0iv" value="false" />
-      <property role="13i0it" value="false" />
-      <property role="TrG5h" value="getSectionIndexText" />
-      <ref role="13i0hy" to="u8e7:4o4$mVTwnPA" resolve="getBookmarkText" />
-      <node concept="3Tm1VV" id="aiIotWBg4S" role="1B3o_S" />
-      <node concept="3clFbS" id="aiIotWBg4Z" role="3clF47">
-        <node concept="3clFbF" id="aiIotWBg6u" role="3cqZAp">
-          <node concept="2OqwBi" id="aiIotWBgnx" role="3clFbG">
-            <node concept="13iPFW" id="aiIotWBg6p" role="2Oq$k0" />
-            <node concept="2qgKlT" id="aiIotWBhec" role="2OqNvi">
-              <ref role="37wK5l" to="u8e7:3JrMqIyfmQ4" resolve="getBreadcrumbText" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="17QB3L" id="aiIotWBg50" role="3clF45" />
     </node>
   </node>
   <node concept="13h7C7" id="6TjoDcE5T6A">

--- a/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/languageModels/constraints.mps
+++ b/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/languageModels/constraints.mps
@@ -2,7 +2,6 @@
 <model ref="r:a5b5b4fe-a87a-44d6-a204-cb07050793ac(com.mbeddr.doc.constraints)">
   <persistence version="9" />
   <languages>
-    <use id="13744753-c81f-424a-9c1b-cf8943bf4e86" name="jetbrains.mps.lang.sharedConcepts" version="-1" />
     <use id="3f41734b-72c3-42c8-b22c-bacd5a878e17" name="com.mbeddr.mpsutil.propertydefault" version="-1" />
     <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="8" />
   </languages>
@@ -12,9 +11,6 @@
     <import index="vs0r" ref="r:f7764ca4-8c75-4049-922b-08516400a727(com.mbeddr.core.base.structure)" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" />
     <import index="18ew" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.util(MPS.Core/)" />
-    <import index="lui2" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.module(MPS.OpenAPI/)" />
-    <import index="w1kc" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel(MPS.Core/)" />
-    <import index="z1c3" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.project(MPS.Core/)" />
     <import index="o8zo" ref="r:314576fc-3aee-4386-a0a5-a38348ac317d(jetbrains.mps.scope)" />
     <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" implicit="true" />
   </imports>

--- a/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/languageModels/editor.mps
+++ b/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/languageModels/editor.mps
@@ -12,7 +12,6 @@
     <use id="a0ab8c10-c118-4755-ba27-3853435cf524" name="de.itemis.mps.tooltips" version="-1" />
     <use id="b8bb702e-43ed-4090-a902-d180d3e5f292" name="de.slisson.mps.conditionalEditor" version="-1" />
     <use id="52733268-be24-4f5f-ab84-a73b7c0c03b0" name="de.slisson.mps.richtext.customcell" version="-1" />
-    <use id="654422bf-e75f-44dc-936d-188890a746ce" name="de.slisson.mps.reflection" version="-1" />
     <use id="a247e09e-2435-45ba-b8d2-07e93feba96a" name="jetbrains.mps.baseLanguage.tuples" version="-1" />
     <use id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor" version="-1" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
@@ -36,7 +35,6 @@
     <import index="exr9" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor(MPS.Editor/)" />
     <import index="hyam" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt.event(JDK/)" />
     <import index="r791" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:javax.swing.text(JDK/)" />
-    <import index="tpce" ref="r:00000000-0000-4000-0000-011c89590292(jetbrains.mps.lang.structure.structure)" />
     <import index="ag3p" ref="04e1f940-330e-483b-9a6a-1648b396a81c/r:4f3facd2-2d6c-40e4-a229-cdeb0a5137d8(com.mbeddr.mpsutil.hyperlink/com.mbeddr.mpsutil.hyperlink.runtime)" />
     <import index="btm1" ref="b0f8641f-bd77-4421-8425-30d9088a82f7/java:org.apache.commons.lang3(org.apache.commons/)" />
     <import index="23h6" ref="r:7141fd54-a831-41ba-8753-74008b0b9af4(de.slisson.mps.richtext.editor)" />
@@ -53,7 +51,6 @@
     <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
     <import index="g51k" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor.cells(MPS.Editor/)" />
     <import index="kcid" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor.cellLayout(MPS.Editor/)" />
-    <import index="eh3q" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor.text(MPS.Editor/)" />
     <import index="ni5j" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util.regex(JDK/)" />
     <import index="mhfm" ref="3f233e7f-b8a6-46d2-a57f-795d56775243/java:org.jetbrains.annotations(Annotations/)" />
     <import index="z0fb" ref="r:0b928dd6-dd7e-45a8-b309-a2e315b7877a(de.itemis.mps.editor.celllayout.styles.editor)" />

--- a/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/languageModels/intentions.mps
+++ b/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/languageModels/intentions.mps
@@ -6,7 +6,6 @@
     <use id="13744753-c81f-424a-9c1b-cf8943bf4e86" name="jetbrains.mps.lang.sharedConcepts" version="0" />
     <use id="aee9cad2-acd4-4608-aef2-0004f6a1cdbd" name="jetbrains.mps.lang.actions" version="4" />
     <use id="b92f861d-0184-446d-b88b-6dcf0e070241" name="com.mbeddr.mpsutil.intentions" version="0" />
-    <use id="63e0e566-5131-447e-90e3-12ea330e1a00" name="com.mbeddr.mpsutil.blutil" version="1" />
     <use id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor" version="11" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>

--- a/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/languageModels/migration.mps
+++ b/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/languageModels/migration.mps
@@ -3,12 +3,9 @@
   <persistence version="9" />
   <languages>
     <use id="90746344-04fd-4286-97d5-b46ae6a81709" name="jetbrains.mps.lang.migration" version="0" />
-    <use id="28f9e497-3b42-4291-aeba-0a1039153ab1" name="jetbrains.mps.lang.plugin" version="2" />
-    <use id="d4615e3b-d671-4ba9-af01-2b78369b0ba7" name="jetbrains.mps.lang.pattern" version="1" />
     <devkit ref="2677cb18-f558-4e33-bc38-a5139cee06dc(jetbrains.mps.devkit.language-design)" />
   </languages>
   <imports>
-    <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" />
     <import index="lui2" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.module(MPS.OpenAPI/)" />
     <import index="slm6" ref="90746344-04fd-4286-97d5-b46ae6a81709/r:52a3d974-bd4f-4651-ba6e-a2de5e336d95(jetbrains.mps.lang.migration/jetbrains.mps.lang.migration.methods)" implicit="true" />
     <import index="2c95" ref="r:5f7188a9-e7b4-4a2e-bef9-38d2cf379fdc(com.mbeddr.doc.structure)" implicit="true" />

--- a/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/languageModels/plugin.mps
+++ b/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/languageModels/plugin.mps
@@ -24,7 +24,6 @@
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" />
     <import index="z1c3" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.project(MPS.Core/)" />
     <import index="eoo2" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.nio.file(JDK/)" />
-    <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
     <import index="2c95" ref="r:5f7188a9-e7b4-4a2e-bef9-38d2cf379fdc(com.mbeddr.doc.structure)" />
     <import index="guwi" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.io(JDK/)" />
     <import index="fn29" ref="r:6ba2667b-185e-45cd-ac65-e4b9d66da28e(jetbrains.mps.smodel.resources)" />

--- a/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/languageModels/scripts.mps
+++ b/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/languageModels/scripts.mps
@@ -3,7 +3,6 @@
   <persistence version="9" />
   <languages>
     <use id="0eddeefa-c2d6-4437-bc2c-de50fd4ce470" name="jetbrains.mps.lang.script" version="0" />
-    <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports />
   <registry />

--- a/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/languageModels/structure.mps
+++ b/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/languageModels/structure.mps
@@ -9,7 +9,6 @@
     <import index="vs0r" ref="r:f7764ca4-8c75-4049-922b-08516400a727(com.mbeddr.core.base.structure)" />
     <import index="87nw" ref="r:ca2ab6bb-f6e7-4c0f-a88c-b78b9b31fff3(de.slisson.mps.richtext.structure)" />
     <import index="kwxp" ref="b4d28e19-7d2d-47e9-943e-3a41f97a0e52/r:4903509f-5416-46ff-9a8b-44b5a178b568(com.mbeddr.mpsutil.plantuml.node/com.mbeddr.mpsutil.plantuml.node.structure)" />
-    <import index="570t" ref="r:f06c514c-4b4c-4bfc-ad27-ef90a5bd8ded(com.mbeddr.mpsutil.breadcrumb.structure)" />
     <import index="68mc" ref="r:2a10821d-612f-4a73-b7b0-ed6b57106321(com.mbeddr.mpsutil.filepicker.structure)" />
     <import index="tpc2" ref="r:00000000-0000-4000-0000-011c8959029e(jetbrains.mps.lang.editor.structure)" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" />
@@ -108,9 +107,6 @@
     <node concept="PrWs8" id="60pdW7uM1gq" role="PzmwI">
       <ref role="PrY4T" to="vs0r:9MiAwFsXp0" resolve="ITreeViewRoot" />
     </node>
-    <node concept="PrWs8" id="4zsoa5EdazX" role="PzmwI">
-      <ref role="PrY4T" to="570t:3JrMqIyfmMY" resolve="IBreadcrumb" />
-    </node>
   </node>
   <node concept="PlHQZ" id="2TZO3DbuxwP">
     <property role="TrG5h" value="IDocumentContent" />
@@ -118,9 +114,6 @@
     <property role="EcuMT" value="3350625596579911733" />
     <node concept="PrWs8" id="2TZO3Dbv5pF" role="PrDN$">
       <ref role="PrY4T" to="vs0r:65XyadYKJgN" resolve="IIdentifierNamedConcept" />
-    </node>
-    <node concept="PrWs8" id="1o2NPvZml3z" role="PrDN$">
-      <ref role="PrY4T" to="570t:3JrMqIyfmMY" resolve="IBreadcrumb" />
     </node>
   </node>
   <node concept="1TIwiD" id="2TZO3Dbuxxg">
@@ -159,9 +152,6 @@
     </node>
     <node concept="PrWs8" id="jpyKDg34iD" role="PzmwI">
       <ref role="PrY4T" to="vs0r:jpyKDg1onz" resolve="ISearchSupport" />
-    </node>
-    <node concept="PrWs8" id="1F0U9H6cCL0" role="PzmwI">
-      <ref role="PrY4T" to="570t:3JrMqIyfmMY" resolve="IBreadcrumb" />
     </node>
     <node concept="PrWs8" id="39jEAIlrcKU" role="PzmwI">
       <ref role="PrY4T" to="vs0r:7NyyyjNt9Bq" resolve="ITreeViewable" />
@@ -1297,9 +1287,6 @@
     <ref role="1TJDcQ" node="2TZO3Dbv6Ju" resolve="AbstractSection" />
     <node concept="PrWs8" id="3DAECxG6nQF" role="PzmwI">
       <ref role="PrY4T" to="vs0r:3m8H$lmFM60" resolve="IDocumentable" />
-    </node>
-    <node concept="PrWs8" id="aiIotWrcya" role="PzmwI">
-      <ref role="PrY4T" to="570t:4o4$mVTwnFM" resolve="ISectionIndex" />
     </node>
   </node>
   <node concept="1TIwiD" id="1YUFCeFQmC9">


### PR DESCRIPTION
Historically we had one big mpsutil plugin. Loading it was a all or nothing choice. I removed some of the bigger "subsystem" from the single plugin and created small plugins out of them. This allows fine grained loading in downstream projects. RCPs can easier decide which plugins they want to strip. 

It should also allow us an easier transition to mps-extenstion repo as we can move the plugins one by one. 

I also made sure that the big mpsutil plugin depends on the newly created ones. Downstream projects will not see any change until they decide to change their dependencies. 