### PR TITLE
Replacing equal() with :eq: in order to avoid NPE in check_IControlled…

### DIFF
--- a/code/languages/com.mbeddr.core/languages/com.mbeddr.core.base/languageModels/typesystem.mps
+++ b/code/languages/com.mbeddr.core/languages/com.mbeddr.core.base/languageModels/typesystem.mps
@@ -1344,24 +1344,21 @@
                     <node concept="1bVj0M" id="7ii2FhSPkbJ" role="23t8la">
                       <node concept="3clFbS" id="7ii2FhSPkbK" role="1bW5cS">
                         <node concept="3clFbF" id="7ii2FhSPkbL" role="3cqZAp">
-                          <node concept="2OqwBi" id="7ii2FhSPkbM" role="3clFbG">
-                            <node concept="2OqwBi" id="7ii2FhSPkbN" role="2Oq$k0">
+                          <node concept="17R0WA" id="T75u2vrN_m" role="3clFbG">
+                            <node concept="2OqwBi" id="T75u2vrO_q" role="3uHU7w">
+                              <node concept="1YBJjd" id="T75u2vrOda" role="2Oq$k0">
+                                <ref role="1YBMHb" node="7ii2FhSOKRZ" resolve="cnc" />
+                              </node>
+                              <node concept="3TrcHB" id="T75u2vrPf0" role="2OqNvi">
+                                <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                              </node>
+                            </node>
+                            <node concept="2OqwBi" id="7ii2FhSPkbN" role="3uHU7B">
                               <node concept="37vLTw" id="7ii2FhSPkbO" role="2Oq$k0">
                                 <ref role="3cqZAo" node="7ii2FhSPkbU" resolve="it" />
                               </node>
                               <node concept="2qgKlT" id="7ii2FhSPkbP" role="2OqNvi">
                                 <ref role="37wK5l" to="hwgx:2GIWVTRHLfj" resolve="getControlledName" />
-                              </node>
-                            </node>
-                            <node concept="liA8E" id="7ii2FhSPkbQ" role="2OqNvi">
-                              <ref role="37wK5l" to="wyt6:~String.equals(java.lang.Object):boolean" resolve="equals" />
-                              <node concept="2OqwBi" id="7ii2FhSPkbR" role="37wK5m">
-                                <node concept="1YBJjd" id="7ii2FhSPkbS" role="2Oq$k0">
-                                  <ref role="1YBMHb" node="7ii2FhSOKRZ" resolve="cnc" />
-                                </node>
-                                <node concept="3TrcHB" id="7ii2FhSPkbT" role="2OqNvi">
-                                  <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
-                                </node>
                               </node>
                             </node>
                           </node>


### PR DESCRIPTION
In com.mbeddr.core\languages\com.mbeddr.core.base\languageModels\typesystem replaced equals() with :eq: to avoid NPE in check_IControlledNamedConcepts.
