### PR TITLE
PushHintOption can contain custom java code

### DIFF
--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.refactoring/generator/template/com/mbeddr/mpsutil/refactoring/generator/template/main@generator.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.refactoring/generator/template/com/mbeddr/mpsutil/refactoring/generator/template/main@generator.mps
@@ -3007,6 +3007,40 @@
             </node>
           </node>
         </node>
+        <node concept="3clFbH" id="6NK6gIFxnS$" role="3cqZAp">
+          <node concept="2b32R4" id="6NK6gIFxnS_" role="lGtFl">
+            <node concept="3JmXsc" id="6NK6gIFxnSA" role="2P8S$">
+              <node concept="3clFbS" id="6NK6gIFxnSB" role="2VODD2">
+                <node concept="3clFbF" id="6NK6gIFxnSC" role="3cqZAp">
+                  <node concept="2OqwBi" id="6NK6gIFxnSD" role="3clFbG">
+                    <node concept="2OqwBi" id="6NK6gIFxnSE" role="2Oq$k0">
+                      <node concept="2OqwBi" id="6NK6gIFxyAn" role="2Oq$k0">
+                        <node concept="2OqwBi" id="6NK6gIFxtvP" role="2Oq$k0">
+                          <node concept="2OqwBi" id="6NK6gIFxnSF" role="2Oq$k0">
+                            <node concept="30H73N" id="6NK6gIFxnSG" role="2Oq$k0" />
+                            <node concept="3Tsc0h" id="6NK6gIFxr$b" role="2OqNvi">
+                              <ref role="3TtcxE" to="4w5v:7s1RrJAf_qa" resolve="options" />
+                            </node>
+                          </node>
+                          <node concept="1uHKPH" id="6NK6gIFxvow" role="2OqNvi" />
+                        </node>
+                        <node concept="3TrEf2" id="6NK6gIFxyZP" role="2OqNvi">
+                          <ref role="3Tt5mk" to="4w5v:6NK6gIFvhsH" resolve="block" />
+                        </node>
+                      </node>
+                      <node concept="3TrEf2" id="6NK6gIFxnSI" role="2OqNvi">
+                        <ref role="3Tt5mk" to="tpee:gyVODHa" resolve="body" />
+                      </node>
+                    </node>
+                    <node concept="3Tsc0h" id="6NK6gIFxnSJ" role="2OqNvi">
+                      <ref role="3TtcxE" to="tpee:fzcqZ_x" resolve="statement" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
       </node>
       <node concept="2AHcQZ" id="1URh_kuDmZm" role="2AJF6D">
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
@@ -3463,6 +3497,32 @@
               </node>
               <node concept="37vLTw" id="1WqRI525_ya" role="37wK5m">
                 <ref role="3cqZAo" node="1WqRI525xS8" resolve="hintId" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbH" id="6NK6gIFwhho" role="3cqZAp">
+            <node concept="2b32R4" id="6NK6gIFxjJN" role="lGtFl">
+              <node concept="3JmXsc" id="6NK6gIFxjJZ" role="2P8S$">
+                <node concept="3clFbS" id="6NK6gIFxjKb" role="2VODD2">
+                  <node concept="3clFbF" id="6NK6gIFxk6j" role="3cqZAp">
+                    <node concept="2OqwBi" id="6NK6gIFxmS8" role="3clFbG">
+                      <node concept="2OqwBi" id="6NK6gIFxlIb" role="2Oq$k0">
+                        <node concept="2OqwBi" id="6NK6gIFxkig" role="2Oq$k0">
+                          <node concept="30H73N" id="6NK6gIFxk6i" role="2Oq$k0" />
+                          <node concept="3TrEf2" id="6NK6gIFxldy" role="2OqNvi">
+                            <ref role="3Tt5mk" to="4w5v:6NK6gIFvhsH" resolve="block" />
+                          </node>
+                        </node>
+                        <node concept="3TrEf2" id="6NK6gIFxmfK" role="2OqNvi">
+                          <ref role="3Tt5mk" to="tpee:gyVODHa" resolve="body" />
+                        </node>
+                      </node>
+                      <node concept="3Tsc0h" id="6NK6gIFxnuK" role="2OqNvi">
+                        <ref role="3TtcxE" to="tpee:fzcqZ_x" resolve="statement" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
               </node>
             </node>
           </node>

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.refactoring/languageModels/behavior.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.refactoring/languageModels/behavior.mps
@@ -12,6 +12,7 @@
     <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" />
     <import index="tp2q" ref="r:00000000-0000-4000-0000-011c8959032e(jetbrains.mps.baseLanguage.collections.structure)" />
     <import index="tp25" ref="r:00000000-0000-4000-0000-011c89590301(jetbrains.mps.lang.smodel.structure)" />
+    <import index="tp4k" ref="r:00000000-0000-4000-0000-011c89590368(jetbrains.mps.lang.plugin.structure)" />
   </imports>
   <registry>
     <language id="af65afd8-f0dd-4942-87d9-63a55f2a9db1" name="jetbrains.mps.lang.behavior">
@@ -37,6 +38,9 @@
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
+        <child id="1145553007750" name="creator" index="2ShVmc" />
       </concept>
       <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
         <child id="1137022507850" name="body" index="2VODD2" />
@@ -135,6 +139,11 @@
       <concept id="1151689724996" name="jetbrains.mps.baseLanguage.collections.structure.SequenceType" flags="in" index="A3Dl8">
         <child id="1151689745422" name="elementType" index="A3Ik2" />
       </concept>
+      <concept id="1237721394592" name="jetbrains.mps.baseLanguage.collections.structure.AbstractContainerCreator" flags="nn" index="HWqM0">
+        <child id="1237721435808" name="initValue" index="HW$Y0" />
+        <child id="1237721435807" name="elementType" index="HW$YZ" />
+      </concept>
+      <concept id="1160600644654" name="jetbrains.mps.baseLanguage.collections.structure.ListCreatorWithInit" flags="nn" index="Tc6Ow" />
       <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="nn" index="TSZUe" />
     </language>
   </registry>
@@ -291,6 +300,67 @@
         </node>
       </node>
       <node concept="3Tqbb2" id="35bnz87moh8" role="3clF45">
+        <ref role="ehGHo" to="tpee:fz3vP1H" resolve="Type" />
+      </node>
+    </node>
+  </node>
+  <node concept="13h7C7" id="6NK6gIFy2rv">
+    <property role="3GE5qa" value="projectionMode.body" />
+    <ref role="13h7C2" to="4w5v:6NK6gIFy2ru" resolve="PushHintFunction" />
+    <node concept="13hLZK" id="6NK6gIFy2rw" role="13h7CW">
+      <node concept="3clFbS" id="6NK6gIFy2rx" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="6NK6gIFy2rE" role="13h7CS">
+      <property role="13i0is" value="false" />
+      <property role="TrG5h" value="getParameterConcepts" />
+      <property role="13i0it" value="false" />
+      <property role="13i0iv" value="false" />
+      <ref role="13i0hy" to="tpek:2xELmDxyi2v" resolve="getParameterConcepts" />
+      <node concept="3Tm1VV" id="6NK6gIFy2rM" role="1B3o_S" />
+      <node concept="3clFbS" id="6NK6gIFy2rN" role="3clF47">
+        <node concept="3clFbF" id="6NK6gIFy2E7" role="3cqZAp">
+          <node concept="2ShNRf" id="6NK6gIFy2E5" role="3clFbG">
+            <node concept="Tc6Ow" id="6NK6gIFy3Nv" role="2ShVmc">
+              <node concept="3bZ5Sz" id="6NK6gIFy454" role="HW$YZ">
+                <ref role="3bZ5Sy" to="tpee:g76ryKb" resolve="ConceptFunctionParameter" />
+              </node>
+              <node concept="35c_gC" id="6NK6gIFy5NM" role="HW$Y0">
+                <ref role="35c_gD" to="tp4k:hwtl41J" resolve="ConceptFunctionParameter_AnActionEvent" />
+              </node>
+              <node concept="35c_gC" id="6NK6gIFy8_g" role="HW$Y0">
+                <ref role="35c_gD" to="4w5v:6NK6gIFy6St" resolve="Parameter_PushHint" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="_YKpA" id="6NK6gIFy2rO" role="3clF45">
+        <node concept="3bZ5Sz" id="6NK6gIFy2rP" role="_ZDj9">
+          <ref role="3bZ5Sy" to="tpee:g76ryKb" resolve="ConceptFunctionParameter" />
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="13h7C7" id="6NK6gIFy8Gv">
+    <property role="3GE5qa" value="projectionMode.body" />
+    <ref role="13h7C2" to="4w5v:6NK6gIFy6St" resolve="Parameter_PushHint" />
+    <node concept="13hLZK" id="6NK6gIFy8Gw" role="13h7CW">
+      <node concept="3clFbS" id="6NK6gIFy8Gx" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="6NK6gIFy8GE" role="13h7CS">
+      <property role="TrG5h" value="getType" />
+      <property role="13i0it" value="false" />
+      <property role="13i0iv" value="false" />
+      <ref role="13i0hy" to="tpek:27DJnJtIQ9C" resolve="getType" />
+      <node concept="3Tm1VV" id="6NK6gIFy8GF" role="1B3o_S" />
+      <node concept="3clFbS" id="6NK6gIFy8GK" role="3clF47">
+        <node concept="3clFbF" id="6NK6gIFy8MV" role="3cqZAp">
+          <node concept="2c44tf" id="6NK6gIFy8MT" role="3clFbG">
+            <node concept="10P_77" id="6NK6gIFy8OL" role="2c44tc" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tqbb2" id="6NK6gIFy8GL" role="3clF45">
         <ref role="ehGHo" to="tpee:fz3vP1H" resolve="Type" />
       </node>
     </node>

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.refactoring/languageModels/editor.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.refactoring/languageModels/editor.mps
@@ -13,7 +13,9 @@
   </imports>
   <registry>
     <language id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor">
-      <concept id="1071666914219" name="jetbrains.mps.lang.editor.structure.ConceptEditorDeclaration" flags="ig" index="24kQdi" />
+      <concept id="1071666914219" name="jetbrains.mps.lang.editor.structure.ConceptEditorDeclaration" flags="ig" index="24kQdi">
+        <child id="1078153129734" name="inspectedCellModel" index="6VMZX" />
+      </concept>
       <concept id="1140524381322" name="jetbrains.mps.lang.editor.structure.CellModel_ListWithRole" flags="ng" index="2czfm3">
         <child id="1140524464360" name="cellLayout" index="2czzBx" />
       </concept>
@@ -44,6 +46,7 @@
       <concept id="1088185857835" name="jetbrains.mps.lang.editor.structure.InlineEditorComponent" flags="ig" index="1sVBvm" />
       <concept id="1139848536355" name="jetbrains.mps.lang.editor.structure.CellModel_WithRole" flags="ng" index="1$h60E">
         <property id="1214560368769" name="emptyNoTargetText" index="39s7Ar" />
+        <property id="1139852716018" name="noTargetText" index="1$x2rV" />
         <property id="1140017977771" name="readOnly" index="1Intyy" />
         <reference id="1140103550593" name="relationDeclaration" index="1NtTu8" />
       </concept>
@@ -348,6 +351,13 @@
           <node concept="l2Vlx" id="5RfdBauX4Yt" role="2czzBx" />
         </node>
       </node>
+    </node>
+    <node concept="3EZMnI" id="6NK6gIFviwD" role="6VMZX">
+      <node concept="3F1sOY" id="6NK6gIFviwQ" role="3EZMnx">
+        <property role="1$x2rV" value="pushHint code" />
+        <ref role="1NtTu8" to="4w5v:6NK6gIFvhsH" resolve="pushHintFunction" />
+      </node>
+      <node concept="2iRkQZ" id="6NK6gIFviwG" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="3onExzPmfSk">

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.refactoring/languageModels/structure.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.refactoring/languageModels/structure.mps
@@ -18,6 +18,7 @@
     <language id="c72da2b9-7cce-4447-8389-f407dc1158b7" name="jetbrains.mps.lang.structure">
       <concept id="1169125787135" name="jetbrains.mps.lang.structure.structure.AbstractConceptDeclaration" flags="ig" index="PkWjJ">
         <property id="6714410169261853888" name="conceptId" index="EcuMT" />
+        <property id="4628067390765907488" name="conceptShortDescription" index="R4oN_" />
         <property id="4628067390765956802" name="abstract" index="R5$K7" />
         <property id="5092175715804935370" name="conceptAlias" index="34LRSv" />
         <child id="1071489727083" name="linkDeclaration" index="1TKVEi" />
@@ -194,6 +195,12 @@
       <property role="20lbJX" value="0..n" />
       <ref role="20lvS9" to="aozb:3y7CaIpppfq" resolve="DisableContextInstanceAction" />
     </node>
+    <node concept="1TJgyj" id="6NK6gIFvhsH" role="1TKVEi">
+      <property role="IQ2ns" value="7849801688419211053" />
+      <property role="20lmBu" value="aggregation" />
+      <property role="20kJfa" value="pushHintFunction" />
+      <ref role="20lvS9" node="6NK6gIFy2ru" resolve="PushHintFunction" />
+    </node>
     <node concept="1TJgyi" id="3onExzPlXp7" role="1TKVEl">
       <property role="TrG5h" value="menuLabel" />
       <property role="IQ2nx" value="3897771026684565063" />
@@ -219,6 +226,21 @@
     <property role="34LRSv" value="project tree node" />
     <property role="EcuMT" value="3711601327033637790" />
     <ref role="1TJDcQ" node="6xlxoSXdwNy" resolve="NodeChooser" />
+  </node>
+  <node concept="1TIwiD" id="6NK6gIFy2ru">
+    <property role="EcuMT" value="7849801688419935966" />
+    <property role="3GE5qa" value="projectionMode.body" />
+    <property role="TrG5h" value="PushHintFunction" />
+    <property role="R4oN_" value="embedded block of code" />
+    <property role="34LRSv" value="pushHint code" />
+    <ref role="1TJDcQ" to="tpee:gyVMwX8" resolve="ConceptFunction" />
+  </node>
+  <node concept="1TIwiD" id="6NK6gIFy6St">
+    <property role="EcuMT" value="7849801688419954205" />
+    <property role="3GE5qa" value="projectionMode.body" />
+    <property role="TrG5h" value="Parameter_PushHint" />
+    <property role="34LRSv" value="pushHint" />
+    <ref role="1TJDcQ" to="tpee:g76ryKb" resolve="ConceptFunctionParameter" />
   </node>
 </model>
 


### PR DESCRIPTION
This PR enables the possibility to define custom code for [PushHintOption](http://127.0.0.1:63320/node?ref=1fc20ffe-f35b-4791-a0b7-d706bad5c49a%2Fr%3A18d75373-a465-46d0-9749-aacc22a947bc%28com.mbeddr.mpsutil.refactoring%2Fcom.mbeddr.mpsutil.refactoring.structure%29%2F3897771026684496949&project=com.mbeddr.mpsutil) which ends up in the genrerated java code. 

A PushHintOption contains now an optional  child of type [PushHintFunction](http://127.0.0.1:63320/node?ref=1fc20ffe-f35b-4791-a0b7-d706bad5c49a%2Fr%3A18d75373-a465-46d0-9749-aacc22a947bc%28com.mbeddr.mpsutil.refactoring%2Fcom.mbeddr.mpsutil.refactoring.structure%29%2F7849801688419935966&project=com.mbeddr.mpsutil) with some predefined arguments. 
see:

![grafik](https://user-images.githubusercontent.com/16648247/42769938-002cd2a0-8924-11e8-9d85-93f78c868fcb.png)

This allows the user of the language to integrate his own custom code in the generated [setSelected](http://127.0.0.1:63320/node?ref=f47c72c0-b22e-4aef-a0e3-1bd67990c535%2Fr%3A836cb6d0-7a03-40c1-8e6a-754de267c44b%28com.mbeddr.mpsutil.refactoring%237518061998923596540%2Fcom.mbeddr.mpsutil.refactoring.generator.template.main%40generator%29%2F2213315073276211060&project=com.mbeddr.mpsutil). 

To allow this this following adaptions were done:

- Metamodel of PushHintOption was adapted
- Additional [Parameter_PushHint](http://127.0.0.1:63320/node?ref=1fc20ffe-f35b-4791-a0b7-d706bad5c49a%2Fr%3A18d75373-a465-46d0-9749-aacc22a947bc%28com.mbeddr.mpsutil.refactoring%2Fcom.mbeddr.mpsutil.refactoring.structure%29%2F7849801688419954205&project=com.mbeddr.mpsutil) was implemented
- generators were adapted to insert the user defined code to the correct location