### PR TITLE
mpsutil.conceptdiagram: Automatically collect concepts

### DIFF
--- a/build/com.mbeddr.allScripts/build.xml
+++ b/build/com.mbeddr.allScripts/build.xml
@@ -750,7 +750,7 @@
         <fileset file="${artifacts.mps}/lib/log4j.jar" />
         <fileset file="${artifacts.mps}/lib/jdom.jar" />
         <fileset file="${artifacts.mps}/lib/trove4j.jar" />
-        <fileset file="${artifacts.mps}/lib/ecj-4.10.jar" />
+        <fileset file="${artifacts.mps}/lib/ecj-4.7.2.jar" />
         <fileset file="${artifacts.de.itemis.mps.extensions}/de.slisson.mps.all/languages/de.slisson.mps.all/de.itemis.mps.extensions.build.jar" />
         <fileset file="${artifacts.mps}/plugins/mps-execution-configurations/languages/mps-execution-configurations/jetbrains.mps.execution.configurations.implementation.plugin.jar" />
       </classpath>

--- a/build/com.mbeddr.allScripts/build.xml
+++ b/build/com.mbeddr.allScripts/build.xml
@@ -750,7 +750,7 @@
         <fileset file="${artifacts.mps}/lib/log4j.jar" />
         <fileset file="${artifacts.mps}/lib/jdom.jar" />
         <fileset file="${artifacts.mps}/lib/trove4j.jar" />
-        <fileset file="${artifacts.mps}/lib/ecj-4.7.2.jar" />
+        <fileset file="${artifacts.mps}/lib/ecj-4.10.jar" />
         <fileset file="${artifacts.de.itemis.mps.extensions}/de.slisson.mps.all/languages/de.slisson.mps.all/de.itemis.mps.extensions.build.jar" />
         <fileset file="${artifacts.mps}/plugins/mps-execution-configurations/languages/mps-execution-configurations/jetbrains.mps.execution.configurations.implementation.plugin.jar" />
       </classpath>

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.conceptdiagram/com.mbeddr.mpsutil.conceptdiagram.mpl
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.conceptdiagram/com.mbeddr.mpsutil.conceptdiagram.mpl
@@ -67,6 +67,11 @@
     <dependency reexport="true">f7ad14aa-a3e2-4301-8822-d919845c8bcf(de.itemis.mps.editor.diagram.shapes)</dependency>
     <dependency reexport="false">5b1f863d-65a0-41a6-a801-33896be24202(jetbrains.mps.ide.editor)</dependency>
     <dependency reexport="false">7866978e-a0f0-4cc7-81bc-4d213d9375e1(jetbrains.mps.lang.smodel)</dependency>
+    <dependency reexport="false">1e7c1f95-336c-4cec-b00e-8cc6e0c2b265(com.mbeddr.mpsutil.preferenceform)</dependency>
+    <dependency reexport="false">1cb9239f-7fc3-45b7-9e20-c0a4e56ee1b0(com.mbeddr.mpsutil.forms)</dependency>
+    <dependency reexport="false">1338ba73-5059-479b-a929-de86597a62b8(com.mbeddr.mpsutil.jung.pluginSolution)</dependency>
+    <dependency reexport="false">63650c59-16c8-498a-99c8-005c7ee9515d(jetbrains.mps.lang.access)</dependency>
+    <dependency reexport="false">642f71f8-327a-425b-84f9-44ad58786d27(jetbrains.mps.lang.project.modules)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:fa13cc63-c476-4d46-9c96-d53670abe7bc:de.itemis.mps.editor.diagram" version="0" />
@@ -80,6 +85,7 @@
     <language slang="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" version="0" />
     <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
     <language slang="l:df345b11-b8c7-4213-ac66-48d2a9b75d88:jetbrains.mps.baseLanguageInternal" version="0" />
+    <language slang="l:63650c59-16c8-498a-99c8-005c7ee9515d:jetbrains.mps.lang.access" version="0" />
     <language slang="l:aee9cad2-acd4-4608-aef2-0004f6a1cdbd:jetbrains.mps.lang.actions" version="4" />
     <language slang="l:f159adf4-3c93-40f9-9c5a-1f245a8697af:jetbrains.mps.lang.aspect" version="2" />
     <language slang="l:af65afd8-f0dd-4942-87d9-63a55f2a9db1:jetbrains.mps.lang.behavior" version="2" />
@@ -120,6 +126,9 @@
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
     <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
     <module reference="9d1cb9f8-2ae0-4895-91c8-ff32e8afc27d(com.mbeddr.mpsutil.conceptdiagram)" version="0" />
+    <module reference="1cb9239f-7fc3-45b7-9e20-c0a4e56ee1b0(com.mbeddr.mpsutil.forms)" version="0" />
+    <module reference="1338ba73-5059-479b-a929-de86597a62b8(com.mbeddr.mpsutil.jung.pluginSolution)" version="0" />
+    <module reference="1e7c1f95-336c-4cec-b00e-8cc6e0c2b265(com.mbeddr.mpsutil.preferenceform)" version="0" />
     <module reference="848ef45d-e560-4e35-853c-f35a64cc135c(de.itemis.mps.editor.celllayout.runtime)" version="0" />
     <module reference="24c96a96-b7a1-4f30-82da-0f8e279a2661(de.itemis.mps.editor.celllayout.styles)" version="0" />
     <module reference="7b45fa94-2707-4a1a-9e6a-ce40c4aaf35a(de.itemis.mps.editor.collapsible.runtime)" version="0" />
@@ -131,15 +140,20 @@
     <module reference="0022e9df-2136-4ef8-81b2-08650aeb1dc7(de.itemis.mps.tooltips.runtime)" version="0" />
     <module reference="f0fff802-6d26-4d2e-b89d-391357265626(de.slisson.mps.hacks.editor)" version="0" />
     <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
+    <module reference="443f4c36-fcf5-4eb6-9500-8d06ed259e3e(jetbrains.mps.baseLanguage.classifiers)" version="0" />
     <module reference="fd392034-7849-419d-9071-12563d152375(jetbrains.mps.baseLanguage.closures)" version="0" />
     <module reference="83888646-71ce-4f1c-9c53-c54016f6ad4f(jetbrains.mps.baseLanguage.collections)" version="0" />
     <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
     <module reference="5b1f863d-65a0-41a6-a801-33896be24202(jetbrains.mps.ide.editor)" version="0" />
     <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
+    <module reference="63650c59-16c8-498a-99c8-005c7ee9515d(jetbrains.mps.lang.access)" version="0" />
     <module reference="d936855b-48da-4812-a8a0-2bfddd633ac5(jetbrains.mps.lang.behavior.api)" version="0" />
+    <module reference="fe9d76d7-5809-45c9-ae28-a40915b4d6ff(jetbrains.mps.lang.checkedName)" version="0" />
     <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
     <module reference="a9e4c532-c5f5-4bb7-99ef-42abb73bbb70(jetbrains.mps.lang.descriptor.aspects)" version="0" />
     <module reference="446c26eb-2b7b-4bf0-9b35-f83fa582753e(jetbrains.mps.lang.modelapi)" version="0" />
+    <module reference="28f9e497-3b42-4291-aeba-0a1039153ab1(jetbrains.mps.lang.plugin)" version="0" />
+    <module reference="642f71f8-327a-425b-84f9-44ad58786d27(jetbrains.mps.lang.project.modules)" version="0" />
     <module reference="7866978e-a0f0-4cc7-81bc-4d213d9375e1(jetbrains.mps.lang.smodel)" version="1" />
     <module reference="c72da2b9-7cce-4447-8389-f407dc1158b7(jetbrains.mps.lang.structure)" version="0" />
     <module reference="9ded098b-ad6a-4657-bfd9-48636cfe8bc3(jetbrains.mps.lang.traceable)" version="0" />

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.conceptdiagram/languageModels/editor.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.conceptdiagram/languageModels/editor.mps
@@ -6,9 +6,8 @@
     <use id="a247e09e-2435-45ba-b8d2-07e93feba96a" name="jetbrains.mps.baseLanguage.tuples" version="0" />
     <use id="aee9cad2-acd4-4608-aef2-0004f6a1cdbd" name="jetbrains.mps.lang.actions" version="4" />
     <use id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections" version="1" />
-    <use id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core" version="1" />
-    <use id="c72da2b9-7cce-4447-8389-f407dc1158b7" name="jetbrains.mps.lang.structure" version="7" />
     <use id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor" version="12" />
+    <use id="63650c59-16c8-498a-99c8-005c7ee9515d" name="jetbrains.mps.lang.access" version="0" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
@@ -29,9 +28,11 @@
     <import index="tp25" ref="r:00000000-0000-4000-0000-011c89590301(jetbrains.mps.lang.smodel.structure)" />
     <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" />
     <import index="pjrh" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel.adapter(MPS.Core/)" />
+    <import index="dxuu" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:javax.swing(JDK/)" />
+    <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" />
+    <import index="hyam" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt.event(JDK/)" />
     <import index="tpcn" ref="r:00000000-0000-4000-0000-011c8959028b(jetbrains.mps.lang.structure.behavior)" implicit="true" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
-    <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
     <import index="tpcu" ref="r:00000000-0000-4000-0000-011c89590282(jetbrains.mps.lang.core.behavior)" implicit="true" />
   </imports>
   <registry>
@@ -65,14 +66,12 @@
       <concept id="1080736578640" name="jetbrains.mps.lang.editor.structure.BaseEditorComponent" flags="ig" index="2wURMF">
         <child id="1080736633877" name="cellModel" index="2wV5jI" />
       </concept>
+      <concept id="795210086017940429" name="jetbrains.mps.lang.editor.structure.ReadOnlyStyleClassItem" flags="lg" index="xShMh" />
       <concept id="5944657839000868711" name="jetbrains.mps.lang.editor.structure.ConceptEditorContextHints" flags="ig" index="2ABfQD">
         <child id="5944657839000877563" name="hints" index="2ABdcP" />
       </concept>
       <concept id="5944657839003601246" name="jetbrains.mps.lang.editor.structure.ConceptEditorHintDeclaration" flags="ig" index="2BsEeg">
         <property id="168363875802087287" name="showInUI" index="2gpH_U" />
-      </concept>
-      <concept id="1164824717996" name="jetbrains.mps.lang.editor.structure.CellMenuDescriptor" flags="ng" index="OXEIz">
-        <child id="1164824815888" name="cellMenuPart" index="OY2wv" />
       </concept>
       <concept id="1078938745671" name="jetbrains.mps.lang.editor.structure.EditorComponentDeclaration" flags="ig" index="PKFIW" />
       <concept id="1078939183254" name="jetbrains.mps.lang.editor.structure.CellModel_Component" flags="sg" stub="3162947552742194261" index="PMmxH">
@@ -95,16 +94,11 @@
         <property id="1235999920262" name="align" index="37lx6p" />
       </concept>
       <concept id="1221057094638" name="jetbrains.mps.lang.editor.structure.QueryFunction_Integer" flags="in" index="1cFabM" />
-      <concept id="1165424453110" name="jetbrains.mps.lang.editor.structure.CellMenuPart_Generic_Item" flags="ng" index="1oHujT">
-        <property id="1165424453111" name="matchingText" index="1oHujS" />
-        <child id="1165424453112" name="handlerFunction" index="1oHujR" />
+      <concept id="1103016434866" name="jetbrains.mps.lang.editor.structure.CellModel_JComponent" flags="sg" stub="8104358048506731196" index="3gTLQM">
+        <child id="1176475119347" name="componentProvider" index="3FoqZy" />
       </concept>
-      <concept id="1165424657443" name="jetbrains.mps.lang.editor.structure.CellMenuPart_Generic_Item_Handler" flags="in" index="1oIgkG" />
       <concept id="1139848536355" name="jetbrains.mps.lang.editor.structure.CellModel_WithRole" flags="ng" index="1$h60E">
         <reference id="1140103550593" name="relationDeclaration" index="1NtTu8" />
-      </concept>
-      <concept id="1073389214265" name="jetbrains.mps.lang.editor.structure.EditorCellModel" flags="ng" index="3EYTF0">
-        <child id="1164826688380" name="menuDescriptor" index="P5bDN" />
       </concept>
       <concept id="1073389446423" name="jetbrains.mps.lang.editor.structure.CellModel_Collection" flags="sn" stub="3013115976261988961" index="3EZMnI">
         <child id="1106270802874" name="cellLayout" index="2iSdaV" />
@@ -118,13 +112,14 @@
         <child id="1219418656006" name="styleItem" index="3F10Kt" />
       </concept>
       <concept id="1073390211982" name="jetbrains.mps.lang.editor.structure.CellModel_RefNodeList" flags="sg" stub="2794558372793454595" index="3F2HdR" />
-      <concept id="1163613822479" name="jetbrains.mps.lang.editor.structure.CellMenuPart_Abstract_editedNode" flags="nn" index="3GMtW1" />
+      <concept id="1176474535556" name="jetbrains.mps.lang.editor.structure.QueryFunction_JComponent" flags="in" index="3Fmcul" />
       <concept id="1225898583838" name="jetbrains.mps.lang.editor.structure.ReadOnlyModelAccessor" flags="ng" index="1HfYo3">
         <child id="1225898971709" name="getter" index="1Hhtcw" />
       </concept>
       <concept id="1225900081164" name="jetbrains.mps.lang.editor.structure.CellModel_ReadOnlyModelAccessor" flags="sg" stub="3708815482283559694" index="1HlG4h">
         <child id="1225900141900" name="modelAccessor" index="1HlULh" />
       </concept>
+      <concept id="1161622981231" name="jetbrains.mps.lang.editor.structure.ConceptFunctionParameter_editorContext" flags="nn" index="1Q80Hx" />
       <concept id="1176717841777" name="jetbrains.mps.lang.editor.structure.QueryFunction_ModelAccess_Getter" flags="in" index="3TQlhw" />
       <concept id="1166049232041" name="jetbrains.mps.lang.editor.structure.AbstractComponent" flags="ng" index="1XWOmA">
         <reference id="1166049300910" name="conceptDeclaration" index="1XX52x" />
@@ -297,6 +292,14 @@
       <concept id="1170345865475" name="jetbrains.mps.baseLanguage.structure.AnonymousClass" flags="ig" index="1Y3b0j">
         <reference id="1170346070688" name="classifier" index="1Y3XeK" />
       </concept>
+    </language>
+    <language id="63650c59-16c8-498a-99c8-005c7ee9515d" name="jetbrains.mps.lang.access">
+      <concept id="8974276187400348173" name="jetbrains.mps.lang.access.structure.CommandClosureLiteral" flags="nn" index="1QHqEC" />
+      <concept id="8974276187400348170" name="jetbrains.mps.lang.access.structure.BaseExecuteCommandStatement" flags="nn" index="1QHqEJ">
+        <child id="1423104411234567454" name="repo" index="ukAjM" />
+        <child id="8974276187400348171" name="commandClosureLiteral" index="1QHqEI" />
+      </concept>
+      <concept id="8974276187400348177" name="jetbrains.mps.lang.access.structure.ExecuteCommandStatement" flags="nn" index="1QHqEO" />
     </language>
     <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
       <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
@@ -2931,20 +2934,30 @@
                   <node concept="37u81S" id="5oCf_1NSDWt" role="33vP2m" />
                 </node>
               </node>
-              <node concept="3clFbF" id="6vp$_2vnanW" role="3cqZAp">
-                <node concept="2OqwBi" id="6vp$_2vndvJ" role="3clFbG">
-                  <node concept="37vLTw" id="5oCf_1NSDlz" role="2Oq$k0">
+              <node concept="3clFbF" id="6fDk5b64flU" role="3cqZAp">
+                <node concept="2OqwBi" id="6fDk5b64flV" role="3clFbG">
+                  <node concept="37vLTw" id="6fDk5b64flW" role="2Oq$k0">
                     <ref role="3cqZAo" node="5oCf_1NSDlj" resolve="a" />
                   </node>
-                  <node concept="3YRAZt" id="6vp$_2vndVE" role="2OqNvi" />
+                  <node concept="3YRAZt" id="6fDk5b64flX" role="2OqNvi" />
                 </node>
               </node>
-              <node concept="3clFbF" id="6vp$_2vngr6" role="3cqZAp">
-                <node concept="2OqwBi" id="6vp$_2vngxr" role="3clFbG">
-                  <node concept="37vLTw" id="5oCf_1NSDWu" role="2Oq$k0">
-                    <ref role="3cqZAo" node="5oCf_1NSDWs" resolve="b" />
+              <node concept="3clFbJ" id="6fDk5b64flS" role="3cqZAp">
+                <node concept="3clFbS" id="6fDk5b64flT" role="3clFbx">
+                  <node concept="3clFbF" id="6vp$_2vngr6" role="3cqZAp">
+                    <node concept="2OqwBi" id="6vp$_2vngxr" role="3clFbG">
+                      <node concept="37vLTw" id="5oCf_1NSDWu" role="2Oq$k0">
+                        <ref role="3cqZAo" node="5oCf_1NSDWs" resolve="b" />
+                      </node>
+                      <node concept="3YRAZt" id="6vp$_2vnh3f" role="2OqNvi" />
+                    </node>
                   </node>
-                  <node concept="3YRAZt" id="6vp$_2vnh3f" role="2OqNvi" />
+                </node>
+                <node concept="2OqwBi" id="6fDk5b64flY" role="3clFbw">
+                  <node concept="23r2z0" id="6fDk5b64flZ" role="2Oq$k0" />
+                  <node concept="3TrcHB" id="6fDk5b64fm0" role="2OqNvi">
+                    <ref role="3TsBF5" to="45ke:6fDk5b6392$" resolve="modelAccess" />
+                  </node>
                 </node>
               </node>
             </node>
@@ -3154,12 +3167,22 @@
                   <node concept="3YRAZt" id="6fDk5b5SHsB" role="2OqNvi" />
                 </node>
               </node>
-              <node concept="3clFbF" id="6fDk5b5SHsC" role="3cqZAp">
-                <node concept="2OqwBi" id="6fDk5b5SHsD" role="3clFbG">
-                  <node concept="37vLTw" id="6fDk5b5SHsE" role="2Oq$k0">
-                    <ref role="3cqZAo" node="6fDk5b5SHsx" resolve="b" />
+              <node concept="3clFbJ" id="6fDk5b64eCm" role="3cqZAp">
+                <node concept="3clFbS" id="6fDk5b64eCo" role="3clFbx">
+                  <node concept="3clFbF" id="6fDk5b5SHsC" role="3cqZAp">
+                    <node concept="2OqwBi" id="6fDk5b5SHsD" role="3clFbG">
+                      <node concept="37vLTw" id="6fDk5b5SHsE" role="2Oq$k0">
+                        <ref role="3cqZAo" node="6fDk5b5SHsx" resolve="b" />
+                      </node>
+                      <node concept="3YRAZt" id="6fDk5b5SHsF" role="2OqNvi" />
+                    </node>
                   </node>
-                  <node concept="3YRAZt" id="6fDk5b5SHsF" role="2OqNvi" />
+                </node>
+                <node concept="2OqwBi" id="6fDk5b64eVd" role="3clFbw">
+                  <node concept="23r2z0" id="6fDk5b64eKF" role="2Oq$k0" />
+                  <node concept="3TrcHB" id="6fDk5b64f8D" role="2OqNvi">
+                    <ref role="3TsBF5" to="45ke:6fDk5b6392$" resolve="modelAccess" />
+                  </node>
                 </node>
               </node>
             </node>
@@ -3577,100 +3600,110 @@
                   </node>
                 </node>
               </node>
-              <node concept="3clFbJ" id="6vp$_2vnjFY" role="3cqZAp">
-                <node concept="3clFbS" id="6vp$_2vnjFZ" role="3clFbx">
-                  <node concept="3clFbF" id="6vp$_2vnpjM" role="3cqZAp">
-                    <node concept="2OqwBi" id="6vp$_2vnqX2" role="3clFbG">
-                      <node concept="2OqwBi" id="6vp$_2vnpmB" role="2Oq$k0">
-                        <node concept="1PxgMI" id="6vp$_2vnq7B" role="2Oq$k0">
-                          <node concept="37vLTw" id="6vp$_2vnpjL" role="1m5AlR">
-                            <ref role="3cqZAo" node="6vp$_2vno_N" resolve="source" />
-                          </node>
-                          <node concept="chp4Y" id="5RIakkDITmb" role="3oSUPX">
-                            <ref role="cht4Q" to="tpce:f_TIwhg" resolve="ConceptDeclaration" />
-                          </node>
-                        </node>
-                        <node concept="3TrEf2" id="6vp$_2vnqxE" role="2OqNvi">
-                          <ref role="3Tt5mk" to="tpce:f_TJDff" resolve="extends" />
-                        </node>
-                      </node>
-                      <node concept="2oxUTD" id="6vp$_2vns5s" role="2OqNvi">
-                        <node concept="10Nm6u" id="6vp$_2vns77" role="2oxUTC" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="2OqwBi" id="6vp$_2vnoK1" role="3clFbw">
-                  <node concept="37vLTw" id="6vp$_2vno_R" role="2Oq$k0">
-                    <ref role="3cqZAo" node="6vp$_2vno_N" resolve="source" />
-                  </node>
-                  <node concept="1mIQ4w" id="6vp$_2vnpf7" role="2OqNvi">
-                    <node concept="chp4Y" id="6vp$_2vnpgG" role="cj9EA">
-                      <ref role="cht4Q" to="tpce:f_TIwhg" resolve="ConceptDeclaration" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="9aQIb" id="6vp$_2vns7Y" role="9aQIa">
-                  <node concept="3clFbS" id="6vp$_2vns7Z" role="9aQI4">
-                    <node concept="3cpWs8" id="5oCf_1NSKkj" role="3cqZAp">
-                      <node concept="3cpWsn" id="5oCf_1NSKkk" role="3cpWs9">
-                        <property role="TrG5h" value="x" />
-                        <node concept="3Tqbb2" id="5oCf_1NSKjR" role="1tU5fm">
-                          <ref role="ehGHo" to="tpce:h0PrWoo" resolve="InterfaceConceptReference" />
-                        </node>
-                        <node concept="2OqwBi" id="5oCf_1NSKkl" role="33vP2m">
-                          <node concept="2OqwBi" id="5oCf_1NSKkm" role="2Oq$k0">
-                            <node concept="1PxgMI" id="5oCf_1NSKkn" role="2Oq$k0">
-                              <node concept="37vLTw" id="5oCf_1NSKko" role="1m5AlR">
+              <node concept="3clFbJ" id="6fDk5b6da$F" role="3cqZAp">
+                <node concept="3clFbS" id="6fDk5b6da$H" role="3clFbx">
+                  <node concept="3clFbJ" id="6vp$_2vnjFY" role="3cqZAp">
+                    <node concept="3clFbS" id="6vp$_2vnjFZ" role="3clFbx">
+                      <node concept="3clFbF" id="6vp$_2vnpjM" role="3cqZAp">
+                        <node concept="2OqwBi" id="6vp$_2vnqX2" role="3clFbG">
+                          <node concept="2OqwBi" id="6vp$_2vnpmB" role="2Oq$k0">
+                            <node concept="1PxgMI" id="6vp$_2vnq7B" role="2Oq$k0">
+                              <node concept="37vLTw" id="6vp$_2vnpjL" role="1m5AlR">
                                 <ref role="3cqZAo" node="6vp$_2vno_N" resolve="source" />
                               </node>
-                              <node concept="chp4Y" id="5RIakkDITlY" role="3oSUPX">
-                                <ref role="cht4Q" to="tpce:h0PlHMJ" resolve="InterfaceConceptDeclaration" />
+                              <node concept="chp4Y" id="5RIakkDITmb" role="3oSUPX">
+                                <ref role="cht4Q" to="tpce:f_TIwhg" resolve="ConceptDeclaration" />
                               </node>
                             </node>
-                            <node concept="3Tsc0h" id="5oCf_1NSKkp" role="2OqNvi">
-                              <ref role="3TtcxE" to="tpce:h0PrDRO" resolve="extends" />
+                            <node concept="3TrEf2" id="6vp$_2vnqxE" role="2OqNvi">
+                              <ref role="3Tt5mk" to="tpce:f_TJDff" resolve="extends" />
                             </node>
                           </node>
-                          <node concept="1z4cxt" id="5oCf_1NSKkq" role="2OqNvi">
-                            <node concept="1bVj0M" id="5oCf_1NSKkr" role="23t8la">
-                              <node concept="3clFbS" id="5oCf_1NSKks" role="1bW5cS">
-                                <node concept="3clFbF" id="5oCf_1NSKkt" role="3cqZAp">
-                                  <node concept="17R0WA" id="5oCf_1NSKku" role="3clFbG">
-                                    <node concept="1LFfDK" id="5oCf_1NSKkv" role="3uHU7w">
-                                      <node concept="3cmrfG" id="5oCf_1NSKkw" role="1LF_Uc">
-                                        <property role="3cmrfH" value="1" />
-                                      </node>
-                                      <node concept="37u81S" id="5oCf_1NSKkx" role="1LFl5Q" />
-                                    </node>
-                                    <node concept="2OqwBi" id="5oCf_1NSKky" role="3uHU7B">
-                                      <node concept="37vLTw" id="5oCf_1NSKkz" role="2Oq$k0">
-                                        <ref role="3cqZAo" node="5oCf_1NSKk_" resolve="it" />
-                                      </node>
-                                      <node concept="3TrEf2" id="5oCf_1NSKk$" role="2OqNvi">
-                                        <ref role="3Tt5mk" to="tpce:h0PrY0D" resolve="intfc" />
+                          <node concept="2oxUTD" id="6vp$_2vns5s" role="2OqNvi">
+                            <node concept="10Nm6u" id="6vp$_2vns77" role="2oxUTC" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="2OqwBi" id="6vp$_2vnoK1" role="3clFbw">
+                      <node concept="37vLTw" id="6vp$_2vno_R" role="2Oq$k0">
+                        <ref role="3cqZAo" node="6vp$_2vno_N" resolve="source" />
+                      </node>
+                      <node concept="1mIQ4w" id="6vp$_2vnpf7" role="2OqNvi">
+                        <node concept="chp4Y" id="6vp$_2vnpgG" role="cj9EA">
+                          <ref role="cht4Q" to="tpce:f_TIwhg" resolve="ConceptDeclaration" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="9aQIb" id="6vp$_2vns7Y" role="9aQIa">
+                      <node concept="3clFbS" id="6vp$_2vns7Z" role="9aQI4">
+                        <node concept="3cpWs8" id="5oCf_1NSKkj" role="3cqZAp">
+                          <node concept="3cpWsn" id="5oCf_1NSKkk" role="3cpWs9">
+                            <property role="TrG5h" value="x" />
+                            <node concept="3Tqbb2" id="5oCf_1NSKjR" role="1tU5fm">
+                              <ref role="ehGHo" to="tpce:h0PrWoo" resolve="InterfaceConceptReference" />
+                            </node>
+                            <node concept="2OqwBi" id="5oCf_1NSKkl" role="33vP2m">
+                              <node concept="2OqwBi" id="5oCf_1NSKkm" role="2Oq$k0">
+                                <node concept="1PxgMI" id="5oCf_1NSKkn" role="2Oq$k0">
+                                  <node concept="37vLTw" id="5oCf_1NSKko" role="1m5AlR">
+                                    <ref role="3cqZAo" node="6vp$_2vno_N" resolve="source" />
+                                  </node>
+                                  <node concept="chp4Y" id="5RIakkDITlY" role="3oSUPX">
+                                    <ref role="cht4Q" to="tpce:h0PlHMJ" resolve="InterfaceConceptDeclaration" />
+                                  </node>
+                                </node>
+                                <node concept="3Tsc0h" id="5oCf_1NSKkp" role="2OqNvi">
+                                  <ref role="3TtcxE" to="tpce:h0PrDRO" resolve="extends" />
+                                </node>
+                              </node>
+                              <node concept="1z4cxt" id="5oCf_1NSKkq" role="2OqNvi">
+                                <node concept="1bVj0M" id="5oCf_1NSKkr" role="23t8la">
+                                  <node concept="3clFbS" id="5oCf_1NSKks" role="1bW5cS">
+                                    <node concept="3clFbF" id="5oCf_1NSKkt" role="3cqZAp">
+                                      <node concept="17R0WA" id="5oCf_1NSKku" role="3clFbG">
+                                        <node concept="1LFfDK" id="5oCf_1NSKkv" role="3uHU7w">
+                                          <node concept="3cmrfG" id="5oCf_1NSKkw" role="1LF_Uc">
+                                            <property role="3cmrfH" value="1" />
+                                          </node>
+                                          <node concept="37u81S" id="5oCf_1NSKkx" role="1LFl5Q" />
+                                        </node>
+                                        <node concept="2OqwBi" id="5oCf_1NSKky" role="3uHU7B">
+                                          <node concept="37vLTw" id="5oCf_1NSKkz" role="2Oq$k0">
+                                            <ref role="3cqZAo" node="5oCf_1NSKk_" resolve="it" />
+                                          </node>
+                                          <node concept="3TrEf2" id="5oCf_1NSKk$" role="2OqNvi">
+                                            <ref role="3Tt5mk" to="tpce:h0PrY0D" resolve="intfc" />
+                                          </node>
+                                        </node>
                                       </node>
                                     </node>
                                   </node>
+                                  <node concept="Rh6nW" id="5oCf_1NSKk_" role="1bW2Oz">
+                                    <property role="TrG5h" value="it" />
+                                    <node concept="2jxLKc" id="5oCf_1NSKkA" role="1tU5fm" />
+                                  </node>
                                 </node>
-                              </node>
-                              <node concept="Rh6nW" id="5oCf_1NSKk_" role="1bW2Oz">
-                                <property role="TrG5h" value="it" />
-                                <node concept="2jxLKc" id="5oCf_1NSKkA" role="1tU5fm" />
                               </node>
                             </node>
                           </node>
                         </node>
-                      </node>
-                    </node>
-                    <node concept="3clFbF" id="6vp$_2vnsb9" role="3cqZAp">
-                      <node concept="2OqwBi" id="6vp$_2vntWY" role="3clFbG">
-                        <node concept="37vLTw" id="5oCf_1NSKkB" role="2Oq$k0">
-                          <ref role="3cqZAo" node="5oCf_1NSKkk" resolve="x" />
+                        <node concept="3clFbF" id="6vp$_2vnsb9" role="3cqZAp">
+                          <node concept="2OqwBi" id="6vp$_2vntWY" role="3clFbG">
+                            <node concept="37vLTw" id="5oCf_1NSKkB" role="2Oq$k0">
+                              <ref role="3cqZAo" node="5oCf_1NSKkk" resolve="x" />
+                            </node>
+                            <node concept="3YRAZt" id="6vp$_2vnSDj" role="2OqNvi" />
+                          </node>
                         </node>
-                        <node concept="3YRAZt" id="6vp$_2vnSDj" role="2OqNvi" />
                       </node>
                     </node>
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="6fDk5b6daZn" role="3clFbw">
+                  <node concept="23r2z0" id="6fDk5b6daOP" role="2Oq$k0" />
+                  <node concept="3TrcHB" id="6fDk5b6dbcN" role="2OqNvi">
+                    <ref role="3TsBF5" to="45ke:6fDk5b6392$" resolve="modelAccess" />
                   </node>
                 </node>
               </node>
@@ -3847,6 +3880,17 @@
             </node>
             <node concept="238au4" id="47lMzc0J16z" role="1PNbKP">
               <node concept="3EZMnI" id="47lMzc0La7P" role="2wV5jI">
+                <node concept="VSNWy" id="6fDk5b6L5Vo" role="3F10Kt">
+                  <node concept="1cFabM" id="6fDk5b6L5Vp" role="1d8cEk">
+                    <node concept="3clFbS" id="6fDk5b6L5Vq" role="2VODD2">
+                      <node concept="3clFbF" id="6fDk5b6L5Vr" role="3cqZAp">
+                        <node concept="3cmrfG" id="6fDk5b6L5Vs" role="3clFbG">
+                          <property role="3cmrfH" value="10" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
                 <node concept="2iRfu4" id="47lMzc0La7Q" role="2iSdaV" />
                 <node concept="3F0A7n" id="47lMzc0J1ee" role="3EZMnx">
                   <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
@@ -3898,23 +3942,22 @@
               </node>
             </node>
           </node>
-          <node concept="238au4" id="2igMYjpBzJP" role="3kqczz">
-            <node concept="3EZMnI" id="2igMYjpBzJQ" role="2wV5jI">
-              <node concept="3F0A7n" id="2igMYjpBzJR" role="3EZMnx">
-                <ref role="1NtTu8" to="tpce:fA0kJcN" resolve="role" />
-              </node>
-              <node concept="2iRfu4" id="2igMYjpBzJS" role="2iSdaV" />
-              <node concept="VPM3Z" id="2igMYjpBzJT" role="3F10Kt">
-                <property role="VOm3f" value="false" />
-              </node>
-            </node>
-          </node>
           <node concept="2fs66k" id="6vp$_2vpcbT" role="1ide8m">
             <node concept="3clFbS" id="6vp$_2vpcbU" role="2VODD2">
-              <node concept="3clFbF" id="6vp$_2vpcrb" role="3cqZAp">
-                <node concept="2OqwBi" id="6vp$_2vpcul" role="3clFbG">
-                  <node concept="37u81S" id="6vp$_2vpcra" role="2Oq$k0" />
-                  <node concept="3YRAZt" id="6vp$_2vpcWt" role="2OqNvi" />
+              <node concept="3clFbJ" id="6fDk5b6dbNs" role="3cqZAp">
+                <node concept="2OqwBi" id="6fDk5b6dbY9" role="3clFbw">
+                  <node concept="23r2z0" id="6fDk5b6dbNK" role="2Oq$k0" />
+                  <node concept="3TrcHB" id="6fDk5b6dcvr" role="2OqNvi">
+                    <ref role="3TsBF5" to="45ke:6fDk5b6392$" resolve="modelAccess" />
+                  </node>
+                </node>
+                <node concept="3clFbS" id="6fDk5b6dbNu" role="3clFbx">
+                  <node concept="3clFbF" id="6vp$_2vpcrb" role="3cqZAp">
+                    <node concept="2OqwBi" id="6vp$_2vpcul" role="3clFbG">
+                      <node concept="37u81S" id="6vp$_2vpcra" role="2Oq$k0" />
+                      <node concept="3YRAZt" id="6vp$_2vpcWt" role="2OqNvi" />
+                    </node>
+                  </node>
                 </node>
               </node>
             </node>
@@ -4054,10 +4097,20 @@
           </node>
           <node concept="2fs66k" id="6vp$_2vpcXB" role="1ide8m">
             <node concept="3clFbS" id="6vp$_2vpcXC" role="2VODD2">
-              <node concept="3clFbF" id="6vp$_2vpd4t" role="3cqZAp">
-                <node concept="2OqwBi" id="6vp$_2vpd5Y" role="3clFbG">
-                  <node concept="37u81S" id="6vp$_2vpd4s" role="2Oq$k0" />
-                  <node concept="3YRAZt" id="6vp$_2vpdfV" role="2OqNvi" />
+              <node concept="3clFbJ" id="6fDk5b6dc_q" role="3cqZAp">
+                <node concept="2OqwBi" id="6fDk5b6dc_r" role="3clFbw">
+                  <node concept="23r2z0" id="6fDk5b6dc_s" role="2Oq$k0" />
+                  <node concept="3TrcHB" id="6fDk5b6dc_t" role="2OqNvi">
+                    <ref role="3TsBF5" to="45ke:6fDk5b6392$" resolve="modelAccess" />
+                  </node>
+                </node>
+                <node concept="3clFbS" id="6fDk5b6dc_u" role="3clFbx">
+                  <node concept="3clFbF" id="6fDk5b6dc_v" role="3cqZAp">
+                    <node concept="2OqwBi" id="6fDk5b6dc_w" role="3clFbG">
+                      <node concept="37u81S" id="6fDk5b6dc_x" role="2Oq$k0" />
+                      <node concept="3YRAZt" id="6fDk5b6dc_y" role="2OqNvi" />
+                    </node>
+                  </node>
                 </node>
               </node>
             </node>
@@ -4082,368 +4135,572 @@
       </node>
       <node concept="2iRkQZ" id="2igMYjpAqwn" role="2iSdaV" />
     </node>
-    <node concept="3EZMnI" id="7ER1loq4auu" role="6VMZX">
-      <node concept="2iRfu4" id="7ER1loq4aux" role="2iSdaV" />
-      <node concept="3F0ifn" id="7ER1loq4fvy" role="3EZMnx">
-        <property role="3F0ifm" value="auto import concepts" />
-        <node concept="OXEIz" id="7ER1loq4fy9" role="P5bDN">
-          <node concept="1oHujT" id="7ER1loq8575" role="OY2wv">
-            <property role="1oHujS" value="add all child concepts" />
-            <node concept="1oIgkG" id="7ER1loq8577" role="1oHujR">
-              <node concept="3clFbS" id="7ER1loq8579" role="2VODD2">
-                <node concept="3clFbF" id="7ER1loq9D3q" role="3cqZAp">
-                  <node concept="2OqwBi" id="7ER1loq9Vdf" role="3clFbG">
-                    <node concept="2OqwBi" id="7ER1loq9F8J" role="2Oq$k0">
-                      <node concept="2OqwBi" id="7ER1loq9DbS" role="2Oq$k0">
-                        <node concept="3GMtW1" id="7ER1loq9D3p" role="2Oq$k0" />
-                        <node concept="3Tsc0h" id="7ER1loq9Dsa" role="2OqNvi">
-                          <ref role="3TtcxE" to="45ke:2igMYjp_Ggs" resolve="contents" />
-                        </node>
-                      </node>
-                      <node concept="13MTOL" id="7ER1loq9Ufs" role="2OqNvi">
-                        <ref role="13MTZf" to="45ke:2igMYjpPzq8" resolve="concept" />
+    <node concept="3EZMnI" id="6fDk5b63WY0" role="6VMZX">
+      <node concept="2iRkQZ" id="6fDk5b63WY1" role="2iSdaV" />
+      <node concept="3EZMnI" id="52KiyBHh8bW" role="3EZMnx">
+        <node concept="2iRfu4" id="52KiyBHh8bX" role="2iSdaV" />
+        <node concept="3gTLQM" id="52KiyBH8dxf" role="3EZMnx">
+          <node concept="3Fmcul" id="52KiyBH8dxh" role="3FoqZy">
+            <node concept="3clFbS" id="52KiyBH8dxj" role="2VODD2">
+              <node concept="3cpWs8" id="52KiyBH8gzh" role="3cqZAp">
+                <node concept="3cpWsn" id="52KiyBH8gzi" role="3cpWs9">
+                  <property role="TrG5h" value="button" />
+                  <node concept="3uibUv" id="52KiyBH8gzj" role="1tU5fm">
+                    <ref role="3uigEE" to="dxuu:~JButton" resolve="JButton" />
+                  </node>
+                  <node concept="2ShNRf" id="52KiyBH8h7j" role="33vP2m">
+                    <node concept="1pGfFk" id="52KiyBH8nqe" role="2ShVmc">
+                      <ref role="37wK5l" to="dxuu:~JButton.&lt;init&gt;(java.lang.String)" resolve="JButton" />
+                      <node concept="Xl_RD" id="52KiyBH8w8j" role="37wK5m">
+                        <property role="Xl_RC" value="add concepts of current model" />
                       </node>
                     </node>
-                    <node concept="2es0OD" id="7ER1loqa3gV" role="2OqNvi">
-                      <node concept="1bVj0M" id="7ER1loqa3gX" role="23t8la">
-                        <node concept="3clFbS" id="7ER1loqa3gY" role="1bW5cS">
-                          <node concept="3clFbF" id="7ER1loqa3sJ" role="3cqZAp">
-                            <node concept="2OqwBi" id="7ER1loqawN5" role="3clFbG">
-                              <node concept="2es0OD" id="7ER1loqaO5F" role="2OqNvi">
-                                <node concept="1bVj0M" id="7ER1loqaO5H" role="23t8la">
-                                  <node concept="3clFbS" id="7ER1loqaO5I" role="1bW5cS">
-                                    <node concept="3clFbF" id="7ER1loqaOBL" role="3cqZAp">
-                                      <node concept="2OqwBi" id="7ER1loqccZo" role="3clFbG">
-                                        <node concept="2OqwBi" id="7ER1loqaXWi" role="2Oq$k0">
-                                          <node concept="2OqwBi" id="7ER1loqaR$j" role="2Oq$k0">
-                                            <node concept="2OqwBi" id="7ER1loqaORX" role="2Oq$k0">
-                                              <node concept="3GMtW1" id="7ER1loqaOBK" role="2Oq$k0" />
-                                              <node concept="3Tsc0h" id="7ER1loqaPSM" role="2OqNvi">
-                                                <ref role="3TtcxE" to="45ke:2igMYjp_Ggs" resolve="contents" />
-                                              </node>
-                                            </node>
-                                            <node concept="WFELt" id="7ER1loqaVDv" role="2OqNvi">
-                                              <ref role="1A0vxQ" to="45ke:2igMYjpPzq7" resolve="AbstractConceptDeclarationRef" />
-                                            </node>
-                                          </node>
-                                          <node concept="3TrEf2" id="7ER1loqb_Bx" role="2OqNvi">
-                                            <ref role="3Tt5mk" to="45ke:2igMYjpPzq8" resolve="concept" />
-                                          </node>
-                                        </node>
-                                        <node concept="2oxUTD" id="7ER1loqfLxI" role="2OqNvi">
-                                          <node concept="2OqwBi" id="7ER1loqnAYe" role="2oxUTC">
-                                            <node concept="37vLTw" id="7ER1loqnAm9" role="2Oq$k0">
-                                              <ref role="3cqZAo" node="7ER1loqaO5J" resolve="child" />
-                                            </node>
-                                            <node concept="3TrEf2" id="7ER1loqrbi7" role="2OqNvi">
-                                              <ref role="3Tt5mk" to="tpce:fA0lvVK" resolve="target" />
-                                            </node>
-                                          </node>
-                                        </node>
-                                      </node>
-                                    </node>
-                                  </node>
-                                  <node concept="Rh6nW" id="7ER1loqaO5J" role="1bW2Oz">
-                                    <property role="TrG5h" value="child" />
-                                    <node concept="2jxLKc" id="7ER1loqaO5K" role="1tU5fm" />
-                                  </node>
-                                </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbF" id="52KiyBH8CQ8" role="3cqZAp">
+                <node concept="2OqwBi" id="52KiyBH8DC5" role="3clFbG">
+                  <node concept="37vLTw" id="52KiyBH8CQ6" role="2Oq$k0">
+                    <ref role="3cqZAo" node="52KiyBH8gzi" resolve="button" />
+                  </node>
+                  <node concept="liA8E" id="52KiyBH8EPX" role="2OqNvi">
+                    <ref role="37wK5l" to="dxuu:~AbstractButton.addActionListener(java.awt.event.ActionListener):void" resolve="addActionListener" />
+                    <node concept="2ShNRf" id="52KiyBH8Py8" role="37wK5m">
+                      <node concept="YeOm9" id="52KiyBH8Rf3" role="2ShVmc">
+                        <node concept="1Y3b0j" id="52KiyBH8Rf6" role="YeSDq">
+                          <property role="2bfB8j" value="true" />
+                          <ref role="1Y3XeK" to="hyam:~ActionListener" resolve="ActionListener" />
+                          <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
+                          <node concept="3Tm1VV" id="52KiyBH8Rf7" role="1B3o_S" />
+                          <node concept="3clFb_" id="52KiyBH8Rf9" role="jymVt">
+                            <property role="TrG5h" value="actionPerformed" />
+                            <node concept="3Tm1VV" id="52KiyBH8Rfa" role="1B3o_S" />
+                            <node concept="3cqZAl" id="52KiyBH8Rfc" role="3clF45" />
+                            <node concept="37vLTG" id="52KiyBH8Rfd" role="3clF46">
+                              <property role="TrG5h" value="click" />
+                              <node concept="3uibUv" id="52KiyBH8Rfe" role="1tU5fm">
+                                <ref role="3uigEE" to="hyam:~ActionEvent" resolve="ActionEvent" />
                               </node>
-                              <node concept="2OqwBi" id="7ER1loqhzZA" role="2Oq$k0">
-                                <node concept="2OqwBi" id="7ER1loqqGEU" role="2Oq$k0">
-                                  <node concept="2OqwBi" id="7ER1loqgUY2" role="2Oq$k0">
-                                    <node concept="37vLTw" id="7ER1loqgUnz" role="2Oq$k0">
-                                      <ref role="3cqZAo" node="7ER1loqa3gZ" resolve="existingConcept" />
-                                    </node>
-                                    <node concept="32TBzR" id="7ER1loqgXR0" role="2OqNvi" />
-                                  </node>
-                                  <node concept="v3k3i" id="7ER1loqqMbS" role="2OqNvi">
-                                    <node concept="chp4Y" id="7ER1loqqNpF" role="v3oSu">
-                                      <ref role="cht4Q" to="tpce:f_TJgxE" resolve="LinkDeclaration" />
-                                    </node>
-                                  </node>
-                                </node>
-                                <node concept="3zZkjj" id="7ER1loqhHPn" role="2OqNvi">
-                                  <node concept="1bVj0M" id="7ER1loqhHPp" role="23t8la">
-                                    <node concept="3clFbS" id="7ER1loqhHPq" role="1bW5cS">
-                                      <node concept="3clFbF" id="7ER1loqhIQW" role="3cqZAp">
-                                        <node concept="2OqwBi" id="7ER1loqhV66" role="3clFbG">
-                                          <node concept="2OqwBi" id="7ER1loqhNZw" role="2Oq$k0">
-                                            <node concept="2OqwBi" id="7ER1loqhJs8" role="2Oq$k0">
-                                              <node concept="3GMtW1" id="7ER1loqhIQV" role="2Oq$k0" />
-                                              <node concept="3Tsc0h" id="7ER1loqhKVV" role="2OqNvi">
-                                                <ref role="3TtcxE" to="45ke:2igMYjp_Ggs" resolve="contents" />
-                                              </node>
+                            </node>
+                            <node concept="3clFbS" id="52KiyBH8Rff" role="3clF47">
+                              <node concept="1QHqEO" id="52KiyBHbTda" role="3cqZAp">
+                                <node concept="1QHqEC" id="52KiyBHc5Qz" role="1QHqEI">
+                                  <node concept="3clFbS" id="52KiyBHc5Q$" role="1bW5cS">
+                                    <node concept="3clFbF" id="52KiyBHht$9" role="3cqZAp">
+                                      <node concept="2OqwBi" id="52KiyBHht$a" role="3clFbG">
+                                        <node concept="2OqwBi" id="52KiyBHht$b" role="2Oq$k0">
+                                          <node concept="2OqwBi" id="52KiyBHht$c" role="2Oq$k0">
+                                            <node concept="2OqwBi" id="52KiyBHht$d" role="2Oq$k0">
+                                              <node concept="pncrf" id="52KiyBHhxrr" role="2Oq$k0" />
+                                              <node concept="I4A8Y" id="52KiyBHht$f" role="2OqNvi" />
                                             </node>
-                                            <node concept="13MTOL" id="7ER1loqhSqI" role="2OqNvi">
-                                              <ref role="13MTZf" to="45ke:2igMYjpPzq8" resolve="concept" />
+                                            <node concept="2RRcyG" id="52KiyBHht$g" role="2OqNvi">
+                                              <ref role="2RRcyH" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
                                             </node>
                                           </node>
-                                          <node concept="2HxqBE" id="7ER1loqp60R" role="2OqNvi">
-                                            <node concept="1bVj0M" id="7ER1loqp60T" role="23t8la">
-                                              <node concept="3clFbS" id="7ER1loqp60U" role="1bW5cS">
-                                                <node concept="3clFbF" id="7ER1loqp60V" role="3cqZAp">
-                                                  <node concept="3y3z36" id="7ER1loqp7q4" role="3clFbG">
-                                                    <node concept="37vLTw" id="7ER1loqp60Y" role="3uHU7B">
-                                                      <ref role="3cqZAo" node="7ER1loqp60Z" resolve="existingConcept" />
-                                                    </node>
-                                                    <node concept="2OqwBi" id="7ER1loqqPb8" role="3uHU7w">
-                                                      <node concept="37vLTw" id="7ER1loqp60X" role="2Oq$k0">
-                                                        <ref role="3cqZAo" node="7ER1loqhHPr" resolve="child" />
+                                          <node concept="3zZkjj" id="52KiyBHht$h" role="2OqNvi">
+                                            <node concept="1bVj0M" id="52KiyBHht$i" role="23t8la">
+                                              <node concept="3clFbS" id="52KiyBHht$j" role="1bW5cS">
+                                                <node concept="3clFbF" id="52KiyBHht$k" role="3cqZAp">
+                                                  <node concept="3fqX7Q" id="52KiyBHht$l" role="3clFbG">
+                                                    <node concept="2OqwBi" id="52KiyBHht$m" role="3fr31v">
+                                                      <node concept="2OqwBi" id="52KiyBHht$n" role="2Oq$k0">
+                                                        <node concept="2OqwBi" id="52KiyBHht$o" role="2Oq$k0">
+                                                          <node concept="pncrf" id="52KiyBHhwn$" role="2Oq$k0" />
+                                                          <node concept="3Tsc0h" id="52KiyBHht$q" role="2OqNvi">
+                                                            <ref role="3TtcxE" to="45ke:2igMYjp_Ggs" resolve="contents" />
+                                                          </node>
+                                                        </node>
+                                                        <node concept="13MTOL" id="52KiyBHht$r" role="2OqNvi">
+                                                          <ref role="13MTZf" to="45ke:2igMYjpPzq8" resolve="concept" />
+                                                        </node>
                                                       </node>
-                                                      <node concept="3TrEf2" id="7ER1loqqQVE" role="2OqNvi">
-                                                        <ref role="3Tt5mk" to="tpce:fA0lvVK" resolve="target" />
+                                                      <node concept="3JPx81" id="52KiyBHht$s" role="2OqNvi">
+                                                        <node concept="37vLTw" id="52KiyBHht$t" role="25WWJ7">
+                                                          <ref role="3cqZAo" node="52KiyBHht$u" resolve="it" />
+                                                        </node>
                                                       </node>
                                                     </node>
                                                   </node>
                                                 </node>
                                               </node>
-                                              <node concept="Rh6nW" id="7ER1loqp60Z" role="1bW2Oz">
-                                                <property role="TrG5h" value="existingConcept" />
-                                                <node concept="2jxLKc" id="7ER1loqp610" role="1tU5fm" />
+                                              <node concept="Rh6nW" id="52KiyBHht$u" role="1bW2Oz">
+                                                <property role="TrG5h" value="it" />
+                                                <node concept="2jxLKc" id="52KiyBHht$v" role="1tU5fm" />
                                               </node>
                                             </node>
                                           </node>
                                         </node>
-                                      </node>
-                                    </node>
-                                    <node concept="Rh6nW" id="7ER1loqhHPr" role="1bW2Oz">
-                                      <property role="TrG5h" value="child" />
-                                      <node concept="2jxLKc" id="7ER1loqhHPs" role="1tU5fm" />
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="Rh6nW" id="7ER1loqa3gZ" role="1bW2Oz">
-                          <property role="TrG5h" value="existingConcept" />
-                          <node concept="2jxLKc" id="7ER1loqa3h0" role="1tU5fm" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="1oHujT" id="7ER1loqskWa" role="OY2wv">
-            <property role="1oHujS" value="add all direct extensions" />
-            <node concept="1oIgkG" id="7ER1loqskWb" role="1oHujR">
-              <node concept="3clFbS" id="7ER1loqskWc" role="2VODD2">
-                <node concept="3clFbF" id="7ER1loqskWd" role="3cqZAp">
-                  <node concept="2OqwBi" id="7ER1loqskWe" role="3clFbG">
-                    <node concept="2OqwBi" id="7ER1loqskWf" role="2Oq$k0">
-                      <node concept="2OqwBi" id="7ER1loqskWg" role="2Oq$k0">
-                        <node concept="3GMtW1" id="7ER1loqskWh" role="2Oq$k0" />
-                        <node concept="3Tsc0h" id="7ER1loqskWi" role="2OqNvi">
-                          <ref role="3TtcxE" to="45ke:2igMYjp_Ggs" resolve="contents" />
-                        </node>
-                      </node>
-                      <node concept="13MTOL" id="7ER1loqskWj" role="2OqNvi">
-                        <ref role="13MTZf" to="45ke:2igMYjpPzq8" resolve="concept" />
-                      </node>
-                    </node>
-                    <node concept="2es0OD" id="7ER1loqskWk" role="2OqNvi">
-                      <node concept="1bVj0M" id="7ER1loqskWl" role="23t8la">
-                        <node concept="3clFbS" id="7ER1loqskWm" role="1bW5cS">
-                          <node concept="3clFbF" id="7ER1loqskWx" role="3cqZAp">
-                            <node concept="2OqwBi" id="7ER1loqskWy" role="3clFbG">
-                              <node concept="2es0OD" id="7ER1loqskWz" role="2OqNvi">
-                                <node concept="1bVj0M" id="7ER1loqskW$" role="23t8la">
-                                  <node concept="3clFbS" id="7ER1loqskW_" role="1bW5cS">
-                                    <node concept="3clFbF" id="7ER1loqskWA" role="3cqZAp">
-                                      <node concept="2OqwBi" id="7ER1loqskWB" role="3clFbG">
-                                        <node concept="2OqwBi" id="7ER1loqskWC" role="2Oq$k0">
-                                          <node concept="2OqwBi" id="7ER1loqskWD" role="2Oq$k0">
-                                            <node concept="2OqwBi" id="7ER1loqskWE" role="2Oq$k0">
-                                              <node concept="3GMtW1" id="7ER1loqskWF" role="2Oq$k0" />
-                                              <node concept="3Tsc0h" id="7ER1loqskWG" role="2OqNvi">
-                                                <ref role="3TtcxE" to="45ke:2igMYjp_Ggs" resolve="contents" />
-                                              </node>
-                                            </node>
-                                            <node concept="WFELt" id="7ER1loqskWH" role="2OqNvi">
-                                              <ref role="1A0vxQ" to="45ke:2igMYjpPzq7" resolve="AbstractConceptDeclarationRef" />
-                                            </node>
-                                          </node>
-                                          <node concept="3TrEf2" id="7ER1loqskWI" role="2OqNvi">
-                                            <ref role="3Tt5mk" to="45ke:2igMYjpPzq8" resolve="concept" />
-                                          </node>
-                                        </node>
-                                        <node concept="2oxUTD" id="7ER1loqskWJ" role="2OqNvi">
-                                          <node concept="37vLTw" id="7ER1loqskWL" role="2oxUTC">
-                                            <ref role="3cqZAo" node="7ER1loqskWN" resolve="extension" />
-                                          </node>
-                                        </node>
-                                      </node>
-                                    </node>
-                                  </node>
-                                  <node concept="Rh6nW" id="7ER1loqskWN" role="1bW2Oz">
-                                    <property role="TrG5h" value="extension" />
-                                    <node concept="2jxLKc" id="7ER1loqskWO" role="1tU5fm" />
-                                  </node>
-                                </node>
-                              </node>
-                              <node concept="2OqwBi" id="7ER1loqskWP" role="2Oq$k0">
-                                <node concept="2OqwBi" id="7ER1loqskWR" role="2Oq$k0">
-                                  <node concept="37vLTw" id="7ER1loqskWS" role="2Oq$k0">
-                                    <ref role="3cqZAo" node="7ER1loqskXj" resolve="existingConcept" />
-                                  </node>
-                                  <node concept="2qgKlT" id="7ER1loqs_uD" role="2OqNvi">
-                                    <ref role="37wK5l" to="tpcn:2A8AB0rAWpG" resolve="getAllSuperConcepts" />
-                                    <node concept="3clFbT" id="7ER1loqtcnh" role="37wK5m" />
-                                  </node>
-                                </node>
-                                <node concept="3zZkjj" id="7ER1loqskWW" role="2OqNvi">
-                                  <node concept="1bVj0M" id="7ER1loqskWX" role="23t8la">
-                                    <node concept="3clFbS" id="7ER1loqskWY" role="1bW5cS">
-                                      <node concept="3clFbF" id="7ER1loqskWZ" role="3cqZAp">
-                                        <node concept="2OqwBi" id="7ER1loqskX0" role="3clFbG">
-                                          <node concept="2OqwBi" id="7ER1loqskX1" role="2Oq$k0">
-                                            <node concept="2OqwBi" id="7ER1loqskX2" role="2Oq$k0">
-                                              <node concept="3GMtW1" id="7ER1loqskX3" role="2Oq$k0" />
-                                              <node concept="3Tsc0h" id="7ER1loqskX4" role="2OqNvi">
-                                                <ref role="3TtcxE" to="45ke:2igMYjp_Ggs" resolve="contents" />
-                                              </node>
-                                            </node>
-                                            <node concept="13MTOL" id="7ER1loqskX5" role="2OqNvi">
-                                              <ref role="13MTZf" to="45ke:2igMYjpPzq8" resolve="concept" />
-                                            </node>
-                                          </node>
-                                          <node concept="2HxqBE" id="7ER1loqskX6" role="2OqNvi">
-                                            <node concept="1bVj0M" id="7ER1loqskX7" role="23t8la">
-                                              <node concept="3clFbS" id="7ER1loqskX8" role="1bW5cS">
-                                                <node concept="3clFbF" id="7ER1loqskX9" role="3cqZAp">
-                                                  <node concept="3y3z36" id="7ER1loqskXa" role="3clFbG">
-                                                    <node concept="37vLTw" id="7ER1loqskXb" role="3uHU7B">
-                                                      <ref role="3cqZAo" node="7ER1loqskXf" resolve="existingConcept" />
+                                        <node concept="2es0OD" id="52KiyBHht$w" role="2OqNvi">
+                                          <node concept="1bVj0M" id="52KiyBHht$x" role="23t8la">
+                                            <node concept="3clFbS" id="52KiyBHht$y" role="1bW5cS">
+                                              <node concept="3clFbF" id="52KiyBHht$z" role="3cqZAp">
+                                                <node concept="2OqwBi" id="52KiyBHht$$" role="3clFbG">
+                                                  <node concept="2OqwBi" id="52KiyBHht$_" role="2Oq$k0">
+                                                    <node concept="2OqwBi" id="52KiyBHht$A" role="2Oq$k0">
+                                                      <node concept="2OqwBi" id="52KiyBHht$B" role="2Oq$k0">
+                                                        <node concept="pncrf" id="52KiyBHhv3y" role="2Oq$k0" />
+                                                        <node concept="3Tsc0h" id="52KiyBHht$D" role="2OqNvi">
+                                                          <ref role="3TtcxE" to="45ke:2igMYjp_Ggs" resolve="contents" />
+                                                        </node>
+                                                      </node>
+                                                      <node concept="WFELt" id="52KiyBHht$E" role="2OqNvi">
+                                                        <ref role="1A0vxQ" to="45ke:2igMYjpPzq7" resolve="AbstractConceptDeclarationRef" />
+                                                      </node>
                                                     </node>
-                                                    <node concept="37vLTw" id="7ER1loqskXd" role="3uHU7w">
-                                                      <ref role="3cqZAo" node="7ER1loqskXh" resolve="extension" />
+                                                    <node concept="3TrEf2" id="52KiyBHht$F" role="2OqNvi">
+                                                      <ref role="3Tt5mk" to="45ke:2igMYjpPzq8" resolve="concept" />
+                                                    </node>
+                                                  </node>
+                                                  <node concept="2oxUTD" id="52KiyBHht$G" role="2OqNvi">
+                                                    <node concept="37vLTw" id="52KiyBHht$H" role="2oxUTC">
+                                                      <ref role="3cqZAo" node="52KiyBHht$I" resolve="it" />
                                                     </node>
                                                   </node>
                                                 </node>
                                               </node>
-                                              <node concept="Rh6nW" id="7ER1loqskXf" role="1bW2Oz">
-                                                <property role="TrG5h" value="existingConcept" />
-                                                <node concept="2jxLKc" id="7ER1loqskXg" role="1tU5fm" />
-                                              </node>
+                                            </node>
+                                            <node concept="Rh6nW" id="52KiyBHht$I" role="1bW2Oz">
+                                              <property role="TrG5h" value="it" />
+                                              <node concept="2jxLKc" id="52KiyBHht$J" role="1tU5fm" />
                                             </node>
                                           </node>
                                         </node>
                                       </node>
                                     </node>
-                                    <node concept="Rh6nW" id="7ER1loqskXh" role="1bW2Oz">
-                                      <property role="TrG5h" value="extension" />
-                                      <node concept="2jxLKc" id="7ER1loqskXi" role="1tU5fm" />
-                                    </node>
+                                  </node>
+                                </node>
+                                <node concept="2OqwBi" id="52KiyBHs0yA" role="ukAjM">
+                                  <node concept="1Q80Hx" id="52KiyBHs0yB" role="2Oq$k0" />
+                                  <node concept="liA8E" id="52KiyBHs0yC" role="2OqNvi">
+                                    <ref role="37wK5l" to="cj4x:~EditorContext.getRepository():org.jetbrains.mps.openapi.module.SRepository" resolve="getRepository" />
                                   </node>
                                 </node>
                               </node>
                             </node>
                           </node>
                         </node>
-                        <node concept="Rh6nW" id="7ER1loqskXj" role="1bW2Oz">
-                          <property role="TrG5h" value="existingConcept" />
-                          <node concept="2jxLKc" id="7ER1loqskXk" role="1tU5fm" />
-                        </node>
                       </node>
                     </node>
                   </node>
                 </node>
               </node>
+              <node concept="3clFbF" id="52KiyBH8ock" role="3cqZAp">
+                <node concept="37vLTw" id="52KiyBH8oci" role="3clFbG">
+                  <ref role="3cqZAo" node="52KiyBH8gzi" resolve="button" />
+                </node>
+              </node>
             </node>
           </node>
-          <node concept="1oHujT" id="7ER1loq4f$K" role="OY2wv">
-            <property role="1oHujS" value="add all concepts of current model" />
-            <node concept="1oIgkG" id="7ER1loq4f$L" role="1oHujR">
-              <node concept="3clFbS" id="7ER1loq4f$M" role="2VODD2">
-                <node concept="3clFbF" id="7ER1loq4n5x" role="3cqZAp">
-                  <node concept="2OqwBi" id="7ER1loq4sHr" role="3clFbG">
-                    <node concept="2OqwBi" id="7ER1loq4n5z" role="2Oq$k0">
-                      <node concept="2OqwBi" id="7ER1loq4n5$" role="2Oq$k0">
-                        <node concept="2OqwBi" id="7ER1loq4n5_" role="2Oq$k0">
-                          <node concept="3GMtW1" id="7ER1loq4rZr" role="2Oq$k0" />
-                          <node concept="I4A8Y" id="7ER1loq4n5B" role="2OqNvi" />
-                        </node>
-                        <node concept="2RRcyG" id="7ER1loq4n5C" role="2OqNvi">
-                          <ref role="2RRcyH" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
-                        </node>
+        </node>
+        <node concept="3gTLQM" id="52KiyBHhaa6" role="3EZMnx">
+          <node concept="3Fmcul" id="52KiyBHhaa7" role="3FoqZy">
+            <node concept="3clFbS" id="52KiyBHhaa8" role="2VODD2">
+              <node concept="3cpWs8" id="52KiyBHhaa9" role="3cqZAp">
+                <node concept="3cpWsn" id="52KiyBHhaaa" role="3cpWs9">
+                  <property role="TrG5h" value="button" />
+                  <node concept="3uibUv" id="52KiyBHhaab" role="1tU5fm">
+                    <ref role="3uigEE" to="dxuu:~JButton" resolve="JButton" />
+                  </node>
+                  <node concept="2ShNRf" id="52KiyBHhaac" role="33vP2m">
+                    <node concept="1pGfFk" id="52KiyBHhaad" role="2ShVmc">
+                      <ref role="37wK5l" to="dxuu:~JButton.&lt;init&gt;(java.lang.String)" resolve="JButton" />
+                      <node concept="Xl_RD" id="52KiyBHhaae" role="37wK5m">
+                        <property role="Xl_RC" value="add direct extensions" />
                       </node>
-                      <node concept="3zZkjj" id="7ER1loq4n5D" role="2OqNvi">
-                        <node concept="1bVj0M" id="7ER1loq4n5E" role="23t8la">
-                          <node concept="3clFbS" id="7ER1loq4n5F" role="1bW5cS">
-                            <node concept="3clFbF" id="7ER1loq4n5G" role="3cqZAp">
-                              <node concept="3fqX7Q" id="7ER1loq4n5H" role="3clFbG">
-                                <node concept="2OqwBi" id="7ER1loq4n5I" role="3fr31v">
-                                  <node concept="2OqwBi" id="7ER1loq4n5J" role="2Oq$k0">
-                                    <node concept="2OqwBi" id="7ER1loq4n5K" role="2Oq$k0">
-                                      <node concept="3GMtW1" id="7ER1loq4sgR" role="2Oq$k0" />
-                                      <node concept="3Tsc0h" id="7ER1loq4n5M" role="2OqNvi">
-                                        <ref role="3TtcxE" to="45ke:2igMYjp_Ggs" resolve="contents" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbF" id="52KiyBHhaaf" role="3cqZAp">
+                <node concept="2OqwBi" id="52KiyBHhaag" role="3clFbG">
+                  <node concept="37vLTw" id="52KiyBHhaah" role="2Oq$k0">
+                    <ref role="3cqZAo" node="52KiyBHhaaa" resolve="button" />
+                  </node>
+                  <node concept="liA8E" id="52KiyBHhaai" role="2OqNvi">
+                    <ref role="37wK5l" to="dxuu:~AbstractButton.addActionListener(java.awt.event.ActionListener):void" resolve="addActionListener" />
+                    <node concept="2ShNRf" id="52KiyBHhaaj" role="37wK5m">
+                      <node concept="YeOm9" id="52KiyBHhaak" role="2ShVmc">
+                        <node concept="1Y3b0j" id="52KiyBHhaal" role="YeSDq">
+                          <property role="2bfB8j" value="true" />
+                          <ref role="1Y3XeK" to="hyam:~ActionListener" resolve="ActionListener" />
+                          <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
+                          <node concept="3Tm1VV" id="52KiyBHhaam" role="1B3o_S" />
+                          <node concept="3clFb_" id="52KiyBHhaan" role="jymVt">
+                            <property role="TrG5h" value="actionPerformed" />
+                            <node concept="3Tm1VV" id="52KiyBHhaao" role="1B3o_S" />
+                            <node concept="3cqZAl" id="52KiyBHhaap" role="3clF45" />
+                            <node concept="37vLTG" id="52KiyBHhaaq" role="3clF46">
+                              <property role="TrG5h" value="click" />
+                              <node concept="3uibUv" id="52KiyBHhaar" role="1tU5fm">
+                                <ref role="3uigEE" to="hyam:~ActionEvent" resolve="ActionEvent" />
+                              </node>
+                            </node>
+                            <node concept="3clFbS" id="52KiyBHhaas" role="3clF47">
+                              <node concept="1QHqEO" id="52KiyBHhaat" role="3cqZAp">
+                                <node concept="1QHqEC" id="52KiyBHhaau" role="1QHqEI">
+                                  <node concept="3clFbS" id="52KiyBHhaav" role="1bW5cS">
+                                    <node concept="3clFbF" id="52KiyBHhmxU" role="3cqZAp">
+                                      <node concept="2OqwBi" id="52KiyBHhmxV" role="3clFbG">
+                                        <node concept="2OqwBi" id="52KiyBHhmxW" role="2Oq$k0">
+                                          <node concept="2OqwBi" id="52KiyBHhmxX" role="2Oq$k0">
+                                            <node concept="pncrf" id="52KiyBHhog_" role="2Oq$k0" />
+                                            <node concept="3Tsc0h" id="52KiyBHhmxZ" role="2OqNvi">
+                                              <ref role="3TtcxE" to="45ke:2igMYjp_Ggs" resolve="contents" />
+                                            </node>
+                                          </node>
+                                          <node concept="13MTOL" id="52KiyBHhmy0" role="2OqNvi">
+                                            <ref role="13MTZf" to="45ke:2igMYjpPzq8" resolve="concept" />
+                                          </node>
+                                        </node>
+                                        <node concept="2es0OD" id="52KiyBHhmy1" role="2OqNvi">
+                                          <node concept="1bVj0M" id="52KiyBHhmy2" role="23t8la">
+                                            <node concept="3clFbS" id="52KiyBHhmy3" role="1bW5cS">
+                                              <node concept="3clFbF" id="52KiyBHhmy4" role="3cqZAp">
+                                                <node concept="2OqwBi" id="52KiyBHhmy5" role="3clFbG">
+                                                  <node concept="2es0OD" id="52KiyBHhmy6" role="2OqNvi">
+                                                    <node concept="1bVj0M" id="52KiyBHhmy7" role="23t8la">
+                                                      <node concept="3clFbS" id="52KiyBHhmy8" role="1bW5cS">
+                                                        <node concept="3clFbF" id="52KiyBHhmy9" role="3cqZAp">
+                                                          <node concept="2OqwBi" id="52KiyBHhmya" role="3clFbG">
+                                                            <node concept="2OqwBi" id="52KiyBHhmyb" role="2Oq$k0">
+                                                              <node concept="2OqwBi" id="52KiyBHhmyc" role="2Oq$k0">
+                                                                <node concept="2OqwBi" id="52KiyBHhmyd" role="2Oq$k0">
+                                                                  <node concept="pncrf" id="52KiyBHhqG3" role="2Oq$k0" />
+                                                                  <node concept="3Tsc0h" id="52KiyBHhmyf" role="2OqNvi">
+                                                                    <ref role="3TtcxE" to="45ke:2igMYjp_Ggs" resolve="contents" />
+                                                                  </node>
+                                                                </node>
+                                                                <node concept="WFELt" id="52KiyBHhmyg" role="2OqNvi">
+                                                                  <ref role="1A0vxQ" to="45ke:2igMYjpPzq7" resolve="AbstractConceptDeclarationRef" />
+                                                                </node>
+                                                              </node>
+                                                              <node concept="3TrEf2" id="52KiyBHhmyh" role="2OqNvi">
+                                                                <ref role="3Tt5mk" to="45ke:2igMYjpPzq8" resolve="concept" />
+                                                              </node>
+                                                            </node>
+                                                            <node concept="2oxUTD" id="52KiyBHhmyi" role="2OqNvi">
+                                                              <node concept="37vLTw" id="52KiyBHhmyj" role="2oxUTC">
+                                                                <ref role="3cqZAo" node="52KiyBHhmyk" resolve="extension" />
+                                                              </node>
+                                                            </node>
+                                                          </node>
+                                                        </node>
+                                                      </node>
+                                                      <node concept="Rh6nW" id="52KiyBHhmyk" role="1bW2Oz">
+                                                        <property role="TrG5h" value="extension" />
+                                                        <node concept="2jxLKc" id="52KiyBHhmyl" role="1tU5fm" />
+                                                      </node>
+                                                    </node>
+                                                  </node>
+                                                  <node concept="2OqwBi" id="52KiyBHhmym" role="2Oq$k0">
+                                                    <node concept="2OqwBi" id="52KiyBHhmyn" role="2Oq$k0">
+                                                      <node concept="37vLTw" id="52KiyBHhmyo" role="2Oq$k0">
+                                                        <ref role="3cqZAo" node="52KiyBHhmyK" resolve="existingConcept" />
+                                                      </node>
+                                                      <node concept="2qgKlT" id="52KiyBHhmyp" role="2OqNvi">
+                                                        <ref role="37wK5l" to="tpcn:hMuxyK2" resolve="getImmediateSuperconcepts" />
+                                                      </node>
+                                                    </node>
+                                                    <node concept="3zZkjj" id="52KiyBHhmyr" role="2OqNvi">
+                                                      <node concept="1bVj0M" id="52KiyBHhmys" role="23t8la">
+                                                        <node concept="3clFbS" id="52KiyBHhmyt" role="1bW5cS">
+                                                          <node concept="3clFbF" id="52KiyBHhmyu" role="3cqZAp">
+                                                            <node concept="2OqwBi" id="52KiyBHhmyv" role="3clFbG">
+                                                              <node concept="2OqwBi" id="52KiyBHhmyw" role="2Oq$k0">
+                                                                <node concept="2OqwBi" id="52KiyBHhmyx" role="2Oq$k0">
+                                                                  <node concept="pncrf" id="52KiyBHhpr7" role="2Oq$k0" />
+                                                                  <node concept="3Tsc0h" id="52KiyBHhmyz" role="2OqNvi">
+                                                                    <ref role="3TtcxE" to="45ke:2igMYjp_Ggs" resolve="contents" />
+                                                                  </node>
+                                                                </node>
+                                                                <node concept="13MTOL" id="52KiyBHhmy$" role="2OqNvi">
+                                                                  <ref role="13MTZf" to="45ke:2igMYjpPzq8" resolve="concept" />
+                                                                </node>
+                                                              </node>
+                                                              <node concept="2HxqBE" id="52KiyBHhmy_" role="2OqNvi">
+                                                                <node concept="1bVj0M" id="52KiyBHhmyA" role="23t8la">
+                                                                  <node concept="3clFbS" id="52KiyBHhmyB" role="1bW5cS">
+                                                                    <node concept="3clFbF" id="52KiyBHhmyC" role="3cqZAp">
+                                                                      <node concept="3y3z36" id="52KiyBHhmyD" role="3clFbG">
+                                                                        <node concept="37vLTw" id="52KiyBHhmyE" role="3uHU7B">
+                                                                          <ref role="3cqZAo" node="52KiyBHhmyG" resolve="existingConcept" />
+                                                                        </node>
+                                                                        <node concept="37vLTw" id="52KiyBHhmyF" role="3uHU7w">
+                                                                          <ref role="3cqZAo" node="52KiyBHhmyI" resolve="extension" />
+                                                                        </node>
+                                                                      </node>
+                                                                    </node>
+                                                                  </node>
+                                                                  <node concept="Rh6nW" id="52KiyBHhmyG" role="1bW2Oz">
+                                                                    <property role="TrG5h" value="existingConcept" />
+                                                                    <node concept="2jxLKc" id="52KiyBHhmyH" role="1tU5fm" />
+                                                                  </node>
+                                                                </node>
+                                                              </node>
+                                                            </node>
+                                                          </node>
+                                                        </node>
+                                                        <node concept="Rh6nW" id="52KiyBHhmyI" role="1bW2Oz">
+                                                          <property role="TrG5h" value="extension" />
+                                                          <node concept="2jxLKc" id="52KiyBHhmyJ" role="1tU5fm" />
+                                                        </node>
+                                                      </node>
+                                                    </node>
+                                                  </node>
+                                                </node>
+                                              </node>
+                                            </node>
+                                            <node concept="Rh6nW" id="52KiyBHhmyK" role="1bW2Oz">
+                                              <property role="TrG5h" value="existingConcept" />
+                                              <node concept="2jxLKc" id="52KiyBHhmyL" role="1tU5fm" />
+                                            </node>
+                                          </node>
+                                        </node>
                                       </node>
                                     </node>
-                                    <node concept="13MTOL" id="7ER1loq4n5N" role="2OqNvi">
-                                      <ref role="13MTZf" to="45ke:2igMYjpPzq8" resolve="concept" />
-                                    </node>
                                   </node>
-                                  <node concept="3JPx81" id="7ER1loq4n5O" role="2OqNvi">
-                                    <node concept="37vLTw" id="7ER1loq4n5P" role="25WWJ7">
-                                      <ref role="3cqZAo" node="7ER1loq4n5Q" resolve="it" />
-                                    </node>
+                                </node>
+                                <node concept="2OqwBi" id="52KiyBHrZh_" role="ukAjM">
+                                  <node concept="1Q80Hx" id="52KiyBHrYCA" role="2Oq$k0" />
+                                  <node concept="liA8E" id="52KiyBHs0wB" role="2OqNvi">
+                                    <ref role="37wK5l" to="cj4x:~EditorContext.getRepository():org.jetbrains.mps.openapi.module.SRepository" resolve="getRepository" />
                                   </node>
                                 </node>
                               </node>
                             </node>
                           </node>
-                          <node concept="Rh6nW" id="7ER1loq4n5Q" role="1bW2Oz">
-                            <property role="TrG5h" value="it" />
-                            <node concept="2jxLKc" id="7ER1loq4n5R" role="1tU5fm" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="2es0OD" id="7ER1loq4_Hl" role="2OqNvi">
-                      <node concept="1bVj0M" id="7ER1loq4_Hn" role="23t8la">
-                        <node concept="3clFbS" id="7ER1loq4_Ho" role="1bW5cS">
-                          <node concept="3clFbF" id="7ER1loq4_Zv" role="3cqZAp">
-                            <node concept="2OqwBi" id="7ER1loq5xV$" role="3clFbG">
-                              <node concept="2OqwBi" id="7ER1loq4TmP" role="2Oq$k0">
-                                <node concept="2OqwBi" id="7ER1loq4CtT" role="2Oq$k0">
-                                  <node concept="2OqwBi" id="7ER1loq4AbD" role="2Oq$k0">
-                                    <node concept="3GMtW1" id="7ER1loq4_Zu" role="2Oq$k0" />
-                                    <node concept="3Tsc0h" id="7ER1loq4AT3" role="2OqNvi">
-                                      <ref role="3TtcxE" to="45ke:2igMYjp_Ggs" resolve="contents" />
-                                    </node>
-                                  </node>
-                                  <node concept="WFELt" id="7ER1loq4Qp7" role="2OqNvi">
-                                    <ref role="1A0vxQ" to="45ke:2igMYjpPzq7" resolve="AbstractConceptDeclarationRef" />
-                                  </node>
-                                </node>
-                                <node concept="3TrEf2" id="7ER1loq4Uhx" role="2OqNvi">
-                                  <ref role="3Tt5mk" to="45ke:2igMYjpPzq8" resolve="concept" />
-                                </node>
-                              </node>
-                              <node concept="2oxUTD" id="7ER1loq69k8" role="2OqNvi">
-                                <node concept="37vLTw" id="7ER1loq6adW" role="2oxUTC">
-                                  <ref role="3cqZAo" node="7ER1loq4_Hp" resolve="it" />
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="Rh6nW" id="7ER1loq4_Hp" role="1bW2Oz">
-                          <property role="TrG5h" value="it" />
-                          <node concept="2jxLKc" id="7ER1loq4_Hq" role="1tU5fm" />
                         </node>
                       </node>
                     </node>
                   </node>
                 </node>
               </node>
+              <node concept="3clFbF" id="52KiyBHhabu" role="3cqZAp">
+                <node concept="37vLTw" id="52KiyBHhabv" role="3clFbG">
+                  <ref role="3cqZAo" node="52KiyBHhaaa" resolve="button" />
+                </node>
+              </node>
             </node>
           </node>
+        </node>
+        <node concept="3gTLQM" id="52KiyBHhbRY" role="3EZMnx">
+          <node concept="3Fmcul" id="52KiyBHhbRZ" role="3FoqZy">
+            <node concept="3clFbS" id="52KiyBHhbS0" role="2VODD2">
+              <node concept="3cpWs8" id="52KiyBHhbS1" role="3cqZAp">
+                <node concept="3cpWsn" id="52KiyBHhbS2" role="3cpWs9">
+                  <property role="TrG5h" value="button" />
+                  <node concept="3uibUv" id="52KiyBHhbS3" role="1tU5fm">
+                    <ref role="3uigEE" to="dxuu:~JButton" resolve="JButton" />
+                  </node>
+                  <node concept="2ShNRf" id="52KiyBHhbS4" role="33vP2m">
+                    <node concept="1pGfFk" id="52KiyBHhbS5" role="2ShVmc">
+                      <ref role="37wK5l" to="dxuu:~JButton.&lt;init&gt;(java.lang.String)" resolve="JButton" />
+                      <node concept="Xl_RD" id="52KiyBHhbS6" role="37wK5m">
+                        <property role="Xl_RC" value="add child concepts" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbF" id="52KiyBHhbS7" role="3cqZAp">
+                <node concept="2OqwBi" id="52KiyBHhbS8" role="3clFbG">
+                  <node concept="37vLTw" id="52KiyBHhbS9" role="2Oq$k0">
+                    <ref role="3cqZAo" node="52KiyBHhbS2" resolve="button" />
+                  </node>
+                  <node concept="liA8E" id="52KiyBHhbSa" role="2OqNvi">
+                    <ref role="37wK5l" to="dxuu:~AbstractButton.addActionListener(java.awt.event.ActionListener):void" resolve="addActionListener" />
+                    <node concept="2ShNRf" id="52KiyBHhbSb" role="37wK5m">
+                      <node concept="YeOm9" id="52KiyBHhbSc" role="2ShVmc">
+                        <node concept="1Y3b0j" id="52KiyBHhbSd" role="YeSDq">
+                          <property role="2bfB8j" value="true" />
+                          <ref role="1Y3XeK" to="hyam:~ActionListener" resolve="ActionListener" />
+                          <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
+                          <node concept="3Tm1VV" id="52KiyBHhbSe" role="1B3o_S" />
+                          <node concept="3clFb_" id="52KiyBHhbSf" role="jymVt">
+                            <property role="TrG5h" value="actionPerformed" />
+                            <node concept="3Tm1VV" id="52KiyBHhbSg" role="1B3o_S" />
+                            <node concept="3cqZAl" id="52KiyBHhbSh" role="3clF45" />
+                            <node concept="37vLTG" id="52KiyBHhbSi" role="3clF46">
+                              <property role="TrG5h" value="click" />
+                              <node concept="3uibUv" id="52KiyBHhbSj" role="1tU5fm">
+                                <ref role="3uigEE" to="hyam:~ActionEvent" resolve="ActionEvent" />
+                              </node>
+                            </node>
+                            <node concept="3clFbS" id="52KiyBHhbSk" role="3clF47">
+                              <node concept="1QHqEO" id="52KiyBHhbSl" role="3cqZAp">
+                                <node concept="1QHqEC" id="52KiyBHhbSm" role="1QHqEI">
+                                  <node concept="3clFbS" id="52KiyBHhbSn" role="1bW5cS">
+                                    <node concept="3clFbF" id="52KiyBHhbSo" role="3cqZAp">
+                                      <node concept="2OqwBi" id="52KiyBHhbSp" role="3clFbG">
+                                        <node concept="2OqwBi" id="52KiyBHhbSq" role="2Oq$k0">
+                                          <node concept="2OqwBi" id="52KiyBHhbSr" role="2Oq$k0">
+                                            <node concept="pncrf" id="52KiyBHhbSs" role="2Oq$k0" />
+                                            <node concept="3Tsc0h" id="52KiyBHhbSt" role="2OqNvi">
+                                              <ref role="3TtcxE" to="45ke:2igMYjp_Ggs" resolve="contents" />
+                                            </node>
+                                          </node>
+                                          <node concept="13MTOL" id="52KiyBHhbSu" role="2OqNvi">
+                                            <ref role="13MTZf" to="45ke:2igMYjpPzq8" resolve="concept" />
+                                          </node>
+                                        </node>
+                                        <node concept="2es0OD" id="52KiyBHhbSv" role="2OqNvi">
+                                          <node concept="1bVj0M" id="52KiyBHhbSw" role="23t8la">
+                                            <node concept="3clFbS" id="52KiyBHhbSx" role="1bW5cS">
+                                              <node concept="3clFbF" id="52KiyBHhbSy" role="3cqZAp">
+                                                <node concept="2OqwBi" id="52KiyBHhbSz" role="3clFbG">
+                                                  <node concept="2es0OD" id="52KiyBHhbS$" role="2OqNvi">
+                                                    <node concept="1bVj0M" id="52KiyBHhbS_" role="23t8la">
+                                                      <node concept="3clFbS" id="52KiyBHhbSA" role="1bW5cS">
+                                                        <node concept="3clFbF" id="52KiyBHhbSB" role="3cqZAp">
+                                                          <node concept="2OqwBi" id="52KiyBHhbSC" role="3clFbG">
+                                                            <node concept="2OqwBi" id="52KiyBHhbSD" role="2Oq$k0">
+                                                              <node concept="2OqwBi" id="52KiyBHhbSE" role="2Oq$k0">
+                                                                <node concept="2OqwBi" id="52KiyBHhbSF" role="2Oq$k0">
+                                                                  <node concept="pncrf" id="52KiyBHhbSG" role="2Oq$k0" />
+                                                                  <node concept="3Tsc0h" id="52KiyBHhbSH" role="2OqNvi">
+                                                                    <ref role="3TtcxE" to="45ke:2igMYjp_Ggs" resolve="contents" />
+                                                                  </node>
+                                                                </node>
+                                                                <node concept="WFELt" id="52KiyBHhbSI" role="2OqNvi">
+                                                                  <ref role="1A0vxQ" to="45ke:2igMYjpPzq7" resolve="AbstractConceptDeclarationRef" />
+                                                                </node>
+                                                              </node>
+                                                              <node concept="3TrEf2" id="52KiyBHhbSJ" role="2OqNvi">
+                                                                <ref role="3Tt5mk" to="45ke:2igMYjpPzq8" resolve="concept" />
+                                                              </node>
+                                                            </node>
+                                                            <node concept="2oxUTD" id="52KiyBHhbSK" role="2OqNvi">
+                                                              <node concept="2OqwBi" id="52KiyBHhbSL" role="2oxUTC">
+                                                                <node concept="37vLTw" id="52KiyBHhbSM" role="2Oq$k0">
+                                                                  <ref role="3cqZAo" node="52KiyBHhbSO" resolve="child" />
+                                                                </node>
+                                                                <node concept="3TrEf2" id="52KiyBHhbSN" role="2OqNvi">
+                                                                  <ref role="3Tt5mk" to="tpce:fA0lvVK" resolve="target" />
+                                                                </node>
+                                                              </node>
+                                                            </node>
+                                                          </node>
+                                                        </node>
+                                                      </node>
+                                                      <node concept="Rh6nW" id="52KiyBHhbSO" role="1bW2Oz">
+                                                        <property role="TrG5h" value="child" />
+                                                        <node concept="2jxLKc" id="52KiyBHhbSP" role="1tU5fm" />
+                                                      </node>
+                                                    </node>
+                                                  </node>
+                                                  <node concept="2OqwBi" id="52KiyBHhbSQ" role="2Oq$k0">
+                                                    <node concept="2OqwBi" id="52KiyBHhbSR" role="2Oq$k0">
+                                                      <node concept="2OqwBi" id="52KiyBHhbSS" role="2Oq$k0">
+                                                        <node concept="37vLTw" id="52KiyBHhbST" role="2Oq$k0">
+                                                          <ref role="3cqZAo" node="52KiyBHhbTk" resolve="existingConcept" />
+                                                        </node>
+                                                        <node concept="32TBzR" id="52KiyBHhbSU" role="2OqNvi" />
+                                                      </node>
+                                                      <node concept="v3k3i" id="52KiyBHhbSV" role="2OqNvi">
+                                                        <node concept="chp4Y" id="52KiyBHhbSW" role="v3oSu">
+                                                          <ref role="cht4Q" to="tpce:f_TJgxE" resolve="LinkDeclaration" />
+                                                        </node>
+                                                      </node>
+                                                    </node>
+                                                    <node concept="3zZkjj" id="52KiyBHhbSX" role="2OqNvi">
+                                                      <node concept="1bVj0M" id="52KiyBHhbSY" role="23t8la">
+                                                        <node concept="3clFbS" id="52KiyBHhbSZ" role="1bW5cS">
+                                                          <node concept="3clFbF" id="52KiyBHhbT0" role="3cqZAp">
+                                                            <node concept="2OqwBi" id="52KiyBHhbT1" role="3clFbG">
+                                                              <node concept="2OqwBi" id="52KiyBHhbT2" role="2Oq$k0">
+                                                                <node concept="2OqwBi" id="52KiyBHhbT3" role="2Oq$k0">
+                                                                  <node concept="pncrf" id="52KiyBHhbT4" role="2Oq$k0" />
+                                                                  <node concept="3Tsc0h" id="52KiyBHhbT5" role="2OqNvi">
+                                                                    <ref role="3TtcxE" to="45ke:2igMYjp_Ggs" resolve="contents" />
+                                                                  </node>
+                                                                </node>
+                                                                <node concept="13MTOL" id="52KiyBHhbT6" role="2OqNvi">
+                                                                  <ref role="13MTZf" to="45ke:2igMYjpPzq8" resolve="concept" />
+                                                                </node>
+                                                              </node>
+                                                              <node concept="2HxqBE" id="52KiyBHhbT7" role="2OqNvi">
+                                                                <node concept="1bVj0M" id="52KiyBHhbT8" role="23t8la">
+                                                                  <node concept="3clFbS" id="52KiyBHhbT9" role="1bW5cS">
+                                                                    <node concept="3clFbF" id="52KiyBHhbTa" role="3cqZAp">
+                                                                      <node concept="3y3z36" id="52KiyBHhbTb" role="3clFbG">
+                                                                        <node concept="37vLTw" id="52KiyBHhbTc" role="3uHU7B">
+                                                                          <ref role="3cqZAo" node="52KiyBHhbTg" resolve="existingConcept" />
+                                                                        </node>
+                                                                        <node concept="2OqwBi" id="52KiyBHhbTd" role="3uHU7w">
+                                                                          <node concept="37vLTw" id="52KiyBHhbTe" role="2Oq$k0">
+                                                                            <ref role="3cqZAo" node="52KiyBHhbTi" resolve="child" />
+                                                                          </node>
+                                                                          <node concept="3TrEf2" id="52KiyBHhbTf" role="2OqNvi">
+                                                                            <ref role="3Tt5mk" to="tpce:fA0lvVK" resolve="target" />
+                                                                          </node>
+                                                                        </node>
+                                                                      </node>
+                                                                    </node>
+                                                                  </node>
+                                                                  <node concept="Rh6nW" id="52KiyBHhbTg" role="1bW2Oz">
+                                                                    <property role="TrG5h" value="existingConcept" />
+                                                                    <node concept="2jxLKc" id="52KiyBHhbTh" role="1tU5fm" />
+                                                                  </node>
+                                                                </node>
+                                                              </node>
+                                                            </node>
+                                                          </node>
+                                                        </node>
+                                                        <node concept="Rh6nW" id="52KiyBHhbTi" role="1bW2Oz">
+                                                          <property role="TrG5h" value="child" />
+                                                          <node concept="2jxLKc" id="52KiyBHhbTj" role="1tU5fm" />
+                                                        </node>
+                                                      </node>
+                                                    </node>
+                                                  </node>
+                                                </node>
+                                              </node>
+                                            </node>
+                                            <node concept="Rh6nW" id="52KiyBHhbTk" role="1bW2Oz">
+                                              <property role="TrG5h" value="existingConcept" />
+                                              <node concept="2jxLKc" id="52KiyBHhbTl" role="1tU5fm" />
+                                            </node>
+                                          </node>
+                                        </node>
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                                <node concept="2OqwBi" id="52KiyBHrQjr" role="ukAjM">
+                                  <node concept="1Q80Hx" id="52KiyBHrPw0" role="2Oq$k0" />
+                                  <node concept="liA8E" id="52KiyBHrYiF" role="2OqNvi">
+                                    <ref role="37wK5l" to="cj4x:~EditorContext.getRepository():org.jetbrains.mps.openapi.module.SRepository" resolve="getRepository" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbF" id="52KiyBHhbTm" role="3cqZAp">
+                <node concept="37vLTw" id="52KiyBHhbTn" role="3clFbG">
+                  <ref role="3cqZAo" node="52KiyBHhbS2" resolve="button" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3EZMnI" id="6fDk5b645hr" role="3EZMnx">
+        <node concept="2iRfu4" id="6fDk5b645hs" role="2iSdaV" />
+        <node concept="3F0ifn" id="6fDk5b644m1" role="3EZMnx">
+          <property role="3F0ifm" value="direct model access:" />
+          <node concept="xShMh" id="6fDk5b6B2i0" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
+        </node>
+        <node concept="3F0A7n" id="6fDk5b64d3Z" role="3EZMnx">
+          <ref role="1NtTu8" to="45ke:6fDk5b6392$" resolve="modelAccess" />
         </node>
       </node>
     </node>

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.conceptdiagram/languageModels/editor.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.conceptdiagram/languageModels/editor.mps
@@ -32,6 +32,7 @@
     <import index="tpcn" ref="r:00000000-0000-4000-0000-011c8959028b(jetbrains.mps.lang.structure.behavior)" implicit="true" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
+    <import index="tpcu" ref="r:00000000-0000-4000-0000-011c89590282(jetbrains.mps.lang.core.behavior)" implicit="true" />
   </imports>
   <registry>
     <language id="a247e09e-2435-45ba-b8d2-07e93feba96a" name="jetbrains.mps.baseLanguage.tuples">
@@ -48,6 +49,7 @@
     </language>
     <language id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor">
       <concept id="1071666914219" name="jetbrains.mps.lang.editor.structure.ConceptEditorDeclaration" flags="ig" index="24kQdi">
+        <child id="1078153129734" name="inspectedCellModel" index="6VMZX" />
         <child id="2597348684684069742" name="contextHints" index="CpUAK" />
       </concept>
       <concept id="6822301196700715228" name="jetbrains.mps.lang.editor.structure.ConceptEditorHintDeclarationReference" flags="ig" index="2aJ2om">
@@ -68,6 +70,9 @@
       </concept>
       <concept id="5944657839003601246" name="jetbrains.mps.lang.editor.structure.ConceptEditorHintDeclaration" flags="ig" index="2BsEeg">
         <property id="168363875802087287" name="showInUI" index="2gpH_U" />
+      </concept>
+      <concept id="1164824717996" name="jetbrains.mps.lang.editor.structure.CellMenuDescriptor" flags="ng" index="OXEIz">
+        <child id="1164824815888" name="cellMenuPart" index="OY2wv" />
       </concept>
       <concept id="1078938745671" name="jetbrains.mps.lang.editor.structure.EditorComponentDeclaration" flags="ig" index="PKFIW" />
       <concept id="1078939183254" name="jetbrains.mps.lang.editor.structure.CellModel_Component" flags="sg" stub="3162947552742194261" index="PMmxH">
@@ -90,8 +95,16 @@
         <property id="1235999920262" name="align" index="37lx6p" />
       </concept>
       <concept id="1221057094638" name="jetbrains.mps.lang.editor.structure.QueryFunction_Integer" flags="in" index="1cFabM" />
+      <concept id="1165424453110" name="jetbrains.mps.lang.editor.structure.CellMenuPart_Generic_Item" flags="ng" index="1oHujT">
+        <property id="1165424453111" name="matchingText" index="1oHujS" />
+        <child id="1165424453112" name="handlerFunction" index="1oHujR" />
+      </concept>
+      <concept id="1165424657443" name="jetbrains.mps.lang.editor.structure.CellMenuPart_Generic_Item_Handler" flags="in" index="1oIgkG" />
       <concept id="1139848536355" name="jetbrains.mps.lang.editor.structure.CellModel_WithRole" flags="ng" index="1$h60E">
         <reference id="1140103550593" name="relationDeclaration" index="1NtTu8" />
+      </concept>
+      <concept id="1073389214265" name="jetbrains.mps.lang.editor.structure.EditorCellModel" flags="ng" index="3EYTF0">
+        <child id="1164826688380" name="menuDescriptor" index="P5bDN" />
       </concept>
       <concept id="1073389446423" name="jetbrains.mps.lang.editor.structure.CellModel_Collection" flags="sn" stub="3013115976261988961" index="3EZMnI">
         <child id="1106270802874" name="cellLayout" index="2iSdaV" />
@@ -105,6 +118,7 @@
         <child id="1219418656006" name="styleItem" index="3F10Kt" />
       </concept>
       <concept id="1073390211982" name="jetbrains.mps.lang.editor.structure.CellModel_RefNodeList" flags="sg" stub="2794558372793454595" index="3F2HdR" />
+      <concept id="1163613822479" name="jetbrains.mps.lang.editor.structure.CellMenuPart_Abstract_editedNode" flags="nn" index="3GMtW1" />
       <concept id="1225898583838" name="jetbrains.mps.lang.editor.structure.ReadOnlyModelAccessor" flags="ng" index="1HfYo3">
         <child id="1225898971709" name="getter" index="1Hhtcw" />
       </concept>
@@ -265,6 +279,7 @@
         <child id="1081773367579" name="rightExpression" index="3uHU7w" />
         <child id="1081773367580" name="leftExpression" index="3uHU7B" />
       </concept>
+      <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
       <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
       </concept>
@@ -357,6 +372,7 @@
       <concept id="5468226901223973329" name="de.itemis.mps.editor.diagram.structure.PortObject" flags="ng" index="15kUEO" />
       <concept id="8963411245957652387" name="de.itemis.mps.editor.diagram.structure.Content_GenericElementQuery_Query" flags="ig" index="37q72E" />
       <concept id="8963411245958754161" name="de.itemis.mps.editor.diagram.structure.Content_GenericElementQuery_ParameterObject" flags="ng" index="37u81S" />
+      <concept id="5051221038171022699" name="de.itemis.mps.editor.diagram.structure.ShadeColor" flags="lg" index="38c6YI" />
       <concept id="3454709602156468860" name="de.itemis.mps.editor.diagram.structure.ShapeParameterDeclaration" flags="ng" index="1xmO9C">
         <child id="3454709602156468949" name="type" index="1xmOb1" />
       </concept>
@@ -419,10 +435,14 @@
       <concept id="1171315804604" name="jetbrains.mps.lang.smodel.structure.Model_RootsOperation" flags="nn" index="2RRcyG">
         <reference id="1171315804605" name="concept" index="2RRcyH" />
       </concept>
-      <concept id="1139184414036" name="jetbrains.mps.lang.smodel.structure.LinkList_AddNewChildOperation" flags="nn" index="WFELt" />
+      <concept id="1139184414036" name="jetbrains.mps.lang.smodel.structure.LinkList_AddNewChildOperation" flags="nn" index="WFELt">
+        <reference id="1139877738879" name="concept" index="1A0vxQ" />
+      </concept>
       <concept id="1180031783296" name="jetbrains.mps.lang.smodel.structure.Concept_IsSubConceptOfOperation" flags="nn" index="2Zo12i">
         <child id="1180031783297" name="conceptArgument" index="2Zo12j" />
       </concept>
+      <concept id="1171500988903" name="jetbrains.mps.lang.smodel.structure.Node_GetChildrenOperation" flags="nn" index="32TBzR" />
+      <concept id="6995935425733782641" name="jetbrains.mps.lang.smodel.structure.Model_GetModule" flags="nn" index="13u695" />
       <concept id="3562215692195599741" name="jetbrains.mps.lang.smodel.structure.SLinkImplicitSelect" flags="nn" index="13MTOL">
         <reference id="3562215692195600259" name="link" index="13MTZf" />
       </concept>
@@ -497,6 +517,7 @@
       <concept id="1153944233411" name="jetbrains.mps.baseLanguage.collections.structure.ForEachVariableReference" flags="nn" index="2GrUjf">
         <reference id="1153944258490" name="variable" index="2Gs0qQ" />
       </concept>
+      <concept id="1235566831861" name="jetbrains.mps.baseLanguage.collections.structure.AllOperation" flags="nn" index="2HxqBE" />
       <concept id="1237721394592" name="jetbrains.mps.baseLanguage.collections.structure.AbstractContainerCreator" flags="nn" index="HWqM0">
         <child id="1237721435808" name="initValue" index="HW$Y0" />
         <child id="1237721435807" name="elementType" index="HW$YZ" />
@@ -2817,15 +2838,43 @@
           <node concept="37q72E" id="2igMYjpB09y" role="2M4AHN">
             <node concept="3clFbS" id="2igMYjpB09$" role="2VODD2">
               <node concept="3clFbF" id="2igMYjpB5g8" role="3cqZAp">
-                <node concept="2OqwBi" id="2igMYjpB6Nv" role="3clFbG">
-                  <node concept="2OqwBi" id="2igMYjpB5iV" role="2Oq$k0">
-                    <node concept="23r2z0" id="2igMYjpB5g7" role="2Oq$k0" />
-                    <node concept="3Tsc0h" id="2igMYjpB5C7" role="2OqNvi">
-                      <ref role="3TtcxE" to="45ke:2igMYjp_Ggs" resolve="contents" />
+                <node concept="2OqwBi" id="6fDk5b5S$Ip" role="3clFbG">
+                  <node concept="2OqwBi" id="2igMYjpB6Nv" role="2Oq$k0">
+                    <node concept="2OqwBi" id="2igMYjpB5iV" role="2Oq$k0">
+                      <node concept="23r2z0" id="2igMYjpB5g7" role="2Oq$k0" />
+                      <node concept="3Tsc0h" id="2igMYjpB5C7" role="2OqNvi">
+                        <ref role="3TtcxE" to="45ke:2igMYjp_Ggs" resolve="contents" />
+                      </node>
+                    </node>
+                    <node concept="13MTOL" id="2igMYjpPH5y" role="2OqNvi">
+                      <ref role="13MTZf" to="45ke:2igMYjpPzq8" resolve="concept" />
                     </node>
                   </node>
-                  <node concept="13MTOL" id="2igMYjpPH5y" role="2OqNvi">
-                    <ref role="13MTZf" to="45ke:2igMYjpPzq8" resolve="concept" />
+                  <node concept="3zZkjj" id="6fDk5b5SAbz" role="2OqNvi">
+                    <node concept="1bVj0M" id="6fDk5b5SAb_" role="23t8la">
+                      <node concept="3clFbS" id="6fDk5b5SAbA" role="1bW5cS">
+                        <node concept="3clFbF" id="6fDk5b5SBi5" role="3cqZAp">
+                          <node concept="2OqwBi" id="6fDk5b5SEm7" role="3clFbG">
+                            <node concept="2OqwBi" id="6fDk5b5SCu6" role="2Oq$k0">
+                              <node concept="2OqwBi" id="6fDk5b5SBwZ" role="2Oq$k0">
+                                <node concept="23r2z0" id="6fDk5b5SBi4" role="2Oq$k0" />
+                                <node concept="I4A8Y" id="6fDk5b5SC7p" role="2OqNvi" />
+                              </node>
+                              <node concept="2RRcyG" id="6fDk5b5SD0U" role="2OqNvi" />
+                            </node>
+                            <node concept="3JPx81" id="6fDk5b5SH5U" role="2OqNvi">
+                              <node concept="37vLTw" id="6fDk5b5SHg7" role="25WWJ7">
+                                <ref role="3cqZAo" node="6fDk5b5SAbB" resolve="it" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="Rh6nW" id="6fDk5b5SAbB" role="1bW2Oz">
+                        <property role="TrG5h" value="it" />
+                        <node concept="2jxLKc" id="6fDk5b5SAbC" role="1tU5fm" />
+                      </node>
+                    </node>
                   </node>
                 </node>
               </node>
@@ -2904,6 +2953,224 @@
             <property role="3clFbU" value="true" />
           </node>
           <node concept="37u81S" id="5oCf_1NYdjG" role="2Kg1p8" />
+        </node>
+        <node concept="ahg9e" id="6fDk5b5SHrb" role="aCds2">
+          <node concept="2316IU" id="6fDk5b5SHrc" role="15ipcR">
+            <node concept="Xl_RD" id="6fDk5b5SHrd" role="2316E2">
+              <property role="Xl_RC" value="extensions" />
+            </node>
+            <node concept="2xQOud" id="6fDk5b5SHre" role="2316E4">
+              <ref role="2xQOue" to="wo6c:5WYUu8Hc_F_" resolve="EmptyShape" />
+            </node>
+            <node concept="3b6qkQ" id="6fDk5b5SHrf" role="2316E7">
+              <property role="$nhwW" value="0.5" />
+            </node>
+            <node concept="3b6qkQ" id="6fDk5b5SHrg" role="2316E6">
+              <property role="$nhwW" value="0.0" />
+            </node>
+          </node>
+          <node concept="2316IU" id="6fDk5b5SHrh" role="15ipcR">
+            <node concept="Xl_RD" id="6fDk5b5SHri" role="2316E2">
+              <property role="Xl_RC" value="subtypes" />
+            </node>
+            <node concept="2xQOud" id="6fDk5b5SHrj" role="2316E4">
+              <ref role="2xQOue" to="wo6c:5WYUu8Hc_F_" resolve="EmptyShape" />
+            </node>
+            <node concept="3b6qkQ" id="6fDk5b5SHrk" role="2316E7">
+              <property role="$nhwW" value="0.5" />
+            </node>
+            <node concept="3b6qkQ" id="6fDk5b5SHrl" role="2316E6">
+              <property role="$nhwW" value="1.0" />
+            </node>
+          </node>
+          <node concept="230Hcy" id="6fDk5b5SHrm" role="15ipcR">
+            <node concept="2OqwBi" id="6fDk5b5SHrn" role="230Hdr">
+              <node concept="37u81S" id="6fDk5b5SHro" role="2Oq$k0" />
+              <node concept="3Tsc0h" id="6fDk5b5SHrp" role="2OqNvi">
+                <ref role="3TtcxE" to="tpce:f_TKVDF" resolve="linkDeclaration" />
+              </node>
+            </node>
+            <node concept="2316IU" id="6fDk5b5SHrq" role="230Hdp">
+              <node concept="3cpWs3" id="6fDk5b5SHrr" role="2316E2">
+                <node concept="2OqwBi" id="6fDk5b5SHrs" role="3uHU7w">
+                  <node concept="15kUEO" id="6fDk5b5SHrt" role="2Oq$k0" />
+                  <node concept="2bSWHS" id="6fDk5b5SHru" role="2OqNvi" />
+                </node>
+                <node concept="Xl_RD" id="6fDk5b5SHrv" role="3uHU7B">
+                  <property role="Xl_RC" value="link" />
+                </node>
+              </node>
+              <node concept="2xQOud" id="6fDk5b5SHrw" role="2316E4">
+                <ref role="2xQOue" to="wo6c:5WYUu8Hc_F_" resolve="EmptyShape" />
+              </node>
+              <node concept="3b6qkQ" id="6fDk5b5SHrx" role="2316E7">
+                <property role="$nhwW" value="1.0" />
+              </node>
+            </node>
+          </node>
+          <node concept="230Hcy" id="6fDk5b5SHry" role="15ipcR">
+            <node concept="2316IU" id="6fDk5b5SHrz" role="230Hdp">
+              <node concept="3cpWs3" id="6fDk5b5SHr$" role="2316E2">
+                <node concept="2OqwBi" id="6fDk5b5SHr_" role="3uHU7w">
+                  <node concept="2YIFZM" id="6fDk5b5SHrA" role="2Oq$k0">
+                    <ref role="37wK5l" node="6vp$_2v9X_n" resolve="collectAllIncomingLinks" />
+                    <ref role="1Pybhc" node="3OnN3di58LB" resolve="DiagramHelper" />
+                    <node concept="37u81S" id="6fDk5b5SHrB" role="37wK5m" />
+                    <node concept="23r2z0" id="6fDk5b5SHrC" role="37wK5m" />
+                  </node>
+                  <node concept="2WmjW8" id="6fDk5b5SHrD" role="2OqNvi">
+                    <node concept="15kUEO" id="6fDk5b5SHrE" role="25WWJ7" />
+                  </node>
+                </node>
+                <node concept="Xl_RD" id="6fDk5b5SHrF" role="3uHU7B">
+                  <property role="Xl_RC" value="linkInput" />
+                </node>
+              </node>
+              <node concept="2xQOud" id="6fDk5b5SHrG" role="2316E4">
+                <ref role="2xQOue" to="wo6c:5WYUu8Hc_F_" resolve="EmptyShape" />
+              </node>
+              <node concept="3b6qkQ" id="6fDk5b5SHrH" role="2316E7">
+                <property role="$nhwW" value="0.0" />
+              </node>
+            </node>
+            <node concept="2YIFZM" id="6fDk5b5SHrI" role="230Hdr">
+              <ref role="37wK5l" node="6vp$_2v9X_n" resolve="collectAllIncomingLinks" />
+              <ref role="1Pybhc" node="3OnN3di58LB" resolve="DiagramHelper" />
+              <node concept="37u81S" id="6fDk5b5SHrJ" role="37wK5m" />
+              <node concept="23r2z0" id="6fDk5b5SHrK" role="37wK5m" />
+            </node>
+          </node>
+          <node concept="238au4" id="6fDk5b5SHrL" role="23bJyd">
+            <node concept="PMmxH" id="6fDk5b5SHrM" role="2wV5jI">
+              <ref role="PMmxG" node="6fDk5b60d7c" resolve="AbstractForeignConceptDeclarationBox" />
+            </node>
+          </node>
+          <node concept="3Tqbb2" id="6fDk5b5SHrN" role="2M4AHM">
+            <ref role="ehGHo" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
+          </node>
+          <node concept="37q72E" id="6fDk5b5SHrO" role="2M4AHN">
+            <node concept="3clFbS" id="6fDk5b5SHrP" role="2VODD2">
+              <node concept="3clFbF" id="6fDk5b5SHrQ" role="3cqZAp">
+                <node concept="2OqwBi" id="6fDk5b5SHrR" role="3clFbG">
+                  <node concept="2OqwBi" id="6fDk5b5SHrS" role="2Oq$k0">
+                    <node concept="2OqwBi" id="6fDk5b5SHrT" role="2Oq$k0">
+                      <node concept="23r2z0" id="6fDk5b5SHrU" role="2Oq$k0" />
+                      <node concept="3Tsc0h" id="6fDk5b5SHrV" role="2OqNvi">
+                        <ref role="3TtcxE" to="45ke:2igMYjp_Ggs" resolve="contents" />
+                      </node>
+                    </node>
+                    <node concept="13MTOL" id="6fDk5b5SHrW" role="2OqNvi">
+                      <ref role="13MTZf" to="45ke:2igMYjpPzq8" resolve="concept" />
+                    </node>
+                  </node>
+                  <node concept="3zZkjj" id="6fDk5b5SHrX" role="2OqNvi">
+                    <node concept="1bVj0M" id="6fDk5b5SHrY" role="23t8la">
+                      <node concept="3clFbS" id="6fDk5b5SHrZ" role="1bW5cS">
+                        <node concept="3clFbF" id="6fDk5b5SHs0" role="3cqZAp">
+                          <node concept="3fqX7Q" id="6fDk5b5SMBE" role="3clFbG">
+                            <node concept="2OqwBi" id="6fDk5b5SMBG" role="3fr31v">
+                              <node concept="2OqwBi" id="6fDk5b5SMBH" role="2Oq$k0">
+                                <node concept="2OqwBi" id="6fDk5b5SMBI" role="2Oq$k0">
+                                  <node concept="23r2z0" id="6fDk5b5SMBJ" role="2Oq$k0" />
+                                  <node concept="I4A8Y" id="6fDk5b5SMBK" role="2OqNvi" />
+                                </node>
+                                <node concept="2RRcyG" id="6fDk5b5SMBL" role="2OqNvi" />
+                              </node>
+                              <node concept="3JPx81" id="6fDk5b5SMBM" role="2OqNvi">
+                                <node concept="37vLTw" id="6fDk5b5SMBN" role="25WWJ7">
+                                  <ref role="3cqZAo" node="6fDk5b5SHs9" resolve="it" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="Rh6nW" id="6fDk5b5SHs9" role="1bW2Oz">
+                        <property role="TrG5h" value="it" />
+                        <node concept="2jxLKc" id="6fDk5b5SHsa" role="1tU5fm" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="37u81S" id="6fDk5b5SHsb" role="2M4AHK" />
+          <node concept="2fs66k" id="6fDk5b5SHsc" role="2fs69h">
+            <node concept="3clFbS" id="6fDk5b5SHsd" role="2VODD2">
+              <node concept="3cpWs8" id="6fDk5b5SHse" role="3cqZAp">
+                <node concept="3cpWsn" id="6fDk5b5SHsf" role="3cpWs9">
+                  <property role="TrG5h" value="a" />
+                  <node concept="3Tqbb2" id="6fDk5b5SHsg" role="1tU5fm">
+                    <ref role="ehGHo" to="45ke:2igMYjpPzq7" resolve="AbstractConceptDeclarationRef" />
+                  </node>
+                  <node concept="2OqwBi" id="6fDk5b5SHsh" role="33vP2m">
+                    <node concept="2OqwBi" id="6fDk5b5SHsi" role="2Oq$k0">
+                      <node concept="23r2z0" id="6fDk5b5SHsj" role="2Oq$k0" />
+                      <node concept="3Tsc0h" id="6fDk5b5SHsk" role="2OqNvi">
+                        <ref role="3TtcxE" to="45ke:2igMYjp_Ggs" resolve="contents" />
+                      </node>
+                    </node>
+                    <node concept="1z4cxt" id="6fDk5b5SHsl" role="2OqNvi">
+                      <node concept="1bVj0M" id="6fDk5b5SHsm" role="23t8la">
+                        <node concept="3clFbS" id="6fDk5b5SHsn" role="1bW5cS">
+                          <node concept="3clFbF" id="6fDk5b5SHso" role="3cqZAp">
+                            <node concept="17R0WA" id="6fDk5b5SHsp" role="3clFbG">
+                              <node concept="37u81S" id="6fDk5b5SHsq" role="3uHU7w" />
+                              <node concept="2OqwBi" id="6fDk5b5SHsr" role="3uHU7B">
+                                <node concept="37vLTw" id="6fDk5b5SHss" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="6fDk5b5SHsu" resolve="it" />
+                                </node>
+                                <node concept="3TrEf2" id="6fDk5b5SHst" role="2OqNvi">
+                                  <ref role="3Tt5mk" to="45ke:2igMYjpPzq8" resolve="concept" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="Rh6nW" id="6fDk5b5SHsu" role="1bW2Oz">
+                          <property role="TrG5h" value="it" />
+                          <node concept="2jxLKc" id="6fDk5b5SHsv" role="1tU5fm" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3cpWs8" id="6fDk5b5SHsw" role="3cqZAp">
+                <node concept="3cpWsn" id="6fDk5b5SHsx" role="3cpWs9">
+                  <property role="TrG5h" value="b" />
+                  <node concept="3Tqbb2" id="6fDk5b5SHsy" role="1tU5fm">
+                    <ref role="ehGHo" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
+                  </node>
+                  <node concept="37u81S" id="6fDk5b5SHsz" role="33vP2m" />
+                </node>
+              </node>
+              <node concept="3clFbF" id="6fDk5b5SHs$" role="3cqZAp">
+                <node concept="2OqwBi" id="6fDk5b5SHs_" role="3clFbG">
+                  <node concept="37vLTw" id="6fDk5b5SHsA" role="2Oq$k0">
+                    <ref role="3cqZAo" node="6fDk5b5SHsf" resolve="a" />
+                  </node>
+                  <node concept="3YRAZt" id="6fDk5b5SHsB" role="2OqNvi" />
+                </node>
+              </node>
+              <node concept="3clFbF" id="6fDk5b5SHsC" role="3cqZAp">
+                <node concept="2OqwBi" id="6fDk5b5SHsD" role="3clFbG">
+                  <node concept="37vLTw" id="6fDk5b5SHsE" role="2Oq$k0">
+                    <ref role="3cqZAo" node="6fDk5b5SHsx" resolve="b" />
+                  </node>
+                  <node concept="3YRAZt" id="6fDk5b5SHsF" role="2OqNvi" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbT" id="6fDk5b5SHsG" role="SH2gk">
+            <property role="3clFbU" value="true" />
+          </node>
+          <node concept="37u81S" id="6fDk5b5SHsH" role="2Kg1p8" />
+          <node concept="38c6YI" id="6fDk5b5SHsI" role="3F10Kt">
+            <property role="Vb096" value="lightGray" />
+          </node>
         </node>
         <node concept="2M4Efz" id="2igMYjpBzJU" role="aCds2">
           <node concept="37q72E" id="2igMYjpBzJV" role="2M4AHN">
@@ -3578,6 +3845,14 @@
                 </node>
               </node>
             </node>
+            <node concept="238au4" id="47lMzc0J16z" role="1PNbKP">
+              <node concept="3EZMnI" id="47lMzc0La7P" role="2wV5jI">
+                <node concept="2iRfu4" id="47lMzc0La7Q" role="2iSdaV" />
+                <node concept="3F0A7n" id="47lMzc0J1ee" role="3EZMnx">
+                  <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
+                </node>
+              </node>
+            </node>
           </node>
           <node concept="1PNbMa" id="2igMYjpBzJK" role="1PN8qh">
             <node concept="23hSXV" id="6vp$_2vah1m" role="ljJml">
@@ -3806,6 +4081,371 @@
         </node>
       </node>
       <node concept="2iRkQZ" id="2igMYjpAqwn" role="2iSdaV" />
+    </node>
+    <node concept="3EZMnI" id="7ER1loq4auu" role="6VMZX">
+      <node concept="2iRfu4" id="7ER1loq4aux" role="2iSdaV" />
+      <node concept="3F0ifn" id="7ER1loq4fvy" role="3EZMnx">
+        <property role="3F0ifm" value="auto import concepts" />
+        <node concept="OXEIz" id="7ER1loq4fy9" role="P5bDN">
+          <node concept="1oHujT" id="7ER1loq8575" role="OY2wv">
+            <property role="1oHujS" value="add all child concepts" />
+            <node concept="1oIgkG" id="7ER1loq8577" role="1oHujR">
+              <node concept="3clFbS" id="7ER1loq8579" role="2VODD2">
+                <node concept="3clFbF" id="7ER1loq9D3q" role="3cqZAp">
+                  <node concept="2OqwBi" id="7ER1loq9Vdf" role="3clFbG">
+                    <node concept="2OqwBi" id="7ER1loq9F8J" role="2Oq$k0">
+                      <node concept="2OqwBi" id="7ER1loq9DbS" role="2Oq$k0">
+                        <node concept="3GMtW1" id="7ER1loq9D3p" role="2Oq$k0" />
+                        <node concept="3Tsc0h" id="7ER1loq9Dsa" role="2OqNvi">
+                          <ref role="3TtcxE" to="45ke:2igMYjp_Ggs" resolve="contents" />
+                        </node>
+                      </node>
+                      <node concept="13MTOL" id="7ER1loq9Ufs" role="2OqNvi">
+                        <ref role="13MTZf" to="45ke:2igMYjpPzq8" resolve="concept" />
+                      </node>
+                    </node>
+                    <node concept="2es0OD" id="7ER1loqa3gV" role="2OqNvi">
+                      <node concept="1bVj0M" id="7ER1loqa3gX" role="23t8la">
+                        <node concept="3clFbS" id="7ER1loqa3gY" role="1bW5cS">
+                          <node concept="3clFbF" id="7ER1loqa3sJ" role="3cqZAp">
+                            <node concept="2OqwBi" id="7ER1loqawN5" role="3clFbG">
+                              <node concept="2es0OD" id="7ER1loqaO5F" role="2OqNvi">
+                                <node concept="1bVj0M" id="7ER1loqaO5H" role="23t8la">
+                                  <node concept="3clFbS" id="7ER1loqaO5I" role="1bW5cS">
+                                    <node concept="3clFbF" id="7ER1loqaOBL" role="3cqZAp">
+                                      <node concept="2OqwBi" id="7ER1loqccZo" role="3clFbG">
+                                        <node concept="2OqwBi" id="7ER1loqaXWi" role="2Oq$k0">
+                                          <node concept="2OqwBi" id="7ER1loqaR$j" role="2Oq$k0">
+                                            <node concept="2OqwBi" id="7ER1loqaORX" role="2Oq$k0">
+                                              <node concept="3GMtW1" id="7ER1loqaOBK" role="2Oq$k0" />
+                                              <node concept="3Tsc0h" id="7ER1loqaPSM" role="2OqNvi">
+                                                <ref role="3TtcxE" to="45ke:2igMYjp_Ggs" resolve="contents" />
+                                              </node>
+                                            </node>
+                                            <node concept="WFELt" id="7ER1loqaVDv" role="2OqNvi">
+                                              <ref role="1A0vxQ" to="45ke:2igMYjpPzq7" resolve="AbstractConceptDeclarationRef" />
+                                            </node>
+                                          </node>
+                                          <node concept="3TrEf2" id="7ER1loqb_Bx" role="2OqNvi">
+                                            <ref role="3Tt5mk" to="45ke:2igMYjpPzq8" resolve="concept" />
+                                          </node>
+                                        </node>
+                                        <node concept="2oxUTD" id="7ER1loqfLxI" role="2OqNvi">
+                                          <node concept="2OqwBi" id="7ER1loqnAYe" role="2oxUTC">
+                                            <node concept="37vLTw" id="7ER1loqnAm9" role="2Oq$k0">
+                                              <ref role="3cqZAo" node="7ER1loqaO5J" resolve="child" />
+                                            </node>
+                                            <node concept="3TrEf2" id="7ER1loqrbi7" role="2OqNvi">
+                                              <ref role="3Tt5mk" to="tpce:fA0lvVK" resolve="target" />
+                                            </node>
+                                          </node>
+                                        </node>
+                                      </node>
+                                    </node>
+                                  </node>
+                                  <node concept="Rh6nW" id="7ER1loqaO5J" role="1bW2Oz">
+                                    <property role="TrG5h" value="child" />
+                                    <node concept="2jxLKc" id="7ER1loqaO5K" role="1tU5fm" />
+                                  </node>
+                                </node>
+                              </node>
+                              <node concept="2OqwBi" id="7ER1loqhzZA" role="2Oq$k0">
+                                <node concept="2OqwBi" id="7ER1loqqGEU" role="2Oq$k0">
+                                  <node concept="2OqwBi" id="7ER1loqgUY2" role="2Oq$k0">
+                                    <node concept="37vLTw" id="7ER1loqgUnz" role="2Oq$k0">
+                                      <ref role="3cqZAo" node="7ER1loqa3gZ" resolve="existingConcept" />
+                                    </node>
+                                    <node concept="32TBzR" id="7ER1loqgXR0" role="2OqNvi" />
+                                  </node>
+                                  <node concept="v3k3i" id="7ER1loqqMbS" role="2OqNvi">
+                                    <node concept="chp4Y" id="7ER1loqqNpF" role="v3oSu">
+                                      <ref role="cht4Q" to="tpce:f_TJgxE" resolve="LinkDeclaration" />
+                                    </node>
+                                  </node>
+                                </node>
+                                <node concept="3zZkjj" id="7ER1loqhHPn" role="2OqNvi">
+                                  <node concept="1bVj0M" id="7ER1loqhHPp" role="23t8la">
+                                    <node concept="3clFbS" id="7ER1loqhHPq" role="1bW5cS">
+                                      <node concept="3clFbF" id="7ER1loqhIQW" role="3cqZAp">
+                                        <node concept="2OqwBi" id="7ER1loqhV66" role="3clFbG">
+                                          <node concept="2OqwBi" id="7ER1loqhNZw" role="2Oq$k0">
+                                            <node concept="2OqwBi" id="7ER1loqhJs8" role="2Oq$k0">
+                                              <node concept="3GMtW1" id="7ER1loqhIQV" role="2Oq$k0" />
+                                              <node concept="3Tsc0h" id="7ER1loqhKVV" role="2OqNvi">
+                                                <ref role="3TtcxE" to="45ke:2igMYjp_Ggs" resolve="contents" />
+                                              </node>
+                                            </node>
+                                            <node concept="13MTOL" id="7ER1loqhSqI" role="2OqNvi">
+                                              <ref role="13MTZf" to="45ke:2igMYjpPzq8" resolve="concept" />
+                                            </node>
+                                          </node>
+                                          <node concept="2HxqBE" id="7ER1loqp60R" role="2OqNvi">
+                                            <node concept="1bVj0M" id="7ER1loqp60T" role="23t8la">
+                                              <node concept="3clFbS" id="7ER1loqp60U" role="1bW5cS">
+                                                <node concept="3clFbF" id="7ER1loqp60V" role="3cqZAp">
+                                                  <node concept="3y3z36" id="7ER1loqp7q4" role="3clFbG">
+                                                    <node concept="37vLTw" id="7ER1loqp60Y" role="3uHU7B">
+                                                      <ref role="3cqZAo" node="7ER1loqp60Z" resolve="existingConcept" />
+                                                    </node>
+                                                    <node concept="2OqwBi" id="7ER1loqqPb8" role="3uHU7w">
+                                                      <node concept="37vLTw" id="7ER1loqp60X" role="2Oq$k0">
+                                                        <ref role="3cqZAo" node="7ER1loqhHPr" resolve="child" />
+                                                      </node>
+                                                      <node concept="3TrEf2" id="7ER1loqqQVE" role="2OqNvi">
+                                                        <ref role="3Tt5mk" to="tpce:fA0lvVK" resolve="target" />
+                                                      </node>
+                                                    </node>
+                                                  </node>
+                                                </node>
+                                              </node>
+                                              <node concept="Rh6nW" id="7ER1loqp60Z" role="1bW2Oz">
+                                                <property role="TrG5h" value="existingConcept" />
+                                                <node concept="2jxLKc" id="7ER1loqp610" role="1tU5fm" />
+                                              </node>
+                                            </node>
+                                          </node>
+                                        </node>
+                                      </node>
+                                    </node>
+                                    <node concept="Rh6nW" id="7ER1loqhHPr" role="1bW2Oz">
+                                      <property role="TrG5h" value="child" />
+                                      <node concept="2jxLKc" id="7ER1loqhHPs" role="1tU5fm" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="Rh6nW" id="7ER1loqa3gZ" role="1bW2Oz">
+                          <property role="TrG5h" value="existingConcept" />
+                          <node concept="2jxLKc" id="7ER1loqa3h0" role="1tU5fm" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1oHujT" id="7ER1loqskWa" role="OY2wv">
+            <property role="1oHujS" value="add all direct extensions" />
+            <node concept="1oIgkG" id="7ER1loqskWb" role="1oHujR">
+              <node concept="3clFbS" id="7ER1loqskWc" role="2VODD2">
+                <node concept="3clFbF" id="7ER1loqskWd" role="3cqZAp">
+                  <node concept="2OqwBi" id="7ER1loqskWe" role="3clFbG">
+                    <node concept="2OqwBi" id="7ER1loqskWf" role="2Oq$k0">
+                      <node concept="2OqwBi" id="7ER1loqskWg" role="2Oq$k0">
+                        <node concept="3GMtW1" id="7ER1loqskWh" role="2Oq$k0" />
+                        <node concept="3Tsc0h" id="7ER1loqskWi" role="2OqNvi">
+                          <ref role="3TtcxE" to="45ke:2igMYjp_Ggs" resolve="contents" />
+                        </node>
+                      </node>
+                      <node concept="13MTOL" id="7ER1loqskWj" role="2OqNvi">
+                        <ref role="13MTZf" to="45ke:2igMYjpPzq8" resolve="concept" />
+                      </node>
+                    </node>
+                    <node concept="2es0OD" id="7ER1loqskWk" role="2OqNvi">
+                      <node concept="1bVj0M" id="7ER1loqskWl" role="23t8la">
+                        <node concept="3clFbS" id="7ER1loqskWm" role="1bW5cS">
+                          <node concept="3clFbF" id="7ER1loqskWx" role="3cqZAp">
+                            <node concept="2OqwBi" id="7ER1loqskWy" role="3clFbG">
+                              <node concept="2es0OD" id="7ER1loqskWz" role="2OqNvi">
+                                <node concept="1bVj0M" id="7ER1loqskW$" role="23t8la">
+                                  <node concept="3clFbS" id="7ER1loqskW_" role="1bW5cS">
+                                    <node concept="3clFbF" id="7ER1loqskWA" role="3cqZAp">
+                                      <node concept="2OqwBi" id="7ER1loqskWB" role="3clFbG">
+                                        <node concept="2OqwBi" id="7ER1loqskWC" role="2Oq$k0">
+                                          <node concept="2OqwBi" id="7ER1loqskWD" role="2Oq$k0">
+                                            <node concept="2OqwBi" id="7ER1loqskWE" role="2Oq$k0">
+                                              <node concept="3GMtW1" id="7ER1loqskWF" role="2Oq$k0" />
+                                              <node concept="3Tsc0h" id="7ER1loqskWG" role="2OqNvi">
+                                                <ref role="3TtcxE" to="45ke:2igMYjp_Ggs" resolve="contents" />
+                                              </node>
+                                            </node>
+                                            <node concept="WFELt" id="7ER1loqskWH" role="2OqNvi">
+                                              <ref role="1A0vxQ" to="45ke:2igMYjpPzq7" resolve="AbstractConceptDeclarationRef" />
+                                            </node>
+                                          </node>
+                                          <node concept="3TrEf2" id="7ER1loqskWI" role="2OqNvi">
+                                            <ref role="3Tt5mk" to="45ke:2igMYjpPzq8" resolve="concept" />
+                                          </node>
+                                        </node>
+                                        <node concept="2oxUTD" id="7ER1loqskWJ" role="2OqNvi">
+                                          <node concept="37vLTw" id="7ER1loqskWL" role="2oxUTC">
+                                            <ref role="3cqZAo" node="7ER1loqskWN" resolve="extension" />
+                                          </node>
+                                        </node>
+                                      </node>
+                                    </node>
+                                  </node>
+                                  <node concept="Rh6nW" id="7ER1loqskWN" role="1bW2Oz">
+                                    <property role="TrG5h" value="extension" />
+                                    <node concept="2jxLKc" id="7ER1loqskWO" role="1tU5fm" />
+                                  </node>
+                                </node>
+                              </node>
+                              <node concept="2OqwBi" id="7ER1loqskWP" role="2Oq$k0">
+                                <node concept="2OqwBi" id="7ER1loqskWR" role="2Oq$k0">
+                                  <node concept="37vLTw" id="7ER1loqskWS" role="2Oq$k0">
+                                    <ref role="3cqZAo" node="7ER1loqskXj" resolve="existingConcept" />
+                                  </node>
+                                  <node concept="2qgKlT" id="7ER1loqs_uD" role="2OqNvi">
+                                    <ref role="37wK5l" to="tpcn:2A8AB0rAWpG" resolve="getAllSuperConcepts" />
+                                    <node concept="3clFbT" id="7ER1loqtcnh" role="37wK5m" />
+                                  </node>
+                                </node>
+                                <node concept="3zZkjj" id="7ER1loqskWW" role="2OqNvi">
+                                  <node concept="1bVj0M" id="7ER1loqskWX" role="23t8la">
+                                    <node concept="3clFbS" id="7ER1loqskWY" role="1bW5cS">
+                                      <node concept="3clFbF" id="7ER1loqskWZ" role="3cqZAp">
+                                        <node concept="2OqwBi" id="7ER1loqskX0" role="3clFbG">
+                                          <node concept="2OqwBi" id="7ER1loqskX1" role="2Oq$k0">
+                                            <node concept="2OqwBi" id="7ER1loqskX2" role="2Oq$k0">
+                                              <node concept="3GMtW1" id="7ER1loqskX3" role="2Oq$k0" />
+                                              <node concept="3Tsc0h" id="7ER1loqskX4" role="2OqNvi">
+                                                <ref role="3TtcxE" to="45ke:2igMYjp_Ggs" resolve="contents" />
+                                              </node>
+                                            </node>
+                                            <node concept="13MTOL" id="7ER1loqskX5" role="2OqNvi">
+                                              <ref role="13MTZf" to="45ke:2igMYjpPzq8" resolve="concept" />
+                                            </node>
+                                          </node>
+                                          <node concept="2HxqBE" id="7ER1loqskX6" role="2OqNvi">
+                                            <node concept="1bVj0M" id="7ER1loqskX7" role="23t8la">
+                                              <node concept="3clFbS" id="7ER1loqskX8" role="1bW5cS">
+                                                <node concept="3clFbF" id="7ER1loqskX9" role="3cqZAp">
+                                                  <node concept="3y3z36" id="7ER1loqskXa" role="3clFbG">
+                                                    <node concept="37vLTw" id="7ER1loqskXb" role="3uHU7B">
+                                                      <ref role="3cqZAo" node="7ER1loqskXf" resolve="existingConcept" />
+                                                    </node>
+                                                    <node concept="37vLTw" id="7ER1loqskXd" role="3uHU7w">
+                                                      <ref role="3cqZAo" node="7ER1loqskXh" resolve="extension" />
+                                                    </node>
+                                                  </node>
+                                                </node>
+                                              </node>
+                                              <node concept="Rh6nW" id="7ER1loqskXf" role="1bW2Oz">
+                                                <property role="TrG5h" value="existingConcept" />
+                                                <node concept="2jxLKc" id="7ER1loqskXg" role="1tU5fm" />
+                                              </node>
+                                            </node>
+                                          </node>
+                                        </node>
+                                      </node>
+                                    </node>
+                                    <node concept="Rh6nW" id="7ER1loqskXh" role="1bW2Oz">
+                                      <property role="TrG5h" value="extension" />
+                                      <node concept="2jxLKc" id="7ER1loqskXi" role="1tU5fm" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="Rh6nW" id="7ER1loqskXj" role="1bW2Oz">
+                          <property role="TrG5h" value="existingConcept" />
+                          <node concept="2jxLKc" id="7ER1loqskXk" role="1tU5fm" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1oHujT" id="7ER1loq4f$K" role="OY2wv">
+            <property role="1oHujS" value="add all concepts of current model" />
+            <node concept="1oIgkG" id="7ER1loq4f$L" role="1oHujR">
+              <node concept="3clFbS" id="7ER1loq4f$M" role="2VODD2">
+                <node concept="3clFbF" id="7ER1loq4n5x" role="3cqZAp">
+                  <node concept="2OqwBi" id="7ER1loq4sHr" role="3clFbG">
+                    <node concept="2OqwBi" id="7ER1loq4n5z" role="2Oq$k0">
+                      <node concept="2OqwBi" id="7ER1loq4n5$" role="2Oq$k0">
+                        <node concept="2OqwBi" id="7ER1loq4n5_" role="2Oq$k0">
+                          <node concept="3GMtW1" id="7ER1loq4rZr" role="2Oq$k0" />
+                          <node concept="I4A8Y" id="7ER1loq4n5B" role="2OqNvi" />
+                        </node>
+                        <node concept="2RRcyG" id="7ER1loq4n5C" role="2OqNvi">
+                          <ref role="2RRcyH" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
+                        </node>
+                      </node>
+                      <node concept="3zZkjj" id="7ER1loq4n5D" role="2OqNvi">
+                        <node concept="1bVj0M" id="7ER1loq4n5E" role="23t8la">
+                          <node concept="3clFbS" id="7ER1loq4n5F" role="1bW5cS">
+                            <node concept="3clFbF" id="7ER1loq4n5G" role="3cqZAp">
+                              <node concept="3fqX7Q" id="7ER1loq4n5H" role="3clFbG">
+                                <node concept="2OqwBi" id="7ER1loq4n5I" role="3fr31v">
+                                  <node concept="2OqwBi" id="7ER1loq4n5J" role="2Oq$k0">
+                                    <node concept="2OqwBi" id="7ER1loq4n5K" role="2Oq$k0">
+                                      <node concept="3GMtW1" id="7ER1loq4sgR" role="2Oq$k0" />
+                                      <node concept="3Tsc0h" id="7ER1loq4n5M" role="2OqNvi">
+                                        <ref role="3TtcxE" to="45ke:2igMYjp_Ggs" resolve="contents" />
+                                      </node>
+                                    </node>
+                                    <node concept="13MTOL" id="7ER1loq4n5N" role="2OqNvi">
+                                      <ref role="13MTZf" to="45ke:2igMYjpPzq8" resolve="concept" />
+                                    </node>
+                                  </node>
+                                  <node concept="3JPx81" id="7ER1loq4n5O" role="2OqNvi">
+                                    <node concept="37vLTw" id="7ER1loq4n5P" role="25WWJ7">
+                                      <ref role="3cqZAo" node="7ER1loq4n5Q" resolve="it" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="Rh6nW" id="7ER1loq4n5Q" role="1bW2Oz">
+                            <property role="TrG5h" value="it" />
+                            <node concept="2jxLKc" id="7ER1loq4n5R" role="1tU5fm" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="2es0OD" id="7ER1loq4_Hl" role="2OqNvi">
+                      <node concept="1bVj0M" id="7ER1loq4_Hn" role="23t8la">
+                        <node concept="3clFbS" id="7ER1loq4_Ho" role="1bW5cS">
+                          <node concept="3clFbF" id="7ER1loq4_Zv" role="3cqZAp">
+                            <node concept="2OqwBi" id="7ER1loq5xV$" role="3clFbG">
+                              <node concept="2OqwBi" id="7ER1loq4TmP" role="2Oq$k0">
+                                <node concept="2OqwBi" id="7ER1loq4CtT" role="2Oq$k0">
+                                  <node concept="2OqwBi" id="7ER1loq4AbD" role="2Oq$k0">
+                                    <node concept="3GMtW1" id="7ER1loq4_Zu" role="2Oq$k0" />
+                                    <node concept="3Tsc0h" id="7ER1loq4AT3" role="2OqNvi">
+                                      <ref role="3TtcxE" to="45ke:2igMYjp_Ggs" resolve="contents" />
+                                    </node>
+                                  </node>
+                                  <node concept="WFELt" id="7ER1loq4Qp7" role="2OqNvi">
+                                    <ref role="1A0vxQ" to="45ke:2igMYjpPzq7" resolve="AbstractConceptDeclarationRef" />
+                                  </node>
+                                </node>
+                                <node concept="3TrEf2" id="7ER1loq4Uhx" role="2OqNvi">
+                                  <ref role="3Tt5mk" to="45ke:2igMYjpPzq8" resolve="concept" />
+                                </node>
+                              </node>
+                              <node concept="2oxUTD" id="7ER1loq69k8" role="2OqNvi">
+                                <node concept="37vLTw" id="7ER1loq6adW" role="2oxUTC">
+                                  <ref role="3cqZAo" node="7ER1loq4_Hp" resolve="it" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="Rh6nW" id="7ER1loq4_Hp" role="1bW2Oz">
+                          <property role="TrG5h" value="it" />
+                          <node concept="2jxLKc" id="7ER1loq4_Hq" role="1tU5fm" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
     </node>
   </node>
   <node concept="2xDbr0" id="7z30MUmeewT">
@@ -5490,6 +6130,124 @@
     <node concept="3Tm1VV" id="6vp$_2vGRGg" role="1B3o_S" />
     <node concept="3uibUv" id="6vp$_2vH4dg" role="EKbjA">
       <ref role="3uigEE" to="f4zo:~SubstituteInfo" resolve="SubstituteInfo" />
+    </node>
+  </node>
+  <node concept="PKFIW" id="6fDk5b60d7c">
+    <property role="TrG5h" value="AbstractForeignConceptDeclarationBox" />
+    <ref role="1XX52x" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
+    <node concept="3EZMnI" id="6fDk5b60d7d" role="2wV5jI">
+      <node concept="2iRkQZ" id="6fDk5b60d7e" role="2iSdaV" />
+      <node concept="VPM3Z" id="6fDk5b60d7f" role="3F10Kt">
+        <property role="VOm3f" value="false" />
+      </node>
+      <node concept="3EZMnI" id="6fDk5b60d7g" role="3EZMnx">
+        <node concept="2iRkQZ" id="6fDk5b60d7h" role="2iSdaV" />
+        <node concept="VPM3Z" id="6fDk5b60d7i" role="3F10Kt">
+          <property role="VOm3f" value="false" />
+        </node>
+        <node concept="37jFXN" id="6fDk5b60d7j" role="3F10Kt">
+          <property role="37lx6p" value="CENTER" />
+        </node>
+        <node concept="1HlG4h" id="6fDk5b60d7k" role="3EZMnx">
+          <node concept="1HfYo3" id="6fDk5b60d7l" role="1HlULh">
+            <node concept="3TQlhw" id="6fDk5b60d7m" role="1Hhtcw">
+              <node concept="3clFbS" id="6fDk5b60d7n" role="2VODD2">
+                <node concept="3clFbF" id="6fDk5b60d7o" role="3cqZAp">
+                  <node concept="3K4zz7" id="6fDk5b60d7p" role="3clFbG">
+                    <node concept="Xl_RD" id="6fDk5b60d7q" role="3K4E3e">
+                      <property role="Xl_RC" value="«interface»" />
+                    </node>
+                    <node concept="Xl_RD" id="6fDk5b60d7r" role="3K4GZi">
+                      <property role="Xl_RC" value="«concept»" />
+                    </node>
+                    <node concept="2OqwBi" id="6fDk5b60d7s" role="3K4Cdx">
+                      <node concept="pncrf" id="6fDk5b60d7t" role="2Oq$k0" />
+                      <node concept="1mIQ4w" id="6fDk5b60d7u" role="2OqNvi">
+                        <node concept="chp4Y" id="6fDk5b60d7v" role="cj9EA">
+                          <ref role="cht4Q" to="tpce:h0PlHMJ" resolve="InterfaceConceptDeclaration" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="37jFXN" id="6fDk5b60d7w" role="3F10Kt">
+            <property role="37lx6p" value="CENTER" />
+          </node>
+          <node concept="VSNWy" id="6fDk5b60d7x" role="3F10Kt">
+            <node concept="1cFabM" id="6fDk5b60d7y" role="1d8cEk">
+              <node concept="3clFbS" id="6fDk5b60d7z" role="2VODD2">
+                <node concept="3clFbF" id="6fDk5b60d7$" role="3cqZAp">
+                  <node concept="3cmrfG" id="6fDk5b60d7_" role="3clFbG">
+                    <property role="3cmrfH" value="10" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="VechU" id="6fDk5b60d7A" role="3F10Kt">
+            <property role="Vb096" value="darkGray" />
+          </node>
+        </node>
+        <node concept="1HlG4h" id="6fDk5b60emf" role="3EZMnx">
+          <node concept="37jFXN" id="6fDk5b61Do7" role="3F10Kt">
+            <property role="37lx6p" value="CENTER" />
+          </node>
+          <node concept="VSNWy" id="6fDk5b61CBB" role="3F10Kt">
+            <node concept="1cFabM" id="6fDk5b61CBC" role="1d8cEk">
+              <node concept="3clFbS" id="6fDk5b61CBD" role="2VODD2">
+                <node concept="3clFbF" id="6fDk5b61CBE" role="3cqZAp">
+                  <node concept="3cmrfG" id="6fDk5b61CBF" role="3clFbG">
+                    <property role="3cmrfH" value="10" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="VechU" id="6fDk5b61DR2" role="3F10Kt">
+            <property role="Vb096" value="darkGray" />
+          </node>
+          <node concept="1HfYo3" id="6fDk5b60emh" role="1HlULh">
+            <node concept="3TQlhw" id="6fDk5b60emj" role="1Hhtcw">
+              <node concept="3clFbS" id="6fDk5b60eml" role="2VODD2">
+                <node concept="3clFbF" id="6fDk5b60eAe" role="3cqZAp">
+                  <node concept="2OqwBi" id="6fDk5b60hY3" role="3clFbG">
+                    <node concept="2OqwBi" id="6fDk5b60gyX" role="2Oq$k0">
+                      <node concept="2OqwBi" id="6fDk5b60eTn" role="2Oq$k0">
+                        <node concept="pncrf" id="6fDk5b60eAd" role="2Oq$k0" />
+                        <node concept="I4A8Y" id="6fDk5b60g8B" role="2OqNvi" />
+                      </node>
+                      <node concept="13u695" id="6fDk5b60hmn" role="2OqNvi" />
+                    </node>
+                    <node concept="2qgKlT" id="6fDk5b60ixI" role="2OqNvi">
+                      <ref role="37wK5l" to="tpcu:hEwIO9y" resolve="getFqName" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3F0A7n" id="6fDk5b60d7B" role="3EZMnx">
+          <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
+          <node concept="37jFXN" id="6fDk5b60d7C" role="3F10Kt">
+            <property role="37lx6p" value="CENTER" />
+          </node>
+        </node>
+      </node>
+      <node concept="3S8TqV" id="6fDk5b60d7D" role="3EZMnx" />
+      <node concept="3EZMnI" id="6fDk5b60d7E" role="3EZMnx">
+        <node concept="VPM3Z" id="6fDk5b60d7F" role="3F10Kt">
+          <property role="VOm3f" value="false" />
+        </node>
+        <node concept="2iRkQZ" id="6fDk5b60d7G" role="2iSdaV" />
+        <node concept="3F2HdR" id="6fDk5b60d7H" role="3EZMnx">
+          <ref role="1NtTu8" to="tpce:f_TKVDG" resolve="propertyDeclaration" />
+          <node concept="2iRkQZ" id="6fDk5b60d7I" role="2czzBx" />
+        </node>
+      </node>
     </node>
   </node>
 </model>

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.conceptdiagram/languageModels/structure.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.conceptdiagram/languageModels/structure.mps
@@ -12,9 +12,13 @@
   </imports>
   <registry>
     <language id="c72da2b9-7cce-4447-8389-f407dc1158b7" name="jetbrains.mps.lang.structure">
+      <concept id="7862711839422615209" name="jetbrains.mps.lang.structure.structure.DocumentedNodeAnnotation" flags="ng" index="t5JxF">
+        <property id="7862711839422615217" name="text" index="t5JxN" />
+      </concept>
       <concept id="1169125787135" name="jetbrains.mps.lang.structure.structure.AbstractConceptDeclaration" flags="ig" index="PkWjJ">
         <property id="6714410169261853888" name="conceptId" index="EcuMT" />
         <child id="1071489727083" name="linkDeclaration" index="1TKVEi" />
+        <child id="1071489727084" name="propertyDeclaration" index="1TKVEl" />
       </concept>
       <concept id="1169127622168" name="jetbrains.mps.lang.structure.structure.InterfaceConceptReference" flags="ig" index="PrWs8">
         <reference id="1169127628841" name="intfc" index="PrY4T" />
@@ -23,6 +27,10 @@
         <property id="1096454100552" name="rootable" index="19KtqR" />
         <reference id="1071489389519" name="extends" index="1TJDcQ" />
         <child id="1169129564478" name="implements" index="PzmwI" />
+      </concept>
+      <concept id="1071489288299" name="jetbrains.mps.lang.structure.structure.PropertyDeclaration" flags="ig" index="1TJgyi">
+        <property id="241647608299431129" name="propertyId" index="IQ2nx" />
+        <reference id="1082985295845" name="dataType" index="AX2Wp" />
       </concept>
       <concept id="1071489288298" name="jetbrains.mps.lang.structure.structure.LinkDeclaration" flags="ig" index="1TJgyj">
         <property id="1071599776563" name="role" index="20kJfa" />
@@ -33,6 +41,9 @@
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
@@ -59,6 +70,14 @@
     </node>
     <node concept="PrWs8" id="2igMYjp$jPf" role="PzmwI">
       <ref role="PrY4T" to="tpck:h0TrEE$" resolve="INamedConcept" />
+    </node>
+    <node concept="1TJgyi" id="6fDk5b6392$" role="1TKVEl">
+      <property role="IQ2nx" value="7199373795768701092" />
+      <property role="TrG5h" value="modelAccess" />
+      <ref role="AX2Wp" to="tpck:fKAQMTB" resolve="boolean" />
+      <node concept="t5JxF" id="6fDk5b639F_" role="lGtFl">
+        <property role="t5JxN" value="true, if changes in the diagram shall be directly reflected in the model" />
+      </node>
     </node>
   </node>
   <node concept="1TIwiD" id="2igMYjpPzq7">


### PR DESCRIPTION
To customize the concept diagram easily for documentation of the language structure, you want to customize the concept diagram easily.

The PR brings
* different visualization of concepts, which do not belong the own structure, see http://127.0.0.1:63320/node?ref=r%3A90fb00a7-f318-4957-80af-5ff5b4d8f74b%28com.mbeddr.mpsutil.conceptdiagram.sandbox.structure%29%2F6689164969966991143&project=com.mbeddr.mpsutil
* three buttons in the inspector of the concept diagram to
  * add all the concepts of the language with a single click
  * add all super concepts to easily visualize the inheritance hierarchy
  * add all concepts used as childs of the concepts of the diagram
* a boolean flag which allows to edit the concept diagram without directly changing the model