### PR TITLE
build: fixed maintenance branch versioning

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,7 +59,7 @@ subprojects {
             } else {
                 ext.mbeddrBuildCounter = GitBasedVersioning.getGitCommitCount()
             }
-            if(mbeddrBuild == "stable") {
+            if(mbeddrBuild == "stable" || mbeddrBuild.startsWith("maintenance")) {
                 mbeddrBuild = "master"
             }
             ext.mbeddrBuildNumber = GitBasedVersioning.getVersion(mbeddrBuild, mbeddrMajor, mbeddrMinor, mbeddrBuildCounter)


### PR DESCRIPTION
I am not sure if this is the optimal solution. However, should fix the problem that the artifacts built from maintenance version have the branch name as a  prefix. We need to fix this so that we can use the agreed "1.1.+" version specifier to get the latest platform.