### PR TITLE
c.m.m.e.QueryList: catch INSERT in front of a QueryList

### DIFF
--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.editor.querylist.demolang/languageModels/editor.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.editor.querylist.demolang/languageModels/editor.mps
@@ -3,7 +3,8 @@
   <persistence version="9" />
   <languages>
     <use id="120e1c9d-4e27-4478-b2af-b2c3bd3850b0" name="com.mbeddr.mpsutil.editor.querylist" version="-1" />
-    <use id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor" version="12" />
+    <use id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor" version="-1" />
+    <use id="aee9cad2-acd4-4608-aef2-0004f6a1cdbd" name="jetbrains.mps.lang.actions" version="-1" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
@@ -36,6 +37,7 @@
         <child id="1080736633877" name="cellModel" index="2wV5jI" />
       </concept>
       <concept id="795210086017940429" name="jetbrains.mps.lang.editor.structure.ReadOnlyStyleClassItem" flags="lg" index="xShMh" />
+      <concept id="1186403751766" name="jetbrains.mps.lang.editor.structure.FontStyleStyleClassItem" flags="ln" index="Vb9p2" />
       <concept id="1186414536763" name="jetbrains.mps.lang.editor.structure.BooleanStyleSheetItem" flags="ln" index="VOi$J">
         <property id="1186414551515" name="flag" index="VOm3f" />
       </concept>
@@ -235,6 +237,10 @@
       <concept id="147976780035556419" name="com.mbeddr.mpsutil.editor.querylist.structure.Parameter_QueryLinkListData" flags="ng" index="3N2NLr" />
       <concept id="147976780035550100" name="com.mbeddr.mpsutil.editor.querylist.structure.Function_LoadQueryLinkListData" flags="ng" index="3N2Xec" />
     </language>
+    <language id="aee9cad2-acd4-4608-aef2-0004f6a1cdbd" name="jetbrains.mps.lang.actions">
+      <concept id="767145758118872824" name="jetbrains.mps.lang.actions.structure.NF_Node_InsertNewNextSiblingOperation" flags="nn" index="2DeJnS" />
+      <concept id="767145758118872826" name="jetbrains.mps.lang.actions.structure.NF_Node_InsertNewPrevSiblingOperation" flags="nn" index="2DeJnU" />
+    </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
       <concept id="1226359078165" name="jetbrains.mps.lang.smodel.structure.LinkRefExpression" flags="nn" index="28GBK8">
         <reference id="1226359078166" name="conceptDeclaration" index="28GBKb" />
@@ -251,6 +257,9 @@
       <concept id="2396822768958367367" name="jetbrains.mps.lang.smodel.structure.AbstractTypeCastExpression" flags="nn" index="$5XWr">
         <child id="6733348108486823193" name="leftExpression" index="1m5AlR" />
         <child id="3906496115198199033" name="conceptArgument" index="3oSUPX" />
+      </concept>
+      <concept id="1143221076066" name="jetbrains.mps.lang.smodel.structure.Node_InsertNewPrevSiblingOperation" flags="nn" index="Hik5C">
+        <reference id="1143221076069" name="concept" index="Hik5J" />
       </concept>
       <concept id="1143224066846" name="jetbrains.mps.lang.smodel.structure.Node_InsertNextSiblingOperation" flags="nn" index="HtI8k">
         <child id="1143224066849" name="insertedNode" index="HtI8F" />
@@ -275,11 +284,15 @@
         <reference id="2644386474301421079" name="linkDeclaration" index="359W_F" />
       </concept>
       <concept id="1139613262185" name="jetbrains.mps.lang.smodel.structure.Node_GetParentOperation" flags="nn" index="1mfA1w" />
+      <concept id="1172008320231" name="jetbrains.mps.lang.smodel.structure.Node_IsNotNullOperation" flags="nn" index="3x8VRR" />
       <concept id="1144101972840" name="jetbrains.mps.lang.smodel.structure.OperationParm_Concept" flags="ng" index="1xMEDy">
         <child id="1207343664468" name="conceptArgument" index="ri$Ld" />
       </concept>
       <concept id="1180636770613" name="jetbrains.mps.lang.smodel.structure.SNodeCreator" flags="nn" index="3zrR0B">
         <child id="1180636770616" name="createdType" index="3zrR0E" />
+      </concept>
+      <concept id="1139858892567" name="jetbrains.mps.lang.smodel.structure.Node_InsertNewNextSiblingOperation" flags="nn" index="1$SAou">
+        <reference id="1139858951584" name="concept" index="1$SOMD" />
       </concept>
       <concept id="1140137987495" name="jetbrains.mps.lang.smodel.structure.SNodeTypeCastExpression" flags="nn" index="1PxgMI" />
       <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
@@ -315,6 +328,7 @@
         <child id="1224414456414" name="elementType" index="kMuH3" />
       </concept>
       <concept id="1151702311717" name="jetbrains.mps.baseLanguage.collections.structure.ToListOperation" flags="nn" index="ANE8D" />
+      <concept id="1227022159410" name="jetbrains.mps.baseLanguage.collections.structure.AddFirstElementOperation" flags="nn" index="2Ke4WJ" />
       <concept id="1203518072036" name="jetbrains.mps.baseLanguage.collections.structure.SmartClosureParameterDeclaration" flags="ig" index="Rh6nW" />
       <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="nn" index="TSZUe" />
       <concept id="1165525191778" name="jetbrains.mps.baseLanguage.collections.structure.GetFirstOperation" flags="nn" index="1uHKPH" />
@@ -1534,6 +1548,238 @@
         <ref role="1NtTu8" to="gei:lPJxikhi71" resolve="statement" />
       </node>
       <node concept="2iRfu4" id="5wsE7kXaqYk" role="2iSdaV" />
+    </node>
+  </node>
+  <node concept="24kQdi" id="1GpxVmAerDU">
+    <ref role="1XX52x" to="gei:1GpxVmAerDt" resolve="RootWithChildren" />
+    <node concept="3EZMnI" id="1GpxVmAerDW" role="2wV5jI">
+      <node concept="3F0ifn" id="1GpxVmAerE6" role="3EZMnx">
+        <property role="3F0ifm" value="Manual Test 1: QueryList First" />
+      </node>
+      <node concept="3F0ifn" id="1GpxVmAerP1" role="3EZMnx">
+        <property role="3F0ifm" value="Focus this and hit return. What gets created?" />
+        <node concept="Vb9p2" id="1GpxVmAerQu" role="3F10Kt" />
+      </node>
+      <node concept="3EZMnI" id="1GpxVmAerEf" role="3EZMnx">
+        <node concept="3EZMnI" id="1GpxVmAerEr" role="3EZMnx">
+          <node concept="VPM3Z" id="1GpxVmAerEt" role="3F10Kt">
+            <property role="VOm3f" value="false" />
+          </node>
+          <node concept="3F0ifn" id="1GpxVmAerEv" role="3EZMnx">
+            <property role="3F0ifm" value="QueryList of names1" />
+          </node>
+          <node concept="s8t4o" id="1GpxVmAerEP" role="3EZMnx">
+            <property role="28Zw97" value="true" />
+            <ref role="28F8cf" to="tpee:f$Xl_Og" resolve="StringLiteral" />
+            <node concept="s8sZD" id="1GpxVmAerES" role="sbcd9">
+              <node concept="3clFbS" id="1GpxVmAerET" role="2VODD2">
+                <node concept="3clFbF" id="1GpxVmAes5D" role="3cqZAp">
+                  <node concept="2OqwBi" id="1GpxVmAeshh" role="3clFbG">
+                    <node concept="pncrf" id="1GpxVmAes5C" role="2Oq$k0" />
+                    <node concept="3Tsc0h" id="1GpxVmAesrH" role="2OqNvi">
+                      <ref role="3TtcxE" to="gei:1GpxVmAerDu" resolve="names1" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="ARxKT" id="1GpxVmAes$a" role="AS3tk">
+              <node concept="3clFbS" id="1GpxVmAes$b" role="2VODD2">
+                <node concept="3clFbJ" id="1GpxVmAesCB" role="3cqZAp">
+                  <node concept="2OqwBi" id="1GpxVmAet6C" role="3clFbw">
+                    <node concept="AS6u$" id="1GpxVmAesRZ" role="2Oq$k0" />
+                    <node concept="3x8VRR" id="1GpxVmAetEn" role="2OqNvi" />
+                  </node>
+                  <node concept="3clFbS" id="1GpxVmAesCD" role="3clFbx">
+                    <node concept="3clFbJ" id="1GpxVmAetGk" role="3cqZAp">
+                      <node concept="AVj8N" id="1GpxVmAetTz" role="3clFbw" />
+                      <node concept="3clFbS" id="1GpxVmAetGm" role="3clFbx">
+                        <node concept="3clFbF" id="1GpxVmAetUi" role="3cqZAp">
+                          <node concept="2OqwBi" id="1GpxVmAeu0Q" role="3clFbG">
+                            <node concept="AS6u$" id="1GpxVmAetUh" role="2Oq$k0" />
+                            <node concept="2DeJnU" id="1GpxVmAeBMp" role="2OqNvi">
+                              <ref role="Hik5J" to="tpee:f$Xl_Og" resolve="StringLiteral" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="9aQIb" id="1GpxVmAeCM5" role="9aQIa">
+                        <node concept="3clFbS" id="1GpxVmAeCM6" role="9aQI4">
+                          <node concept="3clFbF" id="1GpxVmAeDfo" role="3cqZAp">
+                            <node concept="2OqwBi" id="1GpxVmAeDfp" role="3clFbG">
+                              <node concept="AS6u$" id="1GpxVmAeDfq" role="2Oq$k0" />
+                              <node concept="2DeJnS" id="1GpxVmAeD$p" role="2OqNvi">
+                                <ref role="1$SOMD" to="tpee:f$Xl_Og" resolve="StringLiteral" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="9aQIb" id="1GpxVmAetxI" role="9aQIa">
+                    <node concept="3clFbS" id="1GpxVmAetxJ" role="9aQI4">
+                      <node concept="3clFbF" id="1GpxVmAeEgh" role="3cqZAp">
+                        <node concept="2OqwBi" id="1GpxVmAeGxg" role="3clFbG">
+                          <node concept="2OqwBi" id="1GpxVmAeESq" role="2Oq$k0">
+                            <node concept="pncrf" id="1GpxVmAeELg" role="2Oq$k0" />
+                            <node concept="3Tsc0h" id="1GpxVmAeF32" role="2OqNvi">
+                              <ref role="3TtcxE" to="gei:1GpxVmAerDu" resolve="names1" />
+                            </node>
+                          </node>
+                          <node concept="2Ke4WJ" id="1GpxVmAeI0a" role="2OqNvi">
+                            <node concept="2ShNRf" id="1GpxVmAeKhq" role="25WWJ7">
+                              <node concept="3zrR0B" id="1GpxVmAeM_G" role="2ShVmc">
+                                <node concept="3Tqbb2" id="1GpxVmAeM_I" role="3zrR0E">
+                                  <ref role="ehGHo" to="tpee:f$Xl_Og" resolve="StringLiteral" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="2iRkQZ" id="1GpxVmAgQp9" role="2czzBy" />
+          </node>
+          <node concept="2iRfu4" id="1GpxVmAerEw" role="2iSdaV" />
+        </node>
+        <node concept="3EZMnI" id="1GpxVmAerHF" role="3EZMnx">
+          <node concept="VPM3Z" id="1GpxVmAerHH" role="3F10Kt">
+            <property role="VOm3f" value="false" />
+          </node>
+          <node concept="3F0ifn" id="1GpxVmAerHJ" role="3EZMnx">
+            <property role="3F0ifm" value="RefNodeList of names2" />
+          </node>
+          <node concept="3F2HdR" id="1GpxVmAerIm" role="3EZMnx">
+            <ref role="1NtTu8" to="gei:1GpxVmAh8uH" resolve="names2" />
+            <node concept="2iRkQZ" id="1GpxVmAgTk0" role="2czzBx" />
+          </node>
+          <node concept="2iRfu4" id="1GpxVmAerHK" role="2iSdaV" />
+        </node>
+        <node concept="2iRkQZ" id="1GpxVmAerEi" role="2iSdaV" />
+        <node concept="lj46D" id="1GpxVmAg9a0" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+      <node concept="3F0ifn" id="1GpxVmAerIv" role="3EZMnx" />
+      <node concept="3F0ifn" id="1GpxVmAerJc" role="3EZMnx" />
+      <node concept="3F0ifn" id="1GpxVmAerJV" role="3EZMnx">
+        <property role="3F0ifm" value="Manual Test 2: RefNodeList First" />
+      </node>
+      <node concept="3F0ifn" id="1GpxVmAerUQ" role="3EZMnx">
+        <property role="3F0ifm" value="Focus this and hit return. What gets created?" />
+        <node concept="Vb9p2" id="1GpxVmAerUR" role="3F10Kt" />
+      </node>
+      <node concept="3EZMnI" id="1GpxVmAerLv" role="3EZMnx">
+        <node concept="3EZMnI" id="1GpxVmAerLG" role="3EZMnx">
+          <node concept="VPM3Z" id="1GpxVmAerLH" role="3F10Kt">
+            <property role="VOm3f" value="false" />
+          </node>
+          <node concept="3F0ifn" id="1GpxVmAerLI" role="3EZMnx">
+            <property role="3F0ifm" value="RefNodeList of names3" />
+          </node>
+          <node concept="3F2HdR" id="1GpxVmAerLJ" role="3EZMnx">
+            <ref role="1NtTu8" to="gei:1GpxVmAh8uM" resolve="names3" />
+            <node concept="2iRkQZ" id="1GpxVmAgTk4" role="2czzBx" />
+          </node>
+          <node concept="2iRfu4" id="1GpxVmAerLL" role="2iSdaV" />
+        </node>
+        <node concept="3EZMnI" id="1GpxVmAerLw" role="3EZMnx">
+          <node concept="VPM3Z" id="1GpxVmAerLx" role="3F10Kt">
+            <property role="VOm3f" value="false" />
+          </node>
+          <node concept="3F0ifn" id="1GpxVmAerLy" role="3EZMnx">
+            <property role="3F0ifm" value="QueryList of names4" />
+          </node>
+          <node concept="s8t4o" id="1GpxVmAerLz" role="3EZMnx">
+            <property role="28Zw97" value="true" />
+            <ref role="28F8cf" to="tpee:f$Xl_Og" resolve="StringLiteral" />
+            <node concept="s8sZD" id="1GpxVmAerL_" role="sbcd9">
+              <node concept="3clFbS" id="1GpxVmAerLA" role="2VODD2">
+                <node concept="3clFbF" id="1GpxVmAerLB" role="3cqZAp">
+                  <node concept="2OqwBi" id="1GpxVmAf2pm" role="3clFbG">
+                    <node concept="pncrf" id="1GpxVmAf2fk" role="2Oq$k0" />
+                    <node concept="3Tsc0h" id="1GpxVmAhks_" role="2OqNvi">
+                      <ref role="3TtcxE" to="gei:1GpxVmAh8uT" resolve="names4" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="ARxKT" id="1GpxVmAeXQ_" role="AS3tk">
+              <node concept="3clFbS" id="1GpxVmAeXQA" role="2VODD2">
+                <node concept="3clFbJ" id="1GpxVmAeXQB" role="3cqZAp">
+                  <node concept="2OqwBi" id="1GpxVmAeXQC" role="3clFbw">
+                    <node concept="AS6u$" id="1GpxVmAeXQD" role="2Oq$k0" />
+                    <node concept="3x8VRR" id="1GpxVmAeXQE" role="2OqNvi" />
+                  </node>
+                  <node concept="3clFbS" id="1GpxVmAeXQF" role="3clFbx">
+                    <node concept="3clFbJ" id="1GpxVmAeXQG" role="3cqZAp">
+                      <node concept="AVj8N" id="1GpxVmAeXQH" role="3clFbw" />
+                      <node concept="3clFbS" id="1GpxVmAeXQI" role="3clFbx">
+                        <node concept="3clFbF" id="1GpxVmAeXQJ" role="3cqZAp">
+                          <node concept="2OqwBi" id="1GpxVmAeXQK" role="3clFbG">
+                            <node concept="AS6u$" id="1GpxVmAeXQL" role="2Oq$k0" />
+                            <node concept="2DeJnU" id="1GpxVmAeXQM" role="2OqNvi">
+                              <ref role="Hik5J" to="tpee:f$Xl_Og" resolve="StringLiteral" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="9aQIb" id="1GpxVmAeXQN" role="9aQIa">
+                        <node concept="3clFbS" id="1GpxVmAeXQO" role="9aQI4">
+                          <node concept="3clFbF" id="1GpxVmAeXQP" role="3cqZAp">
+                            <node concept="2OqwBi" id="1GpxVmAeXQQ" role="3clFbG">
+                              <node concept="AS6u$" id="1GpxVmAeXQR" role="2Oq$k0" />
+                              <node concept="2DeJnS" id="1GpxVmAeXQS" role="2OqNvi">
+                                <ref role="1$SOMD" to="tpee:f$Xl_Og" resolve="StringLiteral" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="9aQIb" id="1GpxVmAeXQT" role="9aQIa">
+                    <node concept="3clFbS" id="1GpxVmAeXQU" role="9aQI4">
+                      <node concept="3clFbF" id="1GpxVmAeXQY" role="3cqZAp">
+                        <node concept="2OqwBi" id="1GpxVmAeXQZ" role="3clFbG">
+                          <node concept="2OqwBi" id="1GpxVmAeXR0" role="2Oq$k0">
+                            <node concept="pncrf" id="1GpxVmAeXR1" role="2Oq$k0" />
+                            <node concept="3Tsc0h" id="1GpxVmAhl5K" role="2OqNvi">
+                              <ref role="3TtcxE" to="gei:1GpxVmAh8uT" resolve="names4" />
+                            </node>
+                          </node>
+                          <node concept="2Ke4WJ" id="1GpxVmAeXR3" role="2OqNvi">
+                            <node concept="2ShNRf" id="1GpxVmAeXR4" role="25WWJ7">
+                              <node concept="3zrR0B" id="1GpxVmAeXR5" role="2ShVmc">
+                                <node concept="3Tqbb2" id="1GpxVmAeXR6" role="3zrR0E">
+                                  <ref role="ehGHo" to="tpee:f$Xl_Og" resolve="StringLiteral" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="2iRkQZ" id="1GpxVmAgTkn" role="2czzBy" />
+          </node>
+          <node concept="2iRfu4" id="1GpxVmAerLF" role="2iSdaV" />
+        </node>
+        <node concept="2iRkQZ" id="1GpxVmAerLM" role="2iSdaV" />
+        <node concept="lj46D" id="1GpxVmAgc2T" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+      <node concept="2iRkQZ" id="1GpxVmAerDZ" role="2iSdaV" />
     </node>
   </node>
 </model>

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.editor.querylist.demolang/languageModels/structure.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.editor.querylist.demolang/languageModels/structure.mps
@@ -91,5 +91,39 @@
       <ref role="20lvS9" to="tpee:fzclF8l" resolve="Statement" />
     </node>
   </node>
+  <node concept="1TIwiD" id="1GpxVmAerDt">
+    <property role="EcuMT" value="1952741127689452125" />
+    <property role="TrG5h" value="RootWithChildren" />
+    <property role="19KtqR" value="true" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
+    <node concept="1TJgyj" id="1GpxVmAerDu" role="1TKVEi">
+      <property role="IQ2ns" value="1952741127689452126" />
+      <property role="20lmBu" value="aggregation" />
+      <property role="20kJfa" value="names1" />
+      <property role="20lbJX" value="0..n" />
+      <ref role="20lvS9" to="tpee:f$Xl_Og" resolve="StringLiteral" />
+    </node>
+    <node concept="1TJgyj" id="1GpxVmAh8uH" role="1TKVEi">
+      <property role="IQ2ns" value="1952741127690160045" />
+      <property role="20lmBu" value="aggregation" />
+      <property role="20kJfa" value="names2" />
+      <property role="20lbJX" value="0..n" />
+      <ref role="20lvS9" to="tpee:f$Xl_Og" resolve="StringLiteral" />
+    </node>
+    <node concept="1TJgyj" id="1GpxVmAh8uM" role="1TKVEi">
+      <property role="IQ2ns" value="1952741127690160050" />
+      <property role="20lmBu" value="aggregation" />
+      <property role="20kJfa" value="names3" />
+      <property role="20lbJX" value="0..n" />
+      <ref role="20lvS9" to="tpee:f$Xl_Og" resolve="StringLiteral" />
+    </node>
+    <node concept="1TJgyj" id="1GpxVmAh8uT" role="1TKVEi">
+      <property role="IQ2ns" value="1952741127690160057" />
+      <property role="20lmBu" value="aggregation" />
+      <property role="20kJfa" value="names4" />
+      <property role="20lbJX" value="0..n" />
+      <ref role="20lvS9" to="tpee:f$Xl_Og" resolve="StringLiteral" />
+    </node>
+  </node>
 </model>
 

--- a/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.editor.querylist.runtime/models/com/mbeddr/mpsutil/editor/querylist/runtime.mps
+++ b/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.editor.querylist.runtime/models/com/mbeddr/mpsutil/editor/querylist/runtime.mps
@@ -384,7 +384,7 @@
                 <node concept="1Y3b0j" id="1GpxVmA6BmU" role="YeSDq">
                   <property role="2bfB8j" value="true" />
                   <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
-                  <ref role="1Y3XeK" to="c17a:~SAbstractLink" resolve="SAbstractLink" />
+                  <ref role="1Y3XeK" to="c17a:~SContainmentLink" resolve="SContainmentLink" />
                   <node concept="3Tm1VV" id="1GpxVmA6BmV" role="1B3o_S" />
                   <node concept="2tJIrI" id="1GpxVmA72Zx" role="jymVt" />
                   <node concept="3clFb_" id="1GpxVmA6Bn6" role="jymVt">
@@ -457,8 +457,12 @@
                       <ref role="3uigEE" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
                     </node>
                     <node concept="3clFbS" id="1GpxVmA6URZ" role="3clF47">
-                      <node concept="3clFbF" id="1GpxVmA6US2" role="3cqZAp">
-                        <node concept="10Nm6u" id="1GpxVmA6US1" role="3clFbG" />
+                      <node concept="YS8fn" id="3kkgokhwfpC" role="3cqZAp">
+                        <node concept="2ShNRf" id="3kkgokhwfpD" role="YScLw">
+                          <node concept="1pGfFk" id="3kkgokhwfpE" role="2ShVmc">
+                            <ref role="37wK5l" to="wyt6:~UnsupportedOperationException.&lt;init&gt;()" resolve="UnsupportedOperationException" />
+                          </node>
+                        </node>
                       </node>
                     </node>
                     <node concept="2AHcQZ" id="1GpxVmA6US0" role="2AJF6D">
@@ -474,13 +478,13 @@
                     <node concept="2AHcQZ" id="1GpxVmA6US6" role="2AJF6D">
                       <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
                     </node>
-                    <node concept="3uibUv" id="1GpxVmA6US7" role="3clF45">
-                      <ref role="3uigEE" to="wyt6:~String" resolve="String" />
-                    </node>
+                    <node concept="17QB3L" id="3kkgokhweHG" role="3clF45" />
                     <node concept="3clFbS" id="1GpxVmA6USc" role="3clF47">
-                      <node concept="3clFbF" id="1GpxVmA6USf" role="3cqZAp">
-                        <node concept="Xl_RD" id="1GpxVmA6VBM" role="3clFbG">
-                          <property role="Xl_RC" value="QueryList dummy" />
+                      <node concept="YS8fn" id="3kkgokhwflq" role="3cqZAp">
+                        <node concept="2ShNRf" id="3kkgokhwflr" role="YScLw">
+                          <node concept="1pGfFk" id="3kkgokhwfls" role="2ShVmc">
+                            <ref role="37wK5l" to="wyt6:~UnsupportedOperationException.&lt;init&gt;()" resolve="UnsupportedOperationException" />
+                          </node>
                         </node>
                       </node>
                     </node>
@@ -496,8 +500,12 @@
                     <node concept="3Tm1VV" id="1GpxVmA6USh" role="1B3o_S" />
                     <node concept="10P_77" id="1GpxVmA6USj" role="3clF45" />
                     <node concept="3clFbS" id="1GpxVmA6USn" role="3clF47">
-                      <node concept="3clFbF" id="1GpxVmA6USq" role="3cqZAp">
-                        <node concept="3clFbT" id="1GpxVmA6USp" role="3clFbG" />
+                      <node concept="YS8fn" id="3kkgokhweDF" role="3cqZAp">
+                        <node concept="2ShNRf" id="3kkgokhweDG" role="YScLw">
+                          <node concept="1pGfFk" id="3kkgokhweDH" role="2ShVmc">
+                            <ref role="37wK5l" to="wyt6:~UnsupportedOperationException.&lt;init&gt;()" resolve="UnsupportedOperationException" />
+                          </node>
+                        </node>
                       </node>
                     </node>
                     <node concept="2AHcQZ" id="1GpxVmA6USo" role="2AJF6D">
@@ -513,13 +521,13 @@
                     <node concept="2AHcQZ" id="1GpxVmA6USu" role="2AJF6D">
                       <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
                     </node>
-                    <node concept="3uibUv" id="1GpxVmA6USy" role="3clF45">
-                      <ref role="3uigEE" to="wyt6:~String" resolve="String" />
-                    </node>
+                    <node concept="17QB3L" id="3kkgokhwdUU" role="3clF45" />
                     <node concept="3clFbS" id="1GpxVmA6US_" role="3clF47">
-                      <node concept="3clFbF" id="1GpxVmA6USC" role="3cqZAp">
-                        <node concept="Xl_RD" id="1GpxVmA6VOZ" role="3clFbG">
-                          <property role="Xl_RC" value="QueryList dummy role" />
+                      <node concept="YS8fn" id="3kkgokhweyf" role="3cqZAp">
+                        <node concept="2ShNRf" id="3kkgokhweyg" role="YScLw">
+                          <node concept="1pGfFk" id="3kkgokhweyh" role="2ShVmc">
+                            <ref role="37wK5l" to="wyt6:~UnsupportedOperationException.&lt;init&gt;()" resolve="UnsupportedOperationException" />
+                          </node>
                         </node>
                       </node>
                     </node>
@@ -535,8 +543,10 @@
                     <node concept="3Tm1VV" id="1GpxVmA6USE" role="1B3o_S" />
                     <node concept="10P_77" id="1GpxVmA6USG" role="3clF45" />
                     <node concept="3clFbS" id="1GpxVmA6USJ" role="3clF47">
-                      <node concept="3clFbF" id="1GpxVmA6USM" role="3cqZAp">
-                        <node concept="3clFbT" id="1GpxVmA6USL" role="3clFbG" />
+                      <node concept="3clFbF" id="3kkgokhwdNj" role="3cqZAp">
+                        <node concept="3clFbT" id="3kkgokhwdNi" role="3clFbG">
+                          <property role="3clFbU" value="true" />
+                        </node>
                       </node>
                     </node>
                     <node concept="2AHcQZ" id="1GpxVmA6USK" role="2AJF6D">
@@ -556,8 +566,12 @@
                       <ref role="3uigEE" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
                     </node>
                     <node concept="3clFbS" id="1GpxVmA6USV" role="3clF47">
-                      <node concept="3clFbF" id="1GpxVmA6USY" role="3cqZAp">
-                        <node concept="10Nm6u" id="1GpxVmA6USX" role="3clFbG" />
+                      <node concept="YS8fn" id="3kkgokhwdEZ" role="3cqZAp">
+                        <node concept="2ShNRf" id="3kkgokhwdF0" role="YScLw">
+                          <node concept="1pGfFk" id="3kkgokhwdF1" role="2ShVmc">
+                            <ref role="37wK5l" to="wyt6:~UnsupportedOperationException.&lt;init&gt;()" resolve="UnsupportedOperationException" />
+                          </node>
+                        </node>
                       </node>
                     </node>
                     <node concept="2AHcQZ" id="1GpxVmA6USW" role="2AJF6D">
@@ -575,13 +589,73 @@
                     </node>
                     <node concept="10P_77" id="1GpxVmA6UT6" role="3clF45" />
                     <node concept="3clFbS" id="1GpxVmA6UT9" role="3clF47">
-                      <node concept="3clFbF" id="1GpxVmA6UTc" role="3cqZAp">
-                        <node concept="3clFbT" id="1GpxVmA6UTb" role="3clFbG">
-                          <property role="3clFbU" value="true" />
-                        </node>
+                      <node concept="3clFbF" id="3kkgokhwdAM" role="3cqZAp">
+                        <node concept="3clFbT" id="3kkgokhwdAL" role="3clFbG" />
                       </node>
                     </node>
                     <node concept="2AHcQZ" id="1GpxVmA6UTa" role="2AJF6D">
+                      <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                    </node>
+                  </node>
+                  <node concept="3clFb_" id="3kkgokhvYx5" role="jymVt">
+                    <property role="TrG5h" value="getDeclarationNode" />
+                    <node concept="3Tm1VV" id="3kkgokhvYx6" role="1B3o_S" />
+                    <node concept="2AHcQZ" id="3kkgokhvYx8" role="2AJF6D">
+                      <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
+                    </node>
+                    <node concept="2AHcQZ" id="3kkgokhvYx9" role="2AJF6D">
+                      <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
+                    </node>
+                    <node concept="3uibUv" id="3kkgokhvYxg" role="3clF45">
+                      <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
+                    </node>
+                    <node concept="3clFbS" id="3kkgokhvYxi" role="3clF47">
+                      <node concept="YS8fn" id="3kkgokhwdxR" role="3cqZAp">
+                        <node concept="2ShNRf" id="3kkgokhwdxS" role="YScLw">
+                          <node concept="1pGfFk" id="3kkgokhwdxT" role="2ShVmc">
+                            <ref role="37wK5l" to="wyt6:~UnsupportedOperationException.&lt;init&gt;()" resolve="UnsupportedOperationException" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="2AHcQZ" id="3kkgokhvYxj" role="2AJF6D">
+                      <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                    </node>
+                  </node>
+                  <node concept="3clFb_" id="3kkgokhvYxm" role="jymVt">
+                    <property role="TrG5h" value="getRoleName" />
+                    <node concept="3Tm1VV" id="3kkgokhvYxn" role="1B3o_S" />
+                    <node concept="2AHcQZ" id="3kkgokhvYxp" role="2AJF6D">
+                      <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
+                    </node>
+                    <node concept="17QB3L" id="3kkgokhw0g8" role="3clF45" />
+                    <node concept="3clFbS" id="3kkgokhvYxv" role="3clF47">
+                      <node concept="YS8fn" id="3kkgokhw0RP" role="3cqZAp">
+                        <node concept="2ShNRf" id="3kkgokhw0Ta" role="YScLw">
+                          <node concept="1pGfFk" id="3kkgokhwdjS" role="2ShVmc">
+                            <ref role="37wK5l" to="wyt6:~UnsupportedOperationException.&lt;init&gt;()" resolve="UnsupportedOperationException" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="2AHcQZ" id="3kkgokhvYxw" role="2AJF6D">
+                      <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                    </node>
+                  </node>
+                  <node concept="3clFb_" id="3kkgokhvYxz" role="jymVt">
+                    <property role="TrG5h" value="isUnordered" />
+                    <node concept="3Tm1VV" id="3kkgokhvYx$" role="1B3o_S" />
+                    <node concept="10P_77" id="3kkgokhvYxA" role="3clF45" />
+                    <node concept="3clFbS" id="3kkgokhvYxC" role="3clF47">
+                      <node concept="YS8fn" id="3kkgokhwdul" role="3cqZAp">
+                        <node concept="2ShNRf" id="3kkgokhwdum" role="YScLw">
+                          <node concept="1pGfFk" id="3kkgokhwdun" role="2ShVmc">
+                            <ref role="37wK5l" to="wyt6:~UnsupportedOperationException.&lt;init&gt;()" resolve="UnsupportedOperationException" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="2AHcQZ" id="3kkgokhvYxD" role="2AJF6D">
                       <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
                     </node>
                   </node>

--- a/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.editor.querylist.runtime/models/com/mbeddr/mpsutil/editor/querylist/runtime.mps
+++ b/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.editor.querylist.runtime/models/com/mbeddr/mpsutil/editor/querylist/runtime.mps
@@ -3,12 +3,12 @@
   <persistence version="9" />
   <languages>
     <use id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures" version="-1" />
-    <use id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections" version="1" />
+    <use id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections" version="-1" />
     <use id="774bf8a0-62e5-41e1-af63-f4812e60e48b" name="jetbrains.mps.baseLanguage.checkedDots" version="-1" />
     <use id="d7706f63-9be2-479c-a3da-ae92af1e64d5" name="jetbrains.mps.lang.generator.generationContext" version="-1" />
-    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="13" />
-    <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="8" />
-    <use id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc" version="2" />
+    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="-1" />
+    <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="-1" />
+    <use id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc" version="-1" />
   </languages>
   <imports>
     <import index="g51k" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor.cells(MPS.Editor/)" />
@@ -38,6 +38,9 @@
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
       <concept id="1080223426719" name="jetbrains.mps.baseLanguage.structure.OrExpression" flags="nn" index="22lmx$" />
+      <concept id="1082485599095" name="jetbrains.mps.baseLanguage.structure.BlockStatement" flags="nn" index="9aQIb">
+        <child id="1082485599096" name="statements" index="9aQI4" />
+      </concept>
       <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
         <child id="1068498886297" name="rValue" index="37vLTx" />
         <child id="1068498886295" name="lValue" index="37vLTJ" />
@@ -155,6 +158,7 @@
       </concept>
       <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
       <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
+        <child id="1082485599094" name="ifFalseStatement" index="9aQIa" />
         <child id="1068580123160" name="condition" index="3clFbw" />
         <child id="1068580123161" name="ifTrue" index="3clFbx" />
       </concept>
@@ -252,7 +256,12 @@
       <concept id="1225797177491" name="jetbrains.mps.baseLanguage.closures.structure.InvokeFunctionOperation" flags="nn" index="1Bd96e" />
     </language>
     <language id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc">
+      <concept id="2546654756694997551" name="jetbrains.mps.baseLanguage.javadoc.structure.LinkInlineDocTag" flags="ng" index="92FcH">
+        <child id="2546654756694997556" name="reference" index="92FcQ" />
+        <child id="3106559687488913694" name="line" index="2XjZqd" />
+      </concept>
       <concept id="5349172909345501395" name="jetbrains.mps.baseLanguage.javadoc.structure.BaseDocComment" flags="ng" index="P$AiS">
+        <child id="8465538089690331502" name="body" index="TZ5H$" />
         <child id="5383422241790532083" name="tags" index="3nqlJM" />
       </concept>
       <concept id="5349172909345532724" name="jetbrains.mps.baseLanguage.javadoc.structure.MethodDocComment" flags="ng" index="P$JXv" />
@@ -261,6 +270,12 @@
       </concept>
       <concept id="8465538089690331492" name="jetbrains.mps.baseLanguage.javadoc.structure.DeprecatedBlockDocTag" flags="ng" index="TZ5HI">
         <child id="2667874559098216723" name="text" index="3HnX3l" />
+      </concept>
+      <concept id="2217234381367530212" name="jetbrains.mps.baseLanguage.javadoc.structure.ClassifierDocReference" flags="ng" index="VXe08">
+        <reference id="2217234381367530213" name="classifier" index="VXe09" />
+      </concept>
+      <concept id="8970989240999019145" name="jetbrains.mps.baseLanguage.javadoc.structure.InlineTagCommentLinePart" flags="ng" index="1dT_AA">
+        <child id="6962838954693749192" name="tag" index="qph3F" />
       </concept>
       <concept id="8970989240999019143" name="jetbrains.mps.baseLanguage.javadoc.structure.TextCommentLinePart" flags="ng" index="1dT_AC">
         <property id="8970989240999019144" name="text" index="1dT_AB" />
@@ -359,6 +374,220 @@
           </node>
           <node concept="37vLTw" id="1BXECvJVdYY" role="37wK5m">
             <ref role="3cqZAo" node="1BXECvJVdNt" resolve="handler" />
+          </node>
+        </node>
+        <node concept="3clFbF" id="1GpxVmA6pYw" role="3cqZAp">
+          <node concept="1rXfSq" id="1GpxVmA6pYu" role="3clFbG">
+            <ref role="37wK5l" to="g51k:~EditorCell_Basic.setSRole(org.jetbrains.mps.openapi.language.SConceptFeature):void" resolve="setSRole" />
+            <node concept="2ShNRf" id="1GpxVmA6q99" role="37wK5m">
+              <node concept="YeOm9" id="1GpxVmA6BmR" role="2ShVmc">
+                <node concept="1Y3b0j" id="1GpxVmA6BmU" role="YeSDq">
+                  <property role="2bfB8j" value="true" />
+                  <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
+                  <ref role="1Y3XeK" to="c17a:~SAbstractLink" resolve="SAbstractLink" />
+                  <node concept="3Tm1VV" id="1GpxVmA6BmV" role="1B3o_S" />
+                  <node concept="2tJIrI" id="1GpxVmA72Zx" role="jymVt" />
+                  <node concept="3clFb_" id="1GpxVmA6Bn6" role="jymVt">
+                    <property role="1EzhhJ" value="false" />
+                    <property role="TrG5h" value="isMultiple" />
+                    <property role="DiZV1" value="false" />
+                    <property role="od$2w" value="false" />
+                    <node concept="3Tm1VV" id="1GpxVmA6Bn7" role="1B3o_S" />
+                    <node concept="2AHcQZ" id="1GpxVmA6Bn9" role="2AJF6D">
+                      <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
+                    </node>
+                    <node concept="P$JXv" id="1GpxVmA6Bna" role="lGtFl">
+                      <node concept="TZ5HI" id="1GpxVmA6Bnb" role="3nqlJM">
+                        <node concept="TZ5HA" id="1GpxVmA6Bnc" role="3HnX3l">
+                          <node concept="1dT_AC" id="1GpxVmA6CMP" role="1dT_Ay">
+                            <property role="1dT_AB" value="" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="TZ5HA" id="1GpxVmA6CPn" role="TZ5H$">
+                        <node concept="1dT_AC" id="1GpxVmA6CPo" role="1dT_Ay">
+                          <property role="1dT_AB" value="Important for " />
+                        </node>
+                        <node concept="1dT_AA" id="1GpxVmA6CPM" role="1dT_Ay">
+                          <node concept="92FcH" id="1GpxVmA6Gfy" role="qph3F">
+                            <node concept="TZ5HA" id="1GpxVmA6Gf$" role="2XjZqd" />
+                            <node concept="VXe08" id="1GpxVmA6TaN" role="92FcQ">
+                              <ref role="VXe09" to="exr9:~ChildrenCollectionFinder" resolve="ChildrenCollectionFinder" />
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="1dT_AC" id="1GpxVmA6CPL" role="1dT_Ay">
+                          <property role="1dT_AB" value="#isMultipleCollectionCell" />
+                        </node>
+                      </node>
+                      <node concept="TZ5HA" id="1GpxVmA6TSN" role="TZ5H$">
+                        <node concept="1dT_AC" id="1GpxVmA6TSO" role="1dT_Ay">
+                          <property role="1dT_AB" value="" />
+                        </node>
+                      </node>
+                      <node concept="TZ5HA" id="1GpxVmA6TTp" role="TZ5H$">
+                        <node concept="1dT_AC" id="1GpxVmA6TTq" role="1dT_Ay">
+                          <property role="1dT_AB" value="To consider querlists for INSERT actions" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="10P_77" id="1GpxVmA6Bnd" role="3clF45" />
+                    <node concept="3clFbS" id="1GpxVmA6Bne" role="3clF47">
+                      <node concept="3clFbF" id="1GpxVmA6CEi" role="3cqZAp">
+                        <node concept="3clFbT" id="1GpxVmA6CEh" role="3clFbG">
+                          <property role="3clFbU" value="true" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="2AHcQZ" id="1GpxVmA6UaL" role="2AJF6D">
+                      <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                    </node>
+                  </node>
+                  <node concept="2tJIrI" id="1GpxVmA748E" role="jymVt" />
+                  <node concept="3clFb_" id="1GpxVmA6URS" role="jymVt">
+                    <property role="1EzhhJ" value="false" />
+                    <property role="TrG5h" value="getTargetConcept" />
+                    <property role="DiZV1" value="false" />
+                    <property role="od$2w" value="false" />
+                    <node concept="3Tm1VV" id="1GpxVmA6URT" role="1B3o_S" />
+                    <node concept="2AHcQZ" id="1GpxVmA6URV" role="2AJF6D">
+                      <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+                    </node>
+                    <node concept="3uibUv" id="1GpxVmA6URW" role="3clF45">
+                      <ref role="3uigEE" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
+                    </node>
+                    <node concept="3clFbS" id="1GpxVmA6URZ" role="3clF47">
+                      <node concept="3clFbF" id="1GpxVmA6US2" role="3cqZAp">
+                        <node concept="10Nm6u" id="1GpxVmA6US1" role="3clFbG" />
+                      </node>
+                    </node>
+                    <node concept="2AHcQZ" id="1GpxVmA6US0" role="2AJF6D">
+                      <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                    </node>
+                  </node>
+                  <node concept="3clFb_" id="1GpxVmA6US3" role="jymVt">
+                    <property role="1EzhhJ" value="false" />
+                    <property role="TrG5h" value="getName" />
+                    <property role="DiZV1" value="false" />
+                    <property role="od$2w" value="false" />
+                    <node concept="3Tm1VV" id="1GpxVmA6US4" role="1B3o_S" />
+                    <node concept="2AHcQZ" id="1GpxVmA6US6" role="2AJF6D">
+                      <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+                    </node>
+                    <node concept="3uibUv" id="1GpxVmA6US7" role="3clF45">
+                      <ref role="3uigEE" to="wyt6:~String" resolve="String" />
+                    </node>
+                    <node concept="3clFbS" id="1GpxVmA6USc" role="3clF47">
+                      <node concept="3clFbF" id="1GpxVmA6USf" role="3cqZAp">
+                        <node concept="Xl_RD" id="1GpxVmA6VBM" role="3clFbG">
+                          <property role="Xl_RC" value="QueryList dummy" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="2AHcQZ" id="1GpxVmA6USd" role="2AJF6D">
+                      <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                    </node>
+                  </node>
+                  <node concept="3clFb_" id="1GpxVmA6USg" role="jymVt">
+                    <property role="1EzhhJ" value="false" />
+                    <property role="TrG5h" value="isValid" />
+                    <property role="DiZV1" value="false" />
+                    <property role="od$2w" value="false" />
+                    <node concept="3Tm1VV" id="1GpxVmA6USh" role="1B3o_S" />
+                    <node concept="10P_77" id="1GpxVmA6USj" role="3clF45" />
+                    <node concept="3clFbS" id="1GpxVmA6USn" role="3clF47">
+                      <node concept="3clFbF" id="1GpxVmA6USq" role="3cqZAp">
+                        <node concept="3clFbT" id="1GpxVmA6USp" role="3clFbG" />
+                      </node>
+                    </node>
+                    <node concept="2AHcQZ" id="1GpxVmA6USo" role="2AJF6D">
+                      <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                    </node>
+                  </node>
+                  <node concept="3clFb_" id="1GpxVmA6USr" role="jymVt">
+                    <property role="1EzhhJ" value="false" />
+                    <property role="TrG5h" value="getRole" />
+                    <property role="DiZV1" value="false" />
+                    <property role="od$2w" value="false" />
+                    <node concept="3Tm1VV" id="1GpxVmA6USs" role="1B3o_S" />
+                    <node concept="2AHcQZ" id="1GpxVmA6USu" role="2AJF6D">
+                      <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
+                    </node>
+                    <node concept="3uibUv" id="1GpxVmA6USy" role="3clF45">
+                      <ref role="3uigEE" to="wyt6:~String" resolve="String" />
+                    </node>
+                    <node concept="3clFbS" id="1GpxVmA6US_" role="3clF47">
+                      <node concept="3clFbF" id="1GpxVmA6USC" role="3cqZAp">
+                        <node concept="Xl_RD" id="1GpxVmA6VOZ" role="3clFbG">
+                          <property role="Xl_RC" value="QueryList dummy role" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="2AHcQZ" id="1GpxVmA6USA" role="2AJF6D">
+                      <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                    </node>
+                  </node>
+                  <node concept="3clFb_" id="1GpxVmA6USD" role="jymVt">
+                    <property role="1EzhhJ" value="false" />
+                    <property role="TrG5h" value="isOptional" />
+                    <property role="DiZV1" value="false" />
+                    <property role="od$2w" value="false" />
+                    <node concept="3Tm1VV" id="1GpxVmA6USE" role="1B3o_S" />
+                    <node concept="10P_77" id="1GpxVmA6USG" role="3clF45" />
+                    <node concept="3clFbS" id="1GpxVmA6USJ" role="3clF47">
+                      <node concept="3clFbF" id="1GpxVmA6USM" role="3cqZAp">
+                        <node concept="3clFbT" id="1GpxVmA6USL" role="3clFbG" />
+                      </node>
+                    </node>
+                    <node concept="2AHcQZ" id="1GpxVmA6USK" role="2AJF6D">
+                      <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                    </node>
+                  </node>
+                  <node concept="3clFb_" id="1GpxVmA6USN" role="jymVt">
+                    <property role="1EzhhJ" value="false" />
+                    <property role="TrG5h" value="getOwner" />
+                    <property role="DiZV1" value="false" />
+                    <property role="od$2w" value="false" />
+                    <node concept="3Tm1VV" id="1GpxVmA6USO" role="1B3o_S" />
+                    <node concept="2AHcQZ" id="1GpxVmA6USQ" role="2AJF6D">
+                      <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+                    </node>
+                    <node concept="3uibUv" id="1GpxVmA6USR" role="3clF45">
+                      <ref role="3uigEE" to="c17a:~SAbstractConcept" resolve="SAbstractConcept" />
+                    </node>
+                    <node concept="3clFbS" id="1GpxVmA6USV" role="3clF47">
+                      <node concept="3clFbF" id="1GpxVmA6USY" role="3cqZAp">
+                        <node concept="10Nm6u" id="1GpxVmA6USX" role="3clFbG" />
+                      </node>
+                    </node>
+                    <node concept="2AHcQZ" id="1GpxVmA6USW" role="2AJF6D">
+                      <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                    </node>
+                  </node>
+                  <node concept="3clFb_" id="1GpxVmA6USZ" role="jymVt">
+                    <property role="1EzhhJ" value="false" />
+                    <property role="TrG5h" value="isReference" />
+                    <property role="DiZV1" value="false" />
+                    <property role="od$2w" value="false" />
+                    <node concept="3Tm1VV" id="1GpxVmA6UT0" role="1B3o_S" />
+                    <node concept="2AHcQZ" id="1GpxVmA6UT2" role="2AJF6D">
+                      <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
+                    </node>
+                    <node concept="10P_77" id="1GpxVmA6UT6" role="3clF45" />
+                    <node concept="3clFbS" id="1GpxVmA6UT9" role="3clF47">
+                      <node concept="3clFbF" id="1GpxVmA6UTc" role="3cqZAp">
+                        <node concept="3clFbT" id="1GpxVmA6UTb" role="3clFbG">
+                          <property role="3clFbU" value="true" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="2AHcQZ" id="1GpxVmA6UTa" role="2AJF6D">
+                      <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
           </node>
         </node>
       </node>
@@ -487,13 +716,37 @@
           <node concept="3clFbS" id="535SrlQ69wp" role="2LFqv$">
             <node concept="3clFbJ" id="535SrlQ6a1r" role="3cqZAp">
               <node concept="3clFbS" id="535SrlQ6a1s" role="3clFbx">
-                <node concept="3cpWs6" id="535SrlQ6c0l" role="3cqZAp">
-                  <node concept="2OqwBi" id="535SrlQ6cXN" role="3cqZAk">
-                    <node concept="37vLTw" id="535SrlQ6cLG" role="2Oq$k0">
-                      <ref role="3cqZAo" node="535SrlQ69wq" resolve="c" />
+                <node concept="3clFbJ" id="1GpxVmAcaz4" role="3cqZAp">
+                  <node concept="3clFbS" id="1GpxVmAcaz6" role="3clFbx">
+                    <node concept="3cpWs6" id="535SrlQ6c0l" role="3cqZAp">
+                      <node concept="2OqwBi" id="535SrlQ6cXN" role="3cqZAk">
+                        <node concept="37vLTw" id="535SrlQ6cLG" role="2Oq$k0">
+                          <ref role="3cqZAo" node="535SrlQ69wq" resolve="c" />
+                        </node>
+                        <node concept="liA8E" id="535SrlQ6dOq" role="2OqNvi">
+                          <ref role="37wK5l" to="f4zo:~EditorCell.getSNode():org.jetbrains.mps.openapi.model.SNode" resolve="getSNode" />
+                        </node>
+                      </node>
                     </node>
-                    <node concept="liA8E" id="535SrlQ6dOq" role="2OqNvi">
-                      <ref role="37wK5l" to="f4zo:~EditorCell.getSNode():org.jetbrains.mps.openapi.model.SNode" resolve="getSNode" />
+                  </node>
+                  <node concept="3clFbC" id="1GpxVmAct43" role="3clFbw">
+                    <node concept="37vLTw" id="1GpxVmActdk" role="3uHU7w">
+                      <ref role="3cqZAo" to="emqf:~AbstractCellListHandler.myListEditorCell_Collection" resolve="myListEditorCell_Collection" />
+                    </node>
+                    <node concept="2OqwBi" id="1GpxVmAcc7n" role="3uHU7B">
+                      <node concept="37vLTw" id="1GpxVmAcc0$" role="2Oq$k0">
+                        <ref role="3cqZAo" node="535SrlQ69wq" resolve="c" />
+                      </node>
+                      <node concept="liA8E" id="1GpxVmAcsME" role="2OqNvi">
+                        <ref role="37wK5l" to="f4zo:~EditorCell.getParent():jetbrains.mps.openapi.editor.cells.EditorCell_Collection" resolve="getParent" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="9aQIb" id="1GpxVmAcy70" role="9aQIa">
+                    <node concept="3clFbS" id="1GpxVmAcy71" role="9aQI4">
+                      <node concept="3cpWs6" id="1GpxVmAczB$" role="3cqZAp">
+                        <node concept="10Nm6u" id="1GpxVmAczCs" role="3cqZAk" />
+                      </node>
                     </node>
                   </node>
                 </node>

--- a/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.editor.querylist.sandbox/models/com/mbeddr/mpsutil/editor/querylist/sandbox.mps
+++ b/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.editor.querylist.sandbox/models/com/mbeddr/mpsutil/editor/querylist/sandbox.mps
@@ -2,13 +2,16 @@
 <model ref="c58b797b-c53c-4442-abff-4d54c72169ea/r:5f236bd8-eb21-40b6-825a-9e614ca27175(com.mbeddr.mpsutil.editor.querylist.sandbox/com.mbeddr.mpsutil.editor.querylist.sandbox)">
   <persistence version="9" />
   <languages>
-    <use id="9b71d0db-bcaf-4144-bb2e-1ddef2b249b9" name="com.mbeddr.mpsutil.editor.querylist.demolang" version="0" />
-    <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="8" />
+    <use id="9b71d0db-bcaf-4144-bb2e-1ddef2b249b9" name="com.mbeddr.mpsutil.editor.querylist.demolang" version="-1" />
+    <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="-1" />
   </languages>
   <imports />
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
       <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="ng" index="2tJIrI" />
+      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
+        <property id="1070475926801" name="value" index="Xl_RC" />
+      </concept>
       <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
       <concept id="1070534513062" name="jetbrains.mps.baseLanguage.structure.DoubleType" flags="in" index="10P55v" />
       <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu" />
@@ -65,19 +68,23 @@
         <child id="393429538060968385" name="statement" index="2hc9Zl" />
       </concept>
       <concept id="6202678563380435581" name="com.mbeddr.mpsutil.editor.querylist.demolang.structure.RootConcept" flags="ng" index="sbcOR">
-        <property id="6202678563380449077" name="showExpressions" index="sb9xZ" />
         <property id="4299801941279353937" name="myProperty" index="2DP_H4" />
         <property id="1646868633684830515" name="showQueryLink" index="3CnFdS" />
         <reference id="1646868633684300706" name="classReference" index="3CDCBD" />
         <child id="393429538060968390" name="statementWrappers" index="2hc9Zi" />
         <child id="6202678563380435709" name="statementList" index="sbcQR" />
       </concept>
+      <concept id="1952741127689452125" name="com.mbeddr.mpsutil.editor.querylist.demolang.structure.RootWithChildren" flags="ng" index="2X83RC">
+        <child id="1952741127689452126" name="names1" index="2X83RF" />
+        <child id="1952741127690160050" name="names3" index="2Xng07" />
+        <child id="1952741127690160057" name="names4" index="2Xng0c" />
+        <child id="1952741127690160045" name="names2" index="2Xng0o" />
+      </concept>
     </language>
   </registry>
   <node concept="sbcOR" id="1BXECvJSpQ4">
     <property role="2DP_H4" value="sdfa" />
     <property role="3CnFdS" value="true" />
-    <property role="sb9xZ" value="true" />
     <ref role="3CDCBD" node="puVMIbwTIw" resolve="Othesdfgfhjhass" />
     <node concept="3clFbS" id="1BXECvJSX8B" role="sbcQR">
       <node concept="3clFbH" id="3jHPIDn8JV$" role="3cqZAp" />
@@ -241,6 +248,58 @@
       </node>
     </node>
     <node concept="3Tm1VV" id="puVMIbwTIx" role="1B3o_S" />
+  </node>
+  <node concept="2X83RC" id="1GpxVmAg3nl">
+    <node concept="Xl_RD" id="1GpxVmAt5pV" role="2Xng07" />
+    <node concept="Xl_RD" id="1GpxVmAsSOB" role="2X83RF" />
+    <node concept="Xl_RD" id="1GpxVmAiooR" role="2Xng0o">
+      <property role="Xl_RC" value="Apfel" />
+    </node>
+    <node concept="Xl_RD" id="1GpxVmAiooS" role="2Xng0o">
+      <property role="Xl_RC" value="Birne" />
+    </node>
+    <node concept="Xl_RD" id="1GpxVmAiooT" role="2Xng0o">
+      <property role="Xl_RC" value="Christbaum" />
+    </node>
+    <node concept="Xl_RD" id="1GpxVmAiooU" role="2Xng0o">
+      <property role="Xl_RC" value="Domino" />
+    </node>
+    <node concept="Xl_RD" id="1GpxVmAj504" role="2X83RF">
+      <property role="Xl_RC" value="Apfel" />
+    </node>
+    <node concept="Xl_RD" id="1GpxVmAj505" role="2X83RF">
+      <property role="Xl_RC" value="Birne" />
+    </node>
+    <node concept="Xl_RD" id="1GpxVmAj506" role="2X83RF">
+      <property role="Xl_RC" value="Christbaum" />
+    </node>
+    <node concept="Xl_RD" id="1GpxVmAj507" role="2X83RF">
+      <property role="Xl_RC" value="Domino" />
+    </node>
+    <node concept="Xl_RD" id="1GpxVmAj508" role="2Xng07">
+      <property role="Xl_RC" value="Apfel" />
+    </node>
+    <node concept="Xl_RD" id="1GpxVmAj509" role="2Xng07">
+      <property role="Xl_RC" value="Birne" />
+    </node>
+    <node concept="Xl_RD" id="1GpxVmAj50a" role="2Xng07">
+      <property role="Xl_RC" value="Christbaum" />
+    </node>
+    <node concept="Xl_RD" id="1GpxVmAj50b" role="2Xng07">
+      <property role="Xl_RC" value="Domino" />
+    </node>
+    <node concept="Xl_RD" id="1GpxVmAj50c" role="2Xng0c">
+      <property role="Xl_RC" value="Apfel" />
+    </node>
+    <node concept="Xl_RD" id="1GpxVmAj50d" role="2Xng0c">
+      <property role="Xl_RC" value="Birne" />
+    </node>
+    <node concept="Xl_RD" id="1GpxVmAj50e" role="2Xng0c">
+      <property role="Xl_RC" value="Christbaum" />
+    </node>
+    <node concept="Xl_RD" id="1GpxVmAj50f" role="2Xng0c">
+      <property role="Xl_RC" value="Domino" />
+    </node>
   </node>
 </model>
 


### PR DESCRIPTION
# Problem
Given I have a node which shows querylists as well as RefNodeLists
When I focus a constant cell outside these lists
And I hit RETURN
Then the next upcoming RefNodeList will receive an INSERT action with a null anchorNode
But unexpectedly, QueryLists will not be considered

See how it jumps over the QueryList:
<img src="https://user-images.githubusercontent.com/569215/51711192-aaa2f680-202b-11e9-9975-8aa511eb8fa7.gif" width="400">

# Rationale
- the reason seems to be that QueryLists return `null` when calling their `getSRole()`
- `ChildrenCollectionFinder#find` seeks for the next cell with `EditorCell#getSRole().isMultiple() == true`
- `EditorActionUtils#callAction` uses it to find the corresponding action and run it

# Approach
- I made the `EditorCell_QueryList` set a dummy `SAbstractLink` as SRole of itself which always returns `true` on calls to`isMultiple()`. The other methods return some null objects.
- Then I needed to fix `QueryListHandler#getAnchorNode` to return null when being provided with cells outside query list cell. So far the INSERTs only came from inside the cell, but now the anchorNode may be null.

As a result, the issue is fixed:
<img src="https://user-images.githubusercontent.com/569215/51711376-39177800-202c-11e9-97bb-29dc804a1546.gif" width="400">


# Todos

- [x] a querylist cell now provides getSRole().isMultiple() == true so that actions propagate similar to RefNodeLists
- [x] manual test case [RootWithChildren](http://127.0.0.1:63320/node?ref=c58b797b-c53c-4442-abff-4d54c72169ea%2Fr%3A5f236bd8-eb21-40b6-825a-9e614ca27175%28com.mbeddr.mpsutil.editor.querylist.sandbox%2Fcom.mbeddr.mpsutil.editor.querylist.sandbox%29%2F1952741127689876949&project=com.mbeddr.mpsutil) added in the demolang and sandbox
- [ ] this change may require existing QueryLists with _insert new_ concept functions to deal with null `anchorNode`s. If it is null, `insertBefore` should not be considered anymore and it should be prepended. Maybe we should catch this in the cell and always set `insertBefore=true`? It would still be an INSERT action though.
