### PR TITLE
delegating factory creation to corresponding analysis configuration node to do pre and post analyses jobs

### DIFF
--- a/code/languages/com.mbeddr.analyses/languages/com.mbeddr.analyses.cbmc/languageModels/behavior.mps
+++ b/code/languages/com.mbeddr.analyses/languages/com.mbeddr.analyses.cbmc/languageModels/behavior.mps
@@ -51,6 +51,9 @@
       </concept>
       <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="2820489544401957797" name="jetbrains.mps.baseLanguage.structure.DefaultClassCreator" flags="nn" index="HV5vD">
+        <reference id="2820489544401957798" name="classifier" index="HV5vE" />
+      </concept>
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
@@ -287,6 +290,24 @@
         <property role="TrG5h" value="repo" />
         <node concept="3uibUv" id="5KHBa6l3cWS" role="1tU5fm">
           <ref role="3uigEE" to="lui2:~SRepository" resolve="SRepository" />
+        </node>
+      </node>
+    </node>
+    <node concept="13i0hz" id="2QuU6zIQ9IH" role="13h7CS">
+      <property role="TrG5h" value="topLevelAnalyzerFactory" />
+      <property role="13i0it" value="true" />
+      <property role="13i0iv" value="false" />
+      <node concept="3uibUv" id="2QuU6zIQiyG" role="3clF45">
+        <ref role="3uigEE" to="tzyt:3_HSwtcWh0_" resolve="CProverAnalyzerFactory" />
+      </node>
+      <node concept="3Tm1VV" id="2QuU6zIQ9IJ" role="1B3o_S" />
+      <node concept="3clFbS" id="2QuU6zIQ9IK" role="3clF47">
+        <node concept="3clFbF" id="2QuU6zIQi_w" role="3cqZAp">
+          <node concept="2ShNRf" id="2QuU6zIQi_u" role="3clFbG">
+            <node concept="HV5vD" id="2QuU6zIQiFp" role="2ShVmc">
+              <ref role="HV5vE" to="tzyt:3_HSwtcWQWH" resolve="AnalysisConfigurationAnalyzerFactory" />
+            </node>
+          </node>
         </node>
       </node>
     </node>
@@ -2991,6 +3012,23 @@
         </node>
       </node>
       <node concept="10Oyi0" id="v5nKjVRSiE" role="3clF45" />
+    </node>
+    <node concept="13i0hz" id="2QuU6zJiopk" role="13h7CS">
+      <property role="TrG5h" value="getTopLevelAnalyzerFactory" />
+      <property role="13i0it" value="true" />
+      <node concept="3Tm1VV" id="2QuU6zJiopl" role="1B3o_S" />
+      <node concept="3uibUv" id="2QuU6zJitsr" role="3clF45">
+        <ref role="3uigEE" to="tzyt:3_HSwtcWh0_" resolve="CProverAnalyzerFactory" />
+      </node>
+      <node concept="3clFbS" id="2QuU6zJiopn" role="3clF47">
+        <node concept="3clFbF" id="2QuU6zJitv0" role="3cqZAp">
+          <node concept="2ShNRf" id="2QuU6zJituY" role="3clFbG">
+            <node concept="HV5vD" id="2QuU6zJitEv" role="2ShVmc">
+              <ref role="HV5vE" to="tzyt:3_HSwtcWQWH" resolve="AnalysisConfigurationAnalyzerFactory" />
+            </node>
+          </node>
+        </node>
+      </node>
     </node>
     <node concept="13hLZK" id="24_rWT3oku$" role="13h7CW">
       <node concept="3clFbS" id="24_rWT3oku_" role="2VODD2" />

--- a/code/languages/com.mbeddr.analyses/languages/com.mbeddr.analyses.cbmc/solutions/pluginSolution/models/com/mbeddr/analyses/cbmc/pluginSolution/plugin.mps
+++ b/code/languages/com.mbeddr.analyses/languages/com.mbeddr.analyses.cbmc/solutions/pluginSolution/models/com/mbeddr/analyses/cbmc/pluginSolution/plugin.mps
@@ -41,6 +41,7 @@
     <import index="b4h4" ref="r:d1d2f189-b1e7-4902-9fc0-3cfa1dc70519(com.mbeddr.analyses.cbmc.editor)" />
     <import index="vbi4" ref="r:101c6aaa-6376-4550-a0fa-eeca066047cc(com.mbeddr.analyses.utils.results_ui)" />
     <import index="npwl" ref="r:ca7aba72-9b45-4105-b4ef-5e520eda75c0(com.mbeddr.analyses.utils.results_model)" />
+    <import index="th2u" ref="r:0d1aaf3f-8f5d-43b9-be00-7a4293d0c172(com.mbeddr.analyses.cbmc.behavior)" />
   </imports>
   <registry>
     <language id="982eb8df-2c96-4bd7-9963-11712ea622e5" name="jetbrains.mps.lang.resources">
@@ -331,6 +332,7 @@
       <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
         <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
       </concept>
+      <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
       <concept id="1143226024141" name="jetbrains.mps.lang.smodel.structure.SModelType" flags="in" index="H_c77" />
       <concept id="1182511038748" name="jetbrains.mps.lang.smodel.structure.Model_NodesIncludingImportedOperation" flags="nn" index="1j9C0f">
         <reference id="1182511038750" name="concept" index="1j9C0d" />
@@ -760,15 +762,21 @@
             </node>
           </node>
         </node>
-        <node concept="3cpWs8" id="4EriiVwnqHm" role="3cqZAp">
-          <node concept="3cpWsn" id="4EriiVwnqHn" role="3cpWs9">
+        <node concept="3cpWs8" id="2QuU6zJivKm" role="3cqZAp">
+          <node concept="3cpWsn" id="2QuU6zJivKn" role="3cpWs9">
             <property role="TrG5h" value="factory" />
-            <node concept="3uibUv" id="3_HSwtcXJ87" role="1tU5fm">
-              <ref role="3uigEE" to="tzyt:3_HSwtcWQWH" resolve="AnalysisConfigurationAnalyzerFactory" />
+            <node concept="3uibUv" id="2QuU6zJivKk" role="1tU5fm">
+              <ref role="3uigEE" to="tzyt:3_HSwtcWh0_" resolve="CProverAnalyzerFactory" />
             </node>
-            <node concept="2ShNRf" id="4EriiVwnqHp" role="33vP2m">
-              <node concept="HV5vD" id="3_HSwtcXS_I" role="2ShVmc">
-                <ref role="HV5vE" to="tzyt:3_HSwtcWQWH" resolve="AnalysisConfigurationAnalyzerFactory" />
+            <node concept="2OqwBi" id="2QuU6zJivKo" role="33vP2m">
+              <node concept="2OqwBi" id="2QuU6zJivKp" role="2Oq$k0">
+                <node concept="2WthIp" id="2QuU6zJivKq" role="2Oq$k0" />
+                <node concept="3gHZIF" id="2QuU6zJivKr" role="2OqNvi">
+                  <ref role="2WH_rO" node="5BkFC2yhAHp" resolve="analysisConfig" />
+                </node>
+              </node>
+              <node concept="2qgKlT" id="2QuU6zJivKs" role="2OqNvi">
+                <ref role="37wK5l" to="th2u:2QuU6zJiopk" resolve="getTopLevelAnalyzerFactory" />
               </node>
             </node>
           </node>
@@ -790,7 +798,7 @@
               </node>
             </node>
             <node concept="37vLTw" id="4EriiVwnqH_" role="37wK5m">
-              <ref role="3cqZAo" node="4EriiVwnqHn" resolve="factory" />
+              <ref role="3cqZAo" node="2QuU6zJivKn" resolve="factory" />
             </node>
             <node concept="37vLTw" id="3_HSwtcXSLa" role="37wK5m">
               <ref role="3cqZAo" node="3_HSwtcXMtu" resolve="config" />
@@ -945,12 +953,18 @@
         <node concept="3cpWs8" id="3_HSwtcYvy$" role="3cqZAp">
           <node concept="3cpWsn" id="3_HSwtcYvy_" role="3cpWs9">
             <property role="TrG5h" value="factory" />
-            <node concept="3uibUv" id="3_HSwtcYvyA" role="1tU5fm">
-              <ref role="3uigEE" to="tzyt:3_HSwtcWQWH" resolve="AnalysisConfigurationAnalyzerFactory" />
+            <node concept="3uibUv" id="2QuU6zJip8B" role="1tU5fm">
+              <ref role="3uigEE" to="tzyt:3_HSwtcWh0_" resolve="CProverAnalyzerFactory" />
             </node>
-            <node concept="2ShNRf" id="3_HSwtcYvyB" role="33vP2m">
-              <node concept="HV5vD" id="3_HSwtcYvyC" role="2ShVmc">
-                <ref role="HV5vE" to="tzyt:3_HSwtcWQWH" resolve="AnalysisConfigurationAnalyzerFactory" />
+            <node concept="2OqwBi" id="2QuU6zITI9T" role="33vP2m">
+              <node concept="2OqwBi" id="2QuU6zITHDC" role="2Oq$k0">
+                <node concept="2WthIp" id="2QuU6zITHDF" role="2Oq$k0" />
+                <node concept="3gHZIF" id="2QuU6zITHDH" role="2OqNvi">
+                  <ref role="2WH_rO" node="6w9LZ1hC3Vo" resolve="analysis" />
+                </node>
+              </node>
+              <node concept="2qgKlT" id="2QuU6zITIF5" role="2OqNvi">
+                <ref role="37wK5l" to="th2u:2QuU6zIQ9IH" resolve="topLevelAnalyzerFactory" />
               </node>
             </node>
           </node>
@@ -1126,15 +1140,21 @@
             </node>
           </node>
         </node>
-        <node concept="3cpWs8" id="3_HSwtcXUsF" role="3cqZAp">
-          <node concept="3cpWsn" id="3_HSwtcXUsG" role="3cpWs9">
+        <node concept="3cpWs8" id="2QuU6zJixC1" role="3cqZAp">
+          <node concept="3cpWsn" id="2QuU6zJixC2" role="3cpWs9">
             <property role="TrG5h" value="factory" />
-            <node concept="3uibUv" id="3_HSwtcXUsH" role="1tU5fm">
-              <ref role="3uigEE" to="tzyt:3_HSwtcWQWH" resolve="AnalysisConfigurationAnalyzerFactory" />
+            <node concept="3uibUv" id="2QuU6zJixC3" role="1tU5fm">
+              <ref role="3uigEE" to="tzyt:3_HSwtcWh0_" resolve="CProverAnalyzerFactory" />
             </node>
-            <node concept="2ShNRf" id="3_HSwtcXUsI" role="33vP2m">
-              <node concept="HV5vD" id="3_HSwtcXUsJ" role="2ShVmc">
-                <ref role="HV5vE" to="tzyt:3_HSwtcWQWH" resolve="AnalysisConfigurationAnalyzerFactory" />
+            <node concept="2OqwBi" id="2QuU6zJixC4" role="33vP2m">
+              <node concept="2OqwBi" id="2QuU6zJixC5" role="2Oq$k0">
+                <node concept="2WthIp" id="2QuU6zJixC6" role="2Oq$k0" />
+                <node concept="3gHZIF" id="2QuU6zJixC7" role="2OqNvi">
+                  <ref role="2WH_rO" node="EVDykUCksa" resolve="analysisConfig" />
+                </node>
+              </node>
+              <node concept="2qgKlT" id="2QuU6zJixC8" role="2OqNvi">
+                <ref role="37wK5l" to="th2u:2QuU6zJiopk" resolve="getTopLevelAnalyzerFactory" />
               </node>
             </node>
           </node>
@@ -1179,7 +1199,7 @@
               </node>
             </node>
             <node concept="37vLTw" id="3_HSwtcY0_I" role="37wK5m">
-              <ref role="3cqZAo" node="3_HSwtcXUsG" resolve="factory" />
+              <ref role="3cqZAo" node="2QuU6zJixC2" resolve="factory" />
             </node>
             <node concept="37vLTw" id="3_HSwtcY0DB" role="37wK5m">
               <ref role="3cqZAo" node="3_HSwtcXUsp" resolve="config" />


### PR DESCRIPTION
Hi,

We would like to execute some job before/after the "formal verification" is triggered/completed. The verification action always creates an object of "AnalysisConfigurationAnalyzerFactory" class which is responsible for collecting all analyses jobs and execute. The object creation can be delegated to the respective Analysis Configuration.  So created a virtual method in CProverBasedAnalysis behaviour and CBMCAnalysisConfigurationContainer behaviour. Changed the action to get the factory from the respective nodes. 

Regards,
Dinesh