### PR TITLE
 Added "Contributing to the mbeddr.platform" to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,23 @@ mbeddr aims at creating a different way of developing embedded software systems.
 At this point we are well ahead in developing an implementation of C in MPS which can then be used as a basis for domain-specific extensions. The development progress can be see from our [blog page](http://mbeddr.com/blog/).
 
 For more details please visit http://mbeddr.com
+
+
+# Contributing to the mbeddr.platform
+
+To contribute your module to the mbeddr platform for reuse, you probably want to add it to the mps utils (`com.mbeddr.mpsutils`). After some incubation time, it may be considered to move it to the MPS-extensions, if the motivation, and implementation have grown mature.
+
+- name your language "com.mbeddr.mpsutil.$yourLanguageName"
+- add it to the MPS project in `code/languages/com.mbeddr.mpsutil` inside a virtual folder "$yourLanguageName"
+- all dedicated modules (like the ones you create below) should go into this virtual folder "$yourLanguageName"
+- add a test solution with automated tests, named "test.com.mbeddr.mpsutil.$yourLanguageName" and make sure they pass
+- if your module is an extension to an MPS language
+     - add a language named "com.mbeddr.mpsutil.$yourLanguageName.sandbox" that demos how to use your language
+     - add a "com.mbeddr.mpsutil.$yourLanguageName.sandbox.sandbox" solution that demonstrates the effect of what the sandbox language implemented
+- open the MPS project "code/languages/com.mbeddr.build"
+    - open the build script at "com.mbeddr.dev" named "com.mbeddr.platform"
+    - add a group named "group.$yourLanguageName"
+    - add a plugin that bundles your extension based on this group with the needed dependencies
+    - add your plugin to the default layout
+    - open the test build script at "com.mbeddr.dev" named "testssssss?" and add your tests
+- run the build locally with `./gradlew publishMbeddrPlatformPublicationToMavenLocal` and check if your project functions with it

--- a/README.md
+++ b/README.md
@@ -22,9 +22,12 @@ To contribute your module to the mbeddr platform for reuse, you probably want to
      - add a language named "com.mbeddr.mpsutil.$yourLanguageName.sandbox" that demos how to use your language
      - add a "com.mbeddr.mpsutil.$yourLanguageName.sandbox.sandbox" solution that demonstrates the effect of what the sandbox language implemented
 - open the MPS project "code/languages/com.mbeddr.build"
-    - open the build script at "com.mbeddr.dev" named "com.mbeddr.platform"
+    - open the build script at "com.mbeddr.platform" named "com.mbeddr.platform"
     - add a group named "group.$yourLanguageName"
     - add a plugin that bundles your extension based on this group with the needed dependencies
     - add your plugin to the default layout
-    - open the test build script at "com.mbeddr.dev" named "testssssss?" and add your tests
+    - open the test build script at "platform/com.mbeddr.platform/com.mbeddr.platform.mpsutils.ts.tests.build" and add your tests
+    - add your test solution and its dependencies to the group "com.mbeddr.platform.tests"
+    - add it to the default layout
+    - add it to the test modules configuration
 - run the build locally with `./gradlew publishMbeddrPlatformPublicationToMavenLocal` and check if your project functions with it


### PR DESCRIPTION
- I wrote down what I identified as needed steps to contribute to mpsutils throughout interviewing @slisson and @coolya 
- didn't find a good naming convention for solutions that demo the results of a sandbox language, best hit: mylanguage.sandbox.sandbox (since it is the sandbox for the sandbox language…)

- maybe it would make sense to leave out the detail steps on build script and test script, since they'll outdate quickly. On the other hand, having such would be a great help to get it right even if not entirely correct anymore.
- maybe we can build a checklist out of that as default PR content?