### PR TITLE
Support for CBMC version 5.9 in CProverPreferenceUI

### DIFF
--- a/code/languages/com.mbeddr.analyses/languages/com.mbeddr.analyses.cbmc.rt/models/com/mbeddr/analyses/cbmc/rt/ui.mps
+++ b/code/languages/com.mbeddr.analyses/languages/com.mbeddr.analyses.cbmc.rt/models/com/mbeddr/analyses/cbmc/rt/ui.mps
@@ -8633,6 +8633,9 @@
           <node concept="2YIFZM" id="4AQNBfV8uWz" role="37wK5m">
             <ref role="37wK5l" to="33ny:~Arrays.asList(java.lang.Object...):java.util.List" resolve="asList" />
             <ref role="1Pybhc" to="33ny:~Arrays" resolve="Arrays" />
+            <node concept="Xl_RD" id="9xehlFjl$N" role="37wK5m">
+              <property role="Xl_RC" value="5.9" />
+            </node>
             <node concept="Xl_RD" id="1so4croawj4" role="37wK5m">
               <property role="Xl_RC" value="5.8" />
             </node>

--- a/code/languages/com.mbeddr.analyses/languages/com.mbeddr.analyses.cbmc/solutions/pluginSolution/models/com/mbeddr/analyses/cbmc/pluginSolution/plugin.mps
+++ b/code/languages/com.mbeddr.analyses/languages/com.mbeddr.analyses.cbmc/solutions/pluginSolution/models/com/mbeddr/analyses/cbmc/pluginSolution/plugin.mps
@@ -2795,7 +2795,7 @@
       <property role="TrG5h" value="usedCBMCVersion" />
       <node concept="17QB3L" id="4AQNBfV986Z" role="1tU5fm" />
       <node concept="Xl_RD" id="4AQNBfV9eRg" role="33vP2m">
-        <property role="Xl_RC" value="5.8" />
+        <property role="Xl_RC" value="5.9" />
       </node>
     </node>
     <node concept="34jfKJ" id="1H8VqTvXlsY" role="34lFYf">


### PR DESCRIPTION
Hi All,

Added support for CBMC version 5.9 in CProverPreferenceUI(Spinner Box). I have made the following changes,

1. Changed the string usedCBMCVersion 5.8 to 5.9 in cproverpreferences.
2. Added another string 5.9 in usedCBMCVersionModel spinnerListModel in CproverPreferenceModel Class.

Please review the changes and merge to milestone/v17.0-1

Regards,
Aswin Sugumaran