### PR TITLE
Enhanced Mandatory port cheking rules 

### DIFF
--- a/code/languages/com.mbeddr.build/solutions/com.mbeddr.ext.build/models/com/mbeddr/ext/build.mps
+++ b/code/languages/com.mbeddr.build/solutions/com.mbeddr.ext.build/models/com/mbeddr/ext/build.mps
@@ -425,6 +425,12 @@
             </node>
           </node>
         </node>
+        <node concept="1SiIV0" id="5wgnsHJYs2G" role="3bR37C">
+          <node concept="3bR9La" id="5wgnsHJYs2H" role="1SiIV1">
+            <property role="3bR36h" value="false" />
+            <ref role="3bR37D" to="p6ld:7tgCHAyOtFQ" resolve="com.mbeddr.ext.compositecomponents" />
+          </node>
+        </node>
       </node>
       <node concept="1E1JtA" id="5qO$P$PrIFQ" role="2G$12L">
         <property role="BnDLt" value="true" />

--- a/code/languages/com.mbeddr.ext/languages/com.mbeddr.ext.components/languageModels/typesystem.mps
+++ b/code/languages/com.mbeddr.ext/languages/com.mbeddr.ext.components/languageModels/typesystem.mps
@@ -2517,56 +2517,68 @@
               </node>
             </node>
             <node concept="1Wc70l" id="33VMAJYY1aB" role="3clFbw">
-              <node concept="1Wc70l" id="36Bkyc4vxPr" role="3uHU7B">
-                <node concept="2OqwBi" id="36Bkyc4p23e" role="3uHU7B">
-                  <node concept="2OqwBi" id="3_MZZHrtKnh" role="2Oq$k0">
-                    <node concept="2OqwBi" id="3_MZZHrtKni" role="2Oq$k0">
-                      <node concept="37vLTw" id="36Bkyc4p0eR" role="2Oq$k0">
-                        <ref role="3cqZAo" node="LUz4xAqU0t" resolve="config" />
-                      </node>
-                      <node concept="2qgKlT" id="3_MZZHrtKnk" role="2OqNvi">
-                        <ref role="37wK5l" to="eup9:6JVEnxIhC2V" resolve="assemblyConnectors" />
-                      </node>
-                    </node>
-                    <node concept="3zZkjj" id="3_MZZHrtKnl" role="2OqNvi">
-                      <node concept="1bVj0M" id="3_MZZHrtKnm" role="23t8la">
-                        <node concept="3clFbS" id="3_MZZHrtKnn" role="1bW5cS">
-                          <node concept="3clFbF" id="3_MZZHrtKno" role="3cqZAp">
-                            <node concept="3clFbC" id="3_MZZHrtKnq" role="3clFbG">
-                              <node concept="2GrUjf" id="36Bkyc4p1aB" role="3uHU7w">
-                                <ref role="2Gs0qQ" node="36Bkyc4hV6a" resolve="providedPort" />
-                              </node>
-                              <node concept="2OqwBi" id="3_MZZHrtKns" role="3uHU7B">
-                                <node concept="2OqwBi" id="3_MZZHrtKnt" role="2Oq$k0">
-                                  <node concept="37vLTw" id="3_MZZHrtKnu" role="2Oq$k0">
-                                    <ref role="3cqZAo" node="3_MZZHrtKn_" resolve="it" />
-                                  </node>
-                                  <node concept="3TrEf2" id="36Bkyc4p0Om" role="2OqNvi">
-                                    <ref role="3Tt5mk" to="v7ag:3TmmsQkDdTX" resolve="target" />
-                                  </node>
-                                </node>
-                                <node concept="3TrEf2" id="36Bkyc4p13z" role="2OqNvi">
-                                  <ref role="3Tt5mk" to="v7ag:2ZeMBoiZpvV" resolve="port" />
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="Rh6nW" id="3_MZZHrtKn_" role="1bW2Oz">
-                          <property role="TrG5h" value="it" />
-                          <node concept="2jxLKc" id="3_MZZHrtKnA" role="1tU5fm" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="1v1jN8" id="36Bkyc4p2rB" role="2OqNvi" />
-                </node>
+              <node concept="1Wc70l" id="5Uve0OVQRi1" role="3uHU7B">
                 <node concept="2OqwBi" id="36Bkyc4vyuz" role="3uHU7w">
                   <node concept="2GrUjf" id="36Bkyc4vy84" role="2Oq$k0">
                     <ref role="2Gs0qQ" node="36Bkyc4hV6a" resolve="providedPort" />
                   </node>
                   <node concept="3TrcHB" id="36Bkyc4vzb_" role="2OqNvi">
                     <ref role="3TsBF5" to="v7ag:36Bkyc49pe4" resolve="mandatory" />
+                  </node>
+                </node>
+                <node concept="1Wc70l" id="36Bkyc4vxPr" role="3uHU7B">
+                  <node concept="2OqwBi" id="36Bkyc4p23e" role="3uHU7B">
+                    <node concept="2OqwBi" id="3_MZZHrtKnh" role="2Oq$k0">
+                      <node concept="2OqwBi" id="3_MZZHrtKni" role="2Oq$k0">
+                        <node concept="37vLTw" id="36Bkyc4p0eR" role="2Oq$k0">
+                          <ref role="3cqZAo" node="LUz4xAqU0t" resolve="config" />
+                        </node>
+                        <node concept="2qgKlT" id="3_MZZHrtKnk" role="2OqNvi">
+                          <ref role="37wK5l" to="eup9:6JVEnxIhC2V" resolve="assemblyConnectors" />
+                        </node>
+                      </node>
+                      <node concept="3zZkjj" id="3_MZZHrtKnl" role="2OqNvi">
+                        <node concept="1bVj0M" id="3_MZZHrtKnm" role="23t8la">
+                          <node concept="3clFbS" id="3_MZZHrtKnn" role="1bW5cS">
+                            <node concept="3clFbF" id="3_MZZHrtKno" role="3cqZAp">
+                              <node concept="3clFbC" id="3_MZZHrtKnq" role="3clFbG">
+                                <node concept="2GrUjf" id="36Bkyc4p1aB" role="3uHU7w">
+                                  <ref role="2Gs0qQ" node="36Bkyc4hV6a" resolve="providedPort" />
+                                </node>
+                                <node concept="2OqwBi" id="3_MZZHrtKns" role="3uHU7B">
+                                  <node concept="2OqwBi" id="3_MZZHrtKnt" role="2Oq$k0">
+                                    <node concept="37vLTw" id="3_MZZHrtKnu" role="2Oq$k0">
+                                      <ref role="3cqZAo" node="3_MZZHrtKn_" resolve="it" />
+                                    </node>
+                                    <node concept="3TrEf2" id="36Bkyc4p0Om" role="2OqNvi">
+                                      <ref role="3Tt5mk" to="v7ag:3TmmsQkDdTX" resolve="target" />
+                                    </node>
+                                  </node>
+                                  <node concept="3TrEf2" id="36Bkyc4p13z" role="2OqNvi">
+                                    <ref role="3Tt5mk" to="v7ag:2ZeMBoiZpvV" resolve="port" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="Rh6nW" id="3_MZZHrtKn_" role="1bW2Oz">
+                            <property role="TrG5h" value="it" />
+                            <node concept="2jxLKc" id="3_MZZHrtKnA" role="1tU5fm" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="1v1jN8" id="36Bkyc4p2rB" role="2OqNvi" />
+                  </node>
+                  <node concept="2OqwBi" id="5Uve0OVQTgb" role="3uHU7w">
+                    <node concept="37vLTw" id="5Uve0OVQSbN" role="2Oq$k0">
+                      <ref role="3cqZAo" node="LUz4xAqU0t" resolve="config" />
+                    </node>
+                    <node concept="1mIQ4w" id="5Uve0OVQUFp" role="2OqNvi">
+                      <node concept="chp4Y" id="5Uve0OVQVSQ" role="cj9EA">
+                        <ref role="cht4Q" to="v7ag:3TmmsQkDdU0" resolve="InstanceConfiguration" />
+                      </node>
+                    </node>
                   </node>
                 </node>
               </node>
@@ -11254,6 +11266,130 @@
           </node>
         </node>
       </node>
+    </node>
+  </node>
+  <node concept="18kY7G" id="6niK5RcgwV4">
+    <property role="3GE5qa" value="adapter" />
+    <property role="TrG5h" value="check_PortAdapter" />
+    <node concept="3clFbS" id="6niK5RcgwV5" role="18ibNy">
+      <node concept="3cpWs8" id="6niK5Rcgx2g" role="3cqZAp">
+        <node concept="3cpWsn" id="6niK5Rcgx2j" role="3cpWs9">
+          <property role="TrG5h" value="adapterInstance" />
+          <node concept="3Tqbb2" id="6niK5Rcgx2f" role="1tU5fm">
+            <ref role="ehGHo" to="v7ag:5JgQ5vqXSDQ" resolve="AdapterInstancePortRef" />
+          </node>
+          <node concept="2OqwBi" id="6niK5Rcgxmk" role="33vP2m">
+            <node concept="1YBJjd" id="6niK5Rcgx2P" role="2Oq$k0">
+              <ref role="1YBMHb" node="6niK5RcgwV7" resolve="portAdapter" />
+            </node>
+            <node concept="3TrEf2" id="6niK5RcgxJa" role="2OqNvi">
+              <ref role="3Tt5mk" to="v7ag:5JgQ5vqY0yt" resolve="portRef" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbJ" id="6niK5RcgxWg" role="3cqZAp">
+        <node concept="3clFbS" id="6niK5RcgxWi" role="3clFbx">
+          <node concept="3cpWs8" id="6niK5RcgzJq" role="3cqZAp">
+            <node concept="3cpWsn" id="6niK5RcgzJt" role="3cpWs9">
+              <property role="TrG5h" value="adapterRef" />
+              <node concept="3Tqbb2" id="6niK5Rch31u" role="1tU5fm">
+                <ref role="ehGHo" to="v7ag:71UKpntog8p" resolve="PortAdapterRefExpr" />
+              </node>
+              <node concept="2OqwBi" id="6niK5RcgUej" role="33vP2m">
+                <node concept="2OqwBi" id="6niK5RcgMjE" role="2Oq$k0">
+                  <node concept="2OqwBi" id="6niK5RcgKPi" role="2Oq$k0">
+                    <node concept="1YBJjd" id="6niK5RcgK$y" role="2Oq$k0">
+                      <ref role="1YBMHb" node="6niK5RcgwV7" resolve="portAdapter" />
+                    </node>
+                    <node concept="I4A8Y" id="6niK5RcgLJt" role="2OqNvi" />
+                  </node>
+                  <node concept="2SmgA7" id="6niK5RcgMCk" role="2OqNvi">
+                    <node concept="chp4Y" id="6niK5RcgMIw" role="1dBWTz">
+                      <ref role="cht4Q" to="v7ag:71UKpntog8p" resolve="PortAdapterRefExpr" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="1z4cxt" id="6niK5Rch0SQ" role="2OqNvi">
+                  <node concept="1bVj0M" id="6niK5Rch0SS" role="23t8la">
+                    <node concept="3clFbS" id="6niK5Rch0ST" role="1bW5cS">
+                      <node concept="3clFbF" id="6niK5Rch0Zi" role="3cqZAp">
+                        <node concept="17R0WA" id="6niK5Rch2us" role="3clFbG">
+                          <node concept="1YBJjd" id="6niK5Rch2AU" role="3uHU7w">
+                            <ref role="1YBMHb" node="6niK5RcgwV7" resolve="portAdapter" />
+                          </node>
+                          <node concept="2OqwBi" id="6niK5Rch1jM" role="3uHU7B">
+                            <node concept="37vLTw" id="6niK5Rch0Zh" role="2Oq$k0">
+                              <ref role="3cqZAo" node="6niK5Rch0SU" resolve="it" />
+                            </node>
+                            <node concept="3TrEf2" id="6niK5Rch1Iw" role="2OqNvi">
+                              <ref role="3Tt5mk" to="v7ag:71UKpntog8q" resolve="portAdater" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="Rh6nW" id="6niK5Rch0SU" role="1bW2Oz">
+                      <property role="TrG5h" value="it" />
+                      <node concept="2jxLKc" id="6niK5Rch0SV" role="1tU5fm" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbJ" id="6niK5Rch36s" role="3cqZAp">
+            <node concept="3clFbS" id="6niK5Rch36u" role="3clFbx">
+              <node concept="2MkqsV" id="6niK5Rch44k" role="3cqZAp">
+                <node concept="3cpWs3" id="6niK5Rch6d$" role="2MkJ7o">
+                  <node concept="Xl_RD" id="6niK5Rch6dB" role="3uHU7w">
+                    <property role="Xl_RC" value=" is not used anywhere in the model" />
+                  </node>
+                  <node concept="3cpWs3" id="6niK5Rch4n0" role="3uHU7B">
+                    <node concept="Xl_RD" id="6niK5Rch44z" role="3uHU7B">
+                      <property role="Xl_RC" value="Mandatory port adapter " />
+                    </node>
+                    <node concept="2OqwBi" id="6niK5Rch4Df" role="3uHU7w">
+                      <node concept="1YBJjd" id="6niK5Rch4ni" role="2Oq$k0">
+                        <ref role="1YBMHb" node="6niK5RcgwV7" resolve="portAdapter" />
+                      </node>
+                      <node concept="3TrcHB" id="6niK5Rch5gK" role="2OqNvi">
+                        <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="1YBJjd" id="6niK5Rchdf5" role="2OEOjV">
+                  <ref role="1YBMHb" node="6niK5RcgwV7" resolve="portAdapter" />
+                </node>
+              </node>
+            </node>
+            <node concept="2OqwBi" id="6niK5Rch3mf" role="3clFbw">
+              <node concept="37vLTw" id="6niK5Rch378" role="2Oq$k0">
+                <ref role="3cqZAo" node="6niK5RcgzJt" resolve="adapterRef" />
+              </node>
+              <node concept="3w_OXm" id="6niK5Rch417" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+        <node concept="2OqwBi" id="6niK5RcgyLs" role="3clFbw">
+          <node concept="2OqwBi" id="6niK5Rcgy5k" role="2Oq$k0">
+            <node concept="37vLTw" id="6niK5RcgxW_" role="2Oq$k0">
+              <ref role="3cqZAo" node="6niK5Rcgx2j" resolve="adapterInstance" />
+            </node>
+            <node concept="3TrEf2" id="6niK5Rcgym4" role="2OqNvi">
+              <ref role="3Tt5mk" to="v7ag:5JgQ5vqXSDS" resolve="port" />
+            </node>
+          </node>
+          <node concept="3TrcHB" id="6niK5RcgzFU" role="2OqNvi">
+            <ref role="3TsBF5" to="v7ag:36Bkyc49pe4" resolve="mandatory" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1YaCAy" id="6niK5RcgwV7" role="1YuTPh">
+      <property role="TrG5h" value="portAdapter" />
+      <ref role="1YaFvo" to="v7ag:4v7hlN6x1z2" resolve="PortAdapter" />
     </node>
   </node>
 </model>

--- a/code/languages/com.mbeddr.ext/languages/com.mbeddr.ext.compositecomponents/compositecomponents.mpl
+++ b/code/languages/com.mbeddr.ext/languages/com.mbeddr.ext.compositecomponents/compositecomponents.mpl
@@ -141,14 +141,12 @@
     <dependency reexport="false">c1c2a88a-323c-4605-a37d-9ab77a2ccbd2(com.mbeddr.mpsutil.suppresswarning)</dependency>
   </dependencies>
   <languageVersions>
-    <language slang="l:63e0e566-5131-447e-90e3-12ea330e1a00:com.mbeddr.mpsutil.blutil" version="1" />
     <language slang="l:120e1c9d-4e27-4478-b2af-b2c3bd3850b0:com.mbeddr.mpsutil.editor.querylist" version="0" />
     <language slang="l:b92f861d-0184-446d-b88b-6dcf0e070241:com.mbeddr.mpsutil.intentions" version="0" />
     <language slang="l:fa13cc63-c476-4d46-9c96-d53670abe7bc:de.itemis.mps.editor.diagram" version="0" />
     <language slang="l:21063c66-85ba-4e98-839b-036445b17ae2:de.itemis.mps.editor.layout" version="0" />
     <language slang="l:a0ab8c10-c118-4755-ba27-3853435cf524:de.itemis.mps.tooltips" version="0" />
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="6" />
-    <language slang="l:ed6d7656-532c-4bc2-81d1-af945aeb8280:jetbrains.mps.baseLanguage.blTypes" version="0" />
     <language slang="l:443f4c36-fcf5-4eb6-9500-8d06ed259e3e:jetbrains.mps.baseLanguage.classifiers" version="0" />
     <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
     <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="0" />
@@ -156,7 +154,6 @@
     <language slang="l:c7d5b9dd-a05f-4be2-bc73-f2e16994cc67:jetbrains.mps.baseLanguage.lightweightdsl" version="1" />
     <language slang="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" version="0" />
     <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
-    <language slang="l:63650c59-16c8-498a-99c8-005c7ee9515d:jetbrains.mps.lang.access" version="0" />
     <language slang="l:aee9cad2-acd4-4608-aef2-0004f6a1cdbd:jetbrains.mps.lang.actions" version="4" />
     <language slang="l:af65afd8-f0dd-4942-87d9-63a55f2a9db1:jetbrains.mps.lang.behavior" version="1" />
     <language slang="l:fe9d76d7-5809-45c9-ae28-a40915b4d6ff:jetbrains.mps.lang.checkedName" version="0" />

--- a/code/languages/com.mbeddr.ext/languages/com.mbeddr.ext.compositecomponents/languageModels/typesystem.mps
+++ b/code/languages/com.mbeddr.ext/languages/com.mbeddr.ext.compositecomponents/languageModels/typesystem.mps
@@ -3,7 +3,6 @@
   <persistence version="9" />
   <languages>
     <use id="7a5dda62-9140-4668-ab76-d5ed1746f2b2" name="jetbrains.mps.lang.typesystem" version="1" />
-    <use id="63e0e566-5131-447e-90e3-12ea330e1a00" name="com.mbeddr.mpsutil.blutil" version="1" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
@@ -85,6 +84,9 @@
       </concept>
       <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
       <concept id="1081855346303" name="jetbrains.mps.baseLanguage.structure.BreakStatement" flags="nn" index="3zACq4" />
+      <concept id="5497648299878491908" name="jetbrains.mps.baseLanguage.structure.BaseVariableReference" flags="nn" index="1M0zk4">
+        <reference id="5497648299878491909" name="baseVariableDeclaration" index="1M0zk5" />
+      </concept>
       <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
     </language>
     <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
@@ -184,8 +186,19 @@
         <child id="6733348108486823193" name="leftExpression" index="1m5AlR" />
         <child id="3906496115198199033" name="conceptArgument" index="3oSUPX" />
       </concept>
+      <concept id="1883223317721008708" name="jetbrains.mps.lang.smodel.structure.IfInstanceOfStatement" flags="nn" index="Jncv_">
+        <reference id="1883223317721008712" name="nodeConcept" index="JncvD" />
+        <child id="1883223317721008709" name="body" index="Jncv$" />
+        <child id="1883223317721008711" name="variable" index="JncvA" />
+        <child id="1883223317721008710" name="nodeExpression" index="JncvB" />
+      </concept>
+      <concept id="1883223317721008713" name="jetbrains.mps.lang.smodel.structure.IfInstanceOfVariable" flags="ng" index="JncvC" />
+      <concept id="1883223317721107059" name="jetbrains.mps.lang.smodel.structure.IfInstanceOfVarReference" flags="nn" index="Jnkvi" />
       <concept id="1171305280644" name="jetbrains.mps.lang.smodel.structure.Node_GetDescendantsOperation" flags="nn" index="2Rf3mk" />
       <concept id="1171407110247" name="jetbrains.mps.lang.smodel.structure.Node_GetAncestorOperation" flags="nn" index="2Xjw5R" />
+      <concept id="3562215692195599741" name="jetbrains.mps.lang.smodel.structure.SLinkImplicitSelect" flags="nn" index="13MTOL">
+        <reference id="3562215692195600259" name="link" index="13MTZf" />
+      </concept>
       <concept id="2644386474300074836" name="jetbrains.mps.lang.smodel.structure.ConceptIdRefExpression" flags="nn" index="35c_gC">
         <reference id="2644386474300074837" name="conceptDeclaration" index="35c_gD" />
       </concept>
@@ -219,6 +232,9 @@
       <concept id="1204796164442" name="jetbrains.mps.baseLanguage.collections.structure.InternalSequenceOperation" flags="nn" index="23sCx2">
         <child id="1204796294226" name="closure" index="23t8la" />
       </concept>
+      <concept id="540871147943773365" name="jetbrains.mps.baseLanguage.collections.structure.SingleArgumentSequenceOperation" flags="nn" index="25WWJ4">
+        <child id="540871147943773366" name="argument" index="25WWJ7" />
+      </concept>
       <concept id="1204980550705" name="jetbrains.mps.baseLanguage.collections.structure.VisitAllOperation" flags="nn" index="2es0OD" />
       <concept id="1151689724996" name="jetbrains.mps.baseLanguage.collections.structure.SequenceType" flags="in" index="A3Dl8">
         <child id="1151689745422" name="elementType" index="A3Ik2" />
@@ -235,6 +251,7 @@
       <concept id="1203518072036" name="jetbrains.mps.baseLanguage.collections.structure.SmartClosureParameterDeclaration" flags="ig" index="Rh6nW" />
       <concept id="1165530316231" name="jetbrains.mps.baseLanguage.collections.structure.IsEmptyOperation" flags="nn" index="1v1jN8" />
       <concept id="1202120902084" name="jetbrains.mps.baseLanguage.collections.structure.WhereOperation" flags="nn" index="3zZkjj" />
+      <concept id="1172254888721" name="jetbrains.mps.baseLanguage.collections.structure.ContainsOperation" flags="nn" index="3JPx81" />
     </language>
   </registry>
   <node concept="18kY7G" id="6JVEnxIjpFZ">
@@ -315,7 +332,6 @@
           </node>
         </node>
       </node>
-      <node concept="3clFbH" id="6Kj2zNCDbgE" role="3cqZAp" />
     </node>
     <node concept="1YaCAy" id="6JVEnxIjpG1" role="1YuTPh">
       <property role="TrG5h" value="ccic" />
@@ -1342,6 +1358,172 @@
     <node concept="1YaCAy" id="4dKKrcEbN2c" role="1YuTPh">
       <property role="TrG5h" value="componentRefExpr" />
       <ref role="1YaFvo" to="g88q:4dKKrcEbMGX" resolve="ComponentRefExpr" />
+    </node>
+  </node>
+  <node concept="18kY7G" id="K3KnZNI9p1">
+    <property role="TrG5h" value="check_ComponentInstanceInCompositeComponent" />
+    <node concept="3clFbS" id="K3KnZNI9p2" role="18ibNy">
+      <node concept="3cpWs8" id="LUz4xAqU0s" role="3cqZAp">
+        <node concept="3cpWsn" id="LUz4xAqU0t" role="3cpWs9">
+          <property role="TrG5h" value="config" />
+          <node concept="3Tqbb2" id="LUz4xAqU0u" role="1tU5fm">
+            <ref role="ehGHo" to="v7ag:6JVEnxIhAG0" resolve="AbstractInstanceConfiguration" />
+          </node>
+          <node concept="2OqwBi" id="LUz4xAqU0z" role="33vP2m">
+            <node concept="1YBJjd" id="LUz4xAqU0y" role="2Oq$k0">
+              <ref role="1YBMHb" node="K3KnZNI9p4" resolve="ci" />
+            </node>
+            <node concept="2Xjw5R" id="LUz4xAqU0B" role="2OqNvi">
+              <node concept="1xMEDy" id="LUz4xAqU0C" role="1xVPHs">
+                <node concept="chp4Y" id="6JVEnxIigsa" role="ri$Ld">
+                  <ref role="cht4Q" to="v7ag:6JVEnxIhAG0" resolve="AbstractInstanceConfiguration" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbH" id="K3KnZNIjGk" role="3cqZAp" />
+      <node concept="Jncv_" id="K3KnZNIy1W" role="3cqZAp">
+        <ref role="JncvD" to="g88q:6JVEnxIhC3j" resolve="CompositeComponentInstanceConfig" />
+        <node concept="37vLTw" id="K3KnZNIyPF" role="JncvB">
+          <ref role="3cqZAo" node="LUz4xAqU0t" resolve="config" />
+        </node>
+        <node concept="3clFbS" id="K3KnZNIy20" role="Jncv$">
+          <node concept="2Gpval" id="K3KnZNFfpU" role="3cqZAp">
+            <node concept="2GrKxI" id="K3KnZNFfpV" role="2Gsz3X">
+              <property role="TrG5h" value="providedPort" />
+            </node>
+            <node concept="2OqwBi" id="K3KnZNIqJL" role="2GsD0m">
+              <node concept="2OqwBi" id="K3KnZNFfpW" role="2Oq$k0">
+                <node concept="1YBJjd" id="K3KnZNIgbC" role="2Oq$k0">
+                  <ref role="1YBMHb" node="K3KnZNI9p4" resolve="ci" />
+                </node>
+                <node concept="3TrEf2" id="K3KnZNIpRL" role="2OqNvi">
+                  <ref role="3Tt5mk" to="v7ag:3TmmsQkDdTR" resolve="component" />
+                </node>
+              </node>
+              <node concept="2qgKlT" id="K3KnZNIs_j" role="2OqNvi">
+                <ref role="37wK5l" to="eup9:71UKpntoZW7" resolve="allProvidedPorts" />
+              </node>
+            </node>
+            <node concept="3clFbS" id="K3KnZNFfq1" role="2LFqv$">
+              <node concept="3clFbJ" id="K3KnZNFfq2" role="3cqZAp">
+                <node concept="3clFbS" id="K3KnZNFfq3" role="3clFbx">
+                  <node concept="2MkqsV" id="K3KnZNFfq4" role="3cqZAp">
+                    <node concept="1YBJjd" id="K3KnZNIEPj" role="2OEOjV">
+                      <ref role="1YBMHb" node="K3KnZNI9p4" resolve="ci" />
+                    </node>
+                    <node concept="3cpWs3" id="K3KnZNFfq6" role="2MkJ7o">
+                      <node concept="3cpWs3" id="K3KnZNFfq7" role="3uHU7B">
+                        <node concept="Xl_RD" id="K3KnZNFfq8" role="3uHU7B">
+                          <property role="Xl_RC" value="mandatory provided port (" />
+                        </node>
+                        <node concept="2OqwBi" id="K3KnZNFfq9" role="3uHU7w">
+                          <node concept="2GrUjf" id="K3KnZNFfqa" role="2Oq$k0">
+                            <ref role="2Gs0qQ" node="K3KnZNFfpV" resolve="providedPort" />
+                          </node>
+                          <node concept="3TrcHB" id="K3KnZNFfqb" role="2OqNvi">
+                            <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="Xl_RD" id="K3KnZNFfqc" role="3uHU7w">
+                        <property role="Xl_RC" value=") is not connected and is not a delegation" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="1Wc70l" id="K3KnZNFfqI" role="3clFbw">
+                  <node concept="3fqX7Q" id="K3KnZNFfqJ" role="3uHU7w">
+                    <node concept="2OqwBi" id="K3KnZNFfqK" role="3fr31v">
+                      <node concept="2OqwBi" id="K3KnZNFfqL" role="2Oq$k0">
+                        <node concept="2OqwBi" id="K3KnZNFfqM" role="2Oq$k0">
+                          <node concept="Jnkvi" id="K3KnZNIDfL" role="2Oq$k0">
+                            <ref role="1M0zk5" node="K3KnZNIy22" resolve="innerConfig" />
+                          </node>
+                          <node concept="2qgKlT" id="K3KnZNHCLs" role="2OqNvi">
+                            <ref role="37wK5l" to="l32i:3_MZZHrtYLf" resolve="delegatingConnectors" />
+                          </node>
+                        </node>
+                        <node concept="13MTOL" id="K3KnZNFfqP" role="2OqNvi">
+                          <ref role="13MTZf" to="g88q:6JVEnxIiRsY" resolve="internalPort" />
+                        </node>
+                      </node>
+                      <node concept="3JPx81" id="K3KnZNFfqQ" role="2OqNvi">
+                        <node concept="2GrUjf" id="K3KnZNFfqR" role="25WWJ7">
+                          <ref role="2Gs0qQ" node="K3KnZNFfpV" resolve="providedPort" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="1Wc70l" id="K3KnZNFfqS" role="3uHU7B">
+                    <node concept="2OqwBi" id="K3KnZNFfqT" role="3uHU7B">
+                      <node concept="2OqwBi" id="K3KnZNFfqU" role="2Oq$k0">
+                        <node concept="2OqwBi" id="K3KnZNFfqV" role="2Oq$k0">
+                          <node concept="2qgKlT" id="K3KnZNFfqW" role="2OqNvi">
+                            <ref role="37wK5l" to="eup9:6JVEnxIhC2V" resolve="assemblyConnectors" />
+                          </node>
+                          <node concept="Jnkvi" id="K3KnZNICym" role="2Oq$k0">
+                            <ref role="1M0zk5" node="K3KnZNIy22" resolve="innerConfig" />
+                          </node>
+                        </node>
+                        <node concept="3zZkjj" id="K3KnZNFfr0" role="2OqNvi">
+                          <node concept="1bVj0M" id="K3KnZNFfr1" role="23t8la">
+                            <node concept="3clFbS" id="K3KnZNFfr2" role="1bW5cS">
+                              <node concept="3clFbF" id="K3KnZNFfr3" role="3cqZAp">
+                                <node concept="3clFbC" id="K3KnZNFfr4" role="3clFbG">
+                                  <node concept="2GrUjf" id="K3KnZNFfr5" role="3uHU7w">
+                                    <ref role="2Gs0qQ" node="K3KnZNFfpV" resolve="providedPort" />
+                                  </node>
+                                  <node concept="2OqwBi" id="K3KnZNFfr6" role="3uHU7B">
+                                    <node concept="2OqwBi" id="K3KnZNFfr7" role="2Oq$k0">
+                                      <node concept="37vLTw" id="K3KnZNFfr8" role="2Oq$k0">
+                                        <ref role="3cqZAo" node="K3KnZNFfrb" resolve="it" />
+                                      </node>
+                                      <node concept="3TrEf2" id="K3KnZNFfr9" role="2OqNvi">
+                                        <ref role="3Tt5mk" to="v7ag:3TmmsQkDdTX" resolve="target" />
+                                      </node>
+                                    </node>
+                                    <node concept="3TrEf2" id="K3KnZNFfra" role="2OqNvi">
+                                      <ref role="3Tt5mk" to="v7ag:2ZeMBoiZpvV" resolve="port" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="Rh6nW" id="K3KnZNFfrb" role="1bW2Oz">
+                              <property role="TrG5h" value="it" />
+                              <node concept="2jxLKc" id="K3KnZNFfrc" role="1tU5fm" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="1v1jN8" id="K3KnZNFfrd" role="2OqNvi" />
+                    </node>
+                    <node concept="2OqwBi" id="K3KnZNFfre" role="3uHU7w">
+                      <node concept="2GrUjf" id="K3KnZNFfrf" role="2Oq$k0">
+                        <ref role="2Gs0qQ" node="K3KnZNFfpV" resolve="providedPort" />
+                      </node>
+                      <node concept="3TrcHB" id="K3KnZNFfrg" role="2OqNvi">
+                        <ref role="3TsBF5" to="v7ag:36Bkyc49pe4" resolve="mandatory" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="JncvC" id="K3KnZNIy22" role="JncvA">
+          <property role="TrG5h" value="innerConfig" />
+          <node concept="2jxLKc" id="K3KnZNIy23" role="1tU5fm" />
+        </node>
+      </node>
+    </node>
+    <node concept="1YaCAy" id="K3KnZNI9p4" role="1YuTPh">
+      <property role="TrG5h" value="ci" />
+      <ref role="1YaFvo" to="v7ag:3TmmsQkDdTQ" resolve="ComponentInstance" />
     </node>
   </node>
 </model>

--- a/code/languages/com.mbeddr.ext/tests/test.ex.ext.compositecomponents/compositecomponents.msd
+++ b/code/languages/com.mbeddr.ext/tests/test.ex.ext.compositecomponents/compositecomponents.msd
@@ -6,6 +6,9 @@
     </modelRoot>
   </models>
   <sourcePath />
+  <dependencies>
+    <dependency reexport="false">54f2a59b-97bb-4c09-af92-928ebf9c5966(com.mbeddr.ext.compositecomponents)</dependency>
+  </dependencies>
   <languageVersions>
     <language slang="l:d4280a54-f6df-4383-aa41-d1b2bffa7eb1:com.mbeddr.core.base" version="5" />
     <language slang="l:2d7fadf5-33f6-4e80-a78f-0f739add2bde:com.mbeddr.core.buildconfig" version="5" />
@@ -56,10 +59,55 @@
     <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
     <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="11" />
     <language slang="l:c72da2b9-7cce-4447-8389-f407dc1158b7:jetbrains.mps.lang.structure" version="6" />
+    <language slang="l:8585453e-6bfb-4d80-98de-b16074f1d86c:jetbrains.mps.lang.test" version="2" />
     <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
     <language slang="l:7a5dda62-9140-4668-ab76-d5ed1746f2b2:jetbrains.mps.lang.typesystem" version="1" />
   </languageVersions>
   <dependencyVersions>
+    <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
+    <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
+    <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
+    <module reference="1ed103c3-3aa6-49b7-9c21-6765ee11f224(MPS.Editor)" version="0" />
+    <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
+    <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
+    <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
+    <module reference="d4280a54-f6df-4383-aa41-d1b2bffa7eb1(com.mbeddr.core.base)" version="3" />
+    <module reference="223dd778-c44f-4ef3-9535-7aa7d12244a6(com.mbeddr.core.debug)" version="0" />
+    <module reference="61c69711-ed61-4850-81d9-7714ff227fb0(com.mbeddr.core.expressions)" version="0" />
+    <module reference="984f0332-8a86-4f5c-9184-03eae96b5d16(com.mbeddr.core.expressions.runtime)" version="0" />
+    <module reference="6d11763d-483d-4b2b-8efc-09336c1b0001(com.mbeddr.core.modules)" version="0" />
+    <module reference="3bf5377a-e904-4ded-9754-5a516023bfaa(com.mbeddr.core.pointers)" version="0" />
+    <module reference="a9d69647-0840-491e-bf39-2eb0805d2011(com.mbeddr.core.statements)" version="0" />
+    <module reference="efda956e-491e-4f00-ba14-36af2f213ecf(com.mbeddr.core.udt)" version="1" />
+    <module reference="97d24244-51db-4e2e-97fc-7bd73b1f5f40(com.mbeddr.ext.components)" version="0" />
+    <module reference="54f2a59b-97bb-4c09-af92-928ebf9c5966(com.mbeddr.ext.compositecomponents)" version="0" />
+    <module reference="63e0e566-5131-447e-90e3-12ea330e1a00(com.mbeddr.mpsutil.blutil)" version="0" />
+    <module reference="a482b416-d0c9-473f-8f67-725ed642b3f3(com.mbeddr.mpsutil.breadcrumb)" version="0" />
+    <module reference="d3a0fd26-445a-466c-900e-10444ddfed52(com.mbeddr.mpsutil.filepicker)" version="0" />
+    <module reference="d09a16fb-1d68-4a92-a5a4-20b4b2f86a62(com.mbeddr.mpsutil.jung)" version="0" />
+    <module reference="b4d28e19-7d2d-47e9-943e-3a41f97a0e52(com.mbeddr.mpsutil.plantuml.node)" version="0" />
+    <module reference="c1c2a88a-323c-4605-a37d-9ab77a2ccbd2(com.mbeddr.mpsutil.suppresswarning)" version="0" />
+    <module reference="cce85e64-7b37-4ad5-b0e6-9d18324cdfb3(de.itemis.mps.selection.runtime)" version="0" />
+    <module reference="92d2ea16-5a42-4fdf-a676-c7604efe3504(de.slisson.mps.richtext)" version="0" />
+    <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
+    <module reference="fd392034-7849-419d-9071-12563d152375(jetbrains.mps.baseLanguage.closures)" version="0" />
+    <module reference="83888646-71ce-4f1c-9c53-c54016f6ad4f(jetbrains.mps.baseLanguage.collections)" version="0" />
+    <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
+    <module reference="fdaaf35f-8ee3-4c37-b09d-9efaeaaa7a41(jetbrains.mps.core.tool.environment)" version="0" />
+    <module reference="23865718-e2ed-41b5-a132-0da1d04e266d(jetbrains.mps.ide.httpsupport.manager)" version="0" />
+    <module reference="ae6d8005-36be-4cb6-945b-8c8cfc033c51(jetbrains.mps.ide.httpsupport.runtime)" version="0" />
+    <module reference="8d29d73f-ed99-4652-ae0a-083cdfe53c34(jetbrains.mps.ide.platform)" version="0" />
+    <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
+    <module reference="63650c59-16c8-498a-99c8-005c7ee9515d(jetbrains.mps.lang.access)" version="0" />
+    <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
+    <module reference="446c26eb-2b7b-4bf0-9b35-f83fa582753e(jetbrains.mps.lang.modelapi)" version="0" />
+    <module reference="7866978e-a0f0-4cc7-81bc-4d213d9375e1(jetbrains.mps.lang.smodel)" version="1" />
+    <module reference="c72da2b9-7cce-4447-8389-f407dc1158b7(jetbrains.mps.lang.structure)" version="0" />
+    <module reference="9ded098b-ad6a-4657-bfd9-48636cfe8bc3(jetbrains.mps.lang.traceable)" version="0" />
+    <module reference="7a5dda62-9140-4668-ab76-d5ed1746f2b2(jetbrains.mps.lang.typesystem)" version="0" />
+    <module reference="5187f5c9-b8a8-4309-90b3-14f9919bd2d8(jetbrains.mps.refactoring)" version="0" />
+    <module reference="8fe4c62a-2020-4ff4-8eda-f322a55bdc9f(jetbrains.mps.refactoring.runtime)" version="0" />
+    <module reference="e6368d5c-b931-4d4d-9941-07b7da7d2e2d(jetbrains.mps.tool.builder)" version="0" />
     <module reference="3f1bb534-4961-4bf0-94b6-2b63276a46ca(test.ex.ext.compositeComponents)" version="0" />
   </dependencyVersions>
 </solution>

--- a/code/languages/com.mbeddr.ext/tests/test.ex.ext.compositecomponents/models/basic@tests.mps
+++ b/code/languages/com.mbeddr.ext/tests/test.ex.ext.compositecomponents/models/basic@tests.mps
@@ -1,0 +1,252 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:92be9b01-6c9d-4dbc-b7d2-06feed9c261a(test.ex.ext.compositeComponents.basic@tests)">
+  <persistence version="9" />
+  <languages>
+    <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="2" />
+    <use id="97d24244-51db-4e2e-97fc-7bd73b1f5f40" name="com.mbeddr.ext.components" version="1" />
+    <use id="54f2a59b-97bb-4c09-af92-928ebf9c5966" name="com.mbeddr.ext.compositecomponents" version="0" />
+    <devkit ref="d2a9c55c-6bdc-4cc2-97e1-4ba7552f5584(com.mbeddr.core)" />
+    <devkit ref="24565007-e59f-42fc-ac10-da3836deec1c(com.mbeddr.components)" />
+  </languages>
+  <imports>
+    <import index="e39d" ref="r:c480d4b6-a379-41b5-b76a-c94ccc817c4e(com.mbeddr.ext.components.typesystem)" />
+    <import index="z4le" ref="r:4595fe28-70e7-433c-8fef-2b74cf276f62(com.mbeddr.ext.compositecomponents.typesystem)" />
+  </imports>
+  <registry>
+    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
+      <concept id="1215507671101" name="jetbrains.mps.lang.test.structure.NodeErrorCheckOperation" flags="ng" index="1TM$A">
+        <child id="8489045168660938517" name="errorRef" index="3lydEf" />
+      </concept>
+      <concept id="1215603922101" name="jetbrains.mps.lang.test.structure.NodeOperationsContainer" flags="ng" index="7CXmI">
+        <child id="1215604436604" name="nodeOperations" index="7EUXB" />
+      </concept>
+      <concept id="1215607067978" name="jetbrains.mps.lang.test.structure.CheckNodeForErrorMessagesOperation" flags="ng" index="7OXhh" />
+      <concept id="7691029917083872157" name="jetbrains.mps.lang.test.structure.IRuleReference" flags="ng" index="2u4UPC">
+        <reference id="8333855927540250453" name="declaration" index="39XzEq" />
+      </concept>
+      <concept id="4531408400484511853" name="jetbrains.mps.lang.test.structure.ReportErrorStatementReference" flags="ng" index="2PYRI3" />
+      <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
+        <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
+      </concept>
+      <concept id="1216913645126" name="jetbrains.mps.lang.test.structure.NodesTestCase" flags="lg" index="1lH9Xt">
+        <child id="1217501822150" name="nodesToCheck" index="1SKRRt" />
+      </concept>
+      <concept id="1216989428737" name="jetbrains.mps.lang.test.structure.TestNode" flags="ng" index="1qefOq">
+        <child id="1216989461394" name="nodeToCheck" index="1qenE9" />
+      </concept>
+    </language>
+    <language id="a9d69647-0840-491e-bf39-2eb0805d2011" name="com.mbeddr.core.statements">
+      <concept id="4185783222026475861" name="com.mbeddr.core.statements.structure.StatementList" flags="ng" index="3XIRFW">
+        <child id="4185783222026475862" name="statements" index="3XIRFZ" />
+      </concept>
+    </language>
+    <language id="6d11763d-483d-4b2b-8efc-09336c1b0001" name="com.mbeddr.core.modules">
+      <concept id="6437088627575722813" name="com.mbeddr.core.modules.structure.Module" flags="ng" index="N3F4X">
+        <child id="6437088627575722833" name="contents" index="N3F5h" />
+      </concept>
+      <concept id="6437088627575722830" name="com.mbeddr.core.modules.structure.ImplementationModule" flags="ng" index="N3F5e" />
+      <concept id="6437088627575722831" name="com.mbeddr.core.modules.structure.IModuleContent" flags="ng" index="N3F5f">
+        <property id="1317894735999272944" name="exported" index="2OOxQR" />
+      </concept>
+      <concept id="6437088627575724001" name="com.mbeddr.core.modules.structure.Function" flags="ng" index="N3Fnx">
+        <child id="4185783222026475860" name="body" index="3XIRFX" />
+      </concept>
+      <concept id="8934095934011938595" name="com.mbeddr.core.modules.structure.EmptyModuleContent" flags="ng" index="2NXPZ9" />
+    </language>
+    <language id="54f2a59b-97bb-4c09-af92-928ebf9c5966" name="com.mbeddr.ext.compositecomponents">
+      <concept id="7780999115923947731" name="com.mbeddr.ext.compositecomponents.structure.CompositeComponentInstanceConfig" flags="ng" index="5JiAF" />
+      <concept id="7780999115923829680" name="com.mbeddr.ext.compositecomponents.structure.CompositeComponent" flags="ng" index="5JLF8" />
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+    <language id="97d24244-51db-4e2e-97fc-7bd73b1f5f40" name="com.mbeddr.ext.components">
+      <concept id="6616025724454668918" name="com.mbeddr.ext.components.structure.AdapterInstancePortRef" flags="ng" index="219P8x">
+        <reference id="6616025724454668919" name="instance" index="219P8w" />
+        <reference id="6616025724454668920" name="port" index="219P8J" />
+      </concept>
+      <concept id="5172178961828157634" name="com.mbeddr.ext.components.structure.PortAdapter" flags="ng" index="21gPQu">
+        <child id="6616025724454701213" name="portRef" index="21ad3a" />
+      </concept>
+      <concept id="7780999115923942144" name="com.mbeddr.ext.components.structure.AbstractInstanceConfiguration" flags="ng" index="5Js9S">
+        <child id="7780999115923944213" name="contents" index="5JtDH" />
+      </concept>
+      <concept id="4491876417845649024" name="com.mbeddr.ext.components.structure.InstanceConfiguration" flags="ng" index="2EWCtd" />
+      <concept id="4491876417845649014" name="com.mbeddr.ext.components.structure.ComponentInstance" flags="ng" index="2EWCuV">
+        <reference id="4491876417845649015" name="component" index="2EWCuU" />
+      </concept>
+      <concept id="4491876417845649011" name="com.mbeddr.ext.components.structure.AtomicComponent" flags="ng" index="2EWCuY" />
+      <concept id="4491876417845641677" name="com.mbeddr.ext.components.structure.OperationTrigger" flags="ng" index="2EWDw0" />
+      <concept id="4491876417845641670" name="com.mbeddr.ext.components.structure.Runnable" flags="ng" index="2EWDwb">
+        <child id="4491876417845643892" name="trigger" index="2EWDeT" />
+        <child id="4491876417845689763" name="body" index="2EWMhI" />
+      </concept>
+      <concept id="4491876417845628841" name="com.mbeddr.ext.components.structure.RequiredPort" flags="ng" index="2EWHp$" />
+      <concept id="4491876417845628840" name="com.mbeddr.ext.components.structure.ProvidedPort" flags="ng" index="2EWHp_">
+        <property id="3577918739316052868" name="mandatory" index="PwG6B" />
+      </concept>
+      <concept id="4491876417845484930" name="com.mbeddr.ext.components.structure.Port" flags="ng" index="2EX0hf">
+        <reference id="4491876417845484932" name="intf" index="2EX0h9" />
+      </concept>
+      <concept id="4491876417845484924" name="com.mbeddr.ext.components.structure.Operation" flags="ng" index="2EX0iL" />
+      <concept id="4491876417845484922" name="com.mbeddr.ext.components.structure.ClientServerInterface" flags="ng" index="2EX0iR">
+        <child id="4491876417845484926" name="contents" index="2EX0iN" />
+      </concept>
+      <concept id="4491876417845474761" name="com.mbeddr.ext.components.structure.Component" flags="ng" index="2EX6K4">
+        <child id="6041318036221669720" name="contents" index="2RW2fA" />
+      </concept>
+      <concept id="591155063063570513" name="com.mbeddr.ext.components.structure.InitializeConfiguration" flags="ng" index="3t9XKO">
+        <reference id="591155063063570514" name="config" index="3t9XKR" />
+      </concept>
+      <concept id="8515777736166878876" name="com.mbeddr.ext.components.structure.EmptyComponentContent" flags="ng" index="3Khz0B" />
+      <concept id="4514118643321588318" name="com.mbeddr.ext.components.structure.IOperationTriggerLike" flags="ng" index="1ZwTiz">
+        <reference id="4514118643321619583" name="calledOperation" index="1ZwxE2" />
+        <reference id="4514118643321592184" name="providedPort" index="1ZwSu5" />
+      </concept>
+    </language>
+    <language id="61c69711-ed61-4850-81d9-7714ff227fb0" name="com.mbeddr.core.expressions">
+      <concept id="318113533128716675" name="com.mbeddr.core.expressions.structure.ITyped" flags="ng" index="2C2TGh">
+        <child id="318113533128716676" name="type" index="2C2TGm" />
+      </concept>
+      <concept id="7892328519581699353" name="com.mbeddr.core.expressions.structure.VoidType" flags="ng" index="19Rifw" />
+      <concept id="8860443239512128054" name="com.mbeddr.core.expressions.structure.Type" flags="ng" index="3TlMgo">
+        <property id="2941277002445651368" name="const" index="2c7vTL" />
+        <property id="2941277002448691247" name="volatile" index="2caQfQ" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="1lH9Xt" id="K3KnZNL8bZ">
+    <property role="TrG5h" value="MandatoryPortTest" />
+    <node concept="1qefOq" id="5TsAcJo1hvO" role="1SKRRt">
+      <node concept="7CXmI" id="5TsAcJo1hvP" role="lGtFl">
+        <node concept="7OXhh" id="5TsAcJo1hvQ" role="7EUXB" />
+      </node>
+      <node concept="N3F5e" id="5TsAcJo1hvR" role="1qenE9">
+        <property role="TrG5h" value="MandatoryPortBugs" />
+        <node concept="5JLF8" id="K3KnZNINum" role="N3F5h">
+          <property role="2OOxQR" value="true" />
+          <property role="TrG5h" value="CompositeCompTest" />
+          <node concept="5JiAF" id="K3KnZNINun" role="2RW2fA">
+            <node concept="2EWCuV" id="K3KnZNINuo" role="5JtDH">
+              <property role="TrG5h" value="compA" />
+              <ref role="2EWCuU" node="5Uve0OVQqn4" resolve="CompA" />
+              <node concept="7CXmI" id="6niK5RciuSu" role="lGtFl">
+                <node concept="1TM$A" id="6niK5RciuSS" role="7EUXB">
+                  <node concept="2PYRI3" id="6niK5RciuST" role="3lydEf">
+                    <ref role="39XzEq" to="z4le:K3KnZNFfq4" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2NXPZ9" id="K3KnZNINtS" role="N3F5h">
+          <property role="TrG5h" value="empty_1531124912859_14" />
+        </node>
+        <node concept="2EWCuY" id="5Uve0OVQqn4" role="N3F5h">
+          <property role="2OOxQR" value="true" />
+          <property role="TrG5h" value="CompA" />
+          <node concept="2EWHp_" id="5Uve0OVQqo6" role="2RW2fA">
+            <property role="TrG5h" value="mandatoryInterface" />
+            <property role="PwG6B" value="true" />
+            <ref role="2EX0h9" node="5Uve0OVQqnn" resolve="IMandatoryInterface" />
+          </node>
+          <node concept="3Khz0B" id="5Uve0OVQqo8" role="2RW2fA" />
+          <node concept="2EWDwb" id="5Uve0OVQqo9" role="2RW2fA">
+            <property role="TrG5h" value="mandatoryInterface_testMandatory" />
+            <node concept="3XIRFW" id="5Uve0OVQqoa" role="2EWMhI" />
+            <node concept="2EWDw0" id="5Uve0OVQqoc" role="2EWDeT">
+              <ref role="1ZwSu5" node="5Uve0OVQqo6" resolve="mandatoryInterface" />
+              <ref role="1ZwxE2" node="5Uve0OVQqnw" resolve="testMandatory" />
+            </node>
+            <node concept="19Rifw" id="5Uve0OVQqod" role="2C2TGm">
+              <property role="2caQfQ" value="false" />
+              <property role="2c7vTL" value="false" />
+            </node>
+          </node>
+        </node>
+        <node concept="2EWCuY" id="5Uve0OVZIlS" role="N3F5h">
+          <property role="2OOxQR" value="true" />
+          <property role="TrG5h" value="CompB" />
+          <node concept="2EWHp$" id="5Uve0OVZImi" role="2RW2fA">
+            <property role="TrG5h" value="mandatoryInterface" />
+            <ref role="2EX0h9" node="5Uve0OVQqnn" resolve="IMandatoryInterface" />
+          </node>
+        </node>
+        <node concept="2NXPZ9" id="5Uve0OVXYBb" role="N3F5h">
+          <property role="TrG5h" value="empty_1531081709561_17" />
+        </node>
+        <node concept="2EWCtd" id="5Uve0OVXYBK" role="N3F5h">
+          <property role="TrG5h" value="testMandatoryConfig" />
+          <node concept="2EWCuV" id="5Uve0OVXYC4" role="5JtDH">
+            <property role="TrG5h" value="compA" />
+            <ref role="2EWCuU" node="5Uve0OVQqn4" resolve="CompA" />
+            <node concept="7CXmI" id="K3KnZNL5m5" role="lGtFl">
+              <node concept="1TM$A" id="K3KnZNL5mr" role="7EUXB">
+                <node concept="2PYRI3" id="K3KnZNL5ms" role="3lydEf">
+                  <ref role="39XzEq" to="e39d:36Bkyc4pcK2" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="21gPQu" id="K3KnZNI7Ls" role="5JtDH">
+            <property role="TrG5h" value="mandatoryPort" />
+            <node concept="219P8x" id="K3KnZNI7Lt" role="21ad3a">
+              <ref role="219P8w" node="5Uve0OVXYC4" resolve="compA" />
+              <ref role="219P8J" node="5Uve0OVQqo6" resolve="mandatoryInterface" />
+            </node>
+            <node concept="7CXmI" id="6niK5Rcigw8" role="lGtFl">
+              <node concept="1TM$A" id="6niK5Rcigwy" role="7EUXB">
+                <node concept="2PYRI3" id="6niK5Rcigwz" role="3lydEf">
+                  <ref role="39XzEq" to="e39d:6niK5Rch44k" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2NXPZ9" id="6niK5RcgKrU" role="N3F5h">
+          <property role="TrG5h" value="empty_1531293445712_1" />
+        </node>
+        <node concept="N3Fnx" id="6niK5RcgKtV" role="N3F5h">
+          <property role="TrG5h" value="testMandatoryPortAdaptor" />
+          <property role="2OOxQR" value="false" />
+          <node concept="3XIRFW" id="6niK5RcgKtX" role="3XIRFX">
+            <node concept="3t9XKO" id="6niK5RcignO" role="3XIRFZ">
+              <ref role="3t9XKR" node="5Uve0OVXYBK" resolve="testMandatoryConfig" />
+            </node>
+          </node>
+          <node concept="19Rifw" id="6niK5RcgKsT" role="2C2TGm">
+            <property role="2caQfQ" value="false" />
+            <property role="2c7vTL" value="false" />
+          </node>
+        </node>
+        <node concept="2NXPZ9" id="5Uve0OVQqna" role="N3F5h">
+          <property role="TrG5h" value="empty_1531076699119_15" />
+        </node>
+        <node concept="2EX0iR" id="5Uve0OVQqnn" role="N3F5h">
+          <property role="2OOxQR" value="true" />
+          <property role="TrG5h" value="IMandatoryInterface" />
+          <node concept="2EX0iL" id="5Uve0OVQqnw" role="2EX0iN">
+            <property role="TrG5h" value="testMandatory" />
+            <node concept="19Rifw" id="5Uve0OVQqnv" role="2C2TGm">
+              <property role="2caQfQ" value="false" />
+              <property role="2c7vTL" value="false" />
+            </node>
+          </node>
+        </node>
+        <node concept="2NXPZ9" id="5TsAcJo1hwk" role="N3F5h">
+          <property role="TrG5h" value="empty_1390382393197_4" />
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="2XOHcx" id="K3KnZNL8qg">
+    <property role="2XOHcw" value="${mbeddr.github.core.home}/code/languages/com.mbeddr.ext/" />
+  </node>
+</model>
+


### PR DESCRIPTION
Following enhacements are made in this pull request:
- Improved checking rule for mandatory port in compoiste component to take into account delegations in addition to connections (an error is not reported anymore if the mandatory port is a delegation).
- Added a checking rule for adapter port to report an error when aan adapter on mandatory port is not used anywhere in the model.