### PR TITLE
editingGuide: added ImageWord

### DIFF
--- a/code/languages/com.mbeddr.build/solutions/com.mbeddr.platform/models/com/mbeddr/platform/build.mps
+++ b/code/languages/com.mbeddr.build/solutions/com.mbeddr.platform/models/com/mbeddr/platform/build.mps
@@ -9943,6 +9943,23 @@
             </node>
           </node>
         </node>
+        <node concept="1SiIV0" id="5JXDvCLh_kV" role="3bR37C">
+          <node concept="3bR9La" id="5JXDvCLh_kW" role="1SiIV1">
+            <property role="3bR36h" value="false" />
+            <ref role="3bR37D" to="ffeo:14x5$qAUbkv" resolve="jetbrains.mps.lang.resources" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="5JXDvCLh_kX" role="3bR37C">
+          <node concept="3bR9La" id="5JXDvCLh_kY" role="1SiIV1">
+            <property role="3bR36h" value="false" />
+            <ref role="3bR37D" to="ffeo:3MI1gu0QouH" resolve="jetbrains.mps.editor.runtime" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="5JXDvCLh_kZ" role="3bR37C">
+          <node concept="1Busua" id="5JXDvCLh_l0" role="1SiIV1">
+            <ref role="1Busuk" to="ffeo:14x5$qAUbkv" resolve="jetbrains.mps.lang.resources" />
+          </node>
+        </node>
       </node>
       <node concept="1E1JtA" id="7dbZP3ALqdK" role="2G$12L">
         <property role="BnDLt" value="true" />

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.editingGuide.execution.lang/com.mbeddr.mpsutil.editingGuide.execution.lang.mpl
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.editingGuide.execution.lang/com.mbeddr.mpsutil.editingGuide.execution.lang.mpl
@@ -28,6 +28,7 @@
         <language slang="l:d7706f63-9be2-479c-a3da-ae92af1e64d5:jetbrains.mps.lang.generator.generationContext" version="0" />
         <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
         <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="0" />
+        <language slang="l:982eb8df-2c96-4bd7-9963-11712ea622e5:jetbrains.mps.lang.resources" version="2" />
         <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="11" />
         <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
         <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
@@ -44,6 +45,7 @@
         <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
         <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
         <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
+        <module reference="982eb8df-2c96-4bd7-9963-11712ea622e5(jetbrains.mps.lang.resources)" version="0" />
         <module reference="9ded098b-ad6a-4657-bfd9-48636cfe8bc3(jetbrains.mps.lang.traceable)" version="0" />
       </dependencyVersions>
       <mapping-priorities />
@@ -110,6 +112,7 @@
     <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
     <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
     <module reference="a9e4c532-c5f5-4bb7-99ef-42abb73bbb70(jetbrains.mps.lang.descriptor.aspects)" version="0" />
+    <module reference="982eb8df-2c96-4bd7-9963-11712ea622e5(jetbrains.mps.lang.resources)" version="0" />
     <module reference="9ded098b-ad6a-4657-bfd9-48636cfe8bc3(jetbrains.mps.lang.traceable)" version="0" />
   </dependencyVersions>
   <extendedLanguages>

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.editingGuide/com.mbeddr.mpsutil.editingGuide.mpl
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.editingGuide/com.mbeddr.mpsutil.editingGuide.mpl
@@ -63,6 +63,8 @@
     <dependency reexport="false">c6e0a639-6829-4d71-a41c-9d693d7cdea5(com.mbeddr.mpsutil.editingGuide.runtime)</dependency>
     <dependency reexport="false">8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)</dependency>
     <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
+    <dependency reexport="false">34e84b8f-afa8-4364-abcd-a279fddddbe7(jetbrains.mps.editor.runtime)</dependency>
+    <dependency reexport="false">982eb8df-2c96-4bd7-9963-11712ea622e5(jetbrains.mps.lang.resources)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:f89904fb-9486-43a1-865e-5ad0375a8a88:de.itemis.mps.editor.bool" version="0" />
@@ -120,6 +122,7 @@
   </runtime>
   <extendedLanguages>
     <extendedLanguage>f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)</extendedLanguage>
+    <extendedLanguage>982eb8df-2c96-4bd7-9963-11712ea622e5(jetbrains.mps.lang.resources)</extendedLanguage>
   </extendedLanguages>
 </language>
 

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.editingGuide/com.mbeddr.mpsutil.editingGuide.mpl
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.editingGuide/com.mbeddr.mpsutil.editingGuide.mpl
@@ -30,6 +30,7 @@
         <language slang="l:d7706f63-9be2-479c-a3da-ae92af1e64d5:jetbrains.mps.lang.generator.generationContext" version="0" />
         <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
         <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="0" />
+        <language slang="l:982eb8df-2c96-4bd7-9963-11712ea622e5:jetbrains.mps.lang.resources" version="2" />
         <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="11" />
         <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
         <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
@@ -49,6 +50,7 @@
         <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
         <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
         <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
+        <module reference="982eb8df-2c96-4bd7-9963-11712ea622e5(jetbrains.mps.lang.resources)" version="0" />
         <module reference="9ded098b-ad6a-4657-bfd9-48636cfe8bc3(jetbrains.mps.lang.traceable)" version="0" />
       </dependencyVersions>
       <mapping-priorities />
@@ -110,10 +112,12 @@
     <module reference="fd392034-7849-419d-9071-12563d152375(jetbrains.mps.baseLanguage.closures)" version="0" />
     <module reference="83888646-71ce-4f1c-9c53-c54016f6ad4f(jetbrains.mps.baseLanguage.collections)" version="0" />
     <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
+    <module reference="34e84b8f-afa8-4364-abcd-a279fddddbe7(jetbrains.mps.editor.runtime)" version="0" />
     <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
     <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
     <module reference="a9e4c532-c5f5-4bb7-99ef-42abb73bbb70(jetbrains.mps.lang.descriptor.aspects)" version="0" />
     <module reference="446c26eb-2b7b-4bf0-9b35-f83fa582753e(jetbrains.mps.lang.modelapi)" version="0" />
+    <module reference="982eb8df-2c96-4bd7-9963-11712ea622e5(jetbrains.mps.lang.resources)" version="0" />
     <module reference="7866978e-a0f0-4cc7-81bc-4d213d9375e1(jetbrains.mps.lang.smodel)" version="1" />
     <module reference="9ded098b-ad6a-4657-bfd9-48636cfe8bc3(jetbrains.mps.lang.traceable)" version="0" />
   </dependencyVersions>

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.editingGuide/models/behavior.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.editingGuide/models/behavior.mps
@@ -18,6 +18,9 @@
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" />
     <import index="3qmy" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.classloading(MPS.Core/)" />
     <import index="t6h5" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang.reflect(JDK/)" />
+    <import index="3767" ref="r:7f24d329-a444-4288-af92-f8ef91dfd241(jetbrains.mps.lang.resources.behavior)" />
+    <import index="tqvn" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel.tempmodel(MPS.Core/)" />
+    <import index="1oap" ref="r:03d44d4c-3d65-461c-9085-0f48e9569e59(jetbrains.mps.lang.resources.structure)" implicit="true" />
   </imports>
   <registry>
     <language id="af65afd8-f0dd-4942-87d9-63a55f2a9db1" name="jetbrains.mps.lang.behavior">
@@ -65,6 +68,9 @@
       <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
         <property id="1070475926801" name="value" index="Xl_RC" />
       </concept>
+      <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
+        <reference id="1144433194310" name="classConcept" index="1Pybhc" />
+      </concept>
       <concept id="1164991038168" name="jetbrains.mps.baseLanguage.structure.ThrowStatement" flags="nn" index="YS8fn">
         <child id="1164991057263" name="throwable" index="YScLw" />
       </concept>
@@ -87,6 +93,7 @@
       <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
       <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
       <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
+      <concept id="1225271408483" name="jetbrains.mps.baseLanguage.structure.IsNotEmptyOperation" flags="nn" index="17RvpY" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
       </concept>
@@ -148,6 +155,7 @@
       <concept id="1116615150612" name="jetbrains.mps.baseLanguage.structure.ClassifierClassExpression" flags="nn" index="3VsKOn">
         <reference id="1116615189566" name="classifier" index="3VsUkX" />
       </concept>
+      <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
     </language>
     <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
       <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
@@ -1015,6 +1023,164 @@
       <node concept="A3Dl8" id="2ZHlC00abFf" role="3clF45">
         <node concept="3Tqbb2" id="2ZHlC00abFg" role="A3Ik2" />
       </node>
+    </node>
+  </node>
+  <node concept="13h7C7" id="7r9XsdeqO$O">
+    <property role="3GE5qa" value="words" />
+    <ref role="13h7C2" to="k8go:2Sndli4jFPI" resolve="ImageWord" />
+    <node concept="13i0hz" id="7r9XsdeqO$Z" role="13h7CS">
+      <property role="TrG5h" value="getModule" />
+      <node concept="3Tm1VV" id="7r9XsdeqO_0" role="1B3o_S" />
+      <node concept="3uibUv" id="7r9XsdeqOA$" role="3clF45">
+        <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
+      </node>
+      <node concept="3clFbS" id="7r9XsdeqO_2" role="3clF47">
+        <node concept="3clFbF" id="7r9XsdeqO_f" role="3cqZAp">
+          <node concept="2OqwBi" id="7r9XsdeqAGC" role="3clFbG">
+            <node concept="1eOMI4" id="7r9XsdeqAGD" role="2Oq$k0">
+              <node concept="10QFUN" id="7r9XsdeqAGE" role="1eOMHV">
+                <node concept="3uibUv" id="7r9XsdeqAGF" role="10QFUM">
+                  <ref role="3uigEE" to="mhbf:~SModel" resolve="SModel" />
+                </node>
+                <node concept="2OqwBi" id="7r9XsdeqOR6" role="10QFUP">
+                  <node concept="13iPFW" id="7r9XsdeqOEo" role="2Oq$k0" />
+                  <node concept="I4A8Y" id="7r9XsdeqP4b" role="2OqNvi" />
+                </node>
+              </node>
+            </node>
+            <node concept="liA8E" id="7r9XsdeqAGJ" role="2OqNvi">
+              <ref role="37wK5l" to="mhbf:~SModel.getModule():org.jetbrains.mps.openapi.module.SModule" resolve="getModule" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="13i0hz" id="7r9Xsder9tx" role="13h7CS">
+      <property role="TrG5h" value="getImageModuleByModuleId" />
+      <node concept="3Tm1VV" id="7r9Xsder9ty" role="1B3o_S" />
+      <node concept="3uibUv" id="7r9Xsder9tz" role="3clF45">
+        <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
+      </node>
+      <node concept="3clFbS" id="7r9Xsder9t$" role="3clF47">
+        <node concept="3cpWs6" id="JJxXu1sChi" role="3cqZAp">
+          <node concept="2YIFZM" id="55ShMBE4Pt7" role="3cqZAk">
+            <ref role="1Pybhc" to="2vci:2ZHlC0034C1" resolve="Helper" />
+            <ref role="37wK5l" to="2vci:55ShMBE4Gnh" resolve="findSModuleByID" />
+            <node concept="2OqwBi" id="JJxXu1sCAU" role="37wK5m">
+              <node concept="BsUDl" id="JJxXu1sD_e" role="2Oq$k0">
+                <ref role="37wK5l" node="7r9XsdeqO$Z" resolve="getModule" />
+              </node>
+              <node concept="liA8E" id="JJxXu1sCT1" role="2OqNvi">
+                <ref role="37wK5l" to="lui2:~SModule.getRepository():org.jetbrains.mps.openapi.module.SRepository" resolve="getRepository" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="JJxXu1sDaK" role="37wK5m">
+              <node concept="13iPFW" id="JJxXu1sCYh" role="2Oq$k0" />
+              <node concept="3TrcHB" id="JJxXu1sDqs" role="2OqNvi">
+                <ref role="3TsBF5" to="k8go:55ShMBE4VYH" resolve="moduleId" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="13i0hz" id="JJxXu1sAqb" role="13h7CS">
+      <property role="TrG5h" value="isEditingGuideActive" />
+      <node concept="3Tm1VV" id="JJxXu1sAqc" role="1B3o_S" />
+      <node concept="10P_77" id="JJxXu1sA_1" role="3clF45" />
+      <node concept="3clFbS" id="JJxXu1sAqe" role="3clF47">
+        <node concept="3cpWs6" id="JJxXu1sAGG" role="3cqZAp">
+          <node concept="2YIFZM" id="JJxXu1sAJE" role="3cqZAk">
+            <ref role="37wK5l" to="tqvn:~TemporaryModels.isTemporary(org.jetbrains.mps.openapi.model.SModel):boolean" resolve="isTemporary" />
+            <ref role="1Pybhc" to="tqvn:~TemporaryModels" resolve="TemporaryModels" />
+            <node concept="2OqwBi" id="JJxXu1sAJF" role="37wK5m">
+              <node concept="13iPFW" id="JJxXu1sAJG" role="2Oq$k0" />
+              <node concept="I4A8Y" id="JJxXu1sAJH" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="13i0hz" id="JJxXu1sw3o" role="13h7CS">
+      <property role="TrG5h" value="isModuleIdRequired" />
+      <node concept="3Tm1VV" id="JJxXu1sw3p" role="1B3o_S" />
+      <node concept="10P_77" id="JJxXu1swTl" role="3clF45" />
+      <node concept="3clFbS" id="JJxXu1sw3r" role="3clF47">
+        <node concept="3cpWs6" id="JJxXu1swUU" role="3cqZAp">
+          <node concept="1Wc70l" id="JJxXu1syaX" role="3cqZAk">
+            <node concept="2OqwBi" id="JJxXu1sxWS" role="3uHU7w">
+              <node concept="2OqwBi" id="JJxXu1sxWT" role="2Oq$k0">
+                <node concept="13iPFW" id="JJxXu1sxWU" role="2Oq$k0" />
+                <node concept="3TrcHB" id="JJxXu1sxWV" role="2OqNvi">
+                  <ref role="3TsBF5" to="1oap:Ib_Fk7zNeV" resolve="file" />
+                </node>
+              </node>
+              <node concept="liA8E" id="JJxXu1sxWW" role="2OqNvi">
+                <ref role="37wK5l" to="wyt6:~String.contains(java.lang.CharSequence):boolean" resolve="contains" />
+                <node concept="Xl_RD" id="JJxXu1sxWX" role="37wK5m">
+                  <property role="Xl_RC" value="${module}" />
+                </node>
+              </node>
+            </node>
+            <node concept="2OqwBi" id="JJxXu1szqp" role="3uHU7B">
+              <node concept="2OqwBi" id="JJxXu1syxH" role="2Oq$k0">
+                <node concept="13iPFW" id="JJxXu1syiL" role="2Oq$k0" />
+                <node concept="3TrcHB" id="JJxXu1syNu" role="2OqNvi">
+                  <ref role="3TsBF5" to="1oap:Ib_Fk7zNeV" resolve="file" />
+                </node>
+              </node>
+              <node concept="17RvpY" id="JJxXu1s$qd" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="13i0hz" id="7r9XsdeqP8E" role="13h7CS">
+      <property role="TrG5h" value="isModuleIdValid" />
+      <node concept="3Tm1VV" id="7r9XsdeqP8F" role="1B3o_S" />
+      <node concept="10P_77" id="7r9XsdeqPdn" role="3clF45" />
+      <node concept="3clFbS" id="7r9XsdeqP8H" role="3clF47">
+        <node concept="3cpWs6" id="7r9XsdeqPEN" role="3cqZAp">
+          <node concept="1Wc70l" id="7r9Xsder5gI" role="3cqZAk">
+            <node concept="2OqwBi" id="7r9Xsder6tD" role="3uHU7w">
+              <node concept="2OqwBi" id="7r9Xsder5_c" role="2Oq$k0">
+                <node concept="13iPFW" id="7r9Xsder5lA" role="2Oq$k0" />
+                <node concept="3TrcHB" id="7r9Xsder5S_" role="2OqNvi">
+                  <ref role="3TsBF5" to="k8go:55ShMBE4VYH" resolve="moduleId" />
+                </node>
+              </node>
+              <node concept="liA8E" id="7r9Xsder73c" role="2OqNvi">
+                <ref role="37wK5l" to="wyt6:~String.equals(java.lang.Object):boolean" resolve="equals" />
+                <node concept="2OqwBi" id="7r9Xsder7Ps" role="37wK5m">
+                  <node concept="2OqwBi" id="7r9Xsder7pl" role="2Oq$k0">
+                    <node concept="BsUDl" id="7r9Xsder78t" role="2Oq$k0">
+                      <ref role="37wK5l" node="7r9XsdeqO$Z" resolve="getModule" />
+                    </node>
+                    <node concept="liA8E" id="7r9Xsder7$C" role="2OqNvi">
+                      <ref role="37wK5l" to="lui2:~SModule.getModuleId():org.jetbrains.mps.openapi.module.SModuleId" resolve="getModuleId" />
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="7r9Xsder87z" role="2OqNvi">
+                    <ref role="37wK5l" to="wyt6:~Object.toString():java.lang.String" resolve="toString" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="2OqwBi" id="7r9Xsder3Ix" role="3uHU7B">
+              <node concept="2OqwBi" id="7r9Xsder1Ua" role="2Oq$k0">
+                <node concept="13iPFW" id="7r9Xsder1EO" role="2Oq$k0" />
+                <node concept="3TrcHB" id="7r9Xsder2db" role="2OqNvi">
+                  <ref role="3TsBF5" to="k8go:55ShMBE4VYH" resolve="moduleId" />
+                </node>
+              </node>
+              <node concept="17RvpY" id="7r9Xsder4w7" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="13hLZK" id="7r9XsdeqO$P" role="13h7CW">
+      <node concept="3clFbS" id="7r9XsdeqO$Q" role="2VODD2" />
     </node>
   </node>
 </model>

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.editingGuide/models/editor.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.editingGuide/models/editor.mps
@@ -9,11 +9,8 @@
   <imports>
     <import index="exr9" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor(MPS.Editor/)" />
     <import index="k8go" ref="r:00731b77-fd60-4ebd-b554-284dbff8495f(com.mbeddr.mpsutil.editingGuide.structure)" />
-    <import index="cj4x" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor(MPS.Editor/)" />
     <import index="7a0s" ref="r:2af017c2-293f-4ebb-99f3-81e353b3d6e6(jetbrains.mps.editor.runtime)" />
-    <import index="lui2" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.module(MPS.OpenAPI/)" />
     <import index="18ew" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.util(MPS.Core/)" />
-    <import index="2vci" ref="r:1f9c504f-7e80-4694-ba90-80ed6336d504(com.mbeddr.mpsutil.editingGuide.runtime.rt)" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
     <import index="1oap" ref="r:03d44d4c-3d65-461c-9085-0f48e9569e59(jetbrains.mps.lang.resources.structure)" implicit="true" />
     <import index="l4gp" ref="r:a2db9c62-2dcd-4812-bc5f-0468bbf0b1c1(com.mbeddr.mpsutil.editingGuide.behavior)" implicit="true" />

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.editingGuide/models/editor.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.editingGuide/models/editor.mps
@@ -9,11 +9,25 @@
   <imports>
     <import index="exr9" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor(MPS.Editor/)" />
     <import index="k8go" ref="r:00731b77-fd60-4ebd-b554-284dbff8495f(com.mbeddr.mpsutil.editingGuide.structure)" />
+    <import index="cj4x" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor(MPS.Editor/)" />
+    <import index="7a0s" ref="r:2af017c2-293f-4ebb-99f3-81e353b3d6e6(jetbrains.mps.editor.runtime)" />
+    <import index="lui2" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.module(MPS.OpenAPI/)" />
+    <import index="18ew" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.util(MPS.Core/)" />
+    <import index="2vci" ref="r:1f9c504f-7e80-4694-ba90-80ed6336d504(com.mbeddr.mpsutil.editingGuide.runtime.rt)" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
+    <import index="1oap" ref="r:03d44d4c-3d65-461c-9085-0f48e9569e59(jetbrains.mps.lang.resources.structure)" implicit="true" />
+    <import index="l4gp" ref="r:a2db9c62-2dcd-4812-bc5f-0468bbf0b1c1(com.mbeddr.mpsutil.editingGuide.behavior)" implicit="true" />
   </imports>
   <registry>
     <language id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor">
-      <concept id="1071666914219" name="jetbrains.mps.lang.editor.structure.ConceptEditorDeclaration" flags="ig" index="24kQdi" />
+      <concept id="1071666914219" name="jetbrains.mps.lang.editor.structure.ConceptEditorDeclaration" flags="ig" index="24kQdi">
+        <child id="1078153129734" name="inspectedCellModel" index="6VMZX" />
+        <child id="2597348684684069742" name="contextHints" index="CpUAK" />
+      </concept>
+      <concept id="1176899348742" name="jetbrains.mps.lang.editor.structure.QueryFunction_ImagePath" flags="in" index="4EIwk" />
+      <concept id="6822301196700715228" name="jetbrains.mps.lang.editor.structure.ConceptEditorHintDeclarationReference" flags="ig" index="2aJ2om">
+        <reference id="5944657839026714445" name="hint" index="2$4xQ3" />
+      </concept>
       <concept id="1140524381322" name="jetbrains.mps.lang.editor.structure.CellModel_ListWithRole" flags="ng" index="2czfm3">
         <child id="1140524464360" name="cellLayout" index="2czzBx" />
       </concept>
@@ -51,10 +65,16 @@
       <concept id="1233758997495" name="jetbrains.mps.lang.editor.structure.PunctuationLeftStyleClassItem" flags="ln" index="11L4FC" />
       <concept id="1233759184865" name="jetbrains.mps.lang.editor.structure.PunctuationRightStyleClassItem" flags="ln" index="11LMrY" />
       <concept id="1221057094638" name="jetbrains.mps.lang.editor.structure.QueryFunction_Integer" flags="in" index="1cFabM" />
+      <concept id="1103016434866" name="jetbrains.mps.lang.editor.structure.CellModel_JComponent" flags="sg" stub="8104358048506731196" index="3gTLQM">
+        <child id="1176475119347" name="componentProvider" index="3FoqZy" />
+      </concept>
       <concept id="1088013125922" name="jetbrains.mps.lang.editor.structure.CellModel_RefCell" flags="sg" stub="730538219795941030" index="1iCGBv">
         <child id="1088186146602" name="editorComponent" index="1sWHZn" />
       </concept>
       <concept id="1088185857835" name="jetbrains.mps.lang.editor.structure.InlineEditorComponent" flags="ig" index="1sVBvm" />
+      <concept id="1139744628335" name="jetbrains.mps.lang.editor.structure.CellModel_Image" flags="sg" stub="8104358048506731195" index="1u4HXA">
+        <child id="1176899909521" name="imagePathProvider" index="4GRq3" />
+      </concept>
       <concept id="1219226236603" name="jetbrains.mps.lang.editor.structure.DrawBracketsStyleClassItem" flags="ln" index="3vyZuw" />
       <concept id="1139848536355" name="jetbrains.mps.lang.editor.structure.CellModel_WithRole" flags="ng" index="1$h60E">
         <reference id="1140103550593" name="relationDeclaration" index="1NtTu8" />
@@ -74,12 +94,14 @@
       </concept>
       <concept id="1073389882823" name="jetbrains.mps.lang.editor.structure.CellModel_RefNode" flags="sg" stub="730538219795960754" index="3F1sOY" />
       <concept id="1073390211982" name="jetbrains.mps.lang.editor.structure.CellModel_RefNodeList" flags="sg" stub="2794558372793454595" index="3F2HdR" />
+      <concept id="1176474535556" name="jetbrains.mps.lang.editor.structure.QueryFunction_JComponent" flags="in" index="3Fmcul" />
       <concept id="1225898583838" name="jetbrains.mps.lang.editor.structure.ReadOnlyModelAccessor" flags="ng" index="1HfYo3">
         <child id="1225898971709" name="getter" index="1Hhtcw" />
       </concept>
       <concept id="1225900081164" name="jetbrains.mps.lang.editor.structure.CellModel_ReadOnlyModelAccessor" flags="sg" stub="3708815482283559694" index="1HlG4h">
         <child id="1225900141900" name="modelAccessor" index="1HlULh" />
       </concept>
+      <concept id="1161622981231" name="jetbrains.mps.lang.editor.structure.ConceptFunctionParameter_editorContext" flags="nn" index="1Q80Hx" />
       <concept id="625126330682908270" name="jetbrains.mps.lang.editor.structure.CellModel_ReferencePresentation" flags="sg" stub="730538219795961225" index="3SHvHV" />
       <concept id="1176717841777" name="jetbrains.mps.lang.editor.structure.QueryFunction_ModelAccess_Getter" flags="in" index="3TQlhw" />
       <concept id="1166049232041" name="jetbrains.mps.lang.editor.structure.AbstractComponent" flags="ng" index="1XWOmA">
@@ -120,11 +142,15 @@
         <property id="1068580320021" name="value" index="3cmrfH" />
       </concept>
       <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
+      <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
+        <child id="1068581517676" name="expression" index="3cqZAk" />
+      </concept>
       <concept id="1079359253375" name="jetbrains.mps.baseLanguage.structure.ParenthesizedExpression" flags="nn" index="1eOMI4">
         <child id="1079359253376" name="expression" index="1eOMHV" />
       </concept>
       <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
       <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
         <child id="1081773367579" name="rightExpression" index="3uHU7w" />
@@ -136,6 +162,14 @@
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
       <concept id="1179168000618" name="jetbrains.mps.lang.smodel.structure.Node_GetIndexInParentOperation" flags="nn" index="2bSWHS" />
+      <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
+      <concept id="2644386474302386080" name="jetbrains.mps.lang.smodel.structure.PropertyIdRefExpression" flags="nn" index="355D3s">
+        <reference id="2644386474302386081" name="conceptDeclaration" index="355D3t" />
+        <reference id="2644386474302386082" name="propertyDeclaration" index="355D3u" />
+      </concept>
+      <concept id="1138056022639" name="jetbrains.mps.lang.smodel.structure.SPropertyAccess" flags="nn" index="3TrcHB">
+        <reference id="1138056395725" name="property" index="3TsBF5" />
+      </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
@@ -576,6 +610,103 @@
         </node>
       </node>
       <node concept="l2Vlx" id="2ZHlC00amN9" role="2iSdaV" />
+    </node>
+  </node>
+  <node concept="24kQdi" id="2Sndli4jFQa">
+    <property role="3GE5qa" value="words" />
+    <ref role="1XX52x" to="k8go:2Sndli4jFPI" resolve="ImageWord" />
+    <node concept="3EZMnI" id="2Sndli4jFQb" role="2wV5jI">
+      <node concept="3F0ifn" id="2Sndli4jFQc" role="3EZMnx">
+        <property role="3F0ifm" value="\img[" />
+        <node concept="11LMrY" id="2Sndli4jFQd" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+      <node concept="3F0A7n" id="2Sndli4jFQe" role="3EZMnx">
+        <ref role="1NtTu8" to="1oap:Ib_Fk7zNeV" resolve="file" />
+      </node>
+      <node concept="3gTLQM" id="Ib_Fk7zNg6" role="3EZMnx">
+        <node concept="3Fmcul" id="Ib_Fk7zNg7" role="3FoqZy">
+          <node concept="3clFbS" id="Ib_Fk7zNg8" role="2VODD2">
+            <node concept="3cpWs6" id="Ib_Fk7zNg9" role="3cqZAp">
+              <node concept="2YIFZM" id="AN0tL0jRgr" role="3cqZAk">
+                <ref role="1Pybhc" to="7a0s:6UDbxo8i0QW" resolve="EditorUtil" />
+                <ref role="37wK5l" to="7a0s:lnREv2ShpJ" resolve="createSelectImageButton" />
+                <node concept="pncrf" id="AN0tL0jRgs" role="37wK5m" />
+                <node concept="355D3s" id="AN0tL0jRgt" role="37wK5m">
+                  <ref role="355D3t" to="k8go:2Sndli4jFPI" resolve="ImageWord" />
+                  <ref role="355D3u" to="1oap:Ib_Fk7zNeV" resolve="file" />
+                </node>
+                <node concept="1Q80Hx" id="AN0tL0jRgu" role="37wK5m" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3F0ifn" id="2Sndli4jFQf" role="3EZMnx">
+        <property role="3F0ifm" value="]" />
+        <node concept="11L4FC" id="2Sndli4jFQg" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+      <node concept="l2Vlx" id="2Sndli4jFQh" role="2iSdaV" />
+    </node>
+    <node concept="3EZMnI" id="55ShMBE5aMO" role="6VMZX">
+      <node concept="2iRkQZ" id="55ShMBE5aMP" role="2iSdaV" />
+      <node concept="3EZMnI" id="55ShMBE5aZ9" role="3EZMnx">
+        <node concept="l2Vlx" id="55ShMBE5aZa" role="2iSdaV" />
+        <node concept="3F0ifn" id="55ShMBE5aZb" role="3EZMnx">
+          <property role="3F0ifm" value="module:" />
+        </node>
+        <node concept="3F0A7n" id="55ShMBE5aZp" role="3EZMnx">
+          <ref role="1NtTu8" to="k8go:55ShMBE4VYH" resolve="moduleId" />
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="24kQdi" id="2Sndli4k2J0">
+    <property role="3GE5qa" value="words" />
+    <ref role="1XX52x" to="k8go:2Sndli4jFPI" resolve="ImageWord" />
+    <node concept="2aJ2om" id="2Sndli4k2J8" role="CpUAK">
+      <ref role="2$4xQ3" node="5h2rxDjXh5K" resolve="InGuideExecutionMode" />
+    </node>
+    <node concept="3EZMnI" id="Ib_Fk7zNfI" role="2wV5jI">
+      <node concept="1u4HXA" id="Ib_Fk7zNfJ" role="3EZMnx">
+        <node concept="4EIwk" id="55ShMBE4aIn" role="4GRq3">
+          <node concept="3clFbS" id="55ShMBE4aIo" role="2VODD2">
+            <node concept="3cpWs6" id="55ShMBE3Q$q" role="3cqZAp">
+              <node concept="2OqwBi" id="55ShMBE4bAy" role="3cqZAk">
+                <node concept="2YIFZM" id="55ShMBE3VdQ" role="2Oq$k0">
+                  <ref role="1Pybhc" to="18ew:~MacrosFactory" resolve="MacrosFactory" />
+                  <ref role="37wK5l" to="18ew:~MacrosFactory.forModule(org.jetbrains.mps.openapi.module.SModule):jetbrains.mps.util.MacroHelper" resolve="forModule" />
+                  <node concept="2OqwBi" id="JJxXu1sFmg" role="37wK5m">
+                    <node concept="pncrf" id="JJxXu1sFmh" role="2Oq$k0" />
+                    <node concept="2qgKlT" id="JJxXu1sFmi" role="2OqNvi">
+                      <ref role="37wK5l" to="l4gp:7r9Xsder9tx" resolve="getImageModuleByModuleId" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="liA8E" id="55ShMBE4c4i" role="2OqNvi">
+                  <ref role="37wK5l" to="18ew:~MacroHelper.expandPath(java.lang.String):java.lang.String" resolve="expandPath" />
+                  <node concept="2OqwBi" id="55ShMBE4cL9" role="37wK5m">
+                    <node concept="pncrf" id="55ShMBE4csx" role="2Oq$k0" />
+                    <node concept="3TrcHB" id="55ShMBE4dHG" role="2OqNvi">
+                      <ref role="3TsBF5" to="1oap:Ib_Fk7zNeV" resolve="file" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="VPM3Z" id="55ShMBE5SJs" role="3F10Kt">
+          <property role="VOm3f" value="false" />
+        </node>
+      </node>
+      <node concept="VPM3Z" id="Ib_Fk7zNg2" role="3F10Kt">
+        <property role="VOm3f" value="false" />
+      </node>
+      <node concept="2iRfu4" id="Ib_Fk7zNg3" role="2iSdaV" />
     </node>
   </node>
 </model>

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.editingGuide/models/intentions.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.editingGuide/models/intentions.mps
@@ -6,6 +6,9 @@
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
+    <import index="18ew" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.util(MPS.Core/)" />
+    <import index="mhbf" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.model(MPS.OpenAPI/)" />
+    <import index="tp25" ref="r:00000000-0000-4000-0000-011c89590301(jetbrains.mps.lang.smodel.structure)" />
     <import index="k8go" ref="r:00731b77-fd60-4ebd-b554-284dbff8495f(com.mbeddr.mpsutil.editingGuide.structure)" implicit="true" />
   </imports>
   <registry>

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.editingGuide/models/structure.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.editingGuide/models/structure.mps
@@ -6,6 +6,7 @@
     <devkit ref="78434eb8-b0e5-444b-850d-e7c4ad2da9ab(jetbrains.mps.devkit.aspect.structure)" />
   </languages>
   <imports>
+    <import index="1oap" ref="r:03d44d4c-3d65-461c-9085-0f48e9569e59(jetbrains.mps.lang.resources.structure)" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
     <import index="87nw" ref="r:ca2ab6bb-f6e7-4c0f-a88c-b78b9b31fff3(de.slisson.mps.richtext.structure)" implicit="true" />
     <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" implicit="true" />
@@ -237,6 +238,21 @@
     <node concept="1TJgyi" id="2ZHlC00a$IO" role="1TKVEl">
       <property role="TrG5h" value="text" />
       <property role="IQ2nx" value="3453511597021612980" />
+      <ref role="AX2Wp" to="tpck:fKAOsGN" resolve="string" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="2Sndli4jFPI">
+    <property role="TrG5h" value="ImageWord" />
+    <property role="3GE5qa" value="words" />
+    <property role="EcuMT" value="3321181887322307950" />
+    <property role="34LRSv" value="\img" />
+    <ref role="1TJDcQ" to="1oap:Ib_Fk7zNdB" resolve="Image" />
+    <node concept="PrWs8" id="2Sndli4jFPJ" role="PzmwI">
+      <ref role="PrY4T" to="87nw:2dWzqxEBBFG" resolve="IWord" />
+    </node>
+    <node concept="1TJgyi" id="55ShMBE4VYH" role="1TKVEl">
+      <property role="IQ2nx" value="5870520359623835565" />
+      <property role="TrG5h" value="moduleId" />
       <ref role="AX2Wp" to="tpck:fKAOsGN" resolve="string" />
     </node>
   </node>

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.editingGuide/models/structure.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.editingGuide/models/structure.mps
@@ -7,9 +7,9 @@
   </languages>
   <imports>
     <import index="1oap" ref="r:03d44d4c-3d65-461c-9085-0f48e9569e59(jetbrains.mps.lang.resources.structure)" />
+    <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" />
+    <import index="87nw" ref="r:ca2ab6bb-f6e7-4c0f-a88c-b78b9b31fff3(de.slisson.mps.richtext.structure)" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
-    <import index="87nw" ref="r:ca2ab6bb-f6e7-4c0f-a88c-b78b9b31fff3(de.slisson.mps.richtext.structure)" implicit="true" />
-    <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" implicit="true" />
   </imports>
   <registry>
     <language id="982eb8df-2c96-4bd7-9963-11712ea622e5" name="jetbrains.mps.lang.resources">

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.editingGuide/models/typesystem.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.editingGuide/models/typesystem.mps
@@ -4,7 +4,245 @@
   <languages>
     <devkit ref="00000000-0000-4000-0000-1de82b3a4936(jetbrains.mps.devkit.aspect.typesystem)" />
   </languages>
-  <imports />
-  <registry />
+  <imports>
+    <import index="mhbf" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.model(MPS.OpenAPI/)" />
+    <import index="2vci" ref="r:1f9c504f-7e80-4694-ba90-80ed6336d504(com.mbeddr.mpsutil.editingGuide.runtime.rt)" />
+    <import index="l4gp" ref="r:a2db9c62-2dcd-4812-bc5f-0468bbf0b1c1(com.mbeddr.mpsutil.editingGuide.behavior)" implicit="true" />
+    <import index="k8go" ref="r:00731b77-fd60-4ebd-b554-284dbff8495f(com.mbeddr.mpsutil.editingGuide.structure)" implicit="true" />
+    <import index="lui2" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.module(MPS.OpenAPI/)" implicit="true" />
+    <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
+        <child id="1068498886297" name="rValue" index="37vLTx" />
+        <child id="1068498886295" name="lValue" index="37vLTJ" />
+      </concept>
+      <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
+        <child id="1137022507850" name="body" index="2VODD2" />
+      </concept>
+      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
+        <property id="1070475926801" name="value" index="Xl_RC" />
+      </concept>
+      <concept id="1070534934090" name="jetbrains.mps.baseLanguage.structure.CastExpression" flags="nn" index="10QFUN">
+        <child id="1070534934091" name="type" index="10QFUM" />
+        <child id="1070534934092" name="expression" index="10QFUP" />
+      </concept>
+      <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
+        <child id="1068580123160" name="condition" index="3clFbw" />
+        <child id="1068580123161" name="ifTrue" index="3clFbx" />
+      </concept>
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1079359253375" name="jetbrains.mps.baseLanguage.structure.ParenthesizedExpression" flags="nn" index="1eOMI4">
+        <child id="1079359253376" name="expression" index="1eOMHV" />
+      </concept>
+      <concept id="1081516740877" name="jetbrains.mps.baseLanguage.structure.NotExpression" flags="nn" index="3fqX7Q">
+        <child id="1081516765348" name="expression" index="3fr31v" />
+      </concept>
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+      </concept>
+      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
+        <child id="1081773367579" name="rightExpression" index="3uHU7w" />
+        <child id="1081773367580" name="leftExpression" index="3uHU7B" />
+      </concept>
+      <concept id="6329021646629104957" name="jetbrains.mps.baseLanguage.structure.TextCommentPart" flags="nn" index="3SKdUq">
+        <property id="6329021646629104958" name="text" index="3SKdUp" />
+      </concept>
+      <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="nn" index="3SKdUt">
+        <child id="6329021646629175155" name="commentPart" index="3SKWNk" />
+      </concept>
+      <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
+    </language>
+    <language id="7a5dda62-9140-4668-ab76-d5ed1746f2b2" name="jetbrains.mps.lang.typesystem">
+      <concept id="1175517767210" name="jetbrains.mps.lang.typesystem.structure.ReportErrorStatement" flags="nn" index="2MkqsV">
+        <child id="1175517851849" name="errorString" index="2MkJ7o" />
+      </concept>
+      <concept id="1227096774658" name="jetbrains.mps.lang.typesystem.structure.MessageStatement" flags="ng" index="2OEH$v">
+        <child id="1227096802791" name="helginsIntention" index="2OEOjU" />
+        <child id="1227096802790" name="nodeToReport" index="2OEOjV" />
+      </concept>
+      <concept id="1216383170661" name="jetbrains.mps.lang.typesystem.structure.TypesystemQuickFix" flags="ng" index="Q5z_Y">
+        <child id="1216383424566" name="executeBlock" index="Q6x$H" />
+        <child id="1216391046856" name="descriptionBlock" index="QzAvj" />
+      </concept>
+      <concept id="1216383287005" name="jetbrains.mps.lang.typesystem.structure.QuickFixExecuteBlock" flags="in" index="Q5ZZ6" />
+      <concept id="1216383337216" name="jetbrains.mps.lang.typesystem.structure.ConceptFunctionParameter_node" flags="nn" index="Q6c8r" />
+      <concept id="1216390987552" name="jetbrains.mps.lang.typesystem.structure.QuickFixDescriptionBlock" flags="in" index="QznSV" />
+      <concept id="1195213580585" name="jetbrains.mps.lang.typesystem.structure.AbstractCheckingRule" flags="ig" index="18hYwZ">
+        <child id="1195213635060" name="body" index="18ibNy" />
+      </concept>
+      <concept id="1195214364922" name="jetbrains.mps.lang.typesystem.structure.NonTypesystemRule" flags="ig" index="18kY7G" />
+      <concept id="1210784285454" name="jetbrains.mps.lang.typesystem.structure.TypesystemIntention" flags="ng" index="3Cnw8n">
+        <property id="1216127910019" name="applyImmediately" index="ARO6o" />
+        <reference id="1216388525179" name="quickFix" index="QpYPw" />
+      </concept>
+      <concept id="1174642788531" name="jetbrains.mps.lang.typesystem.structure.ConceptReference" flags="ig" index="1YaCAy">
+        <reference id="1174642800329" name="concept" index="1YaFvo" />
+      </concept>
+      <concept id="1174648085619" name="jetbrains.mps.lang.typesystem.structure.AbstractRule" flags="ng" index="1YuPPy">
+        <child id="1174648101952" name="applicableNode" index="1YuTPh" />
+      </concept>
+      <concept id="1174650418652" name="jetbrains.mps.lang.typesystem.structure.ApplicableNodeReference" flags="nn" index="1YBJjd">
+        <reference id="1174650432090" name="applicableNode" index="1YBMHb" />
+      </concept>
+    </language>
+    <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
+      <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
+        <reference id="1138405853777" name="concept" index="ehGHo" />
+      </concept>
+      <concept id="1138056022639" name="jetbrains.mps.lang.smodel.structure.SPropertyAccess" flags="nn" index="3TrcHB">
+        <reference id="1138056395725" name="property" index="3TsBF5" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="18kY7G" id="7r9XsdeqjUf">
+    <property role="TrG5h" value="check_ImageWord" />
+    <property role="3GE5qa" value="words" />
+    <node concept="3clFbS" id="7r9XsdeqjUg" role="18ibNy">
+      <node concept="3clFbJ" id="JJxXu1sHvy" role="3cqZAp">
+        <node concept="3clFbS" id="JJxXu1sHv$" role="3clFbx">
+          <node concept="3SKdUt" id="7r9Xsdeqto9" role="3cqZAp">
+            <node concept="3SKdUq" id="7r9Xsdeqtob" role="3SKWNk">
+              <property role="3SKdUp" value="because the editing guide is shown in a temporary model, CellModel_Image cannot find the original module" />
+            </node>
+          </node>
+          <node concept="3SKdUt" id="7r9Xsdequcj" role="3cqZAp">
+            <node concept="3SKdUq" id="7r9Xsdequcl" role="3SKWNk">
+              <property role="3SKdUp" value="for the image =&gt;" />
+            </node>
+            <node concept="3SKdUq" id="7r9Xsdequc2" role="3SKWNk">
+              <property role="3SKdUp" value="developer must specify the module explicitly (automated with quick fix)" />
+            </node>
+          </node>
+          <node concept="2MkqsV" id="7r9XsdeqnpY" role="3cqZAp">
+            <node concept="3Cnw8n" id="7r9XsdeqvpW" role="2OEOjU">
+              <property role="ARO6o" value="true" />
+              <ref role="QpYPw" node="7r9Xsdeqvpo" resolve="fix_ImageWordNoModuleId" />
+            </node>
+            <node concept="Xl_RD" id="7r9XsdeqnqP" role="2MkJ7o">
+              <property role="Xl_RC" value="moduleId must be set if path to image is relative to ${module}" />
+            </node>
+            <node concept="1YBJjd" id="7r9Xsdeqnqa" role="2OEOjV">
+              <ref role="1YBMHb" node="7r9XsdeqjUi" resolve="imageWord" />
+            </node>
+          </node>
+        </node>
+        <node concept="1Wc70l" id="JJxXu1sLDc" role="3clFbw">
+          <node concept="3fqX7Q" id="JJxXu1sN_1" role="3uHU7w">
+            <node concept="2OqwBi" id="JJxXu1sN_3" role="3fr31v">
+              <node concept="1YBJjd" id="JJxXu1sN_4" role="2Oq$k0">
+                <ref role="1YBMHb" node="7r9XsdeqjUi" resolve="imageWord" />
+              </node>
+              <node concept="2qgKlT" id="JJxXu1sN_5" role="2OqNvi">
+                <ref role="37wK5l" to="l4gp:7r9XsdeqP8E" resolve="isModuleIdValid" />
+              </node>
+            </node>
+          </node>
+          <node concept="1Wc70l" id="JJxXu1sJd0" role="3uHU7B">
+            <node concept="3fqX7Q" id="JJxXu1sIaD" role="3uHU7B">
+              <node concept="2OqwBi" id="JJxXu1sIaF" role="3fr31v">
+                <node concept="1YBJjd" id="JJxXu1sIaG" role="2Oq$k0">
+                  <ref role="1YBMHb" node="7r9XsdeqjUi" resolve="imageWord" />
+                </node>
+                <node concept="2qgKlT" id="JJxXu1sIaH" role="2OqNvi">
+                  <ref role="37wK5l" to="l4gp:JJxXu1sAqb" resolve="isEditingGuideActive" />
+                </node>
+              </node>
+            </node>
+            <node concept="2OqwBi" id="JJxXu1sKg7" role="3uHU7w">
+              <node concept="1YBJjd" id="JJxXu1sK0l" role="2Oq$k0">
+                <ref role="1YBMHb" node="7r9XsdeqjUi" resolve="imageWord" />
+              </node>
+              <node concept="2qgKlT" id="JJxXu1sK_l" role="2OqNvi">
+                <ref role="37wK5l" to="l4gp:JJxXu1sw3o" resolve="isModuleIdRequired" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1YaCAy" id="7r9XsdeqjUi" role="1YuTPh">
+      <property role="TrG5h" value="imageWord" />
+      <ref role="1YaFvo" to="k8go:2Sndli4jFPI" resolve="ImageWord" />
+    </node>
+  </node>
+  <node concept="Q5z_Y" id="7r9Xsdeqvpo">
+    <property role="3GE5qa" value="words" />
+    <property role="TrG5h" value="fix_ImageWordNoModuleId" />
+    <node concept="Q5ZZ6" id="7r9Xsdeqvpp" role="Q6x$H">
+      <node concept="3clFbS" id="7r9Xsdeqvpq" role="2VODD2">
+        <node concept="3clFbF" id="7r9XsdeqFg5" role="3cqZAp">
+          <node concept="37vLTI" id="7r9XsdeqGj9" role="3clFbG">
+            <node concept="2OqwBi" id="7r9XsdeqFzE" role="37vLTJ">
+              <node concept="1eOMI4" id="7r9XsdeqFg3" role="2Oq$k0">
+                <node concept="10QFUN" id="7r9XsdeqFg0" role="1eOMHV">
+                  <node concept="3Tqbb2" id="7r9XsdeqFjc" role="10QFUM">
+                    <ref role="ehGHo" to="k8go:2Sndli4jFPI" resolve="ImageWord" />
+                  </node>
+                  <node concept="Q6c8r" id="7r9XsdeqFm2" role="10QFUP" />
+                </node>
+              </node>
+              <node concept="3TrcHB" id="7r9XsdeqFO6" role="2OqNvi">
+                <ref role="3TsBF5" to="k8go:55ShMBE4VYH" resolve="moduleId" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="55ShMBE5dyc" role="37vLTx">
+              <node concept="2OqwBi" id="55ShMBE5dyd" role="2Oq$k0">
+                <node concept="2OqwBi" id="JJxXu1sOHD" role="2Oq$k0">
+                  <node concept="2qgKlT" id="JJxXu1sPiL" role="2OqNvi">
+                    <ref role="37wK5l" to="l4gp:7r9XsdeqO$Z" resolve="getModule" />
+                  </node>
+                  <node concept="1eOMI4" id="JJxXu1sOYd" role="2Oq$k0">
+                    <node concept="10QFUN" id="JJxXu1sOYe" role="1eOMHV">
+                      <node concept="3Tqbb2" id="JJxXu1sOYf" role="10QFUM">
+                        <ref role="ehGHo" to="k8go:2Sndli4jFPI" resolve="ImageWord" />
+                      </node>
+                      <node concept="Q6c8r" id="JJxXu1sOYg" role="10QFUP" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="liA8E" id="55ShMBE5dym" role="2OqNvi">
+                  <ref role="37wK5l" to="lui2:~SModule.getModuleId():org.jetbrains.mps.openapi.module.SModuleId" resolve="getModuleId" />
+                </node>
+              </node>
+              <node concept="liA8E" id="55ShMBE5dyn" role="2OqNvi">
+                <ref role="37wK5l" to="wyt6:~Object.toString():java.lang.String" resolve="toString" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="QznSV" id="7r9XsdeqvwT" role="QzAvj">
+      <node concept="3clFbS" id="7r9XsdeqvwU" role="2VODD2">
+        <node concept="3clFbF" id="7r9XsdeqxEj" role="3cqZAp">
+          <node concept="Xl_RD" id="55ShMBE3bvP" role="3clFbG">
+            <property role="Xl_RC" value="Set Module Id" />
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
 </model>
 

--- a/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.editingGuide.execution/com.mbeddr.mpsutil.editingGuide.execution.msd
+++ b/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.editingGuide.execution/com.mbeddr.mpsutil.editingGuide.execution.msd
@@ -51,6 +51,7 @@
     <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
     <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
     <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
+    <module reference="982eb8df-2c96-4bd7-9963-11712ea622e5(jetbrains.mps.lang.resources)" version="0" />
     <module reference="9ded098b-ad6a-4657-bfd9-48636cfe8bc3(jetbrains.mps.lang.traceable)" version="0" />
   </dependencyVersions>
 </solution>

--- a/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.editingGuide.plugin/com.mbeddr.mpsutil.editingGuide.plugin.msd
+++ b/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.editingGuide.plugin/com.mbeddr.mpsutil.editingGuide.plugin.msd
@@ -37,6 +37,7 @@
     <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
     <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
     <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
+    <module reference="982eb8df-2c96-4bd7-9963-11712ea622e5(jetbrains.mps.lang.resources)" version="0" />
     <module reference="9ded098b-ad6a-4657-bfd9-48636cfe8bc3(jetbrains.mps.lang.traceable)" version="0" />
   </dependencyVersions>
 </solution>

--- a/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.editingGuide.runtime/models/com/mbeddr/mpsutil/editingGuide/runtime/rt.mps
+++ b/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.editingGuide.runtime/models/com/mbeddr/mpsutil/editingGuide/runtime/rt.mps
@@ -10,10 +10,13 @@
     <import index="mhbf" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.model(MPS.OpenAPI/)" />
     <import index="f4zo" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.cells(MPS.Editor/)" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" />
+    <import index="lui2" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.module(MPS.OpenAPI/)" />
+    <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1080223426719" name="jetbrains.mps.baseLanguage.structure.OrExpression" flags="nn" index="22lmx$" />
       <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
         <child id="1068498886297" name="rValue" index="37vLTx" />
         <child id="1068498886295" name="lValue" index="37vLTJ" />
@@ -21,6 +24,9 @@
       <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
       <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="ng" index="2tJIrI" />
+      <concept id="1076505808687" name="jetbrains.mps.baseLanguage.structure.WhileStatement" flags="nn" index="2$JKZl">
+        <child id="1076505808688" name="condition" index="2$JKZa" />
+      </concept>
       <concept id="1188207840427" name="jetbrains.mps.baseLanguage.structure.AnnotationInstance" flags="nn" index="2AHcQZ">
         <reference id="1188208074048" name="annotation" index="2AI5Lk" />
       </concept>
@@ -67,6 +73,8 @@
         <child id="5680397130376446158" name="type" index="1tU5fm" />
       </concept>
       <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
+        <property id="4276006055363816570" name="isSynchronized" index="od$2w" />
+        <property id="1181808852946" name="isFinal" index="DiZV1" />
         <child id="1068580123133" name="returnType" index="3clF45" />
         <child id="1068580123134" name="parameter" index="3clF46" />
         <child id="1068580123135" name="body" index="3clF47" />
@@ -74,9 +82,11 @@
       <concept id="1068580123165" name="jetbrains.mps.baseLanguage.structure.InstanceMethodDeclaration" flags="ig" index="3clFb_">
         <property id="1178608670077" name="isAbstract" index="1EzhhJ" />
       </concept>
+      <concept id="1068580123152" name="jetbrains.mps.baseLanguage.structure.EqualsExpression" flags="nn" index="3clFbC" />
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
+      <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
       <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
         <child id="1068580123160" name="condition" index="3clFbw" />
         <child id="1068580123161" name="ifTrue" index="3clFbx" />
@@ -96,6 +106,9 @@
       </concept>
       <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
       <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
+      <concept id="1079359253375" name="jetbrains.mps.baseLanguage.structure.ParenthesizedExpression" flags="nn" index="1eOMI4">
+        <child id="1079359253376" name="expression" index="1eOMHV" />
+      </concept>
       <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
@@ -104,9 +117,13 @@
       <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
         <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
       </concept>
+      <concept id="7812454656619025416" name="jetbrains.mps.baseLanguage.structure.MethodDeclaration" flags="ng" index="1rXfSm">
+        <property id="8355037393041754995" name="isNative" index="2aFKle" />
+      </concept>
       <concept id="7812454656619025412" name="jetbrains.mps.baseLanguage.structure.LocalMethodCall" flags="nn" index="1rXfSq" />
       <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
         <reference id="1107535924139" name="classifier" index="3uigEE" />
+        <child id="1109201940907" name="parameter" index="11_B2D" />
       </concept>
       <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
         <child id="1081773367579" name="rightExpression" index="3uHU7w" />
@@ -978,6 +995,137 @@
       </node>
     </node>
     <node concept="2tJIrI" id="2ZHlC0034Ci" role="jymVt" />
+    <node concept="2YIFZL" id="55ShMBE4Gnh" role="jymVt">
+      <property role="TrG5h" value="findSModuleByID" />
+      <property role="od$2w" value="false" />
+      <property role="DiZV1" value="false" />
+      <property role="2aFKle" value="false" />
+      <node concept="3clFbS" id="55ShMBE4Gnk" role="3clF47">
+        <node concept="3clFbJ" id="7r9XsdeqDcO" role="3cqZAp">
+          <node concept="3clFbS" id="7r9XsdeqDcQ" role="3clFbx">
+            <node concept="3cpWs6" id="7r9XsdeqDDU" role="3cqZAp">
+              <node concept="10Nm6u" id="7r9XsdeqDFz" role="3cqZAk" />
+            </node>
+          </node>
+          <node concept="22lmx$" id="7r9XsdeqMU9" role="3clFbw">
+            <node concept="1eOMI4" id="7r9XsdeqNtu" role="3uHU7w">
+              <node concept="3clFbC" id="7r9XsdeqNQv" role="1eOMHV">
+                <node concept="10Nm6u" id="7r9XsdeqO1i" role="3uHU7w" />
+                <node concept="37vLTw" id="7r9XsdeqN3d" role="3uHU7B">
+                  <ref role="3cqZAo" node="55ShMBE4LTB" resolve="moduleId" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbC" id="7r9XsdeqDxb" role="3uHU7B">
+              <node concept="37vLTw" id="7r9XsdeqDkC" role="3uHU7B">
+                <ref role="3cqZAo" node="55ShMBE4Gtv" resolve="repo" />
+              </node>
+              <node concept="10Nm6u" id="7r9XsdeqDyB" role="3uHU7w" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="7r9XsdeqDLr" role="3cqZAp" />
+        <node concept="3cpWs8" id="55ShMBE4HEN" role="3cqZAp">
+          <node concept="3cpWsn" id="55ShMBE4HEO" role="3cpWs9">
+            <property role="TrG5h" value="it" />
+            <node concept="3uibUv" id="55ShMBE4HEL" role="1tU5fm">
+              <ref role="3uigEE" to="33ny:~Iterator" resolve="Iterator" />
+              <node concept="3uibUv" id="55ShMBE4HGN" role="11_B2D">
+                <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="55ShMBE4GZl" role="33vP2m">
+              <node concept="2OqwBi" id="55ShMBE4GLH" role="2Oq$k0">
+                <node concept="37vLTw" id="55ShMBE4GGb" role="2Oq$k0">
+                  <ref role="3cqZAo" node="55ShMBE4Gtv" resolve="repo" />
+                </node>
+                <node concept="liA8E" id="55ShMBE4GRz" role="2OqNvi">
+                  <ref role="37wK5l" to="lui2:~SRepository.getModules():java.lang.Iterable" resolve="getModules" />
+                </node>
+              </node>
+              <node concept="liA8E" id="55ShMBE4Hb2" role="2OqNvi">
+                <ref role="37wK5l" to="wyt6:~Iterable.iterator():java.util.Iterator" resolve="iterator" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2$JKZl" id="55ShMBE4GvV" role="3cqZAp">
+          <node concept="3clFbS" id="55ShMBE4GvW" role="2LFqv$">
+            <node concept="3cpWs8" id="55ShMBE4KaH" role="3cqZAp">
+              <node concept="3cpWsn" id="55ShMBE4KaI" role="3cpWs9">
+                <property role="TrG5h" value="module" />
+                <node concept="3uibUv" id="55ShMBE4KaJ" role="1tU5fm">
+                  <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
+                </node>
+                <node concept="2OqwBi" id="55ShMBE4JMp" role="33vP2m">
+                  <node concept="37vLTw" id="55ShMBE4JCe" role="2Oq$k0">
+                    <ref role="3cqZAo" node="55ShMBE4HEO" resolve="it" />
+                  </node>
+                  <node concept="liA8E" id="55ShMBE4JWG" role="2OqNvi">
+                    <ref role="37wK5l" to="33ny:~Iterator.next():java.lang.Object" resolve="next" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbJ" id="55ShMBE4Jsb" role="3cqZAp">
+              <node concept="3clFbS" id="55ShMBE4Jsd" role="3clFbx">
+                <node concept="3cpWs6" id="55ShMBE4MkJ" role="3cqZAp">
+                  <node concept="37vLTw" id="55ShMBE4Mse" role="3cqZAk">
+                    <ref role="3cqZAo" node="55ShMBE4KaI" resolve="module" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2OqwBi" id="55ShMBE4KZg" role="3clFbw">
+                <node concept="2OqwBi" id="55ShMBE5mwv" role="2Oq$k0">
+                  <node concept="2OqwBi" id="55ShMBE4KyL" role="2Oq$k0">
+                    <node concept="37vLTw" id="55ShMBE4KqJ" role="2Oq$k0">
+                      <ref role="3cqZAo" node="55ShMBE4KaI" resolve="module" />
+                    </node>
+                    <node concept="liA8E" id="55ShMBE4KD6" role="2OqNvi">
+                      <ref role="37wK5l" to="lui2:~SModule.getModuleId():org.jetbrains.mps.openapi.module.SModuleId" resolve="getModuleId" />
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="55ShMBE5mRb" role="2OqNvi">
+                    <ref role="37wK5l" to="wyt6:~Object.toString():java.lang.String" resolve="toString" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="55ShMBE4LMm" role="2OqNvi">
+                  <ref role="37wK5l" to="wyt6:~String.equals(java.lang.Object):boolean" resolve="equals" />
+                  <node concept="37vLTw" id="55ShMBE4M0C" role="37wK5m">
+                    <ref role="3cqZAo" node="55ShMBE4LTB" resolve="moduleId" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="55ShMBE4I5e" role="2$JKZa">
+            <node concept="37vLTw" id="55ShMBE4HTV" role="2Oq$k0">
+              <ref role="3cqZAo" node="55ShMBE4HEO" resolve="it" />
+            </node>
+            <node concept="liA8E" id="55ShMBE4Iq1" role="2OqNvi">
+              <ref role="37wK5l" to="33ny:~Iterator.hasNext():boolean" resolve="hasNext" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="55ShMBE4MBh" role="3cqZAp">
+          <node concept="10Nm6u" id="55ShMBE4MD7" role="3cqZAk" />
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="55ShMBE4GeR" role="1B3o_S" />
+      <node concept="3uibUv" id="55ShMBE4Gms" role="3clF45">
+        <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
+      </node>
+      <node concept="37vLTG" id="55ShMBE4Gtv" role="3clF46">
+        <property role="TrG5h" value="repo" />
+        <node concept="3uibUv" id="55ShMBE4Gtu" role="1tU5fm">
+          <ref role="3uigEE" to="lui2:~SRepository" resolve="SRepository" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="55ShMBE4LTB" role="3clF46">
+        <property role="TrG5h" value="moduleId" />
+        <node concept="17QB3L" id="7r9XsdepSaO" role="1tU5fm" />
+      </node>
+    </node>
     <node concept="3Tm1VV" id="2ZHlC0034C2" role="1B3o_S" />
   </node>
 </model>

--- a/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.editingGuide.sandbox/com.mbeddr.mpsutil.editingGuide.sandbox.msd
+++ b/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.editingGuide.sandbox/com.mbeddr.mpsutil.editingGuide.sandbox.msd
@@ -19,6 +19,7 @@
     <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="0" />
     <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="1" />
     <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
+    <language slang="l:982eb8df-2c96-4bd7-9963-11712ea622e5:jetbrains.mps.lang.resources" version="2" />
     <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="11" />
     <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
   </languageVersions>


### PR DESCRIPTION
Added ImageWord (extends IWord) to insert images in richtexts in the editing guide. The solution is exclusive for the editing guide, because it is opened in a temporary model, which makes it a bit tricky to store+resolve the path to the image resource. The implementation is based on the default image cell from jetbrains.