### PR TITLE
Local builds are now $major.$minor-SNAPSHOT

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,8 +65,8 @@ subprojects {
             ext.mbeddrBuildNumber = GitBasedVersioning.getVersion(mbeddrBuild, mbeddrMajor, mbeddrMinor, mbeddrBuildCounter)
             println "##teamcity[buildNumber '${mbeddrBuildNumber}']"
         } else {
-            println "Local build detected. Build will be a SNAPSHOT."
-            ext.mbeddrBuildNumber = "1.0-SNAPSHOT"
+            ext.mbeddrBuildNumber = "${ext.mbeddrMajor}.${ext.mbeddrMinor}-SNAPSHOT"
+            println "Local build detected. Build will have version $ext.mbeddrBuildNumber"
         }
     }
 }


### PR DESCRIPTION
- used to be fixed 1.0-SNAPSHOT
- log the built version

That would be consistent with iets3.core then: https://github.com/IETS3/iets3.core/blob/master/build.gradle#L42

Does anyone have local automation that could break with it?