### PR TITLE
Bugfix/incremental computation badcaches

### DIFF
--- a/code/languages/com.mbeddr.build/solutions/com.mbeddr.platform/models/com/mbeddr/platform/build.mps
+++ b/code/languages/com.mbeddr.build/solutions/com.mbeddr.platform/models/com/mbeddr/platform/build.mps
@@ -18273,6 +18273,12 @@
       <node concept="L2wRC" id="3a1lGlwLNWg" role="39821P">
         <ref role="L2wRA" node="2yMzZpANLwn" resolve="test.com.mbeddr.mpsutil.blutil.test.waitfor" />
       </node>
+      <node concept="L2wRC" id="2YOONxNPAr7" role="39821P">
+        <ref role="L2wRA" node="2YOONxNOeex" resolve="test.com.mbeddr.mpsutil.incrementalcomputation.utils" />
+      </node>
+      <node concept="L2wRC" id="2YOONxNPAhF" role="39821P">
+        <ref role="L2wRA" node="2YOONxNOdFv" resolve="test.com.mbeddr.mpsutil.incrementalcomputation.runtime" />
+      </node>
       <node concept="398223" id="2GRHOLIUBUT" role="39821P">
         <node concept="3_J27D" id="2GRHOLIUBUV" role="Nbhlr">
           <node concept="3Mxwew" id="2GRHOLIUC5d" role="3MwsjC">
@@ -18337,7 +18343,6 @@
         <property role="TrG5h" value="test.ts.richstring" />
         <property role="3LESm3" value="9dc1a5e9-95eb-4eda-9aa7-fa55c4ee8c31" />
         <property role="aoJFB" value="sources and tests" />
-        <property role="2GAjPV" value="false" />
         <node concept="3rtmxn" id="3xFG3bj5cF$" role="3bR31x">
           <node concept="3LXTmp" id="3xFG3bj5cF_" role="3rtmxm">
             <node concept="3qWCbU" id="3xFG3bj5cFA" role="3LXTna">
@@ -18368,13 +18373,11 @@
         </node>
         <node concept="1SiIV0" id="7hVsScEQJWK" role="3bR37C">
           <node concept="3bR9La" id="7hVsScEQJWL" role="1SiIV1">
-            <property role="3bR36h" value="false" />
             <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
           </node>
         </node>
         <node concept="1SiIV0" id="79255UwOlun" role="3bR37C">
           <node concept="3bR9La" id="79255UwOluo" role="1SiIV1">
-            <property role="3bR36h" value="false" />
             <ref role="3bR37D" to="ffeo:7Kfy9QB6KYb" resolve="jetbrains.mps.baseLanguage" />
           </node>
         </node>
@@ -18384,7 +18387,6 @@
         <property role="TrG5h" value="test.ts.javainterpreter" />
         <property role="3LESm3" value="c69d41ac-d672-4068-b5a5-b892873f6bb9" />
         <property role="aoJFB" value="sources and tests" />
-        <property role="2GAjPV" value="false" />
         <node concept="3rtmxn" id="3xFG3bj5cZQ" role="3bR31x">
           <node concept="3LXTmp" id="3xFG3bj5cZR" role="3rtmxm">
             <node concept="3qWCbU" id="3xFG3bj5cZS" role="3LXTna">
@@ -18415,7 +18417,6 @@
         </node>
         <node concept="1SiIV0" id="4J6nqih4qPi" role="3bR37C">
           <node concept="3bR9La" id="4J6nqih4qPj" role="1SiIV1">
-            <property role="3bR36h" value="false" />
             <ref role="3bR37D" to="ffeo:7Kfy9QB6KYb" resolve="jetbrains.mps.baseLanguage" />
           </node>
         </node>
@@ -18424,7 +18425,6 @@
         <property role="BnDLt" value="true" />
         <property role="TrG5h" value="com.mbeddr.mpsutil.javainterpreter.test" />
         <property role="3LESm3" value="2a99790c-a7e4-470f-9488-b37851ebf826" />
-        <property role="2GAjPV" value="false" />
         <node concept="3rtmxn" id="3xFG3bj5cY4" role="3bR31x">
           <node concept="3LXTmp" id="3xFG3bj5cY5" role="3rtmxm">
             <node concept="3qWCbU" id="3xFG3bj5cY6" role="3LXTna">
@@ -18455,13 +18455,11 @@
         </node>
         <node concept="1SiIV0" id="15E$Thf_6lC" role="3bR37C">
           <node concept="3bR9La" id="15E$Thf_6lD" role="1SiIV1">
-            <property role="3bR36h" value="false" />
             <ref role="3bR37D" to="ffeo:7Kfy9QB6KYb" resolve="jetbrains.mps.baseLanguage" />
           </node>
         </node>
         <node concept="1SiIV0" id="15E$Thf_6lG" role="3bR37C">
           <node concept="3bR9La" id="15E$Thf_6lH" role="1SiIV1">
-            <property role="3bR36h" value="false" />
             <ref role="3bR37D" node="2bBLuwR9$cn" resolve="com.mbeddr.mpsutil.interpreter.rt" />
           </node>
         </node>
@@ -18473,11 +18471,9 @@
         <node concept="1yeLz9" id="15E$Thf_6lK" role="1TViLv">
           <property role="TrG5h" value="com.mbeddr.mpsutil.javainterpreter.test#6267356447275018447" />
           <property role="3LESm3" value="da16ac82-9662-4cb8-b6de-3c95e21b838e" />
-          <property role="2GAjPV" value="false" />
         </node>
         <node concept="1SiIV0" id="3zAWwLKfJD7" role="3bR37C">
           <node concept="3bR9La" id="3zAWwLKfJD8" role="1SiIV1">
-            <property role="3bR36h" value="false" />
             <ref role="3bR37D" node="5GUwywcVavP" resolve="com.mbeddr.mpsutil.interpreter" />
           </node>
         </node>
@@ -18487,7 +18483,6 @@
         <property role="TrG5h" value="test.ts.mpsutil.multilingual" />
         <property role="3LESm3" value="fcca86e0-64c4-4aef-824c-434589a89382" />
         <property role="aoJFB" value="sources and tests" />
-        <property role="2GAjPV" value="false" />
         <node concept="3rtmxn" id="3xFG3bj5cQo" role="3bR31x">
           <node concept="3LXTmp" id="3xFG3bj5cQp" role="3rtmxm">
             <node concept="3qWCbU" id="3xFG3bj5cQq" role="3LXTna">
@@ -18524,25 +18519,21 @@
         </node>
         <node concept="1SiIV0" id="4gGXGcLW3Mu" role="3bR37C">
           <node concept="3bR9La" id="4gGXGcLW3Mv" role="1SiIV1">
-            <property role="3bR36h" value="false" />
             <ref role="3bR37D" node="4gGXGcLV_Ec" resolve="com.mbeddr.mpsutil.multilingual.common.runtime" />
           </node>
         </node>
         <node concept="1SiIV0" id="4gGXGcLW3Mw" role="3bR37C">
           <node concept="3bR9La" id="4gGXGcLW3Mx" role="1SiIV1">
-            <property role="3bR36h" value="false" />
             <ref role="3bR37D" node="4gGXGcLVMsv" resolve="com.mbeddr.mpsutil.multilingual.common" />
           </node>
         </node>
         <node concept="1SiIV0" id="2F_EZZysQPX" role="3bR37C">
           <node concept="3bR9La" id="2F_EZZysQPY" role="1SiIV1">
-            <property role="3bR36h" value="false" />
             <ref role="3bR37D" node="7hVsScEP9Zo" resolve="com.mbeddr.mpsutil.richstring" />
           </node>
         </node>
         <node concept="1SiIV0" id="2F_EZZysQPZ" role="3bR37C">
           <node concept="3bR9La" id="2F_EZZysQQ0" role="1SiIV1">
-            <property role="3bR36h" value="false" />
             <ref role="3bR37D" node="4gGXGcLVNj$" resolve="com.mbeddr.mpsutil.multilingual.baseLanguage" />
           </node>
         </node>
@@ -18570,7 +18561,6 @@
         <property role="BnDLt" value="true" />
         <property role="TrG5h" value="test.ts.mpsutil.multilingual.concept.sandbox" />
         <property role="3LESm3" value="c0826d77-5349-4d44-b588-5750e22d096b" />
-        <property role="2GAjPV" value="false" />
         <node concept="3rtmxn" id="3xFG3bj5cT3" role="3bR31x">
           <node concept="3LXTmp" id="3xFG3bj5cT4" role="3rtmxm">
             <node concept="3qWCbU" id="3xFG3bj5cT5" role="3LXTna">
@@ -18607,14 +18597,12 @@
         <node concept="1yeLz9" id="2F_EZZyt3q_" role="1TViLv">
           <property role="TrG5h" value="test.ts.mpsutil.multilingual.concept.sandbox#4912572611776127584" />
           <property role="3LESm3" value="c467ee8b-f807-42dd-8029-99f8ed98d460" />
-          <property role="2GAjPV" value="false" />
         </node>
       </node>
       <node concept="1E1JtD" id="2F_EZZyt3h7" role="2G$12L">
         <property role="BnDLt" value="true" />
         <property role="TrG5h" value="test.ts.mpsutil.multilingual.editor.sandbox" />
         <property role="3LESm3" value="0eba8d68-ca0c-4113-a9e6-19b359352ecf" />
-        <property role="2GAjPV" value="false" />
         <node concept="3rtmxn" id="3xFG3bj5cLV" role="3bR31x">
           <node concept="3LXTmp" id="3xFG3bj5cLW" role="3rtmxm">
             <node concept="3qWCbU" id="3xFG3bj5cLX" role="3LXTna">
@@ -18646,7 +18634,6 @@
         <node concept="1yeLz9" id="2F_EZZyt3rf" role="1TViLv">
           <property role="TrG5h" value="test.ts.mpsutil.multilingual.editor.sandbox#4912572611775887657" />
           <property role="3LESm3" value="0fbcb2bc-923f-4328-beef-a6eb2b652fec" />
-          <property role="2GAjPV" value="false" />
         </node>
         <node concept="1SiIV0" id="2GRHOLITegx" role="3bR37C">
           <node concept="1BurEX" id="2GRHOLITegy" role="1SiIV1">
@@ -18672,7 +18659,6 @@
         <property role="BnDLt" value="true" />
         <property role="TrG5h" value="test.ts.propertydefault" />
         <property role="3LESm3" value="2720ea68-b58e-4435-aab0-4659362f72b6" />
-        <property role="2GAjPV" value="false" />
         <node concept="3rtmxn" id="3xFG3bj5cIa" role="3bR31x">
           <node concept="3LXTmp" id="3xFG3bj5cIb" role="3rtmxm">
             <node concept="3qWCbU" id="3xFG3bj5cIc" role="3LXTna">
@@ -18704,7 +18690,6 @@
         <node concept="1yeLz9" id="1m4fy7KPaaP" role="1TViLv">
           <property role="TrG5h" value="test.ts.propertydefault#1550432487217230054" />
           <property role="3LESm3" value="b113c010-2af4-40e7-a19e-80202e3a4a83" />
-          <property role="2GAjPV" value="false" />
         </node>
       </node>
       <node concept="1E1JtA" id="1m4fy7KPaRX" role="2G$12L">
@@ -18712,7 +18697,6 @@
         <property role="TrG5h" value="test.ts.propertydefaulttest" />
         <property role="3LESm3" value="dff62b6d-9134-45e3-8451-8287afc43e99" />
         <property role="aoJFB" value="sources and tests" />
-        <property role="2GAjPV" value="false" />
         <node concept="3rtmxn" id="3xFG3bj5cTD" role="3bR31x">
           <node concept="3LXTmp" id="3xFG3bj5cTE" role="3rtmxm">
             <node concept="3qWCbU" id="3xFG3bj5cTF" role="3LXTna">
@@ -18743,7 +18727,6 @@
         </node>
         <node concept="1SiIV0" id="1m4fy7KPbtG" role="3bR37C">
           <node concept="3bR9La" id="1m4fy7KPbtH" role="1SiIV1">
-            <property role="3bR36h" value="false" />
             <ref role="3bR37D" node="1m4fy7KPaaI" resolve="test.ts.propertydefault" />
           </node>
         </node>
@@ -18753,7 +18736,6 @@
         <property role="TrG5h" value="test.com.mbeddr.mpsutil.targetchooser" />
         <property role="3LESm3" value="7635626d-0805-4e93-97be-2ad3fde811c0" />
         <property role="aoJFB" value="sources and tests" />
-        <property role="2GAjPV" value="false" />
         <node concept="3rtmxn" id="3xFG3bj5cVn" role="3bR31x">
           <node concept="3LXTmp" id="3xFG3bj5cVo" role="3rtmxm">
             <node concept="3qWCbU" id="3xFG3bj5cVp" role="3LXTna">
@@ -18784,43 +18766,36 @@
         </node>
         <node concept="1SiIV0" id="2KYX2G1nqDv" role="3bR37C">
           <node concept="3bR9La" id="2KYX2G1nqDw" role="1SiIV1">
-            <property role="3bR36h" value="false" />
             <ref role="3bR37D" node="2Nt6prolOb5" resolve="com.mbeddr.mpsutil.targetchooser" />
           </node>
         </node>
         <node concept="1SiIV0" id="2KYX2G1nqDx" role="3bR37C">
           <node concept="3bR9La" id="2KYX2G1nqDy" role="1SiIV1">
-            <property role="3bR36h" value="false" />
             <ref role="3bR37D" to="ffeo:1TaHNgiIbJb" resolve="MPS.Platform" />
           </node>
         </node>
         <node concept="1SiIV0" id="2KYX2G1nqDz" role="3bR37C">
           <node concept="3bR9La" id="2KYX2G1nqD$" role="1SiIV1">
-            <property role="3bR36h" value="false" />
             <ref role="3bR37D" to="ffeo:7Kfy9QB6KXW" resolve="jetbrains.mps.lang.core" />
           </node>
         </node>
         <node concept="1SiIV0" id="2KYX2G1nqD_" role="3bR37C">
           <node concept="3bR9La" id="2KYX2G1nqDA" role="1SiIV1">
-            <property role="3bR36h" value="false" />
             <ref role="3bR37D" to="ffeo:1ia2VB5guYy" resolve="MPS.IDEA" />
           </node>
         </node>
         <node concept="1SiIV0" id="2KYX2G1nqDB" role="3bR37C">
           <node concept="3bR9La" id="2KYX2G1nqDC" role="1SiIV1">
-            <property role="3bR36h" value="false" />
             <ref role="3bR37D" to="ffeo:1H905DlDUSw" resolve="MPS.OpenAPI" />
           </node>
         </node>
         <node concept="1SiIV0" id="2KYX2G1nqDD" role="3bR37C">
           <node concept="3bR9La" id="2KYX2G1nqDE" role="1SiIV1">
-            <property role="3bR36h" value="false" />
             <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
           </node>
         </node>
         <node concept="1SiIV0" id="2KYX2G1nqDF" role="3bR37C">
           <node concept="3bR9La" id="2KYX2G1nqDG" role="1SiIV1">
-            <property role="3bR36h" value="false" />
             <ref role="3bR37D" to="ffeo:1TaHNgiIbIQ" resolve="MPS.Core" />
           </node>
         </node>
@@ -18830,7 +18805,6 @@
         <property role="TrG5h" value="test.com.mbeddr.mpsutil.xml.fix" />
         <property role="3LESm3" value="6d3c26cb-5a54-45af-9595-ca1921bdbf09" />
         <property role="aoJFB" value="sources and tests" />
-        <property role="2GAjPV" value="false" />
         <node concept="3rtmxn" id="3xFG3bj5cS4" role="3bR31x">
           <node concept="3LXTmp" id="3xFG3bj5cS5" role="3rtmxm">
             <node concept="3qWCbU" id="3xFG3bj5cS6" role="3LXTna">
@@ -18861,19 +18835,16 @@
         </node>
         <node concept="1SiIV0" id="1hnjAvpIo1P" role="3bR37C">
           <node concept="3bR9La" id="1hnjAvpIo1Q" role="1SiIV1">
-            <property role="3bR36h" value="false" />
             <ref role="3bR37D" to="ffeo:7Kfy9QB6LgV" resolve="jetbrains.mps.make.runtime" />
           </node>
         </node>
         <node concept="1SiIV0" id="1hnjAvpIo1T" role="3bR37C">
           <node concept="3bR9La" id="1hnjAvpIo1U" role="1SiIV1">
-            <property role="3bR36h" value="false" />
             <ref role="3bR37D" to="ffeo:1TaHNgiIbIQ" resolve="MPS.Core" />
           </node>
         </node>
         <node concept="1SiIV0" id="1hnjAvpIo1V" role="3bR37C">
           <node concept="3bR9La" id="1hnjAvpIo1W" role="1SiIV1">
-            <property role="3bR36h" value="false" />
             <ref role="3bR37D" to="ffeo:2eDSGe9d1q1" resolve="MPS.Workbench" />
           </node>
         </node>
@@ -18882,13 +18853,11 @@
         </node>
         <node concept="1SiIV0" id="7iWvrXvDDJe" role="3bR37C">
           <node concept="3bR9La" id="7iWvrXvDDJf" role="1SiIV1">
-            <property role="3bR36h" value="false" />
             <ref role="3bR37D" node="bGV79BrjCR" resolve="com.mbeddr.mpsutil.xml.fix" />
           </node>
         </node>
         <node concept="1SiIV0" id="2avgMTl5wyw" role="3bR37C">
           <node concept="3bR9La" id="2avgMTl5wyx" role="1SiIV1">
-            <property role="3bR36h" value="false" />
             <ref role="3bR37D" to="90a9:PE3B26QCrP" resolve="org.apache.commons" />
           </node>
         </node>
@@ -18897,7 +18866,6 @@
         <property role="BnDLt" value="true" />
         <property role="TrG5h" value="test.com.mbeddr.mpsutil.xml.fix.support" />
         <property role="3LESm3" value="a71fc24a-23c8-4871-87d3-e77b414b28d2" />
-        <property role="2GAjPV" value="false" />
         <node concept="3rtmxn" id="3xFG3bj5cKI" role="3bR31x">
           <node concept="3LXTmp" id="3xFG3bj5cKJ" role="3rtmxm">
             <node concept="3qWCbU" id="3xFG3bj5cKK" role="3LXTna">
@@ -18929,7 +18897,6 @@
         <node concept="1yeLz9" id="1hnjAvpIo2f" role="1TViLv">
           <property role="TrG5h" value="test.com.mbeddr.mpsutil.xml.fix.support#210803258685952145" />
           <property role="3LESm3" value="12ea1291-43c2-495c-99bf-27bc9db95754" />
-          <property role="2GAjPV" value="false" />
           <node concept="1SiIV0" id="2wu1bNQpoex" role="3bR37C">
             <node concept="3bR9La" id="2wu1bNQpoew" role="1SiIV1">
               <ref role="3bR37D" to="ffeo:7YI57w6K0vJ" resolve="jetbrains.mps.core.xml.sax#2264311582634171386" />
@@ -18941,7 +18908,6 @@
         <property role="BnDLt" value="true" />
         <property role="TrG5h" value="test.com.mbeddr.mpsutil.iconchar" />
         <property role="3LESm3" value="6439a9c3-d5bd-4cb1-b4a1-24ee935afcf9" />
-        <property role="2GAjPV" value="false" />
         <node concept="3rtmxn" id="3xFG3bj5cNg" role="3bR31x">
           <node concept="3LXTmp" id="3xFG3bj5cNh" role="3rtmxm">
             <node concept="3qWCbU" id="3xFG3bj5cNi" role="3LXTna">
@@ -18973,7 +18939,6 @@
         <node concept="1yeLz9" id="3J7tYMorZpm" role="1TViLv">
           <property role="TrG5h" value="test.com.mbeddr.mpsutil.iconchar#8866176685649024459" />
           <property role="3LESm3" value="dc782681-8ee9-440b-9a63-347af0b76d56" />
-          <property role="2GAjPV" value="false" />
         </node>
       </node>
       <node concept="1E1JtA" id="3J7tYMorZ$O" role="2G$12L">
@@ -18981,7 +18946,6 @@
         <property role="TrG5h" value="test.com.mbeddr.mpsutil.iconchar.test" />
         <property role="3LESm3" value="b0eea09e-7c43-47c6-bfb5-2b1b36108b5f" />
         <property role="aoJFB" value="sources and tests" />
-        <property role="2GAjPV" value="false" />
         <node concept="3rtmxn" id="3xFG3bj5cSb" role="3bR31x">
           <node concept="3LXTmp" id="3xFG3bj5cSc" role="3rtmxm">
             <node concept="3qWCbU" id="3xFG3bj5cSd" role="3LXTna">
@@ -19012,7 +18976,6 @@
         </node>
         <node concept="1SiIV0" id="5L7BF$C8GDE" role="3bR37C">
           <node concept="3bR9La" id="5L7BF$C8GDF" role="1SiIV1">
-            <property role="3bR36h" value="false" />
             <ref role="3bR37D" to="ffeo:1TaHNgiIbJb" resolve="MPS.Platform" />
           </node>
         </node>
@@ -19022,7 +18985,6 @@
         <property role="TrG5h" value="test.com.mbeddr.mpsutil.extensionclass" />
         <property role="3LESm3" value="460ef3f4-0093-4c53-8c6a-bb8c36a7a621" />
         <property role="aoJFB" value="sources and tests" />
-        <property role="2GAjPV" value="false" />
         <node concept="3rtmxn" id="3xFG3bj5cVu" role="3bR31x">
           <node concept="3LXTmp" id="3xFG3bj5cVv" role="3rtmxm">
             <node concept="3qWCbU" id="3xFG3bj5cVw" role="3LXTna">
@@ -19053,13 +19015,11 @@
         </node>
         <node concept="1SiIV0" id="4X7wieqKkjE" role="3bR37C">
           <node concept="3bR9La" id="4X7wieqKkjF" role="1SiIV1">
-            <property role="3bR36h" value="false" />
             <ref role="3bR37D" node="4X7wieqKdAv" resolve="com.mbeddr.mpsutil.extensionclass" />
           </node>
         </node>
         <node concept="1SiIV0" id="2avgMTl5w$A" role="3bR37C">
           <node concept="3bR9La" id="2avgMTl5w$B" role="1SiIV1">
-            <property role="3bR36h" value="false" />
             <ref role="3bR37D" to="90a9:PE3B26QCrP" resolve="org.apache.commons" />
           </node>
         </node>
@@ -19069,7 +19029,6 @@
         <property role="TrG5h" value="com.mbeddr.mpsutil.compare.pattern.test" />
         <property role="3LESm3" value="88463ec0-b015-4440-b5f8-3e27fcbaa282" />
         <property role="aoJFB" value="sources and tests" />
-        <property role="2GAjPV" value="false" />
         <node concept="3rtmxn" id="3xFG3bj5cHP" role="3bR31x">
           <node concept="3LXTmp" id="3xFG3bj5cHQ" role="3rtmxm">
             <node concept="3qWCbU" id="3xFG3bj5cHR" role="3LXTna">
@@ -19100,13 +19059,11 @@
         </node>
         <node concept="1SiIV0" id="Um6saBVXOG" role="3bR37C">
           <node concept="3bR9La" id="Um6saBVXOH" role="1SiIV1">
-            <property role="3bR36h" value="false" />
             <ref role="3bR37D" to="ffeo:7Kfy9QB6KYb" resolve="jetbrains.mps.baseLanguage" />
           </node>
         </node>
         <node concept="1SiIV0" id="79i$vAYf031" role="3bR37C">
           <node concept="3bR9La" id="79i$vAYf032" role="1SiIV1">
-            <property role="3bR36h" value="false" />
             <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
           </node>
         </node>
@@ -19116,7 +19073,6 @@
         <property role="TrG5h" value="test.com.mbeddr.mpsutil.blutil.test.waitfor" />
         <property role="3LESm3" value="c4943a3c-45c9-4523-8723-a18368d2c1fc" />
         <property role="aoJFB" value="sources and tests" />
-        <property role="2GAjPV" value="false" />
         <node concept="3rtmxn" id="2yMzZpB1t5G" role="3bR31x">
           <node concept="3LXTmp" id="2yMzZpB1teC" role="3rtmxm">
             <node concept="3qWCbU" id="2yMzZpB1teD" role="3LXTna">
@@ -19147,13 +19103,11 @@
         </node>
         <node concept="1SiIV0" id="2yMzZpANMWr" role="3bR37C">
           <node concept="3bR9La" id="2yMzZpANMWs" role="1SiIV1">
-            <property role="3bR36h" value="false" />
             <ref role="3bR37D" to="ffeo:1ia2VB5guYy" resolve="MPS.IDEA" />
           </node>
         </node>
         <node concept="1SiIV0" id="2yMzZpANMWt" role="3bR37C">
           <node concept="3bR9La" id="2yMzZpANMWu" role="1SiIV1">
-            <property role="3bR36h" value="false" />
             <ref role="3bR37D" to="ffeo:1xb0AuwN7WS" resolve="JUnit" />
           </node>
         </node>
@@ -19162,7 +19116,6 @@
         <property role="BnDLt" value="true" />
         <property role="TrG5h" value="com.mbeddr.mpsutil.asynccell.sandbox" />
         <property role="3LESm3" value="4d43042b-3d26-46a9-888a-1ec4e4a2c81d" />
-        <property role="2GAjPV" value="false" />
         <node concept="3rtmxn" id="2yMzZpB1twq" role="3bR31x">
           <node concept="3LXTmp" id="2yMzZpB1twr" role="3rtmxm">
             <node concept="3qWCbU" id="2yMzZpB1tws" role="3LXTna">
@@ -19193,19 +19146,16 @@
         </node>
         <node concept="1SiIV0" id="2yMzZpB12ZP" role="3bR37C">
           <node concept="3bR9La" id="2yMzZpB12ZQ" role="1SiIV1">
-            <property role="3bR36h" value="false" />
             <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
           </node>
         </node>
         <node concept="1SiIV0" id="2yMzZpB12ZR" role="3bR37C">
           <node concept="3bR9La" id="2yMzZpB12ZS" role="1SiIV1">
-            <property role="3bR36h" value="false" />
             <ref role="3bR37D" to="ffeo:1TaHNgiIbIZ" resolve="MPS.Editor" />
           </node>
         </node>
         <node concept="1SiIV0" id="2yMzZpB12ZT" role="3bR37C">
           <node concept="3bR9La" id="2yMzZpB12ZU" role="1SiIV1">
-            <property role="3bR36h" value="false" />
             <ref role="3bR37D" node="1A$OnV5oFAB" resolve="com.mbeddr.mpsutil.asynccell" />
           </node>
         </node>
@@ -19279,7 +19229,6 @@
         <property role="BnDLt" value="true" />
         <property role="TrG5h" value="com.mbeddr.mpsutil.parameterizedMenu.sandbox" />
         <property role="3LESm3" value="0280da2d-83c6-47d3-bddd-baff7e1a110f" />
-        <property role="2GAjPV" value="false" />
         <node concept="3rtmxn" id="2yMzZpB1ulA" role="3bR31x">
           <node concept="3LXTmp" id="2yMzZpB1ulB" role="3rtmxm">
             <node concept="3qWCbU" id="2yMzZpB1ulC" role="3LXTna">
@@ -19310,13 +19259,11 @@
         </node>
         <node concept="1SiIV0" id="2yMzZpB14yA" role="3bR37C">
           <node concept="3bR9La" id="2yMzZpB14yB" role="1SiIV1">
-            <property role="3bR36h" value="false" />
             <ref role="3bR37D" to="ffeo:1ia2VB5guYy" resolve="MPS.IDEA" />
           </node>
         </node>
         <node concept="1SiIV0" id="2yMzZpB14yC" role="3bR37C">
           <node concept="3bR9La" id="2yMzZpB14yD" role="1SiIV1">
-            <property role="3bR36h" value="false" />
             <ref role="3bR37D" to="ffeo:1TaHNgiIbJb" resolve="MPS.Platform" />
           </node>
         </node>
@@ -19326,7 +19273,6 @@
         <property role="TrG5h" value="test.com.mbeddr.mpsutil.parameterizedMenu" />
         <property role="3LESm3" value="27ece083-b311-4d4d-8800-381f5eebf40e" />
         <property role="aoJFB" value="sources and tests" />
-        <property role="2GAjPV" value="false" />
         <node concept="3rtmxn" id="2yMzZpB1uBq" role="3bR31x">
           <node concept="3LXTmp" id="2yMzZpB1uBr" role="3rtmxm">
             <node concept="3qWCbU" id="2yMzZpB1uBs" role="3LXTna">
@@ -19357,26 +19303,138 @@
         </node>
         <node concept="1SiIV0" id="2yMzZpB0XUd" role="3bR37C">
           <node concept="3bR9La" id="2yMzZpB0XUe" role="1SiIV1">
-            <property role="3bR36h" value="false" />
             <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
           </node>
         </node>
         <node concept="1SiIV0" id="2yMzZpB0XUf" role="3bR37C">
           <node concept="3bR9La" id="2yMzZpB0XUg" role="1SiIV1">
-            <property role="3bR36h" value="false" />
             <ref role="3bR37D" to="ffeo:1TaHNgiIbJ$" resolve="jetbrains.mps.ide.editor" />
           </node>
         </node>
         <node concept="1SiIV0" id="2yMzZpB0XUh" role="3bR37C">
           <node concept="3bR9La" id="2yMzZpB0XUi" role="1SiIV1">
-            <property role="3bR36h" value="false" />
             <ref role="3bR37D" to="ffeo:1TaHNgiIbIZ" resolve="MPS.Editor" />
           </node>
         </node>
         <node concept="1SiIV0" id="2yMzZpB14yW" role="3bR37C">
           <node concept="3bR9La" id="2yMzZpB14yX" role="1SiIV1">
-            <property role="3bR36h" value="false" />
             <ref role="3bR37D" node="2yMzZpB13nR" resolve="com.mbeddr.mpsutil.parameterizedMenu.sandbox" />
+          </node>
+        </node>
+      </node>
+      <node concept="1E1JtD" id="2YOONxNOeex" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="test.com.mbeddr.mpsutil.incrementalcomputation.utils" />
+        <property role="3LESm3" value="d08b386d-5ef3-4be0-9f84-dbefaf9e37f4" />
+        <node concept="3rtmxn" id="2YOONxNOeey" role="3bR31x">
+          <node concept="3LXTmp" id="2YOONxNOeez" role="3rtmxm">
+            <node concept="3qWCbU" id="2YOONxNOee$" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+            <node concept="398BVA" id="2YOONxNOee_" role="3LXTmr">
+              <ref role="398BVh" node="7hVsScEQJ6E" resolve="mbeddr.mpsutil" />
+              <node concept="2Ry0Ak" id="2YOONxNOeeA" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="2YOONxNOeeB" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mbeddr.mpsutil.asynccell.sandbox" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="398BVA" id="2YOONxNOeeC" role="3LF7KH">
+          <ref role="398BVh" node="7hVsScEQJ6E" resolve="mbeddr.mpsutil" />
+          <node concept="2Ry0Ak" id="2YOONxNOeeD" role="iGT6I">
+            <property role="2Ry0Am" value="tests" />
+            <node concept="2Ry0Ak" id="2YOONxNOeeE" role="2Ry0An">
+              <property role="2Ry0Am" value="test.com.mbeddr.mpsutil.incrementalcomputation.utils" />
+              <node concept="2Ry0Ak" id="2YOONxNPvig" role="2Ry0An">
+                <property role="2Ry0Am" value="test.com.mbeddr.mpsutil.incrementalcomputation.utils.mpl" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2YOONxNOeeG" role="3bR37C">
+          <node concept="3bR9La" id="2YOONxNOeeH" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2YOONxNPvjF" role="3bR37C">
+          <node concept="3bR9La" id="2YOONxNPvjG" role="1SiIV1">
+            <ref role="3bR37D" node="3bCcKqaUIpY" resolve="com.mbeddr.mpsutil.incrementalcomputation.runtime" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2YOONxNPvjH" role="3bR37C">
+          <node concept="3bR9La" id="2YOONxNPvjI" role="1SiIV1">
+            <ref role="3bR37D" node="6xaPNaK8EVQ" resolve="org.mockito" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2YOONxNPvjJ" role="3bR37C">
+          <node concept="1Busua" id="2YOONxNPvjK" role="1SiIV1">
+            <ref role="1Busuk" node="3bCcKqaUnoh" resolve="com.mbeddr.mpsutil.incrementalcomputation" />
+          </node>
+        </node>
+        <node concept="1yeLz9" id="2YOONxNPvjL" role="1TViLv">
+          <property role="TrG5h" value="test.com.mbeddr.mpsutil.incrementalcomputation.utils#01" />
+          <property role="3LESm3" value="3b1aa90d-19b5-40ad-a942-37a00114aa1f" />
+        </node>
+      </node>
+      <node concept="1E1JtA" id="2YOONxNOdFv" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="test.com.mbeddr.mpsutil.incrementalcomputation.runtime" />
+        <property role="3LESm3" value="fa260a45-d02c-4dc2-bb84-e976ff916c98" />
+        <property role="aoJFB" value="sources and tests" />
+        <node concept="3rtmxn" id="2YOONxNOdFw" role="3bR31x">
+          <node concept="3LXTmp" id="2YOONxNOdFx" role="3rtmxm">
+            <node concept="3qWCbU" id="2YOONxNOdFy" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+            <node concept="398BVA" id="2YOONxNOdFz" role="3LXTmr">
+              <ref role="398BVh" node="7hVsScEQJ6E" resolve="mbeddr.mpsutil" />
+              <node concept="2Ry0Ak" id="2YOONxNOdF$" role="iGT6I">
+                <property role="2Ry0Am" value="tests" />
+                <node concept="2Ry0Ak" id="2YOONxNOdF_" role="2Ry0An">
+                  <property role="2Ry0Am" value="test.com.mbeddr.mpsutil.asynccell" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="398BVA" id="2YOONxNOdFA" role="3LF7KH">
+          <ref role="398BVh" node="7hVsScEQJ6E" resolve="mbeddr.mpsutil" />
+          <node concept="2Ry0Ak" id="2YOONxNOdFB" role="iGT6I">
+            <property role="2Ry0Am" value="tests" />
+            <node concept="2Ry0Ak" id="2YOONxNOdFC" role="2Ry0An">
+              <property role="2Ry0Am" value="test.com.mbeddr.mpsutil.incrementalcomputation.runtime" />
+              <node concept="2Ry0Ak" id="2YOONxNOebQ" role="2Ry0An">
+                <property role="2Ry0Am" value="test.com.mbeddr.mpsutil.incrementalcomputation.runtime.msd" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2YOONxNOedf" role="3bR37C">
+          <node concept="3bR9La" id="2YOONxNOedg" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2YOONxNOedh" role="3bR37C">
+          <node concept="3bR9La" id="2YOONxNOedi" role="1SiIV1">
+            <ref role="3bR37D" node="3bCcKqaUIpY" resolve="com.mbeddr.mpsutil.incrementalcomputation.runtime" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2YOONxNOedj" role="3bR37C">
+          <node concept="3bR9La" id="2YOONxNOedk" role="1SiIV1">
+            <ref role="3bR37D" node="3bCcKqaUnoh" resolve="com.mbeddr.mpsutil.incrementalcomputation" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2YOONxNOedl" role="3bR37C">
+          <node concept="3bR9La" id="2YOONxNOedm" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:1TaHNgiIbIQ" resolve="MPS.Core" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2YOONxNPvmk" role="3bR37C">
+          <node concept="3bR9La" id="2YOONxNPvml" role="1SiIV1">
+            <ref role="3bR37D" node="2YOONxNOeex" resolve="test.com.mbeddr.mpsutil.incrementalcomputation.utils" />
           </node>
         </node>
       </node>
@@ -19387,7 +19445,6 @@
         <property role="BnDLt" value="true" />
         <property role="TrG5h" value="com.mbeddr.doc.test.documents" />
         <property role="3LESm3" value="4078ebaa-02fd-430a-ab03-975592a2372c" />
-        <property role="2GAjPV" value="false" />
         <node concept="3rtmxn" id="3xFG3bj5cRg" role="3bR31x">
           <node concept="3LXTmp" id="3xFG3bj5cRh" role="3rtmxm">
             <node concept="3qWCbU" id="3xFG3bj5cRi" role="3LXTna">
@@ -19473,6 +19530,9 @@
       </node>
       <node concept="22LTRM" id="6xaPNaK939C" role="22LTRK">
         <ref role="22LTRN" node="6xaPNaK8sYs" resolve="test.com.mbeddr.mpsutil.asynccell" />
+      </node>
+      <node concept="22LTRM" id="2YOONxNPAmG" role="22LTRK">
+        <ref role="22LTRN" node="2YOONxNOdFv" resolve="test.com.mbeddr.mpsutil.incrementalcomputation.runtime" />
       </node>
       <node concept="24cAiW" id="76N1O$Kj6vJ" role="24cAkG" />
     </node>

--- a/code/languages/com.mbeddr.mpsutil/.mps/modules.xml
+++ b/code/languages/com.mbeddr.mpsutil/.mps/modules.xml
@@ -232,6 +232,8 @@
       <modulePath path="$PROJECT_DIR$/tests/test.com.mbeddr.mpsutil.extensionclass/test.com.mbeddr.mpsutil.extensionclass.msd" folder="staging.extensionclass" />
       <modulePath path="$PROJECT_DIR$/tests/test.com.mbeddr.mpsutil.iconchar.test/test.com.mbeddr.mpsutil.iconchar.test.msd" folder="stable.iconchar" />
       <modulePath path="$PROJECT_DIR$/tests/test.com.mbeddr.mpsutil.iconchar/test.com.mbeddr.mpsutil.iconchar.mpl" folder="stable.iconchar" />
+      <modulePath path="$PROJECT_DIR$/tests/test.com.mbeddr.mpsutil.incrementalcomputation.runtime/test.com.mbeddr.mpsutil.incrementalcomputation.runtime.msd" folder="staging.incrementalcomputation.test" />
+      <modulePath path="$PROJECT_DIR$/tests/test.com.mbeddr.mpsutil.incrementalcomputation.utils/test.com.mbeddr.mpsutil.incrementalcomputation.utils.mpl" folder="staging.incrementalcomputation.test" />
       <modulePath path="$PROJECT_DIR$/tests/test.com.mbeddr.mpsutil.parameterizedMenu/test.com.mbeddr.mpsutil.parameterizedMenu.msd" folder="parameterizedMenu" />
       <modulePath path="$PROJECT_DIR$/tests/test.com.mbeddr.mpsutil.placeholderTextList.testlang/test.com.mbeddr.mpsutil.placeholderTextList.testlang.mpl" folder="staging.placeholderTextList" />
       <modulePath path="$PROJECT_DIR$/tests/test.com.mbeddr.mpsutil.placeholderTextList/test.com.mbeddr.mpsutil.placeholderTextList.msd" folder="staging.placeholderTextList" />

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.asynccell.sandbox/models/behavior.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.asynccell.sandbox/models/behavior.mps
@@ -14,6 +14,9 @@
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1082485599095" name="jetbrains.mps.baseLanguage.structure.BlockStatement" flags="nn" index="9aQIb">
+        <child id="1082485599096" name="statements" index="9aQI4" />
+      </concept>
       <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
         <child id="1068498886297" name="rValue" index="37vLTx" />
         <child id="1068498886295" name="lValue" index="37vLTJ" />
@@ -41,10 +44,10 @@
       <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
         <property id="1070475926801" name="value" index="Xl_RC" />
       </concept>
-      <concept id="1182160077978" name="jetbrains.mps.baseLanguage.structure.AnonymousClassCreator" flags="nn" index="YeOm9">
-        <child id="1182160096073" name="cls" index="YeSDq" />
-      </concept>
       <concept id="1081236700938" name="jetbrains.mps.baseLanguage.structure.StaticMethodDeclaration" flags="ig" index="2YIFZL" />
+      <concept id="1164991038168" name="jetbrains.mps.baseLanguage.structure.ThrowStatement" flags="nn" index="YS8fn">
+        <child id="1164991057263" name="throwable" index="YScLw" />
+      </concept>
       <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
       <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
       <concept id="1068390468200" name="jetbrains.mps.baseLanguage.structure.FieldDeclaration" flags="ig" index="312cEg">
@@ -81,6 +84,7 @@
       </concept>
       <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
       <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
+        <child id="1082485599094" name="ifFalseStatement" index="9aQIa" />
         <child id="1068580123160" name="condition" index="3clFbw" />
         <child id="1068580123161" name="ifTrue" index="3clFbx" />
       </concept>
@@ -101,7 +105,6 @@
       </concept>
       <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk" />
       <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
-        <property id="521412098689998745" name="nonStatic" index="2bfB8j" />
         <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
       </concept>
       <concept id="7812454656619025416" name="jetbrains.mps.baseLanguage.structure.MethodDeclaration" flags="ng" index="1rXfSm">
@@ -122,8 +125,11 @@
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
       <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
       <concept id="1146644641414" name="jetbrains.mps.baseLanguage.structure.ProtectedVisibility" flags="nn" index="3Tmbuc" />
-      <concept id="1170345865475" name="jetbrains.mps.baseLanguage.structure.AnonymousClass" flags="ig" index="1Y3b0j">
-        <reference id="1170346070688" name="classifier" index="1Y3XeK" />
+    </language>
+    <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
+      <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
+        <child id="1199569906740" name="parameter" index="1bW2Oz" />
+        <child id="1199569916463" name="body" index="1bW5cS" />
       </concept>
     </language>
     <language id="760a0a8c-eabb-4521-8bfd-65db761a9ba3" name="jetbrains.mps.baseLanguage.logging">
@@ -168,6 +174,14 @@
       <node concept="Xl_RD" id="2u$73V9sRz5" role="33vP2m">
         <property role="Xl_RC" value="my value" />
       </node>
+    </node>
+    <node concept="312cEg" id="2YOONxNStSE" role="jymVt">
+      <property role="TrG5h" value="exception" />
+      <node concept="3Tmbuc" id="2YOONxNStw7" role="1B3o_S" />
+      <node concept="3uibUv" id="2YOONxNSvNh" role="1tU5fm">
+        <ref role="3uigEE" to="wyt6:~RuntimeException" resolve="RuntimeException" />
+      </node>
+      <node concept="10Nm6u" id="2YOONxNSujU" role="33vP2m" />
     </node>
     <node concept="2tJIrI" id="17HIJlKZysZ" role="jymVt" />
     <node concept="2YIFZL" id="17HIJlL07UK" role="jymVt">
@@ -216,20 +230,55 @@
       <property role="DiZV1" value="false" />
       <property role="2aFKle" value="false" />
       <node concept="3clFbS" id="17HIJlL090f" role="3clF47">
-        <node concept="RRSsy" id="17HIJlL0sRI" role="3cqZAp">
-          <property role="RRSoG" value="warn" />
-          <node concept="3cpWs3" id="MypZlGVbiz" role="RRSoy">
-            <node concept="37vLTw" id="MypZlGVbmJ" role="3uHU7w">
-              <ref role="3cqZAo" node="17HIJlKZysM" resolve="value" />
+        <node concept="3clFbJ" id="2YOONxNSuBw" role="3cqZAp">
+          <node concept="3clFbS" id="2YOONxNSuBy" role="3clFbx">
+            <node concept="RRSsy" id="2YOONxNSxKw" role="3cqZAp">
+              <property role="RRSoG" value="warn" />
+              <node concept="3cpWs3" id="2YOONxNSxKx" role="RRSoy">
+                <node concept="Xl_RD" id="2YOONxNSxKz" role="3uHU7B">
+                  <property role="Xl_RC" value="getValue() raises " />
+                </node>
+                <node concept="2OqwBi" id="2YOONxNSyL0" role="3uHU7w">
+                  <node concept="37vLTw" id="2YOONxNSyo6" role="2Oq$k0">
+                    <ref role="3cqZAo" node="2YOONxNStSE" resolve="exception" />
+                  </node>
+                  <node concept="liA8E" id="2YOONxNSz1I" role="2OqNvi">
+                    <ref role="37wK5l" to="wyt6:~Throwable.getMessage():java.lang.String" resolve="getMessage" />
+                  </node>
+                </node>
+              </node>
             </node>
-            <node concept="Xl_RD" id="17HIJlL0tmE" role="3uHU7B">
-              <property role="Xl_RC" value="getValue() = " />
+            <node concept="YS8fn" id="2YOONxNSvvx" role="3cqZAp">
+              <node concept="37vLTw" id="2YOONxNSvzI" role="YScLw">
+                <ref role="3cqZAo" node="2YOONxNStSE" resolve="exception" />
+              </node>
             </node>
           </node>
-        </node>
-        <node concept="3cpWs6" id="17HIJlL092F" role="3cqZAp">
-          <node concept="37vLTw" id="17HIJlL092U" role="3cqZAk">
-            <ref role="3cqZAo" node="17HIJlKZysM" resolve="value" />
+          <node concept="3y3z36" id="2YOONxNSvlA" role="3clFbw">
+            <node concept="10Nm6u" id="2YOONxNSvpC" role="3uHU7w" />
+            <node concept="37vLTw" id="2YOONxNSuUr" role="3uHU7B">
+              <ref role="3cqZAo" node="2YOONxNStSE" resolve="exception" />
+            </node>
+          </node>
+          <node concept="9aQIb" id="2YOONxNSxoE" role="9aQIa">
+            <node concept="3clFbS" id="2YOONxNSxoF" role="9aQI4">
+              <node concept="RRSsy" id="17HIJlL0sRI" role="3cqZAp">
+                <property role="RRSoG" value="warn" />
+                <node concept="3cpWs3" id="MypZlGVbiz" role="RRSoy">
+                  <node concept="37vLTw" id="MypZlGVbmJ" role="3uHU7w">
+                    <ref role="3cqZAo" node="17HIJlKZysM" resolve="value" />
+                  </node>
+                  <node concept="Xl_RD" id="17HIJlL0tmE" role="3uHU7B">
+                    <property role="Xl_RC" value="getValue() = " />
+                  </node>
+                </node>
+              </node>
+              <node concept="3cpWs6" id="17HIJlL092F" role="3cqZAp">
+                <node concept="37vLTw" id="17HIJlL092U" role="3cqZAk">
+                  <ref role="3cqZAo" node="17HIJlKZysM" resolve="value" />
+                </node>
+              </node>
+            </node>
           </node>
         </node>
       </node>
@@ -256,6 +305,17 @@
               </node>
               <node concept="37vLTw" id="17HIJlL0rBK" role="3uHU7w">
                 <ref role="3cqZAo" node="17HIJlL0hC0" resolve="newValue" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="2YOONxNSvXS" role="3cqZAp">
+          <node concept="37vLTI" id="2YOONxNSwG4" role="3clFbG">
+            <node concept="10Nm6u" id="2YOONxNSwNj" role="37vLTx" />
+            <node concept="2OqwBi" id="2YOONxNSw91" role="37vLTJ">
+              <node concept="Xjq3P" id="2YOONxNSvXQ" role="2Oq$k0" />
+              <node concept="2OwXpG" id="2YOONxNSwfa" role="2OqNvi">
+                <ref role="2Oxat5" node="2YOONxNStSE" resolve="exception" />
               </node>
             </node>
           </node>
@@ -289,111 +349,29 @@
       <property role="DiZV1" value="false" />
       <property role="2aFKle" value="false" />
       <node concept="3clFbS" id="17HIJlKZMbi" role="3clF47">
-        <node concept="3clFbF" id="17HIJlL0kz0" role="3cqZAp">
-          <node concept="1rXfSq" id="17HIJlL0kyY" role="3clFbG">
-            <ref role="37wK5l" node="17HIJlL0h$4" resolve="setValue" />
-            <node concept="10Nm6u" id="17HIJlL0kSw" role="37wK5m" />
-          </node>
-        </node>
-        <node concept="3clFbJ" id="17HIJlL0Haz" role="3cqZAp">
-          <node concept="3clFbS" id="17HIJlL0Ha_" role="3clFbx">
-            <node concept="3clFbF" id="17HIJlL0FDE" role="3cqZAp">
-              <node concept="2OqwBi" id="17HIJlL0Gdi" role="3clFbG">
-                <node concept="2OqwBi" id="17HIJlL0FSr" role="2Oq$k0">
-                  <node concept="Xjq3P" id="17HIJlL0FDC" role="2Oq$k0" />
-                  <node concept="2OwXpG" id="17HIJlL0FYQ" role="2OqNvi">
-                    <ref role="2Oxat5" node="17HIJlL0Ew$" resolve="timer" />
-                  </node>
-                </node>
-                <node concept="liA8E" id="17HIJlL0Gns" role="2OqNvi">
-                  <ref role="37wK5l" to="dxuu:~Timer.stop():void" resolve="stop" />
-                </node>
-              </node>
+        <node concept="3clFbF" id="2YOONxNRGur" role="3cqZAp">
+          <node concept="1rXfSq" id="2YOONxNRGuq" role="3clFbG">
+            <ref role="37wK5l" node="2YOONxNRGui" resolve="runAfterMsPassed" />
+            <node concept="37vLTw" id="2YOONxNRGup" role="37wK5m">
+              <ref role="3cqZAo" node="17HIJlL0juE" resolve="delayInMs" />
             </node>
-          </node>
-          <node concept="3y3z36" id="17HIJlL0HTv" role="3clFbw">
-            <node concept="10Nm6u" id="17HIJlL0HXo" role="3uHU7w" />
-            <node concept="2OqwBi" id="17HIJlL0Hx1" role="3uHU7B">
-              <node concept="Xjq3P" id="17HIJlL0HkF" role="2Oq$k0" />
-              <node concept="2OwXpG" id="17HIJlL0HCG" role="2OqNvi">
-                <ref role="2Oxat5" node="17HIJlL0Ew$" resolve="timer" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbH" id="17HIJlL0xR0" role="3cqZAp" />
-        <node concept="3clFbF" id="17HIJlL0EwU" role="3cqZAp">
-          <node concept="37vLTI" id="17HIJlL0EwV" role="3clFbG">
-            <node concept="2OqwBi" id="17HIJlL0EwW" role="37vLTJ">
-              <node concept="Xjq3P" id="17HIJlL0EwX" role="2Oq$k0" />
-              <node concept="2OwXpG" id="17HIJlL0EwY" role="2OqNvi">
-                <ref role="2Oxat5" node="17HIJlL0Ew$" resolve="timer" />
-              </node>
-            </node>
-            <node concept="2ShNRf" id="17HIJlL0EwZ" role="37vLTx">
-              <node concept="1pGfFk" id="17HIJlL0Ex0" role="2ShVmc">
-                <ref role="37wK5l" to="dxuu:~Timer.&lt;init&gt;(int,java.awt.event.ActionListener)" resolve="Timer" />
-                <node concept="37vLTw" id="17HIJlL0Ex1" role="37wK5m">
-                  <ref role="3cqZAo" node="17HIJlL0juE" resolve="delayInMs" />
-                </node>
-                <node concept="2ShNRf" id="17HIJlL0Ex2" role="37wK5m">
-                  <node concept="YeOm9" id="17HIJlL0Ex3" role="2ShVmc">
-                    <node concept="1Y3b0j" id="17HIJlL0Ex4" role="YeSDq">
-                      <property role="2bfB8j" value="true" />
-                      <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
-                      <ref role="1Y3XeK" to="hyam:~ActionListener" resolve="ActionListener" />
-                      <node concept="3Tm1VV" id="17HIJlL0Ex5" role="1B3o_S" />
-                      <node concept="3clFb_" id="17HIJlL0Ex6" role="jymVt">
-                        <property role="1EzhhJ" value="false" />
-                        <property role="TrG5h" value="actionPerformed" />
-                        <property role="DiZV1" value="false" />
-                        <property role="od$2w" value="false" />
-                        <node concept="3Tm1VV" id="17HIJlL0Ex7" role="1B3o_S" />
-                        <node concept="3cqZAl" id="17HIJlL0Ex8" role="3clF45" />
-                        <node concept="37vLTG" id="17HIJlL0Ex9" role="3clF46">
-                          <property role="TrG5h" value="p0" />
-                          <node concept="3uibUv" id="17HIJlL0Exa" role="1tU5fm">
-                            <ref role="3uigEE" to="hyam:~ActionEvent" resolve="ActionEvent" />
-                          </node>
-                        </node>
-                        <node concept="3clFbS" id="17HIJlL0Exb" role="3clF47">
-                          <node concept="3clFbF" id="17HIJlL0Exc" role="3cqZAp">
-                            <node concept="1rXfSq" id="17HIJlL0Exd" role="3clFbG">
-                              <ref role="37wK5l" node="17HIJlL0h$4" resolve="setValue" />
-                              <node concept="37vLTw" id="17HIJlL0Exe" role="37wK5m">
-                                <ref role="3cqZAo" node="17HIJlL0js1" resolve="newValue" />
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
+            <node concept="1bVj0M" id="2YOONxNRHGF" role="37wK5m">
+              <node concept="3clFbS" id="2YOONxNRHGH" role="1bW5cS">
+                <node concept="3clFbF" id="2YOONxNRIi1" role="3cqZAp">
+                  <node concept="1rXfSq" id="2YOONxNRGu2" role="3clFbG">
+                    <ref role="37wK5l" node="17HIJlL0h$4" resolve="setValue" />
+                    <node concept="37vLTw" id="2YOONxNRGuo" role="37wK5m">
+                      <ref role="3cqZAo" node="17HIJlL0js1" resolve="newValue" />
                     </node>
                   </node>
                 </node>
               </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="17HIJlL0Bah" role="3cqZAp">
-          <node concept="2OqwBi" id="17HIJlL0Bp7" role="3clFbG">
-            <node concept="37vLTw" id="17HIJlL0GA1" role="2Oq$k0">
-              <ref role="3cqZAo" node="17HIJlL0Ew$" resolve="timer" />
-            </node>
-            <node concept="liA8E" id="17HIJlL0BGc" role="2OqNvi">
-              <ref role="37wK5l" to="dxuu:~Timer.setRepeats(boolean):void" resolve="setRepeats" />
-              <node concept="3clFbT" id="17HIJlL0Cz2" role="37wK5m">
-                <property role="3clFbU" value="false" />
+              <node concept="37vLTG" id="2YOONxNRI4J" role="1bW2Oz">
+                <property role="TrG5h" value="p" />
+                <node concept="3uibUv" id="2YOONxNRI4I" role="1tU5fm">
+                  <ref role="3uigEE" to="hyam:~ActionEvent" resolve="ActionEvent" />
+                </node>
               </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="17HIJlL0jEp" role="3cqZAp">
-          <node concept="2OqwBi" id="17HIJlL0pGN" role="3clFbG">
-            <node concept="37vLTw" id="17HIJlL0GGE" role="2Oq$k0">
-              <ref role="3cqZAo" node="17HIJlL0Ew$" resolve="timer" />
-            </node>
-            <node concept="liA8E" id="17HIJlL0pUp" role="2OqNvi">
-              <ref role="37wK5l" to="dxuu:~Timer.start():void" resolve="start" />
             </node>
           </node>
         </node>
@@ -408,6 +386,154 @@
       <node concept="37vLTG" id="17HIJlL0juE" role="3clF46">
         <property role="TrG5h" value="delayInMs" />
         <node concept="10Oyi0" id="17HIJlL0jyx" role="1tU5fm" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="2YOONxNRN8o" role="jymVt">
+      <property role="1EzhhJ" value="false" />
+      <property role="TrG5h" value="throwAfterMsPassed" />
+      <property role="od$2w" value="false" />
+      <property role="DiZV1" value="false" />
+      <property role="2aFKle" value="false" />
+      <node concept="3clFbS" id="2YOONxNRN8p" role="3clF47">
+        <node concept="3clFbF" id="2YOONxNRN8q" role="3cqZAp">
+          <node concept="1rXfSq" id="2YOONxNRN8r" role="3clFbG">
+            <ref role="37wK5l" node="2YOONxNRGui" resolve="runAfterMsPassed" />
+            <node concept="37vLTw" id="2YOONxNRN8s" role="37wK5m">
+              <ref role="3cqZAo" node="2YOONxNRN8C" resolve="delayInMs" />
+            </node>
+            <node concept="1bVj0M" id="2YOONxNRN8t" role="37wK5m">
+              <node concept="3clFbS" id="2YOONxNRN8u" role="1bW5cS">
+                <node concept="3clFbF" id="2YOONxNSXJA" role="3cqZAp">
+                  <node concept="37vLTI" id="2YOONxNSY7N" role="3clFbG">
+                    <node concept="37vLTw" id="2YOONxNSYnF" role="37vLTx">
+                      <ref role="3cqZAo" node="2YOONxNRN8A" resolve="exception" />
+                    </node>
+                    <node concept="2OqwBi" id="2YOONxNT55h" role="37vLTJ">
+                      <node concept="Xjq3P" id="2YOONxNT4U2" role="2Oq$k0" />
+                      <node concept="2OwXpG" id="2YOONxNT5hB" role="2OqNvi">
+                        <ref role="2Oxat5" node="2YOONxNStSE" resolve="exception" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="37vLTG" id="2YOONxNRN8y" role="1bW2Oz">
+                <property role="TrG5h" value="p" />
+                <node concept="3uibUv" id="2YOONxNRN8z" role="1tU5fm">
+                  <ref role="3uigEE" to="hyam:~ActionEvent" resolve="ActionEvent" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="2YOONxNRN8$" role="1B3o_S" />
+      <node concept="3cqZAl" id="2YOONxNRN8_" role="3clF45" />
+      <node concept="37vLTG" id="2YOONxNRN8A" role="3clF46">
+        <property role="TrG5h" value="exception" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3uibUv" id="2YOONxNT47t" role="1tU5fm">
+          <ref role="3uigEE" to="wyt6:~RuntimeException" resolve="RuntimeException" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="2YOONxNRN8C" role="3clF46">
+        <property role="TrG5h" value="delayInMs" />
+        <node concept="10Oyi0" id="2YOONxNRN8D" role="1tU5fm" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="2YOONxNRGZi" role="jymVt" />
+    <node concept="3clFb_" id="2YOONxNRGui" role="jymVt">
+      <property role="TrG5h" value="runAfterMsPassed" />
+      <node concept="3Tmbuc" id="2YOONxNRGuj" role="1B3o_S" />
+      <node concept="3cqZAl" id="2YOONxNRGuk" role="3clF45" />
+      <node concept="37vLTG" id="2YOONxNRGud" role="3clF46">
+        <property role="TrG5h" value="delayInMs" />
+        <node concept="10Oyi0" id="2YOONxNRGue" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="2YOONxNRMiO" role="3clF46">
+        <property role="TrG5h" value="listener" />
+        <node concept="3uibUv" id="2YOONxNRMF$" role="1tU5fm">
+          <ref role="3uigEE" to="hyam:~ActionListener" resolve="ActionListener" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="2YOONxNRGtt" role="3clF47">
+        <node concept="3clFbF" id="2YOONxNRGtu" role="3cqZAp">
+          <node concept="1rXfSq" id="2YOONxNRGtv" role="3clFbG">
+            <ref role="37wK5l" node="17HIJlL0h$4" resolve="setValue" />
+            <node concept="10Nm6u" id="2YOONxNRGtw" role="37wK5m" />
+          </node>
+        </node>
+        <node concept="3clFbJ" id="2YOONxNRGtx" role="3cqZAp">
+          <node concept="3clFbS" id="2YOONxNRGty" role="3clFbx">
+            <node concept="3clFbF" id="2YOONxNRGtz" role="3cqZAp">
+              <node concept="2OqwBi" id="2YOONxNRGt$" role="3clFbG">
+                <node concept="2OqwBi" id="2YOONxNRGt_" role="2Oq$k0">
+                  <node concept="Xjq3P" id="2YOONxNRGtA" role="2Oq$k0" />
+                  <node concept="2OwXpG" id="2YOONxNRGtB" role="2OqNvi">
+                    <ref role="2Oxat5" node="17HIJlL0Ew$" resolve="timer" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="2YOONxNRGtC" role="2OqNvi">
+                  <ref role="37wK5l" to="dxuu:~Timer.stop():void" resolve="stop" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3y3z36" id="2YOONxNRGtD" role="3clFbw">
+            <node concept="10Nm6u" id="2YOONxNRGtE" role="3uHU7w" />
+            <node concept="2OqwBi" id="2YOONxNRGtF" role="3uHU7B">
+              <node concept="Xjq3P" id="2YOONxNRGtG" role="2Oq$k0" />
+              <node concept="2OwXpG" id="2YOONxNRGtH" role="2OqNvi">
+                <ref role="2Oxat5" node="17HIJlL0Ew$" resolve="timer" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="2YOONxNRGtI" role="3cqZAp" />
+        <node concept="3clFbF" id="2YOONxNRGtJ" role="3cqZAp">
+          <node concept="37vLTI" id="2YOONxNRGtK" role="3clFbG">
+            <node concept="2OqwBi" id="2YOONxNRGtL" role="37vLTJ">
+              <node concept="Xjq3P" id="2YOONxNRGtM" role="2Oq$k0" />
+              <node concept="2OwXpG" id="2YOONxNRGtN" role="2OqNvi">
+                <ref role="2Oxat5" node="17HIJlL0Ew$" resolve="timer" />
+              </node>
+            </node>
+            <node concept="2ShNRf" id="2YOONxNRGtO" role="37vLTx">
+              <node concept="1pGfFk" id="2YOONxNRGtP" role="2ShVmc">
+                <ref role="37wK5l" to="dxuu:~Timer.&lt;init&gt;(int,java.awt.event.ActionListener)" resolve="Timer" />
+                <node concept="37vLTw" id="2YOONxNRGuf" role="37wK5m">
+                  <ref role="3cqZAo" node="2YOONxNRGud" resolve="delayInMs" />
+                </node>
+                <node concept="37vLTw" id="2YOONxNRMWG" role="37wK5m">
+                  <ref role="3cqZAo" node="2YOONxNRMiO" resolve="listener" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="2YOONxNRGu4" role="3cqZAp">
+          <node concept="2OqwBi" id="2YOONxNRGu5" role="3clFbG">
+            <node concept="37vLTw" id="2YOONxNRGu6" role="2Oq$k0">
+              <ref role="3cqZAo" node="17HIJlL0Ew$" resolve="timer" />
+            </node>
+            <node concept="liA8E" id="2YOONxNRGu7" role="2OqNvi">
+              <ref role="37wK5l" to="dxuu:~Timer.setRepeats(boolean):void" resolve="setRepeats" />
+              <node concept="3clFbT" id="2YOONxNRGu8" role="37wK5m">
+                <property role="3clFbU" value="false" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="2YOONxNRGu9" role="3cqZAp">
+          <node concept="2OqwBi" id="2YOONxNRGua" role="3clFbG">
+            <node concept="37vLTw" id="2YOONxNRGub" role="2Oq$k0">
+              <ref role="3cqZAo" node="17HIJlL0Ew$" resolve="timer" />
+            </node>
+            <node concept="liA8E" id="2YOONxNRGuc" role="2OqNvi">
+              <ref role="37wK5l" to="dxuu:~Timer.start():void" resolve="start" />
+            </node>
+          </node>
+        </node>
       </node>
     </node>
     <node concept="3Tm1VV" id="17HIJlKZys4" role="1B3o_S" />

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.asynccell.sandbox/models/editor.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.asynccell.sandbox/models/editor.mps
@@ -151,6 +151,7 @@
     </language>
     <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
       <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
+        <child id="1199569906740" name="parameter" index="1bW2Oz" />
         <child id="1199569916463" name="body" index="1bW5cS" />
       </concept>
     </language>
@@ -193,59 +194,43 @@
                   </node>
                   <node concept="liA8E" id="17HIJlKZWfd" role="2OqNvi">
                     <ref role="37wK5l" to="dxuu:~AbstractButton.addActionListener(java.awt.event.ActionListener):void" resolve="addActionListener" />
-                    <node concept="2ShNRf" id="17HIJlKZWt8" role="37wK5m">
-                      <node concept="YeOm9" id="17HIJlKZXp_" role="2ShVmc">
-                        <node concept="1Y3b0j" id="17HIJlKZXpC" role="YeSDq">
-                          <property role="2bfB8j" value="true" />
-                          <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
-                          <ref role="1Y3XeK" to="hyam:~ActionListener" resolve="ActionListener" />
-                          <node concept="3Tm1VV" id="17HIJlKZXpD" role="1B3o_S" />
-                          <node concept="3clFb_" id="17HIJlKZXpE" role="jymVt">
-                            <property role="1EzhhJ" value="false" />
-                            <property role="TrG5h" value="actionPerformed" />
-                            <property role="DiZV1" value="false" />
-                            <property role="od$2w" value="false" />
-                            <node concept="3Tm1VV" id="17HIJlKZXpF" role="1B3o_S" />
-                            <node concept="3cqZAl" id="17HIJlKZXpH" role="3clF45" />
-                            <node concept="37vLTG" id="17HIJlKZXpI" role="3clF46">
-                              <property role="TrG5h" value="p0" />
-                              <node concept="3uibUv" id="17HIJlKZXpJ" role="1tU5fm">
-                                <ref role="3uigEE" to="hyam:~ActionEvent" resolve="ActionEvent" />
-                              </node>
+                    <node concept="1bVj0M" id="2YOONxNRT5i" role="37wK5m">
+                      <node concept="3clFbS" id="2YOONxNRT5j" role="1bW5cS">
+                        <node concept="3clFbF" id="17HIJlL0gGV" role="3cqZAp">
+                          <node concept="2OqwBi" id="17HIJlL0h9$" role="3clFbG">
+                            <node concept="2YIFZM" id="17HIJlL0h3p" role="2Oq$k0">
+                              <ref role="1Pybhc" to="re1d:17HIJlKZys3" resolve="MyAsyncCalculator" />
+                              <ref role="37wK5l" to="re1d:17HIJlL07UK" resolve="getInstance" />
                             </node>
-                            <node concept="3clFbS" id="17HIJlKZXpK" role="3clF47">
-                              <node concept="3clFbF" id="17HIJlL0gGV" role="3cqZAp">
-                                <node concept="2OqwBi" id="17HIJlL0h9$" role="3clFbG">
-                                  <node concept="2YIFZM" id="17HIJlL0h3p" role="2Oq$k0">
-                                    <ref role="37wK5l" to="re1d:17HIJlL07UK" resolve="getInstance" />
-                                    <ref role="1Pybhc" to="re1d:17HIJlKZys3" resolve="MyAsyncCalculator" />
-                                  </node>
-                                  <node concept="liA8E" id="17HIJlL0hhV" role="2OqNvi">
-                                    <ref role="37wK5l" to="re1d:17HIJlKZMbf" resolve="setValueAfterMsPassed" />
-                                    <node concept="Xl_RD" id="17HIJlL0orp" role="37wK5m">
-                                      <property role="Xl_RC" value="my result" />
-                                    </node>
-                                    <node concept="3cmrfG" id="17HIJlL0oNv" role="37wK5m">
-                                      <property role="3cmrfH" value="5000" />
-                                    </node>
-                                  </node>
-                                </node>
+                            <node concept="liA8E" id="17HIJlL0hhV" role="2OqNvi">
+                              <ref role="37wK5l" to="re1d:17HIJlKZMbf" resolve="setValueAfterMsPassed" />
+                              <node concept="Xl_RD" id="17HIJlL0orp" role="37wK5m">
+                                <property role="Xl_RC" value="my result" />
                               </node>
-                              <node concept="3clFbF" id="2u$73V9t9yl" role="3cqZAp">
-                                <node concept="2OqwBi" id="2u$73V9t9ym" role="3clFbG">
-                                  <node concept="2OqwBi" id="2u$73V9t9yn" role="2Oq$k0">
-                                    <node concept="1Q80Hx" id="2u$73V9t9yo" role="2Oq$k0" />
-                                    <node concept="liA8E" id="2u$73V9t9yp" role="2OqNvi">
-                                      <ref role="37wK5l" to="cj4x:~EditorContext.getEditorComponent():jetbrains.mps.openapi.editor.EditorComponent" resolve="getEditorComponent" />
-                                    </node>
-                                  </node>
-                                  <node concept="liA8E" id="2u$73V9t9yq" role="2OqNvi">
-                                    <ref role="37wK5l" to="cj4x:~EditorComponent.update():void" resolve="update" />
-                                  </node>
-                                </node>
+                              <node concept="3cmrfG" id="17HIJlL0oNv" role="37wK5m">
+                                <property role="3cmrfH" value="5000" />
                               </node>
                             </node>
                           </node>
+                        </node>
+                        <node concept="3clFbF" id="2u$73V9t9yl" role="3cqZAp">
+                          <node concept="2OqwBi" id="2u$73V9t9ym" role="3clFbG">
+                            <node concept="2OqwBi" id="2u$73V9t9yn" role="2Oq$k0">
+                              <node concept="1Q80Hx" id="2u$73V9t9yo" role="2Oq$k0" />
+                              <node concept="liA8E" id="2u$73V9t9yp" role="2OqNvi">
+                                <ref role="37wK5l" to="cj4x:~EditorContext.getEditorComponent():jetbrains.mps.openapi.editor.EditorComponent" resolve="getEditorComponent" />
+                              </node>
+                            </node>
+                            <node concept="liA8E" id="2u$73V9t9yq" role="2OqNvi">
+                              <ref role="37wK5l" to="cj4x:~EditorComponent.update():void" resolve="update" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="37vLTG" id="2YOONxNRTkd" role="1bW2Oz">
+                        <property role="TrG5h" value="e" />
+                        <node concept="3uibUv" id="2YOONxNRTkc" role="1tU5fm">
+                          <ref role="3uigEE" to="hyam:~ActionEvent" resolve="ActionEvent" />
                         </node>
                       </node>
                     </node>
@@ -255,6 +240,88 @@
               <node concept="3cpWs6" id="17HIJlKZXVd" role="3cqZAp">
                 <node concept="37vLTw" id="17HIJlKZXVI" role="3cqZAk">
                   <ref role="3cqZAo" node="17HIJlKZU71" resolve="button" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3gTLQM" id="2YOONxNRDtn" role="3EZMnx">
+          <node concept="3Fmcul" id="2YOONxNRDto" role="3FoqZy">
+            <node concept="3clFbS" id="2YOONxNRDtp" role="2VODD2">
+              <node concept="3cpWs8" id="2YOONxNRDtq" role="3cqZAp">
+                <node concept="3cpWsn" id="2YOONxNRDtr" role="3cpWs9">
+                  <property role="TrG5h" value="button" />
+                  <node concept="3uibUv" id="2YOONxNRDts" role="1tU5fm">
+                    <ref role="3uigEE" to="dxuu:~JButton" resolve="JButton" />
+                  </node>
+                  <node concept="2ShNRf" id="2YOONxNRDtt" role="33vP2m">
+                    <node concept="1pGfFk" id="2YOONxNRDtu" role="2ShVmc">
+                      <ref role="37wK5l" to="dxuu:~JButton.&lt;init&gt;(java.lang.String)" resolve="JButton" />
+                      <node concept="Xl_RD" id="2YOONxNRDtv" role="37wK5m">
+                        <property role="Xl_RC" value="Throw Exception in 5s" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbF" id="2YOONxNRDtw" role="3cqZAp">
+                <node concept="2OqwBi" id="2YOONxNRDtx" role="3clFbG">
+                  <node concept="37vLTw" id="2YOONxNRDty" role="2Oq$k0">
+                    <ref role="3cqZAo" node="2YOONxNRDtr" resolve="button" />
+                  </node>
+                  <node concept="liA8E" id="2YOONxNRDtz" role="2OqNvi">
+                    <ref role="37wK5l" to="dxuu:~AbstractButton.addActionListener(java.awt.event.ActionListener):void" resolve="addActionListener" />
+                    <node concept="1bVj0M" id="2YOONxNRQT4" role="37wK5m">
+                      <node concept="3clFbS" id="2YOONxNRQT5" role="1bW5cS">
+                        <node concept="3clFbF" id="2YOONxNRQqV" role="3cqZAp">
+                          <node concept="2OqwBi" id="2YOONxNRDtJ" role="3clFbG">
+                            <node concept="2YIFZM" id="2YOONxNRDtK" role="2Oq$k0">
+                              <ref role="1Pybhc" to="re1d:17HIJlKZys3" resolve="MyAsyncCalculator" />
+                              <ref role="37wK5l" to="re1d:17HIJlL07UK" resolve="getInstance" />
+                            </node>
+                            <node concept="liA8E" id="2YOONxNRDtL" role="2OqNvi">
+                              <ref role="37wK5l" to="re1d:2YOONxNRN8o" resolve="throwAfterMsPassed" />
+                              <node concept="2ShNRf" id="2YOONxNROY_" role="37wK5m">
+                                <node concept="1pGfFk" id="2YOONxNRPbh" role="2ShVmc">
+                                  <ref role="37wK5l" to="wyt6:~RuntimeException.&lt;init&gt;(java.lang.String)" resolve="RuntimeException" />
+                                  <node concept="Xl_RD" id="2YOONxNT1E6" role="37wK5m">
+                                    <property role="Xl_RC" value="An error happened during calculation" />
+                                  </node>
+                                </node>
+                              </node>
+                              <node concept="3cmrfG" id="2YOONxNRDtN" role="37wK5m">
+                                <property role="3cmrfH" value="5000" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3clFbF" id="2YOONxNRDtO" role="3cqZAp">
+                          <node concept="2OqwBi" id="2YOONxNRDtP" role="3clFbG">
+                            <node concept="2OqwBi" id="2YOONxNRDtQ" role="2Oq$k0">
+                              <node concept="1Q80Hx" id="2YOONxNRDtR" role="2Oq$k0" />
+                              <node concept="liA8E" id="2YOONxNRDtS" role="2OqNvi">
+                                <ref role="37wK5l" to="cj4x:~EditorContext.getEditorComponent():jetbrains.mps.openapi.editor.EditorComponent" resolve="getEditorComponent" />
+                              </node>
+                            </node>
+                            <node concept="liA8E" id="2YOONxNRDtT" role="2OqNvi">
+                              <ref role="37wK5l" to="cj4x:~EditorComponent.update():void" resolve="update" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="37vLTG" id="2YOONxNRRLM" role="1bW2Oz">
+                        <property role="TrG5h" value="e" />
+                        <node concept="3uibUv" id="2YOONxNRRLL" role="1tU5fm">
+                          <ref role="3uigEE" to="hyam:~ActionEvent" resolve="ActionEvent" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3cpWs6" id="2YOONxNRDtU" role="3cqZAp">
+                <node concept="37vLTw" id="2YOONxNRDtV" role="3cqZAk">
+                  <ref role="3cqZAo" node="2YOONxNRDtr" resolve="button" />
                 </node>
               </node>
             </node>

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.incrementalcomputation/README.md
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.incrementalcomputation/README.md
@@ -1,0 +1,19 @@
+# Introduction
+Some Calculations spread multiple nodes and take a while.
+
+This framework allows to:
+
+- caches calculation results
+- invalidates the caches when the model changes
+- calculates the results incrementally so that only part of it needs to be invalidated
+- incrementalize multiple values by scoping it all. Just provide a value selector object to do so
+
+# Usage
+
+1. Implement the interface `IncrementallyComputedValueHolder`
+2. Call `getValue(aValueSelector)` and see that the value is only calculated once and then cached until the model changes
+
+# Contributors
+
+- Till Fischer
+- Bastian Kruck

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.incrementalcomputation/models/com.mbeddr.mpsutil.incrementalcomputation.behavior.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.incrementalcomputation/models/com.mbeddr.mpsutil.incrementalcomputation.behavior.mps
@@ -99,6 +99,9 @@
         <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
       </concept>
       <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
+      <concept id="1081516740877" name="jetbrains.mps.baseLanguage.structure.NotExpression" flags="nn" index="3fqX7Q">
+        <child id="1081516765348" name="expression" index="3fr31v" />
+      </concept>
       <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
@@ -405,6 +408,38 @@
         <node concept="TZ5HA" id="lNBnHjW_T4" role="TZ5H$">
           <node concept="1dT_AC" id="lNBnHjWA0E" role="1dT_Ay">
             <property role="1dT_AB" value="API to read cached information" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="13i0hz" id="6MPBOWiFIsN" role="13h7CS">
+      <property role="13i0iv" value="false" />
+      <property role="13i0it" value="true" />
+      <property role="TrG5h" value="canCalculate" />
+      <node concept="3Tm1VV" id="6MPBOWiFIsO" role="1B3o_S" />
+      <node concept="10P_77" id="6MPBOWiFIsP" role="3clF45" />
+      <node concept="3clFbS" id="6MPBOWiFIsQ" role="3clF47">
+        <node concept="3cpWs6" id="6MPBOWiFIsR" role="3cqZAp">
+          <node concept="3fqX7Q" id="6MPBOWiFJLV" role="3cqZAk">
+            <node concept="BsUDl" id="6MPBOWiFJLX" role="3fr31v">
+              <ref role="37wK5l" node="QuEk0ZLOai" resolve="hasCycle" />
+              <node concept="37vLTw" id="6MPBOWiFJLY" role="37wK5m">
+                <ref role="3cqZAo" node="6MPBOWiFIsW" resolve="valueSelector" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="6MPBOWiFIsW" role="3clF46">
+        <property role="TrG5h" value="valueSelector" />
+        <node concept="3uibUv" id="6MPBOWiFIsX" role="1tU5fm">
+          <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+        </node>
+      </node>
+      <node concept="P$JXv" id="6MPBOWiFIsY" role="lGtFl">
+        <node concept="TZ5HA" id="6MPBOWiFIsZ" role="TZ5H$">
+          <node concept="1dT_AC" id="6MPBOWiFIt0" role="1dT_Ay">
+            <property role="1dT_AB" value="I decide if the value can be calculated. By default, this is exactly, when having no cycles." />
           </node>
         </node>
       </node>

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.incrementalcomputation/models/com.mbeddr.mpsutil.incrementalcomputation.behavior.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.incrementalcomputation/models/com.mbeddr.mpsutil.incrementalcomputation.behavior.mps
@@ -239,11 +239,6 @@
             <property role="1dT_AB" value="The implementation of this function does not have to check for endless recursion (e.g. due to visiting the same node multiple times)." />
           </node>
         </node>
-        <node concept="TZ5HA" id="2YOONxNWUrW" role="TZ5H$">
-          <node concept="1dT_AC" id="2YOONxNWUrX" role="1dT_Ay">
-            <property role="1dT_AB" value="Note that only one thread can enter this function at a time; so beware of deadlocks." />
-          </node>
-        </node>
       </node>
     </node>
     <node concept="13i0hz" id="KudFejX3SG" role="13h7CS">

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.incrementalcomputation/models/com.mbeddr.mpsutil.incrementalcomputation.behavior.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.incrementalcomputation/models/com.mbeddr.mpsutil.incrementalcomputation.behavior.mps
@@ -89,9 +89,7 @@
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
       </concept>
-      <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT">
-        <property id="1068580123138" name="value" index="3clFbU" />
-      </concept>
+      <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT" />
       <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
         <child id="1068581517676" name="expression" index="3cqZAk" />
       </concept>
@@ -278,38 +276,6 @@
         </node>
       </node>
     </node>
-    <node concept="13i0hz" id="5nAcTtn9HEK" role="13h7CS">
-      <property role="13i0iv" value="false" />
-      <property role="13i0it" value="true" />
-      <property role="TrG5h" value="isActive" />
-      <node concept="37vLTG" id="5nAcTtn9IUF" role="3clF46">
-        <property role="TrG5h" value="valueSelector" />
-        <node concept="3uibUv" id="5nAcTtn9IUG" role="1tU5fm">
-          <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="5nAcTtn9HEL" role="1B3o_S" />
-      <node concept="10P_77" id="5nAcTtn9Iyi" role="3clF45" />
-      <node concept="3clFbS" id="5nAcTtn9HEN" role="3clF47">
-        <node concept="3cpWs6" id="5nAcTtn9IyH" role="3cqZAp">
-          <node concept="3clFbT" id="5nAcTtn9Iz0" role="3cqZAk">
-            <property role="3clFbU" value="true" />
-          </node>
-        </node>
-      </node>
-      <node concept="P$JXv" id="5nAcTtn9Izj" role="lGtFl">
-        <node concept="TZ5HA" id="5nAcTtn9Izk" role="TZ5H$">
-          <node concept="1dT_AC" id="5nAcTtn9Izl" role="1dT_Ay">
-            <property role="1dT_AB" value="This method is called by the propagation framework before (re-)calculation is executed. If 'false' is returned," />
-          </node>
-        </node>
-        <node concept="TZ5HA" id="5nAcTtn9IzK" role="TZ5H$">
-          <node concept="1dT_AC" id="5nAcTtn9IzL" role="1dT_Ay">
-            <property role="1dT_AB" value="(re-)calculation is not executed and getValue() returns null." />
-          </node>
-        </node>
-      </node>
-    </node>
     <node concept="13i0hz" id="5nAcTtnb1YA" role="13h7CS">
       <property role="13i0iv" value="false" />
       <property role="13i0it" value="true" />
@@ -407,7 +373,7 @@
       <node concept="P$JXv" id="lNBnHjW_T3" role="lGtFl">
         <node concept="TZ5HA" id="lNBnHjW_T4" role="TZ5H$">
           <node concept="1dT_AC" id="lNBnHjWA0E" role="1dT_Ay">
-            <property role="1dT_AB" value="API to read cached information" />
+            <property role="1dT_AB" value="API to read cached information. Returns wether the value holder has a cycle regarding this value selector." />
           </node>
         </node>
       </node>

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.incrementalcomputation/models/com.mbeddr.mpsutil.incrementalcomputation.behavior.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.incrementalcomputation/models/com.mbeddr.mpsutil.incrementalcomputation.behavior.mps
@@ -239,6 +239,11 @@
             <property role="1dT_AB" value="The implementation of this function does not have to check for endless recursion (e.g. due to visiting the same node multiple times)." />
           </node>
         </node>
+        <node concept="TZ5HA" id="2YOONxNWUrW" role="TZ5H$">
+          <node concept="1dT_AC" id="2YOONxNWUrX" role="1dT_Ay">
+            <property role="1dT_AB" value="Note that only one thread can enter this function at a time; so beware of deadlocks." />
+          </node>
+        </node>
       </node>
     </node>
     <node concept="13i0hz" id="KudFejX3SG" role="13h7CS">

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.incrementalcomputation/runtime/models/com.mbeddr.mpsutil.incrementalcomputation.runtime.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.incrementalcomputation/runtime/models/com.mbeddr.mpsutil.incrementalcomputation.runtime.mps
@@ -215,10 +215,6 @@
       <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
       </concept>
-      <concept id="1170075670744" name="jetbrains.mps.baseLanguage.structure.SynchronizedStatement" flags="nn" index="1HWtB8">
-        <child id="1170075728144" name="expression" index="1HWFw0" />
-        <child id="1170075736412" name="block" index="1HWHxc" />
-      </concept>
       <concept id="6329021646629104957" name="jetbrains.mps.baseLanguage.structure.TextCommentPart" flags="nn" index="3SKdUq">
         <property id="6329021646629104958" name="text" index="3SKdUp" />
       </concept>
@@ -227,9 +223,6 @@
       </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
       <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
-      <concept id="1116615150612" name="jetbrains.mps.baseLanguage.structure.ClassifierClassExpression" flags="nn" index="3VsKOn">
-        <reference id="1116615189566" name="classifier" index="3VsUkX" />
-      </concept>
       <concept id="1178893518978" name="jetbrains.mps.baseLanguage.structure.ThisConstructorInvocation" flags="nn" index="1VxSAg" />
     </language>
     <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
@@ -1216,99 +1209,92 @@
       <property role="DiZV1" value="false" />
       <property role="2aFKle" value="false" />
       <node concept="3clFbS" id="5YITc37Stks" role="3clF47">
-        <node concept="1HWtB8" id="2YOONxNV0nJ" role="3cqZAp">
-          <node concept="3VsKOn" id="2YOONxNV2uq" role="1HWFw0">
-            <ref role="3VsUkX" node="7ZWgXq7GlHg" resolve="ValueCache" />
+        <node concept="3cpWs8" id="2wC5sgtDqNw" role="3cqZAp">
+          <node concept="3cpWsn" id="2wC5sgtDqNz" role="3cpWs9">
+            <property role="TrG5h" value="newSources" />
+            <node concept="2OqwBi" id="2NSCtASs85h" role="33vP2m">
+              <node concept="2OqwBi" id="2wC5sgtDqN_" role="2Oq$k0">
+                <node concept="2qgKlT" id="2wC5sgtDqNB" role="2OqNvi">
+                  <ref role="37wK5l" to="ao0u:2S2eLhiMzhL" resolve="getDependencies" />
+                  <node concept="37vLTw" id="2wC5sgtDqNC" role="37wK5m">
+                    <ref role="3cqZAo" node="RObVTFnnYE" resolve="_valueSelector" />
+                  </node>
+                </node>
+                <node concept="37vLTw" id="2NSCtASrFTm" role="2Oq$k0">
+                  <ref role="3cqZAo" node="2NSCtASrCpE" resolve="_valueHolder" />
+                </node>
+              </node>
+              <node concept="3$u5V9" id="2NSCtASsakn" role="2OqNvi">
+                <node concept="1bVj0M" id="2NSCtASsakp" role="23t8la">
+                  <node concept="3clFbS" id="2NSCtASsakq" role="1bW5cS">
+                    <node concept="3clFbF" id="2NSCtASsaPu" role="3cqZAp">
+                      <node concept="2OqwBi" id="2NSCtASsbhH" role="3clFbG">
+                        <node concept="37vLTw" id="2NSCtASsaPt" role="2Oq$k0">
+                          <ref role="3cqZAo" node="2NSCtASsakr" resolve="it" />
+                        </node>
+                        <node concept="2qgKlT" id="2NSCtASsbPI" role="2OqNvi">
+                          <ref role="37wK5l" to="ao0u:2S2eLhiM$ey" resolve="getValueHolderInfo" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="Rh6nW" id="2NSCtASsakr" role="1bW2Oz">
+                    <property role="TrG5h" value="it" />
+                    <node concept="2jxLKc" id="2NSCtASsaks" role="1tU5fm" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="A3Dl8" id="50uWDT$I$gC" role="1tU5fm">
+              <node concept="3uibUv" id="2NSCtASsFmb" role="A3Ik2">
+                <ref role="3uigEE" node="2S2eLhiM$hD" resolve="ValueHolderInfo" />
+              </node>
+            </node>
           </node>
-          <node concept="3clFbS" id="2YOONxNV0nN" role="1HWHxc">
-            <node concept="3cpWs8" id="2wC5sgtDqNw" role="3cqZAp">
-              <node concept="3cpWsn" id="2wC5sgtDqNz" role="3cpWs9">
-                <property role="TrG5h" value="newSources" />
-                <node concept="2OqwBi" id="2NSCtASs85h" role="33vP2m">
-                  <node concept="2OqwBi" id="2wC5sgtDqN_" role="2Oq$k0">
-                    <node concept="2qgKlT" id="2wC5sgtDqNB" role="2OqNvi">
-                      <ref role="37wK5l" to="ao0u:2S2eLhiMzhL" resolve="getDependencies" />
-                      <node concept="37vLTw" id="2wC5sgtDqNC" role="37wK5m">
-                        <ref role="3cqZAo" node="RObVTFnnYE" resolve="_valueSelector" />
-                      </node>
-                    </node>
-                    <node concept="37vLTw" id="2NSCtASrFTm" role="2Oq$k0">
-                      <ref role="3cqZAo" node="2NSCtASrCpE" resolve="_valueHolder" />
-                    </node>
-                  </node>
-                  <node concept="3$u5V9" id="2NSCtASsakn" role="2OqNvi">
-                    <node concept="1bVj0M" id="2NSCtASsakp" role="23t8la">
-                      <node concept="3clFbS" id="2NSCtASsakq" role="1bW5cS">
-                        <node concept="3clFbF" id="2NSCtASsaPu" role="3cqZAp">
-                          <node concept="2OqwBi" id="2NSCtASsbhH" role="3clFbG">
-                            <node concept="37vLTw" id="2NSCtASsaPt" role="2Oq$k0">
-                              <ref role="3cqZAo" node="2NSCtASsakr" resolve="it" />
-                            </node>
-                            <node concept="2qgKlT" id="2NSCtASsbPI" role="2OqNvi">
-                              <ref role="37wK5l" to="ao0u:2S2eLhiM$ey" resolve="getValueHolderInfo" />
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="Rh6nW" id="2NSCtASsakr" role="1bW2Oz">
-                        <property role="TrG5h" value="it" />
-                        <node concept="2jxLKc" id="2NSCtASsaks" role="1tU5fm" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="A3Dl8" id="50uWDT$I$gC" role="1tU5fm">
-                  <node concept="3uibUv" id="2NSCtASsFmb" role="A3Ik2">
-                    <ref role="3uigEE" node="2S2eLhiM$hD" resolve="ValueHolderInfo" />
-                  </node>
-                </node>
-              </node>
+        </node>
+        <node concept="3clFbF" id="2wC5sgtDg1R" role="3cqZAp">
+          <node concept="2OqwBi" id="2wC5sgtDhsU" role="3clFbG">
+            <node concept="37vLTw" id="2wC5sgtDsXB" role="2Oq$k0">
+              <ref role="3cqZAo" node="2wC5sgtDqNz" resolve="newSources" />
             </node>
-            <node concept="3clFbF" id="2wC5sgtDg1R" role="3cqZAp">
-              <node concept="2OqwBi" id="2wC5sgtDhsU" role="3clFbG">
-                <node concept="37vLTw" id="2wC5sgtDsXB" role="2Oq$k0">
-                  <ref role="3cqZAo" node="2wC5sgtDqNz" resolve="newSources" />
-                </node>
-                <node concept="2es0OD" id="2wC5sgtDjPt" role="2OqNvi">
-                  <node concept="1bVj0M" id="2wC5sgtDjPv" role="23t8la">
-                    <node concept="3clFbS" id="2wC5sgtDjPw" role="1bW5cS">
-                      <node concept="3clFbF" id="2wC5sgtDjZT" role="3cqZAp">
-                        <node concept="2OqwBi" id="2NSCtASsPAV" role="3clFbG">
-                          <node concept="37vLTw" id="2wC5sgtDjZS" role="2Oq$k0">
-                            <ref role="3cqZAo" node="2wC5sgtDjPx" resolve="source" />
-                          </node>
-                          <node concept="liA8E" id="2NSCtASsPNP" role="2OqNvi">
-                            <ref role="37wK5l" node="RObVTFoPhX" resolve="addPropagationTarget" />
-                            <node concept="37vLTw" id="2NSCtASsQ9_" role="37wK5m">
-                              <ref role="3cqZAo" node="RObVTFnnYE" resolve="_valueSelector" />
-                            </node>
-                            <node concept="37vLTw" id="2NSCtASsQ9A" role="37wK5m">
-                              <ref role="3cqZAo" node="2NSCtASruBg" resolve="_valueHolderInfo" />
-                            </node>
-                          </node>
+            <node concept="2es0OD" id="2wC5sgtDjPt" role="2OqNvi">
+              <node concept="1bVj0M" id="2wC5sgtDjPv" role="23t8la">
+                <node concept="3clFbS" id="2wC5sgtDjPw" role="1bW5cS">
+                  <node concept="3clFbF" id="2wC5sgtDjZT" role="3cqZAp">
+                    <node concept="2OqwBi" id="2NSCtASsPAV" role="3clFbG">
+                      <node concept="37vLTw" id="2wC5sgtDjZS" role="2Oq$k0">
+                        <ref role="3cqZAo" node="2wC5sgtDjPx" resolve="source" />
+                      </node>
+                      <node concept="liA8E" id="2NSCtASsPNP" role="2OqNvi">
+                        <ref role="37wK5l" node="RObVTFoPhX" resolve="addPropagationTarget" />
+                        <node concept="37vLTw" id="2NSCtASsQ9_" role="37wK5m">
+                          <ref role="3cqZAo" node="RObVTFnnYE" resolve="_valueSelector" />
+                        </node>
+                        <node concept="37vLTw" id="2NSCtASsQ9A" role="37wK5m">
+                          <ref role="3cqZAo" node="2NSCtASruBg" resolve="_valueHolderInfo" />
                         </node>
                       </node>
                     </node>
-                    <node concept="Rh6nW" id="2wC5sgtDjPx" role="1bW2Oz">
-                      <property role="TrG5h" value="source" />
-                      <node concept="2jxLKc" id="2wC5sgtDjPy" role="1tU5fm" />
-                    </node>
                   </node>
+                </node>
+                <node concept="Rh6nW" id="2wC5sgtDjPx" role="1bW2Oz">
+                  <property role="TrG5h" value="source" />
+                  <node concept="2jxLKc" id="2wC5sgtDjPy" role="1tU5fm" />
                 </node>
               </node>
             </node>
-            <node concept="3clFbF" id="2wC5sgtDvOA" role="3cqZAp">
-              <node concept="37vLTI" id="2wC5sgtDA02" role="3clFbG">
-                <node concept="2OqwBi" id="50uWDT$I_cC" role="37vLTx">
-                  <node concept="37vLTw" id="2wC5sgtDAIk" role="2Oq$k0">
-                    <ref role="3cqZAo" node="2wC5sgtDqNz" resolve="newSources" />
-                  </node>
-                  <node concept="ANE8D" id="50uWDT$I__H" role="2OqNvi" />
-                </node>
-                <node concept="37vLTw" id="2wC5sgtDvO$" role="37vLTJ">
-                  <ref role="3cqZAo" node="RObVTFnyV1" resolve="_cachedPropagationSources" />
-                </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="2wC5sgtDvOA" role="3cqZAp">
+          <node concept="37vLTI" id="2wC5sgtDA02" role="3clFbG">
+            <node concept="2OqwBi" id="50uWDT$I_cC" role="37vLTx">
+              <node concept="37vLTw" id="2wC5sgtDAIk" role="2Oq$k0">
+                <ref role="3cqZAo" node="2wC5sgtDqNz" resolve="newSources" />
               </node>
+              <node concept="ANE8D" id="50uWDT$I__H" role="2OqNvi" />
+            </node>
+            <node concept="37vLTw" id="2wC5sgtDvO$" role="37vLTJ">
+              <ref role="3cqZAo" node="RObVTFnyV1" resolve="_cachedPropagationSources" />
             </node>
           </node>
         </node>
@@ -1320,6 +1306,7 @@
     <node concept="3clFb_" id="2_5DHynKzeT" role="jymVt">
       <property role="1EzhhJ" value="false" />
       <property role="TrG5h" value="getValueSelector" />
+      <property role="od$2w" value="false" />
       <property role="DiZV1" value="false" />
       <property role="2aFKle" value="false" />
       <node concept="3clFbS" id="2_5DHynKzeW" role="3clF47">
@@ -1349,6 +1336,7 @@
     <node concept="3clFb_" id="KudFejUFph" role="jymVt">
       <property role="1EzhhJ" value="false" />
       <property role="TrG5h" value="getValueHolder" />
+      <property role="od$2w" value="false" />
       <property role="DiZV1" value="false" />
       <property role="2aFKle" value="false" />
       <node concept="3clFbS" id="KudFejUFpk" role="3clF47">
@@ -1378,82 +1366,75 @@
     <node concept="3clFb_" id="2YOONxNCmED" role="jymVt">
       <property role="TrG5h" value="getValue" />
       <node concept="3clFbS" id="2YOONxNCmEF" role="3clF47">
-        <node concept="1HWtB8" id="2YOONxNVeXb" role="3cqZAp">
-          <node concept="3VsKOn" id="2YOONxNVgX6" role="1HWFw0">
-            <ref role="3VsUkX" node="7ZWgXq7GlHg" resolve="ValueCache" />
+        <node concept="1gVbGN" id="2YOONxNCmEG" role="3cqZAp">
+          <node concept="3fqX7Q" id="2YOONxNCmEH" role="1gVkn0">
+            <node concept="37vLTw" id="2YOONxNCmEI" role="3fr31v">
+              <ref role="3cqZAo" node="6MN7yMJ7Ell" resolve="_isDisposed" />
+            </node>
           </node>
-          <node concept="3clFbS" id="2YOONxNVeXf" role="1HWHxc">
-            <node concept="1gVbGN" id="2YOONxNCmEG" role="3cqZAp">
-              <node concept="3fqX7Q" id="2YOONxNCmEH" role="1gVkn0">
-                <node concept="37vLTw" id="2YOONxNCmEI" role="3fr31v">
-                  <ref role="3cqZAo" node="6MN7yMJ7Ell" resolve="_isDisposed" />
-                </node>
-              </node>
-              <node concept="Xl_RD" id="2YOONxNCmEJ" role="1gVpfI">
-                <property role="Xl_RC" value="cache is disposed" />
-              </node>
-            </node>
-            <node concept="3clFbH" id="2YOONxNCmEK" role="3cqZAp" />
-            <node concept="3clFbJ" id="2YOONxNCmEL" role="3cqZAp">
-              <node concept="3clFbS" id="2YOONxNCmEM" role="3clFbx">
-                <node concept="3cpWs6" id="2YOONxNCmEN" role="3cqZAp">
-                  <node concept="37vLTw" id="2YOONxNCmEO" role="3cqZAk">
-                    <ref role="3cqZAo" node="RObVTFmWn7" resolve="_cachedValue" />
-                  </node>
-                </node>
-              </node>
-              <node concept="3y3z36" id="2YOONxNCmEP" role="3clFbw">
-                <node concept="10Nm6u" id="2YOONxNCmEQ" role="3uHU7w" />
-                <node concept="37vLTw" id="2YOONxNCmER" role="3uHU7B">
-                  <ref role="3cqZAo" node="RObVTFmWn7" resolve="_cachedValue" />
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbH" id="2YOONxNCmF2" role="3cqZAp" />
-            <node concept="3clFbJ" id="2YOONxNCmF3" role="3cqZAp">
-              <node concept="3clFbS" id="2YOONxNCmF4" role="3clFbx">
-                <node concept="3cpWs6" id="2YOONxNCmF5" role="3cqZAp">
-                  <node concept="10Nm6u" id="2YOONxNCmF6" role="3cqZAk" />
-                </node>
-              </node>
-              <node concept="3fqX7Q" id="2YOONxNEh1U" role="3clFbw">
-                <node concept="2OqwBi" id="2YOONxNEh1W" role="3fr31v">
-                  <node concept="37vLTw" id="2YOONxNEh1X" role="2Oq$k0">
-                    <ref role="3cqZAo" node="2NSCtASrCpE" resolve="_valueHolder" />
-                  </node>
-                  <node concept="2qgKlT" id="2YOONxNEh1Y" role="2OqNvi">
-                    <ref role="37wK5l" to="ao0u:6MPBOWiFIsN" resolve="canCalculate" />
-                    <node concept="37vLTw" id="2YOONxNEh1Z" role="37wK5m">
-                      <ref role="3cqZAo" node="RObVTFnnYE" resolve="_valueSelector" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbH" id="2YOONxNCmFb" role="3cqZAp" />
-            <node concept="3clFbF" id="2YOONxNCmFc" role="3cqZAp">
-              <node concept="37vLTI" id="2YOONxNCmFd" role="3clFbG">
-                <node concept="2OqwBi" id="2YOONxNCmFe" role="37vLTx">
-                  <node concept="37vLTw" id="2YOONxNCmFf" role="2Oq$k0">
-                    <ref role="3cqZAo" node="2NSCtASrCpE" resolve="_valueHolder" />
-                  </node>
-                  <node concept="2qgKlT" id="2YOONxNCmFg" role="2OqNvi">
-                    <ref role="37wK5l" to="ao0u:RObVTFnZ_0" resolve="calculateValue" />
-                    <node concept="37vLTw" id="2YOONxNCmFh" role="37wK5m">
-                      <ref role="3cqZAo" node="RObVTFnnYE" resolve="_valueSelector" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="37vLTw" id="2YOONxNCmFi" role="37vLTJ">
-                  <ref role="3cqZAo" node="RObVTFmWn7" resolve="_cachedValue" />
-                </node>
-              </node>
-            </node>
-            <node concept="3cpWs6" id="2YOONxNCmFj" role="3cqZAp">
-              <node concept="37vLTw" id="2YOONxNCmFk" role="3cqZAk">
+          <node concept="Xl_RD" id="2YOONxNCmEJ" role="1gVpfI">
+            <property role="Xl_RC" value="cache is disposed" />
+          </node>
+        </node>
+        <node concept="3clFbH" id="2YOONxNCmEK" role="3cqZAp" />
+        <node concept="3clFbJ" id="2YOONxNCmEL" role="3cqZAp">
+          <node concept="3clFbS" id="2YOONxNCmEM" role="3clFbx">
+            <node concept="3cpWs6" id="2YOONxNCmEN" role="3cqZAp">
+              <node concept="37vLTw" id="2YOONxNCmEO" role="3cqZAk">
                 <ref role="3cqZAo" node="RObVTFmWn7" resolve="_cachedValue" />
               </node>
             </node>
+          </node>
+          <node concept="3y3z36" id="2YOONxNCmEP" role="3clFbw">
+            <node concept="10Nm6u" id="2YOONxNCmEQ" role="3uHU7w" />
+            <node concept="37vLTw" id="2YOONxNCmER" role="3uHU7B">
+              <ref role="3cqZAo" node="RObVTFmWn7" resolve="_cachedValue" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="2YOONxNCmF2" role="3cqZAp" />
+        <node concept="3clFbJ" id="2YOONxNCmF3" role="3cqZAp">
+          <node concept="3clFbS" id="2YOONxNCmF4" role="3clFbx">
+            <node concept="3cpWs6" id="2YOONxNCmF5" role="3cqZAp">
+              <node concept="10Nm6u" id="2YOONxNCmF6" role="3cqZAk" />
+            </node>
+          </node>
+          <node concept="3fqX7Q" id="2YOONxNEh1U" role="3clFbw">
+            <node concept="2OqwBi" id="2YOONxNEh1W" role="3fr31v">
+              <node concept="37vLTw" id="2YOONxNEh1X" role="2Oq$k0">
+                <ref role="3cqZAo" node="2NSCtASrCpE" resolve="_valueHolder" />
+              </node>
+              <node concept="2qgKlT" id="2YOONxNEh1Y" role="2OqNvi">
+                <ref role="37wK5l" to="ao0u:6MPBOWiFIsN" resolve="canCalculate" />
+                <node concept="37vLTw" id="2YOONxNEh1Z" role="37wK5m">
+                  <ref role="3cqZAo" node="RObVTFnnYE" resolve="_valueSelector" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="2YOONxNCmFb" role="3cqZAp" />
+        <node concept="3clFbF" id="2YOONxNCmFc" role="3cqZAp">
+          <node concept="37vLTI" id="2YOONxNCmFd" role="3clFbG">
+            <node concept="2OqwBi" id="2YOONxNCmFe" role="37vLTx">
+              <node concept="37vLTw" id="2YOONxNCmFf" role="2Oq$k0">
+                <ref role="3cqZAo" node="2NSCtASrCpE" resolve="_valueHolder" />
+              </node>
+              <node concept="2qgKlT" id="2YOONxNCmFg" role="2OqNvi">
+                <ref role="37wK5l" to="ao0u:RObVTFnZ_0" resolve="calculateValue" />
+                <node concept="37vLTw" id="2YOONxNCmFh" role="37wK5m">
+                  <ref role="3cqZAo" node="RObVTFnnYE" resolve="_valueSelector" />
+                </node>
+              </node>
+            </node>
+            <node concept="37vLTw" id="2YOONxNCmFi" role="37vLTJ">
+              <ref role="3cqZAo" node="RObVTFmWn7" resolve="_cachedValue" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="2YOONxNCmFj" role="3cqZAp">
+          <node concept="37vLTw" id="2YOONxNCmFk" role="3cqZAk">
+            <ref role="3cqZAo" node="RObVTFmWn7" resolve="_cachedValue" />
           </node>
         </node>
       </node>
@@ -1468,286 +1449,278 @@
       <property role="TrG5h" value="invalidate" />
       <property role="DiZV1" value="false" />
       <property role="2aFKle" value="false" />
-      <property role="od$2w" value="true" />
       <node concept="3clFbS" id="RObVTFmWkU" role="3clF47">
-        <node concept="1HWtB8" id="2YOONxNVku0" role="3cqZAp">
-          <node concept="3VsKOn" id="2YOONxNVmaz" role="1HWFw0">
-            <ref role="3VsUkX" node="7ZWgXq7GlHg" resolve="ValueCache" />
+        <node concept="3clFbJ" id="48u7VOfNmZd" role="3cqZAp">
+          <node concept="3clFbS" id="48u7VOfNmZf" role="3clFbx">
+            <node concept="3cpWs6" id="48u7VOfNqcN" role="3cqZAp" />
           </node>
-          <node concept="3clFbS" id="2YOONxNVku4" role="1HWHxc">
-            <node concept="3clFbJ" id="48u7VOfNmZd" role="3cqZAp">
-              <node concept="3clFbS" id="48u7VOfNmZf" role="3clFbx">
-                <node concept="3cpWs6" id="48u7VOfNqcN" role="3cqZAp" />
+          <node concept="2OqwBi" id="48u7VOfNoLH" role="3clFbw">
+            <node concept="37vLTw" id="48u7VOfNnxH" role="2Oq$k0">
+              <ref role="3cqZAo" node="48u7VOfNi4y" resolve="visitedParticipants" />
+            </node>
+            <node concept="3JPx81" id="48u7VOfNpZF" role="2OqNvi">
+              <node concept="37vLTw" id="2NSCtASt9P8" role="25WWJ7">
+                <ref role="3cqZAo" node="2NSCtASruBg" resolve="_valueHolderInfo" />
               </node>
-              <node concept="2OqwBi" id="48u7VOfNoLH" role="3clFbw">
-                <node concept="37vLTw" id="48u7VOfNnxH" role="2Oq$k0">
-                  <ref role="3cqZAo" node="48u7VOfNi4y" resolve="visitedParticipants" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="48u7VOfNqfA" role="3cqZAp">
+          <node concept="2OqwBi" id="48u7VOfNrzw" role="3clFbG">
+            <node concept="37vLTw" id="48u7VOfNqf$" role="2Oq$k0">
+              <ref role="3cqZAo" node="48u7VOfNi4y" resolve="visitedParticipants" />
+            </node>
+            <node concept="TSZUe" id="48u7VOfNHtJ" role="2OqNvi">
+              <node concept="37vLTw" id="2NSCtASt9Y_" role="25WWJ7">
+                <ref role="3cqZAo" node="2NSCtASruBg" resolve="_valueHolderInfo" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="48u7VOfNt1c" role="3cqZAp" />
+        <node concept="3clFbF" id="RObVTFmWpo" role="3cqZAp">
+          <node concept="37vLTI" id="RObVTFmWXl" role="3clFbG">
+            <node concept="10Nm6u" id="RObVTFmWYF" role="37vLTx" />
+            <node concept="37vLTw" id="RObVTFmWpn" role="37vLTJ">
+              <ref role="3cqZAo" node="RObVTFmWn7" resolve="_cachedValue" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="5YITc37Q0aS" role="3cqZAp" />
+        <node concept="3clFbJ" id="5YITc37PWF4" role="3cqZAp">
+          <node concept="3clFbS" id="5YITc37PWF6" role="3clFbx">
+            <node concept="3clFbF" id="5YITc37PX5p" role="3cqZAp">
+              <node concept="37vLTI" id="5YITc37PXXb" role="3clFbG">
+                <node concept="10Nm6u" id="5YITc37QEVO" role="37vLTx" />
+                <node concept="37vLTw" id="5YITc37PX5n" role="37vLTJ">
+                  <ref role="3cqZAo" node="5YITc37PBWJ" resolve="_cachedHasCycle" />
                 </node>
-                <node concept="3JPx81" id="48u7VOfNpZF" role="2OqNvi">
-                  <node concept="37vLTw" id="2NSCtASt9P8" role="25WWJ7">
-                    <ref role="3cqZAo" node="2NSCtASruBg" resolve="_valueHolderInfo" />
+              </node>
+            </node>
+            <node concept="3cpWs8" id="2wC5sgtCbJE" role="3cqZAp">
+              <node concept="3cpWsn" id="2wC5sgtCbJH" role="3cpWs9">
+                <property role="TrG5h" value="newSources" />
+                <node concept="2OqwBi" id="2NSCtAStj5O" role="33vP2m">
+                  <node concept="2OqwBi" id="2wC5sgtCcnH" role="2Oq$k0">
+                    <node concept="37vLTw" id="2wC5sgtCc75" role="2Oq$k0">
+                      <ref role="3cqZAo" node="2NSCtASrCpE" resolve="_valueHolder" />
+                    </node>
+                    <node concept="2qgKlT" id="2wC5sgtCc$2" role="2OqNvi">
+                      <ref role="37wK5l" to="ao0u:2S2eLhiMzhL" resolve="getDependencies" />
+                      <node concept="37vLTw" id="2wC5sgtCcFC" role="37wK5m">
+                        <ref role="3cqZAo" node="RObVTFnnYE" resolve="_valueSelector" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3$u5V9" id="2NSCtAStltz" role="2OqNvi">
+                    <node concept="1bVj0M" id="2NSCtAStlt_" role="23t8la">
+                      <node concept="3clFbS" id="2NSCtAStltA" role="1bW5cS">
+                        <node concept="3clFbF" id="2NSCtAStm01" role="3cqZAp">
+                          <node concept="2OqwBi" id="2NSCtAStmtY" role="3clFbG">
+                            <node concept="37vLTw" id="2NSCtAStm00" role="2Oq$k0">
+                              <ref role="3cqZAo" node="2NSCtAStltB" resolve="it" />
+                            </node>
+                            <node concept="2qgKlT" id="2NSCtAStn9u" role="2OqNvi">
+                              <ref role="37wK5l" to="ao0u:2S2eLhiM$ey" resolve="getValueHolderInfo" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="Rh6nW" id="2NSCtAStltB" role="1bW2Oz">
+                        <property role="TrG5h" value="it" />
+                        <node concept="2jxLKc" id="2NSCtAStltC" role="1tU5fm" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="A3Dl8" id="50uWDT$INtP" role="1tU5fm">
+                  <node concept="3uibUv" id="50uWDT$INtR" role="A3Ik2">
+                    <ref role="3uigEE" node="2S2eLhiM$hD" resolve="ValueHolderInfo" />
                   </node>
                 </node>
               </node>
             </node>
-            <node concept="3clFbF" id="48u7VOfNqfA" role="3cqZAp">
-              <node concept="2OqwBi" id="48u7VOfNrzw" role="3clFbG">
-                <node concept="37vLTw" id="48u7VOfNqf$" role="2Oq$k0">
-                  <ref role="3cqZAo" node="48u7VOfNi4y" resolve="visitedParticipants" />
-                </node>
-                <node concept="TSZUe" id="48u7VOfNHtJ" role="2OqNvi">
-                  <node concept="37vLTw" id="2NSCtASt9Y_" role="25WWJ7">
-                    <ref role="3cqZAo" node="2NSCtASruBg" resolve="_valueHolderInfo" />
+            <node concept="3clFbF" id="2wC5sgtCe9p" role="3cqZAp">
+              <node concept="2OqwBi" id="2wC5sgtDcjX" role="3clFbG">
+                <node concept="2OqwBi" id="2wC5sgtCflW" role="2Oq$k0">
+                  <node concept="37vLTw" id="2wC5sgtCe9n" role="2Oq$k0">
+                    <ref role="3cqZAo" node="2wC5sgtCbJH" resolve="newSources" />
                   </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbH" id="48u7VOfNt1c" role="3cqZAp" />
-            <node concept="3clFbF" id="RObVTFmWpo" role="3cqZAp">
-              <node concept="37vLTI" id="RObVTFmWXl" role="3clFbG">
-                <node concept="10Nm6u" id="RObVTFmWYF" role="37vLTx" />
-                <node concept="37vLTw" id="RObVTFmWpn" role="37vLTJ">
-                  <ref role="3cqZAo" node="RObVTFmWn7" resolve="_cachedValue" />
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbH" id="5YITc37Q0aS" role="3cqZAp" />
-            <node concept="3clFbJ" id="5YITc37PWF4" role="3cqZAp">
-              <node concept="3clFbS" id="5YITc37PWF6" role="3clFbx">
-                <node concept="3clFbF" id="5YITc37PX5p" role="3cqZAp">
-                  <node concept="37vLTI" id="5YITc37PXXb" role="3clFbG">
-                    <node concept="10Nm6u" id="5YITc37QEVO" role="37vLTx" />
-                    <node concept="37vLTw" id="5YITc37PX5n" role="37vLTJ">
-                      <ref role="3cqZAo" node="5YITc37PBWJ" resolve="_cachedHasCycle" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="3cpWs8" id="2wC5sgtCbJE" role="3cqZAp">
-                  <node concept="3cpWsn" id="2wC5sgtCbJH" role="3cpWs9">
-                    <property role="TrG5h" value="newSources" />
-                    <node concept="2OqwBi" id="2NSCtAStj5O" role="33vP2m">
-                      <node concept="2OqwBi" id="2wC5sgtCcnH" role="2Oq$k0">
-                        <node concept="37vLTw" id="2wC5sgtCc75" role="2Oq$k0">
-                          <ref role="3cqZAo" node="2NSCtASrCpE" resolve="_valueHolder" />
-                        </node>
-                        <node concept="2qgKlT" id="2wC5sgtCc$2" role="2OqNvi">
-                          <ref role="37wK5l" to="ao0u:2S2eLhiMzhL" resolve="getDependencies" />
-                          <node concept="37vLTw" id="2wC5sgtCcFC" role="37wK5m">
-                            <ref role="3cqZAo" node="RObVTFnnYE" resolve="_valueSelector" />
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="3$u5V9" id="2NSCtAStltz" role="2OqNvi">
-                        <node concept="1bVj0M" id="2NSCtAStlt_" role="23t8la">
-                          <node concept="3clFbS" id="2NSCtAStltA" role="1bW5cS">
-                            <node concept="3clFbF" id="2NSCtAStm01" role="3cqZAp">
-                              <node concept="2OqwBi" id="2NSCtAStmtY" role="3clFbG">
-                                <node concept="37vLTw" id="2NSCtAStm00" role="2Oq$k0">
-                                  <ref role="3cqZAo" node="2NSCtAStltB" resolve="it" />
-                                </node>
-                                <node concept="2qgKlT" id="2NSCtAStn9u" role="2OqNvi">
-                                  <ref role="37wK5l" to="ao0u:2S2eLhiM$ey" resolve="getValueHolderInfo" />
-                                </node>
+                  <node concept="3zZkjj" id="2wC5sgtCggS" role="2OqNvi">
+                    <node concept="1bVj0M" id="2wC5sgtCggU" role="23t8la">
+                      <node concept="3clFbS" id="2wC5sgtCggV" role="1bW5cS">
+                        <node concept="3clFbF" id="2wC5sgtCgmm" role="3cqZAp">
+                          <node concept="3fqX7Q" id="2wC5sgtDaky" role="3clFbG">
+                            <node concept="2OqwBi" id="2wC5sgtDak$" role="3fr31v">
+                              <node concept="37vLTw" id="2wC5sgtDak_" role="2Oq$k0">
+                                <ref role="3cqZAo" node="RObVTFnyV1" resolve="_cachedPropagationSources" />
                               </node>
-                            </node>
-                          </node>
-                          <node concept="Rh6nW" id="2NSCtAStltB" role="1bW2Oz">
-                            <property role="TrG5h" value="it" />
-                            <node concept="2jxLKc" id="2NSCtAStltC" role="1tU5fm" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="A3Dl8" id="50uWDT$INtP" role="1tU5fm">
-                      <node concept="3uibUv" id="50uWDT$INtR" role="A3Ik2">
-                        <ref role="3uigEE" node="2S2eLhiM$hD" resolve="ValueHolderInfo" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="3clFbF" id="2wC5sgtCe9p" role="3cqZAp">
-                  <node concept="2OqwBi" id="2wC5sgtDcjX" role="3clFbG">
-                    <node concept="2OqwBi" id="2wC5sgtCflW" role="2Oq$k0">
-                      <node concept="37vLTw" id="2wC5sgtCe9n" role="2Oq$k0">
-                        <ref role="3cqZAo" node="2wC5sgtCbJH" resolve="newSources" />
-                      </node>
-                      <node concept="3zZkjj" id="2wC5sgtCggS" role="2OqNvi">
-                        <node concept="1bVj0M" id="2wC5sgtCggU" role="23t8la">
-                          <node concept="3clFbS" id="2wC5sgtCggV" role="1bW5cS">
-                            <node concept="3clFbF" id="2wC5sgtCgmm" role="3cqZAp">
-                              <node concept="3fqX7Q" id="2wC5sgtDaky" role="3clFbG">
-                                <node concept="2OqwBi" id="2wC5sgtDak$" role="3fr31v">
-                                  <node concept="37vLTw" id="2wC5sgtDak_" role="2Oq$k0">
-                                    <ref role="3cqZAo" node="RObVTFnyV1" resolve="_cachedPropagationSources" />
-                                  </node>
-                                  <node concept="3JPx81" id="2wC5sgtDakA" role="2OqNvi">
-                                    <node concept="37vLTw" id="2wC5sgtDaMA" role="25WWJ7">
-                                      <ref role="3cqZAo" node="2wC5sgtCggW" resolve="newSource" />
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                          <node concept="Rh6nW" id="2wC5sgtCggW" role="1bW2Oz">
-                            <property role="TrG5h" value="newSource" />
-                            <node concept="2jxLKc" id="2wC5sgtCggX" role="1tU5fm" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="2es0OD" id="2wC5sgtDcRT" role="2OqNvi">
-                      <node concept="1bVj0M" id="2wC5sgtDcRV" role="23t8la">
-                        <node concept="3clFbS" id="2wC5sgtDcRW" role="1bW5cS">
-                          <node concept="3clFbF" id="2wC5sgtDddv" role="3cqZAp">
-                            <node concept="2OqwBi" id="2NSCtASttBb" role="3clFbG">
-                              <node concept="37vLTw" id="2wC5sgtDddu" role="2Oq$k0">
-                                <ref role="3cqZAo" node="2wC5sgtDcRX" resolve="newSource" />
-                              </node>
-                              <node concept="liA8E" id="2NSCtAStu2O" role="2OqNvi">
-                                <ref role="37wK5l" node="RObVTFoPhX" resolve="addPropagationTarget" />
-                                <node concept="37vLTw" id="2NSCtASty4d" role="37wK5m">
-                                  <ref role="3cqZAo" node="RObVTFnnYE" resolve="_valueSelector" />
-                                </node>
-                                <node concept="37vLTw" id="2NSCtAStA_D" role="37wK5m">
-                                  <ref role="3cqZAo" node="2NSCtASruBg" resolve="_valueHolderInfo" />
+                              <node concept="3JPx81" id="2wC5sgtDakA" role="2OqNvi">
+                                <node concept="37vLTw" id="2wC5sgtDaMA" role="25WWJ7">
+                                  <ref role="3cqZAo" node="2wC5sgtCggW" resolve="newSource" />
                                 </node>
                               </node>
                             </node>
                           </node>
                         </node>
-                        <node concept="Rh6nW" id="2wC5sgtDcRX" role="1bW2Oz">
-                          <property role="TrG5h" value="newSource" />
-                          <node concept="2jxLKc" id="2wC5sgtDcRY" role="1tU5fm" />
-                        </node>
+                      </node>
+                      <node concept="Rh6nW" id="2wC5sgtCggW" role="1bW2Oz">
+                        <property role="TrG5h" value="newSource" />
+                        <node concept="2jxLKc" id="2wC5sgtCggX" role="1tU5fm" />
                       </node>
                     </node>
                   </node>
                 </node>
-                <node concept="3clFbF" id="2wC5sgtDDuy" role="3cqZAp">
-                  <node concept="2OqwBi" id="2wC5sgtDMpu" role="3clFbG">
-                    <node concept="2OqwBi" id="2wC5sgtDEN2" role="2Oq$k0">
-                      <node concept="37vLTw" id="2wC5sgtDDuw" role="2Oq$k0">
-                        <ref role="3cqZAo" node="RObVTFnyV1" resolve="_cachedPropagationSources" />
-                      </node>
-                      <node concept="3zZkjj" id="2wC5sgtDGQ$" role="2OqNvi">
-                        <node concept="1bVj0M" id="2wC5sgtDGQA" role="23t8la">
-                          <node concept="3clFbS" id="2wC5sgtDGQB" role="1bW5cS">
-                            <node concept="3clFbF" id="2wC5sgtDH7Z" role="3cqZAp">
-                              <node concept="3fqX7Q" id="2wC5sgtDKLe" role="3clFbG">
-                                <node concept="2OqwBi" id="2wC5sgtDKLg" role="3fr31v">
-                                  <node concept="37vLTw" id="2wC5sgtDKLh" role="2Oq$k0">
-                                    <ref role="3cqZAo" node="2wC5sgtCbJH" resolve="newSources" />
-                                  </node>
-                                  <node concept="3JPx81" id="2wC5sgtDKLi" role="2OqNvi">
-                                    <node concept="37vLTw" id="2wC5sgtDL5d" role="25WWJ7">
-                                      <ref role="3cqZAo" node="2wC5sgtDGQC" resolve="oldSource" />
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
+                <node concept="2es0OD" id="2wC5sgtDcRT" role="2OqNvi">
+                  <node concept="1bVj0M" id="2wC5sgtDcRV" role="23t8la">
+                    <node concept="3clFbS" id="2wC5sgtDcRW" role="1bW5cS">
+                      <node concept="3clFbF" id="2wC5sgtDddv" role="3cqZAp">
+                        <node concept="2OqwBi" id="2NSCtASttBb" role="3clFbG">
+                          <node concept="37vLTw" id="2wC5sgtDddu" role="2Oq$k0">
+                            <ref role="3cqZAo" node="2wC5sgtDcRX" resolve="newSource" />
                           </node>
-                          <node concept="Rh6nW" id="2wC5sgtDGQC" role="1bW2Oz">
-                            <property role="TrG5h" value="oldSource" />
-                            <node concept="2jxLKc" id="2wC5sgtDGQD" role="1tU5fm" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="2es0OD" id="2wC5sgtDMUn" role="2OqNvi">
-                      <node concept="1bVj0M" id="2wC5sgtDMUp" role="23t8la">
-                        <node concept="3clFbS" id="2wC5sgtDMUq" role="1bW5cS">
-                          <node concept="3clFbF" id="2wC5sgtDODz" role="3cqZAp">
-                            <node concept="2OqwBi" id="2NSCtAStvqt" role="3clFbG">
-                              <node concept="37vLTw" id="2wC5sgtDODy" role="2Oq$k0">
-                                <ref role="3cqZAo" node="2wC5sgtDMUr" resolve="oldSource" />
-                              </node>
-                              <node concept="liA8E" id="2NSCtAStvQK" role="2OqNvi">
-                                <ref role="37wK5l" node="RObVTFoQPx" resolve="removePropagationTarget" />
-                                <node concept="37vLTw" id="2NSCtAStwCu" role="37wK5m">
-                                  <ref role="3cqZAo" node="RObVTFnnYE" resolve="_valueSelector" />
-                                </node>
-                                <node concept="37vLTw" id="2NSCtAStBYY" role="37wK5m">
-                                  <ref role="3cqZAo" node="2NSCtASruBg" resolve="_valueHolderInfo" />
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="Rh6nW" id="2wC5sgtDMUr" role="1bW2Oz">
-                          <property role="TrG5h" value="oldSource" />
-                          <node concept="2jxLKc" id="2wC5sgtDMUs" role="1tU5fm" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="3clFbF" id="2wC5sgtDRvI" role="3cqZAp">
-                  <node concept="37vLTI" id="2wC5sgtDY4f" role="3clFbG">
-                    <node concept="2OqwBi" id="50uWDT$IU91" role="37vLTx">
-                      <node concept="37vLTw" id="2wC5sgtDYtf" role="2Oq$k0">
-                        <ref role="3cqZAo" node="2wC5sgtCbJH" resolve="newSources" />
-                      </node>
-                      <node concept="ANE8D" id="50uWDT$IUyf" role="2OqNvi" />
-                    </node>
-                    <node concept="37vLTw" id="2wC5sgtDRvG" role="37vLTJ">
-                      <ref role="3cqZAo" node="RObVTFnyV1" resolve="_cachedPropagationSources" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="3clFbC" id="797ZNR2k3Zv" role="3clFbw">
-                <node concept="Rm8GO" id="797ZNR2k4Ca" role="3uHU7w">
-                  <ref role="Rm8GQ" node="6sjp2R1WqzY" resolve="ValueAndDependencies" />
-                  <ref role="1Px2BO" node="6sjp2R1WqtZ" resolve="EChangeEffectKind" />
-                </node>
-                <node concept="37vLTw" id="797ZNR2k2VP" role="3uHU7B">
-                  <ref role="3cqZAo" node="797ZNR2k0QU" resolve="changeEffectKind" />
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbH" id="2wC5sgtCbq$" role="3cqZAp" />
-            <node concept="3clFbF" id="61NZ8UZnPxS" role="3cqZAp">
-              <node concept="2OqwBi" id="61NZ8UZnRNZ" role="3clFbG">
-                <node concept="2ShNRf" id="61NZ8UZnPxO" role="2Oq$k0">
-                  <node concept="2Jqq0_" id="61NZ8UZo3OI" role="2ShVmc">
-                    <node concept="3uibUv" id="61NZ8UZo40O" role="HW$YZ">
-                      <ref role="3uigEE" node="2S2eLhiM$hD" resolve="ValueHolderInfo" />
-                    </node>
-                    <node concept="37vLTw" id="61NZ8UZo4QK" role="I$8f6">
-                      <ref role="3cqZAo" node="RObVTFo4eX" resolve="_cachedPropagationTargets" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="2es0OD" id="61NZ8UZnU5o" role="2OqNvi">
-                  <node concept="1bVj0M" id="61NZ8UZnU5q" role="23t8la">
-                    <node concept="3clFbS" id="61NZ8UZnU5r" role="1bW5cS">
-                      <node concept="3clFbF" id="61NZ8UZnU$k" role="3cqZAp">
-                        <node concept="2OqwBi" id="61NZ8UZnU$l" role="3clFbG">
-                          <node concept="37vLTw" id="61NZ8UZnU$m" role="2Oq$k0">
-                            <ref role="3cqZAo" node="61NZ8UZnU5s" resolve="target" />
-                          </node>
-                          <node concept="liA8E" id="61NZ8UZnU$n" role="2OqNvi">
-                            <ref role="37wK5l" node="RObVTFmZbg" resolve="invalidate" />
-                            <node concept="37vLTw" id="61NZ8UZnU$o" role="37wK5m">
+                          <node concept="liA8E" id="2NSCtAStu2O" role="2OqNvi">
+                            <ref role="37wK5l" node="RObVTFoPhX" resolve="addPropagationTarget" />
+                            <node concept="37vLTw" id="2NSCtASty4d" role="37wK5m">
                               <ref role="3cqZAo" node="RObVTFnnYE" resolve="_valueSelector" />
                             </node>
-                            <node concept="37vLTw" id="61NZ8UZnU$p" role="37wK5m">
-                              <ref role="3cqZAo" node="797ZNR2k0QU" resolve="changeEffectKind" />
-                            </node>
-                            <node concept="37vLTw" id="61NZ8UZnU$q" role="37wK5m">
-                              <ref role="3cqZAo" node="48u7VOfNi4y" resolve="visitedParticipants" />
+                            <node concept="37vLTw" id="2NSCtAStA_D" role="37wK5m">
+                              <ref role="3cqZAo" node="2NSCtASruBg" resolve="_valueHolderInfo" />
                             </node>
                           </node>
                         </node>
                       </node>
                     </node>
-                    <node concept="Rh6nW" id="61NZ8UZnU5s" role="1bW2Oz">
-                      <property role="TrG5h" value="target" />
-                      <node concept="2jxLKc" id="61NZ8UZnU5t" role="1tU5fm" />
+                    <node concept="Rh6nW" id="2wC5sgtDcRX" role="1bW2Oz">
+                      <property role="TrG5h" value="newSource" />
+                      <node concept="2jxLKc" id="2wC5sgtDcRY" role="1tU5fm" />
                     </node>
                   </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="2wC5sgtDDuy" role="3cqZAp">
+              <node concept="2OqwBi" id="2wC5sgtDMpu" role="3clFbG">
+                <node concept="2OqwBi" id="2wC5sgtDEN2" role="2Oq$k0">
+                  <node concept="37vLTw" id="2wC5sgtDDuw" role="2Oq$k0">
+                    <ref role="3cqZAo" node="RObVTFnyV1" resolve="_cachedPropagationSources" />
+                  </node>
+                  <node concept="3zZkjj" id="2wC5sgtDGQ$" role="2OqNvi">
+                    <node concept="1bVj0M" id="2wC5sgtDGQA" role="23t8la">
+                      <node concept="3clFbS" id="2wC5sgtDGQB" role="1bW5cS">
+                        <node concept="3clFbF" id="2wC5sgtDH7Z" role="3cqZAp">
+                          <node concept="3fqX7Q" id="2wC5sgtDKLe" role="3clFbG">
+                            <node concept="2OqwBi" id="2wC5sgtDKLg" role="3fr31v">
+                              <node concept="37vLTw" id="2wC5sgtDKLh" role="2Oq$k0">
+                                <ref role="3cqZAo" node="2wC5sgtCbJH" resolve="newSources" />
+                              </node>
+                              <node concept="3JPx81" id="2wC5sgtDKLi" role="2OqNvi">
+                                <node concept="37vLTw" id="2wC5sgtDL5d" role="25WWJ7">
+                                  <ref role="3cqZAo" node="2wC5sgtDGQC" resolve="oldSource" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="Rh6nW" id="2wC5sgtDGQC" role="1bW2Oz">
+                        <property role="TrG5h" value="oldSource" />
+                        <node concept="2jxLKc" id="2wC5sgtDGQD" role="1tU5fm" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="2es0OD" id="2wC5sgtDMUn" role="2OqNvi">
+                  <node concept="1bVj0M" id="2wC5sgtDMUp" role="23t8la">
+                    <node concept="3clFbS" id="2wC5sgtDMUq" role="1bW5cS">
+                      <node concept="3clFbF" id="2wC5sgtDODz" role="3cqZAp">
+                        <node concept="2OqwBi" id="2NSCtAStvqt" role="3clFbG">
+                          <node concept="37vLTw" id="2wC5sgtDODy" role="2Oq$k0">
+                            <ref role="3cqZAo" node="2wC5sgtDMUr" resolve="oldSource" />
+                          </node>
+                          <node concept="liA8E" id="2NSCtAStvQK" role="2OqNvi">
+                            <ref role="37wK5l" node="RObVTFoQPx" resolve="removePropagationTarget" />
+                            <node concept="37vLTw" id="2NSCtAStwCu" role="37wK5m">
+                              <ref role="3cqZAo" node="RObVTFnnYE" resolve="_valueSelector" />
+                            </node>
+                            <node concept="37vLTw" id="2NSCtAStBYY" role="37wK5m">
+                              <ref role="3cqZAo" node="2NSCtASruBg" resolve="_valueHolderInfo" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="Rh6nW" id="2wC5sgtDMUr" role="1bW2Oz">
+                      <property role="TrG5h" value="oldSource" />
+                      <node concept="2jxLKc" id="2wC5sgtDMUs" role="1tU5fm" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="2wC5sgtDRvI" role="3cqZAp">
+              <node concept="37vLTI" id="2wC5sgtDY4f" role="3clFbG">
+                <node concept="2OqwBi" id="50uWDT$IU91" role="37vLTx">
+                  <node concept="37vLTw" id="2wC5sgtDYtf" role="2Oq$k0">
+                    <ref role="3cqZAo" node="2wC5sgtCbJH" resolve="newSources" />
+                  </node>
+                  <node concept="ANE8D" id="50uWDT$IUyf" role="2OqNvi" />
+                </node>
+                <node concept="37vLTw" id="2wC5sgtDRvG" role="37vLTJ">
+                  <ref role="3cqZAo" node="RObVTFnyV1" resolve="_cachedPropagationSources" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbC" id="797ZNR2k3Zv" role="3clFbw">
+            <node concept="Rm8GO" id="797ZNR2k4Ca" role="3uHU7w">
+              <ref role="Rm8GQ" node="6sjp2R1WqzY" resolve="ValueAndDependencies" />
+              <ref role="1Px2BO" node="6sjp2R1WqtZ" resolve="EChangeEffectKind" />
+            </node>
+            <node concept="37vLTw" id="797ZNR2k2VP" role="3uHU7B">
+              <ref role="3cqZAo" node="797ZNR2k0QU" resolve="changeEffectKind" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="2wC5sgtCbq$" role="3cqZAp" />
+        <node concept="3clFbF" id="61NZ8UZnPxS" role="3cqZAp">
+          <node concept="2OqwBi" id="61NZ8UZnRNZ" role="3clFbG">
+            <node concept="2ShNRf" id="61NZ8UZnPxO" role="2Oq$k0">
+              <node concept="2Jqq0_" id="61NZ8UZo3OI" role="2ShVmc">
+                <node concept="3uibUv" id="61NZ8UZo40O" role="HW$YZ">
+                  <ref role="3uigEE" node="2S2eLhiM$hD" resolve="ValueHolderInfo" />
+                </node>
+                <node concept="37vLTw" id="61NZ8UZo4QK" role="I$8f6">
+                  <ref role="3cqZAo" node="RObVTFo4eX" resolve="_cachedPropagationTargets" />
+                </node>
+              </node>
+            </node>
+            <node concept="2es0OD" id="61NZ8UZnU5o" role="2OqNvi">
+              <node concept="1bVj0M" id="61NZ8UZnU5q" role="23t8la">
+                <node concept="3clFbS" id="61NZ8UZnU5r" role="1bW5cS">
+                  <node concept="3clFbF" id="61NZ8UZnU$k" role="3cqZAp">
+                    <node concept="2OqwBi" id="61NZ8UZnU$l" role="3clFbG">
+                      <node concept="37vLTw" id="61NZ8UZnU$m" role="2Oq$k0">
+                        <ref role="3cqZAo" node="61NZ8UZnU5s" resolve="target" />
+                      </node>
+                      <node concept="liA8E" id="61NZ8UZnU$n" role="2OqNvi">
+                        <ref role="37wK5l" node="RObVTFmZbg" resolve="invalidate" />
+                        <node concept="37vLTw" id="61NZ8UZnU$o" role="37wK5m">
+                          <ref role="3cqZAo" node="RObVTFnnYE" resolve="_valueSelector" />
+                        </node>
+                        <node concept="37vLTw" id="61NZ8UZnU$p" role="37wK5m">
+                          <ref role="3cqZAo" node="797ZNR2k0QU" resolve="changeEffectKind" />
+                        </node>
+                        <node concept="37vLTw" id="61NZ8UZnU$q" role="37wK5m">
+                          <ref role="3cqZAo" node="48u7VOfNi4y" resolve="visitedParticipants" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="Rh6nW" id="61NZ8UZnU5s" role="1bW2Oz">
+                  <property role="TrG5h" value="target" />
+                  <node concept="2jxLKc" id="61NZ8UZnU5t" role="1tU5fm" />
                 </node>
               </node>
             </node>
@@ -1778,21 +1751,14 @@
       <property role="DiZV1" value="false" />
       <property role="2aFKle" value="false" />
       <node concept="3clFbS" id="RObVTFrQr9" role="3clF47">
-        <node concept="1HWtB8" id="2YOONxNVrzk" role="3cqZAp">
-          <node concept="3VsKOn" id="2YOONxNVs8c" role="1HWFw0">
-            <ref role="3VsUkX" node="7ZWgXq7GlHg" resolve="ValueCache" />
-          </node>
-          <node concept="3clFbS" id="2YOONxNVrzo" role="1HWHxc">
-            <node concept="3clFbF" id="RObVTFrUHl" role="3cqZAp">
-              <node concept="2OqwBi" id="RObVTFrW0z" role="3clFbG">
-                <node concept="37vLTw" id="RObVTFrUHk" role="2Oq$k0">
-                  <ref role="3cqZAo" node="RObVTFo4eX" resolve="_cachedPropagationTargets" />
-                </node>
-                <node concept="TSZUe" id="RObVTFrYVD" role="2OqNvi">
-                  <node concept="37vLTw" id="RObVTFrZgJ" role="25WWJ7">
-                    <ref role="3cqZAo" node="RObVTFrSfN" resolve="other" />
-                  </node>
-                </node>
+        <node concept="3clFbF" id="RObVTFrUHl" role="3cqZAp">
+          <node concept="2OqwBi" id="RObVTFrW0z" role="3clFbG">
+            <node concept="37vLTw" id="RObVTFrUHk" role="2Oq$k0">
+              <ref role="3cqZAo" node="RObVTFo4eX" resolve="_cachedPropagationTargets" />
+            </node>
+            <node concept="TSZUe" id="RObVTFrYVD" role="2OqNvi">
+              <node concept="37vLTw" id="RObVTFrZgJ" role="25WWJ7">
+                <ref role="3cqZAo" node="RObVTFrSfN" resolve="other" />
               </node>
             </node>
           </node>
@@ -1814,21 +1780,14 @@
       <property role="DiZV1" value="false" />
       <property role="2aFKle" value="false" />
       <node concept="3clFbS" id="RObVTFrTIl" role="3clF47">
-        <node concept="1HWtB8" id="2YOONxNVsJQ" role="3cqZAp">
-          <node concept="3VsKOn" id="2YOONxNVsJR" role="1HWFw0">
-            <ref role="3VsUkX" node="7ZWgXq7GlHg" resolve="ValueCache" />
-          </node>
-          <node concept="3clFbS" id="2YOONxNVsJS" role="1HWHxc">
-            <node concept="3clFbF" id="RObVTFrZDn" role="3cqZAp">
-              <node concept="2OqwBi" id="RObVTFs0WH" role="3clFbG">
-                <node concept="37vLTw" id="RObVTFrZDm" role="2Oq$k0">
-                  <ref role="3cqZAo" node="RObVTFo4eX" resolve="_cachedPropagationTargets" />
-                </node>
-                <node concept="3dhRuq" id="RObVTFs3RV" role="2OqNvi">
-                  <node concept="37vLTw" id="RObVTFs4Dl" role="25WWJ7">
-                    <ref role="3cqZAo" node="RObVTFrTIo" resolve="other" />
-                  </node>
-                </node>
+        <node concept="3clFbF" id="RObVTFrZDn" role="3cqZAp">
+          <node concept="2OqwBi" id="RObVTFs0WH" role="3clFbG">
+            <node concept="37vLTw" id="RObVTFrZDm" role="2Oq$k0">
+              <ref role="3cqZAo" node="RObVTFo4eX" resolve="_cachedPropagationTargets" />
+            </node>
+            <node concept="3dhRuq" id="RObVTFs3RV" role="2OqNvi">
+              <node concept="37vLTw" id="RObVTFs4Dl" role="25WWJ7">
+                <ref role="3cqZAo" node="RObVTFrTIo" resolve="other" />
               </node>
             </node>
           </node>
@@ -1850,115 +1809,108 @@
       <property role="DiZV1" value="false" />
       <property role="2aFKle" value="false" />
       <node concept="3clFbS" id="5YITc37MPxu" role="3clF47">
-        <node concept="1HWtB8" id="2YOONxNV_1A" role="3cqZAp">
-          <node concept="3VsKOn" id="2YOONxNV_1B" role="1HWFw0">
-            <ref role="3VsUkX" node="7ZWgXq7GlHg" resolve="ValueCache" />
+        <node concept="1gVbGN" id="6MN7yMJ82V1" role="3cqZAp">
+          <node concept="3fqX7Q" id="6MN7yMJ82V2" role="1gVkn0">
+            <node concept="37vLTw" id="6MN7yMJ82V3" role="3fr31v">
+              <ref role="3cqZAo" node="6MN7yMJ7Ell" resolve="_isDisposed" />
+            </node>
           </node>
-          <node concept="3clFbS" id="2YOONxNV_1C" role="1HWHxc">
-            <node concept="1gVbGN" id="6MN7yMJ82V1" role="3cqZAp">
-              <node concept="3fqX7Q" id="6MN7yMJ82V2" role="1gVkn0">
-                <node concept="37vLTw" id="6MN7yMJ82V3" role="3fr31v">
-                  <ref role="3cqZAo" node="6MN7yMJ7Ell" resolve="_isDisposed" />
-                </node>
-              </node>
-              <node concept="Xl_RD" id="6MN7yMJ82V4" role="1gVpfI">
-                <property role="Xl_RC" value="cache is disposed" />
+          <node concept="Xl_RD" id="6MN7yMJ82V4" role="1gVpfI">
+            <property role="Xl_RC" value="cache is disposed" />
+          </node>
+        </node>
+        <node concept="3clFbH" id="6MN7yMJ81td" role="3cqZAp" />
+        <node concept="3clFbJ" id="5YITc37QHDg" role="3cqZAp">
+          <node concept="3clFbS" id="5YITc37QHDi" role="3clFbx">
+            <node concept="3cpWs6" id="5YITc37QKQL" role="3cqZAp">
+              <node concept="37vLTw" id="5YITc37QKTf" role="3cqZAk">
+                <ref role="3cqZAo" node="5YITc37PBWJ" resolve="_cachedHasCycle" />
               </node>
             </node>
-            <node concept="3clFbH" id="6MN7yMJ81td" role="3cqZAp" />
-            <node concept="3clFbJ" id="5YITc37QHDg" role="3cqZAp">
-              <node concept="3clFbS" id="5YITc37QHDi" role="3clFbx">
-                <node concept="3cpWs6" id="5YITc37QKQL" role="3cqZAp">
-                  <node concept="37vLTw" id="5YITc37QKTf" role="3cqZAk">
-                    <ref role="3cqZAo" node="5YITc37PBWJ" resolve="_cachedHasCycle" />
+          </node>
+          <node concept="3y3z36" id="5YITc37QKIn" role="3clFbw">
+            <node concept="10Nm6u" id="5YITc37QKNX" role="3uHU7w" />
+            <node concept="37vLTw" id="5YITc37QJAO" role="3uHU7B">
+              <ref role="3cqZAo" node="5YITc37PBWJ" resolve="_cachedHasCycle" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="5YITc37QOdO" role="3cqZAp" />
+        <node concept="2GUZhq" id="5YITc37QZAg" role="3cqZAp">
+          <node concept="3clFbS" id="5YITc37N3n1" role="2GV8ay">
+            <node concept="3clFbF" id="5YITc37OWoq" role="3cqZAp">
+              <node concept="1rXfSq" id="5YITc37OWos" role="3clFbG">
+                <ref role="37wK5l" node="5YITc37MTr0" resolve="checkForCycle" />
+                <node concept="2ShNRf" id="5YITc37OWot" role="37wK5m">
+                  <node concept="2Jqq0_" id="5YITc37OWou" role="2ShVmc">
+                    <node concept="3Tqbb2" id="5YITc37OWov" role="HW$YZ">
+                      <ref role="ehGHo" to="kzoi:2S2eLhiMx2Q" resolve="IncrementallyComputedValueHolder" />
+                    </node>
                   </node>
                 </node>
+                <node concept="37vLTw" id="5YITc37OWow" role="37wK5m">
+                  <ref role="3cqZAo" node="2NSCtASrCpE" resolve="_valueHolder" />
+                </node>
               </node>
-              <node concept="3y3z36" id="5YITc37QKIn" role="3clFbw">
-                <node concept="10Nm6u" id="5YITc37QKNX" role="3uHU7w" />
-                <node concept="37vLTw" id="5YITc37QJAO" role="3uHU7B">
+            </node>
+            <node concept="3clFbF" id="5YITc37QROb" role="3cqZAp">
+              <node concept="37vLTI" id="5YITc37QVdv" role="3clFbG">
+                <node concept="3clFbT" id="5YITc37QVk5" role="37vLTx">
+                  <property role="3clFbU" value="false" />
+                </node>
+                <node concept="37vLTw" id="5YITc37QRO9" role="37vLTJ">
                   <ref role="3cqZAo" node="5YITc37PBWJ" resolve="_cachedHasCycle" />
                 </node>
               </node>
             </node>
-            <node concept="3clFbH" id="5YITc37QOdO" role="3cqZAp" />
-            <node concept="2GUZhq" id="5YITc37QZAg" role="3cqZAp">
-              <node concept="3clFbS" id="5YITc37N3n1" role="2GV8ay">
-                <node concept="3clFbF" id="5YITc37OWoq" role="3cqZAp">
-                  <node concept="1rXfSq" id="5YITc37OWos" role="3clFbG">
-                    <ref role="37wK5l" node="5YITc37MTr0" resolve="checkForCycle" />
-                    <node concept="2ShNRf" id="5YITc37OWot" role="37wK5m">
-                      <node concept="2Jqq0_" id="5YITc37OWou" role="2ShVmc">
-                        <node concept="3Tqbb2" id="5YITc37OWov" role="HW$YZ">
-                          <ref role="ehGHo" to="kzoi:2S2eLhiMx2Q" resolve="IncrementallyComputedValueHolder" />
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="37vLTw" id="5YITc37OWow" role="37wK5m">
-                      <ref role="3cqZAo" node="2NSCtASrCpE" resolve="_valueHolder" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="3clFbF" id="5YITc37QROb" role="3cqZAp">
-                  <node concept="37vLTI" id="5YITc37QVdv" role="3clFbG">
-                    <node concept="3clFbT" id="5YITc37QVk5" role="37vLTx">
-                      <property role="3clFbU" value="false" />
-                    </node>
-                    <node concept="37vLTw" id="5YITc37QRO9" role="37vLTJ">
-                      <ref role="3cqZAo" node="5YITc37PBWJ" resolve="_cachedHasCycle" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="3clFbF" id="5uCOCQhZggl" role="3cqZAp">
-                  <node concept="37vLTI" id="5uCOCQhZh5p" role="3clFbG">
-                    <node concept="10Nm6u" id="5uCOCQhZhbR" role="37vLTx" />
-                    <node concept="37vLTw" id="5uCOCQhZggj" role="37vLTJ">
-                      <ref role="3cqZAo" node="5uCOCQhZdAO" resolve="_cachedCycle" />
-                    </node>
-                  </node>
+            <node concept="3clFbF" id="5uCOCQhZggl" role="3cqZAp">
+              <node concept="37vLTI" id="5uCOCQhZh5p" role="3clFbG">
+                <node concept="10Nm6u" id="5uCOCQhZhbR" role="37vLTx" />
+                <node concept="37vLTw" id="5uCOCQhZggj" role="37vLTJ">
+                  <ref role="3cqZAo" node="5uCOCQhZdAO" resolve="_cachedCycle" />
                 </node>
               </node>
-              <node concept="TDmWw" id="5YITc37N3n2" role="TEXxN">
-                <node concept="3cpWsn" id="5YITc37N3n4" role="TDEfY">
-                  <property role="TrG5h" value="ex" />
-                  <node concept="3uibUv" id="5YITc37Oj8Y" role="1tU5fm">
-                    <ref role="3uigEE" node="5YITc37Og6w" resolve="CycleDetectedException" />
-                  </node>
-                </node>
-                <node concept="3clFbS" id="5YITc37N3n8" role="TDEfX">
-                  <node concept="3clFbF" id="5YITc37QY2Q" role="3cqZAp">
-                    <node concept="37vLTI" id="5YITc37QY2R" role="3clFbG">
-                      <node concept="3clFbT" id="5YITc37QY2S" role="37vLTx">
-                        <property role="3clFbU" value="true" />
-                      </node>
-                      <node concept="37vLTw" id="5YITc37QY2T" role="37vLTJ">
-                        <ref role="3cqZAo" node="5YITc37PBWJ" resolve="_cachedHasCycle" />
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="3clFbF" id="5uCOCQhZhv1" role="3cqZAp">
-                    <node concept="37vLTI" id="5uCOCQhZi9w" role="3clFbG">
-                      <node concept="2OqwBi" id="5uCOCQhZiFL" role="37vLTx">
-                        <node concept="37vLTw" id="5uCOCQhZilB" role="2Oq$k0">
-                          <ref role="3cqZAo" node="5YITc37N3n4" resolve="ex" />
-                        </node>
-                        <node concept="liA8E" id="5uCOCQhZjg$" role="2OqNvi">
-                          <ref role="37wK5l" node="5uCOCQhZ80m" resolve="getCycle" />
-                        </node>
-                      </node>
-                      <node concept="37vLTw" id="5uCOCQhZhuZ" role="37vLTJ">
-                        <ref role="3cqZAo" node="5uCOCQhZdAO" resolve="_cachedCycle" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
+            </node>
+          </node>
+          <node concept="TDmWw" id="5YITc37N3n2" role="TEXxN">
+            <node concept="3cpWsn" id="5YITc37N3n4" role="TDEfY">
+              <property role="TrG5h" value="ex" />
+              <node concept="3uibUv" id="5YITc37Oj8Y" role="1tU5fm">
+                <ref role="3uigEE" node="5YITc37Og6w" resolve="CycleDetectedException" />
               </node>
-              <node concept="3clFbS" id="5YITc37QZAj" role="2GVbov">
-                <node concept="3cpWs6" id="5YITc37R1qs" role="3cqZAp">
-                  <node concept="37vLTw" id="5YITc37R2rJ" role="3cqZAk">
+            </node>
+            <node concept="3clFbS" id="5YITc37N3n8" role="TDEfX">
+              <node concept="3clFbF" id="5YITc37QY2Q" role="3cqZAp">
+                <node concept="37vLTI" id="5YITc37QY2R" role="3clFbG">
+                  <node concept="3clFbT" id="5YITc37QY2S" role="37vLTx">
+                    <property role="3clFbU" value="true" />
+                  </node>
+                  <node concept="37vLTw" id="5YITc37QY2T" role="37vLTJ">
                     <ref role="3cqZAo" node="5YITc37PBWJ" resolve="_cachedHasCycle" />
                   </node>
                 </node>
+              </node>
+              <node concept="3clFbF" id="5uCOCQhZhv1" role="3cqZAp">
+                <node concept="37vLTI" id="5uCOCQhZi9w" role="3clFbG">
+                  <node concept="2OqwBi" id="5uCOCQhZiFL" role="37vLTx">
+                    <node concept="37vLTw" id="5uCOCQhZilB" role="2Oq$k0">
+                      <ref role="3cqZAo" node="5YITc37N3n4" resolve="ex" />
+                    </node>
+                    <node concept="liA8E" id="5uCOCQhZjg$" role="2OqNvi">
+                      <ref role="37wK5l" node="5uCOCQhZ80m" resolve="getCycle" />
+                    </node>
+                  </node>
+                  <node concept="37vLTw" id="5uCOCQhZhuZ" role="37vLTJ">
+                    <ref role="3cqZAo" node="5uCOCQhZdAO" resolve="_cachedCycle" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbS" id="5YITc37QZAj" role="2GVbov">
+            <node concept="3cpWs6" id="5YITc37R1qs" role="3cqZAp">
+              <node concept="37vLTw" id="5YITc37R2rJ" role="3cqZAk">
+                <ref role="3cqZAo" node="5YITc37PBWJ" resolve="_cachedHasCycle" />
               </node>
             </node>
           </node>
@@ -1971,6 +1923,7 @@
     <node concept="3clFb_" id="5uCOCQhZ$YO" role="jymVt">
       <property role="1EzhhJ" value="false" />
       <property role="TrG5h" value="getCycle" />
+      <property role="od$2w" value="false" />
       <property role="DiZV1" value="false" />
       <property role="2aFKle" value="false" />
       <node concept="3clFbS" id="5uCOCQhZ$YR" role="3clF47">
@@ -1989,110 +1942,104 @@
     <node concept="3clFb_" id="5YITc37MTr0" role="jymVt">
       <property role="1EzhhJ" value="false" />
       <property role="TrG5h" value="checkForCycle" />
+      <property role="od$2w" value="false" />
       <property role="DiZV1" value="false" />
       <property role="2aFKle" value="false" />
       <node concept="3clFbS" id="5YITc37MTr1" role="3clF47">
-        <node concept="1HWtB8" id="2YOONxNVKym" role="3cqZAp">
-          <node concept="3VsKOn" id="2YOONxNVKyn" role="1HWFw0">
-            <ref role="3VsUkX" node="7ZWgXq7GlHg" resolve="ValueCache" />
-          </node>
-          <node concept="3clFbS" id="2YOONxNVKyo" role="1HWHxc">
-            <node concept="3clFbJ" id="5YITc37NFbM" role="3cqZAp">
-              <node concept="3clFbS" id="5YITc37NFbO" role="3clFbx">
-                <node concept="3clFbF" id="5uCOCQhZjTA" role="3cqZAp">
-                  <node concept="2OqwBi" id="5uCOCQhZkDH" role="3clFbG">
-                    <node concept="37vLTw" id="5uCOCQhZjT$" role="2Oq$k0">
+        <node concept="3clFbJ" id="5YITc37NFbM" role="3cqZAp">
+          <node concept="3clFbS" id="5YITc37NFbO" role="3clFbx">
+            <node concept="3clFbF" id="5uCOCQhZjTA" role="3cqZAp">
+              <node concept="2OqwBi" id="5uCOCQhZkDH" role="3clFbG">
+                <node concept="37vLTw" id="5uCOCQhZjT$" role="2Oq$k0">
+                  <ref role="3cqZAo" node="5YITc37MTr4" resolve="participantStack" />
+                </node>
+                <node concept="2ArzE6" id="5uCOCQhZls7" role="2OqNvi">
+                  <node concept="37vLTw" id="5uCOCQhZlGN" role="25WWJ7">
+                    <ref role="3cqZAo" node="5YITc37NIo3" resolve="participant" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="YS8fn" id="5YITc37NSNw" role="3cqZAp">
+              <node concept="2ShNRf" id="5YITc37NSOF" role="YScLw">
+                <node concept="1pGfFk" id="5YITc37NT45" role="2ShVmc">
+                  <ref role="37wK5l" node="5YITc37Og6x" resolve="CycleDetectedException" />
+                  <node concept="2OqwBi" id="5uCOCQhZ9vL" role="37wK5m">
+                    <node concept="37vLTw" id="5uCOCQhZ6_p" role="2Oq$k0">
                       <ref role="3cqZAo" node="5YITc37MTr4" resolve="participantStack" />
                     </node>
-                    <node concept="2ArzE6" id="5uCOCQhZls7" role="2OqNvi">
-                      <node concept="37vLTw" id="5uCOCQhZlGN" role="25WWJ7">
-                        <ref role="3cqZAo" node="5YITc37NIo3" resolve="participant" />
+                    <node concept="ANE8D" id="5uCOCQhZakr" role="2OqNvi" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="5YITc37NHCX" role="3clFbw">
+            <node concept="37vLTw" id="5YITc37NGFQ" role="2Oq$k0">
+              <ref role="3cqZAo" node="5YITc37MTr4" resolve="participantStack" />
+            </node>
+            <node concept="3JPx81" id="5YITc37NIm1" role="2OqNvi">
+              <node concept="37vLTw" id="5YITc37NSKV" role="25WWJ7">
+                <ref role="3cqZAo" node="5YITc37NIo3" resolve="participant" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="5YITc37Oy6H" role="3cqZAp" />
+        <node concept="3clFbF" id="5YITc37NUKH" role="3cqZAp">
+          <node concept="2OqwBi" id="5YITc37NYJO" role="3clFbG">
+            <node concept="37vLTw" id="5YITc37NXWG" role="2Oq$k0">
+              <ref role="3cqZAo" node="5YITc37MTr4" resolve="participantStack" />
+            </node>
+            <node concept="2ArzE6" id="5YITc37O096" role="2OqNvi">
+              <node concept="37vLTw" id="5YITc37O0ng" role="25WWJ7">
+                <ref role="3cqZAo" node="5YITc37NIo3" resolve="participant" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="5YITc37ONuk" role="3cqZAp">
+          <node concept="2OqwBi" id="5YITc37OQCs" role="3clFbG">
+            <node concept="2OqwBi" id="5YITc37ONum" role="2Oq$k0">
+              <node concept="37vLTw" id="5YITc37ONun" role="2Oq$k0">
+                <ref role="3cqZAo" node="5YITc37NIo3" resolve="participant" />
+              </node>
+              <node concept="2qgKlT" id="5YITc37ONuo" role="2OqNvi">
+                <ref role="37wK5l" to="ao0u:2S2eLhiMzhL" resolve="getDependencies" />
+                <node concept="37vLTw" id="5YITc37ONup" role="37wK5m">
+                  <ref role="3cqZAo" node="RObVTFnnYE" resolve="_valueSelector" />
+                </node>
+              </node>
+            </node>
+            <node concept="2es0OD" id="5YITc37OTsH" role="2OqNvi">
+              <node concept="1bVj0M" id="5YITc37OTsJ" role="23t8la">
+                <node concept="3clFbS" id="5YITc37OTsK" role="1bW5cS">
+                  <node concept="3clFbF" id="5YITc37Paiz" role="3cqZAp">
+                    <node concept="1rXfSq" id="5YITc37Paiy" role="3clFbG">
+                      <ref role="37wK5l" node="5YITc37MTr0" resolve="checkForCycle" />
+                      <node concept="37vLTw" id="5YITc37Pauu" role="37wK5m">
+                        <ref role="3cqZAo" node="5YITc37MTr4" resolve="participantStack" />
+                      </node>
+                      <node concept="37vLTw" id="5YITc37PaLo" role="37wK5m">
+                        <ref role="3cqZAo" node="5YITc37OTsL" resolve="it" />
                       </node>
                     </node>
                   </node>
                 </node>
-                <node concept="YS8fn" id="5YITc37NSNw" role="3cqZAp">
-                  <node concept="2ShNRf" id="5YITc37NSOF" role="YScLw">
-                    <node concept="1pGfFk" id="5YITc37NT45" role="2ShVmc">
-                      <ref role="37wK5l" node="5YITc37Og6x" resolve="CycleDetectedException" />
-                      <node concept="2OqwBi" id="5uCOCQhZ9vL" role="37wK5m">
-                        <node concept="37vLTw" id="5uCOCQhZ6_p" role="2Oq$k0">
-                          <ref role="3cqZAo" node="5YITc37MTr4" resolve="participantStack" />
-                        </node>
-                        <node concept="ANE8D" id="5uCOCQhZakr" role="2OqNvi" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="2OqwBi" id="5YITc37NHCX" role="3clFbw">
-                <node concept="37vLTw" id="5YITc37NGFQ" role="2Oq$k0">
-                  <ref role="3cqZAo" node="5YITc37MTr4" resolve="participantStack" />
-                </node>
-                <node concept="3JPx81" id="5YITc37NIm1" role="2OqNvi">
-                  <node concept="37vLTw" id="5YITc37NSKV" role="25WWJ7">
-                    <ref role="3cqZAo" node="5YITc37NIo3" resolve="participant" />
-                  </node>
+                <node concept="Rh6nW" id="5YITc37OTsL" role="1bW2Oz">
+                  <property role="TrG5h" value="it" />
+                  <node concept="2jxLKc" id="5YITc37OTsM" role="1tU5fm" />
                 </node>
               </node>
             </node>
-            <node concept="3clFbH" id="5YITc37Oy6H" role="3cqZAp" />
-            <node concept="3clFbF" id="5YITc37NUKH" role="3cqZAp">
-              <node concept="2OqwBi" id="5YITc37NYJO" role="3clFbG">
-                <node concept="37vLTw" id="5YITc37NXWG" role="2Oq$k0">
-                  <ref role="3cqZAo" node="5YITc37MTr4" resolve="participantStack" />
-                </node>
-                <node concept="2ArzE6" id="5YITc37O096" role="2OqNvi">
-                  <node concept="37vLTw" id="5YITc37O0ng" role="25WWJ7">
-                    <ref role="3cqZAo" node="5YITc37NIo3" resolve="participant" />
-                  </node>
-                </node>
-              </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="5YITc37OBzB" role="3cqZAp">
+          <node concept="2OqwBi" id="5YITc37OF5l" role="3clFbG">
+            <node concept="37vLTw" id="5YITc37OBz_" role="2Oq$k0">
+              <ref role="3cqZAo" node="5YITc37MTr4" resolve="participantStack" />
             </node>
-            <node concept="3clFbF" id="5YITc37ONuk" role="3cqZAp">
-              <node concept="2OqwBi" id="5YITc37OQCs" role="3clFbG">
-                <node concept="2OqwBi" id="5YITc37ONum" role="2Oq$k0">
-                  <node concept="37vLTw" id="5YITc37ONun" role="2Oq$k0">
-                    <ref role="3cqZAo" node="5YITc37NIo3" resolve="participant" />
-                  </node>
-                  <node concept="2qgKlT" id="5YITc37ONuo" role="2OqNvi">
-                    <ref role="37wK5l" to="ao0u:2S2eLhiMzhL" resolve="getDependencies" />
-                    <node concept="37vLTw" id="5YITc37ONup" role="37wK5m">
-                      <ref role="3cqZAo" node="RObVTFnnYE" resolve="_valueSelector" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="2es0OD" id="5YITc37OTsH" role="2OqNvi">
-                  <node concept="1bVj0M" id="5YITc37OTsJ" role="23t8la">
-                    <node concept="3clFbS" id="5YITc37OTsK" role="1bW5cS">
-                      <node concept="3clFbF" id="5YITc37Paiz" role="3cqZAp">
-                        <node concept="1rXfSq" id="5YITc37Paiy" role="3clFbG">
-                          <ref role="37wK5l" node="5YITc37MTr0" resolve="checkForCycle" />
-                          <node concept="37vLTw" id="5YITc37Pauu" role="37wK5m">
-                            <ref role="3cqZAo" node="5YITc37MTr4" resolve="participantStack" />
-                          </node>
-                          <node concept="37vLTw" id="5YITc37PaLo" role="37wK5m">
-                            <ref role="3cqZAo" node="5YITc37OTsL" resolve="it" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="Rh6nW" id="5YITc37OTsL" role="1bW2Oz">
-                      <property role="TrG5h" value="it" />
-                      <node concept="2jxLKc" id="5YITc37OTsM" role="1tU5fm" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbF" id="5YITc37OBzB" role="3cqZAp">
-              <node concept="2OqwBi" id="5YITc37OF5l" role="3clFbG">
-                <node concept="37vLTw" id="5YITc37OBz_" role="2Oq$k0">
-                  <ref role="3cqZAo" node="5YITc37MTr4" resolve="participantStack" />
-                </node>
-                <node concept="2AryhJ" id="5YITc37OG_d" role="2OqNvi" />
-              </node>
-            </node>
+            <node concept="2AryhJ" id="5YITc37OG_d" role="2OqNvi" />
           </node>
         </node>
       </node>
@@ -2117,6 +2064,7 @@
     <node concept="3clFb_" id="KudFejWkex" role="jymVt">
       <property role="1EzhhJ" value="false" />
       <property role="TrG5h" value="contentChanged" />
+      <property role="od$2w" value="false" />
       <property role="DiZV1" value="false" />
       <property role="2aFKle" value="false" />
       <node concept="37vLTG" id="KudFejZtIB" role="3clF46">
@@ -2126,27 +2074,20 @@
         </node>
       </node>
       <node concept="3clFbS" id="KudFejWke$" role="3clF47">
-        <node concept="1HWtB8" id="2YOONxNVP3q" role="3cqZAp">
-          <node concept="3VsKOn" id="2YOONxNVP3r" role="1HWFw0">
-            <ref role="3VsUkX" node="7ZWgXq7GlHg" resolve="ValueCache" />
-          </node>
-          <node concept="3clFbS" id="2YOONxNVP3s" role="1HWHxc">
-            <node concept="3clFbF" id="KudFejX3if" role="3cqZAp">
-              <node concept="1rXfSq" id="KudFejX3ie" role="3clFbG">
-                <ref role="37wK5l" node="6sjp2R1XpyA" resolve="reactOnChange" />
-                <node concept="2OqwBi" id="KudFejX3_o" role="37wK5m">
-                  <node concept="37vLTw" id="KudFejX3nI" role="2Oq$k0">
-                    <ref role="3cqZAo" node="2NSCtASrCpE" resolve="_valueHolder" />
-                  </node>
-                  <node concept="2qgKlT" id="KudFejXa0k" role="2OqNvi">
-                    <ref role="37wK5l" to="ao0u:KudFejX3SG" resolve="getChangeEffect" />
-                    <node concept="37vLTw" id="KudFejZ$LS" role="37wK5m">
-                      <ref role="3cqZAo" node="KudFejZtIB" resolve="event" />
-                    </node>
-                    <node concept="37vLTw" id="KudFejYuLw" role="37wK5m">
-                      <ref role="3cqZAo" node="RObVTFnnYE" resolve="_valueSelector" />
-                    </node>
-                  </node>
+        <node concept="3clFbF" id="KudFejX3if" role="3cqZAp">
+          <node concept="1rXfSq" id="KudFejX3ie" role="3clFbG">
+            <ref role="37wK5l" node="6sjp2R1XpyA" resolve="reactOnChange" />
+            <node concept="2OqwBi" id="KudFejX3_o" role="37wK5m">
+              <node concept="37vLTw" id="KudFejX3nI" role="2Oq$k0">
+                <ref role="3cqZAo" node="2NSCtASrCpE" resolve="_valueHolder" />
+              </node>
+              <node concept="2qgKlT" id="KudFejXa0k" role="2OqNvi">
+                <ref role="37wK5l" to="ao0u:KudFejX3SG" resolve="getChangeEffect" />
+                <node concept="37vLTw" id="KudFejZ$LS" role="37wK5m">
+                  <ref role="3cqZAo" node="KudFejZtIB" resolve="event" />
+                </node>
+                <node concept="37vLTw" id="KudFejYuLw" role="37wK5m">
+                  <ref role="3cqZAo" node="RObVTFnnYE" resolve="_valueSelector" />
                 </node>
               </node>
             </node>
@@ -2160,40 +2101,34 @@
     <node concept="3clFb_" id="7CsrqpZonfx" role="jymVt">
       <property role="1EzhhJ" value="false" />
       <property role="TrG5h" value="dispose" />
+      <property role="od$2w" value="false" />
       <property role="DiZV1" value="false" />
       <property role="2aFKle" value="false" />
       <node concept="3clFbS" id="7CsrqpZonf$" role="3clF47">
-        <node concept="1HWtB8" id="2YOONxNVSop" role="3cqZAp">
-          <node concept="3VsKOn" id="2YOONxNVSoq" role="1HWFw0">
-            <ref role="3VsUkX" node="7ZWgXq7GlHg" resolve="ValueCache" />
+        <node concept="3clFbF" id="6MN7yMJ7Gf$" role="3cqZAp">
+          <node concept="37vLTI" id="6MN7yMJ7G_Y" role="3clFbG">
+            <node concept="3clFbT" id="6MN7yMJ7GFb" role="37vLTx">
+              <property role="3clFbU" value="true" />
+            </node>
+            <node concept="37vLTw" id="6MN7yMJ7Gfy" role="37vLTJ">
+              <ref role="3cqZAo" node="6MN7yMJ7Ell" resolve="_isDisposed" />
+            </node>
           </node>
-          <node concept="3clFbS" id="2YOONxNVSor" role="1HWHxc">
-            <node concept="3clFbF" id="6MN7yMJ7Gf$" role="3cqZAp">
-              <node concept="37vLTI" id="6MN7yMJ7G_Y" role="3clFbG">
-                <node concept="3clFbT" id="6MN7yMJ7GFb" role="37vLTx">
-                  <property role="3clFbU" value="true" />
-                </node>
-                <node concept="37vLTw" id="6MN7yMJ7Gfy" role="37vLTJ">
-                  <ref role="3cqZAo" node="6MN7yMJ7Ell" resolve="_isDisposed" />
-                </node>
+        </node>
+        <node concept="3clFbF" id="7CsrqpZoweS" role="3cqZAp">
+          <node concept="2OqwBi" id="7CsrqpZozVw" role="3clFbG">
+            <node concept="2JrnkZ" id="7CsrqpZozxo" role="2Oq$k0">
+              <node concept="37vLTw" id="7CsrqpZoweQ" role="2JrQYb">
+                <ref role="3cqZAo" node="2NSCtASrCpE" resolve="_valueHolder" />
               </node>
             </node>
-            <node concept="3clFbF" id="7CsrqpZoweS" role="3cqZAp">
-              <node concept="2OqwBi" id="7CsrqpZozVw" role="3clFbG">
-                <node concept="2JrnkZ" id="7CsrqpZozxo" role="2Oq$k0">
-                  <node concept="37vLTw" id="7CsrqpZoweQ" role="2JrQYb">
-                    <ref role="3cqZAo" node="2NSCtASrCpE" resolve="_valueHolder" />
-                  </node>
-                </node>
-                <node concept="liA8E" id="7CsrqpZo$cw" role="2OqNvi">
-                  <ref role="37wK5l" to="mhbf:~SNode.putUserObject(java.lang.Object,java.lang.Object):void" resolve="putUserObject" />
-                  <node concept="10M0yZ" id="3mJtqpyRjq3" role="37wK5m">
-                    <ref role="3cqZAo" node="3mJtqpyRiaj" resolve="USER_OBJECT_ID" />
-                    <ref role="1PxDUh" node="2S2eLhiM$hD" resolve="ValueHolderInfo" />
-                  </node>
-                  <node concept="10Nm6u" id="7CsrqpZoAUQ" role="37wK5m" />
-                </node>
+            <node concept="liA8E" id="7CsrqpZo$cw" role="2OqNvi">
+              <ref role="37wK5l" to="mhbf:~SNode.putUserObject(java.lang.Object,java.lang.Object):void" resolve="putUserObject" />
+              <node concept="10M0yZ" id="3mJtqpyRjq3" role="37wK5m">
+                <ref role="3cqZAo" node="3mJtqpyRiaj" resolve="USER_OBJECT_ID" />
+                <ref role="1PxDUh" node="2S2eLhiM$hD" resolve="ValueHolderInfo" />
               </node>
+              <node concept="10Nm6u" id="7CsrqpZoAUQ" role="37wK5m" />
             </node>
           </node>
         </node>
@@ -2205,236 +2140,230 @@
     <node concept="3clFb_" id="6sjp2R1XpyA" role="jymVt">
       <property role="1EzhhJ" value="false" />
       <property role="TrG5h" value="reactOnChange" />
+      <property role="od$2w" value="false" />
       <property role="DiZV1" value="false" />
       <property role="2aFKle" value="false" />
       <node concept="3clFbS" id="6sjp2R1XpyD" role="3clF47">
-        <node concept="1HWtB8" id="2YOONxNVVq7" role="3cqZAp">
-          <node concept="3VsKOn" id="2YOONxNVVq8" role="1HWFw0">
-            <ref role="3VsUkX" node="7ZWgXq7GlHg" resolve="ValueCache" />
+        <node concept="3clFbJ" id="797ZNR2jQA2" role="3cqZAp">
+          <node concept="3clFbS" id="797ZNR2jQA4" role="3clFbx">
+            <node concept="3cpWs6" id="797ZNR2jSz7" role="3cqZAp" />
           </node>
-          <node concept="3clFbS" id="2YOONxNVVq9" role="1HWHxc">
-            <node concept="3clFbJ" id="797ZNR2jQA2" role="3cqZAp">
-              <node concept="3clFbS" id="797ZNR2jQA4" role="3clFbx">
-                <node concept="3cpWs6" id="797ZNR2jSz7" role="3cqZAp" />
+          <node concept="3clFbC" id="797ZNR2kqtC" role="3clFbw">
+            <node concept="10Nm6u" id="797ZNR2kqLi" role="3uHU7w" />
+            <node concept="37vLTw" id="797ZNR2kq65" role="3uHU7B">
+              <ref role="3cqZAo" node="6sjp2R1Xvw4" resolve="changeEffect" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="797ZNR2jSzk" role="3cqZAp" />
+        <node concept="3cpWs8" id="797ZNR2kka8" role="3cqZAp">
+          <node concept="3cpWsn" id="797ZNR2kkab" role="3cpWs9">
+            <property role="TrG5h" value="visitedParticipants" />
+            <node concept="_YKpA" id="797ZNR2kka4" role="1tU5fm">
+              <node concept="3uibUv" id="797ZNR2kkrE" role="_ZDj9">
+                <ref role="3uigEE" node="2S2eLhiM$hD" resolve="ValueHolderInfo" />
               </node>
-              <node concept="3clFbC" id="797ZNR2kqtC" role="3clFbw">
-                <node concept="10Nm6u" id="797ZNR2kqLi" role="3uHU7w" />
-                <node concept="37vLTw" id="797ZNR2kq65" role="3uHU7B">
-                  <ref role="3cqZAo" node="6sjp2R1Xvw4" resolve="changeEffect" />
+            </node>
+            <node concept="2ShNRf" id="797ZNR2kkwW" role="33vP2m">
+              <node concept="2Jqq0_" id="797ZNR2kkwX" role="2ShVmc">
+                <node concept="3uibUv" id="797ZNR2kkwY" role="HW$YZ">
+                  <ref role="3uigEE" node="2S2eLhiM$hD" resolve="ValueHolderInfo" />
                 </node>
               </node>
             </node>
-            <node concept="3clFbH" id="797ZNR2jSzk" role="3cqZAp" />
-            <node concept="3cpWs8" id="797ZNR2kka8" role="3cqZAp">
-              <node concept="3cpWsn" id="797ZNR2kkab" role="3cpWs9">
-                <property role="TrG5h" value="visitedParticipants" />
-                <node concept="_YKpA" id="797ZNR2kka4" role="1tU5fm">
-                  <node concept="3uibUv" id="797ZNR2kkrE" role="_ZDj9">
-                    <ref role="3uigEE" node="2S2eLhiM$hD" resolve="ValueHolderInfo" />
-                  </node>
-                </node>
-                <node concept="2ShNRf" id="797ZNR2kkwW" role="33vP2m">
-                  <node concept="2Jqq0_" id="797ZNR2kkwX" role="2ShVmc">
-                    <node concept="3uibUv" id="797ZNR2kkwY" role="HW$YZ">
-                      <ref role="3uigEE" node="2S2eLhiM$hD" resolve="ValueHolderInfo" />
-                    </node>
-                  </node>
-                </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="7QXl$ZOIJu5" role="3cqZAp" />
+        <node concept="3clFbF" id="ymtTuKAgNy" role="3cqZAp">
+          <node concept="1rXfSq" id="ymtTuKAgNw" role="3clFbG">
+            <ref role="37wK5l" node="RObVTFmWkR" resolve="invalidate" />
+            <node concept="2OqwBi" id="ymtTuKAhCS" role="37wK5m">
+              <node concept="37vLTw" id="ymtTuKAhr6" role="2Oq$k0">
+                <ref role="3cqZAo" node="6sjp2R1Xvw4" resolve="changeEffect" />
+              </node>
+              <node concept="liA8E" id="ymtTuKAhTg" role="2OqNvi">
+                <ref role="37wK5l" node="797ZNR2jJms" resolve="getKind" />
               </node>
             </node>
-            <node concept="3clFbH" id="7QXl$ZOIJu5" role="3cqZAp" />
-            <node concept="3clFbF" id="ymtTuKAgNy" role="3cqZAp">
-              <node concept="1rXfSq" id="ymtTuKAgNw" role="3clFbG">
-                <ref role="37wK5l" node="RObVTFmWkR" resolve="invalidate" />
-                <node concept="2OqwBi" id="ymtTuKAhCS" role="37wK5m">
-                  <node concept="37vLTw" id="ymtTuKAhr6" role="2Oq$k0">
+            <node concept="37vLTw" id="ymtTuKAifV" role="37wK5m">
+              <ref role="3cqZAo" node="797ZNR2kkab" resolve="visitedParticipants" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="7QXl$ZOIJfV" role="3cqZAp" />
+        <node concept="3clFbJ" id="ymtTuKAiPZ" role="3cqZAp">
+          <node concept="3clFbS" id="ymtTuKAiQ1" role="3clFbx">
+            <node concept="3clFbF" id="797ZNR2jNaq" role="3cqZAp">
+              <node concept="2OqwBi" id="797ZNR2jOz4" role="3clFbG">
+                <node concept="2OqwBi" id="797ZNR2jNiU" role="2Oq$k0">
+                  <node concept="37vLTw" id="797ZNR2jNao" role="2Oq$k0">
                     <ref role="3cqZAo" node="6sjp2R1Xvw4" resolve="changeEffect" />
                   </node>
-                  <node concept="liA8E" id="ymtTuKAhTg" role="2OqNvi">
-                    <ref role="37wK5l" node="797ZNR2jJms" resolve="getKind" />
-                  </node>
-                </node>
-                <node concept="37vLTw" id="ymtTuKAifV" role="37wK5m">
-                  <ref role="3cqZAo" node="797ZNR2kkab" resolve="visitedParticipants" />
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbH" id="7QXl$ZOIJfV" role="3cqZAp" />
-            <node concept="3clFbJ" id="ymtTuKAiPZ" role="3cqZAp">
-              <node concept="3clFbS" id="ymtTuKAiQ1" role="3clFbx">
-                <node concept="3clFbF" id="797ZNR2jNaq" role="3cqZAp">
-                  <node concept="2OqwBi" id="797ZNR2jOz4" role="3clFbG">
-                    <node concept="2OqwBi" id="797ZNR2jNiU" role="2Oq$k0">
-                      <node concept="37vLTw" id="797ZNR2jNao" role="2Oq$k0">
-                        <ref role="3cqZAo" node="6sjp2R1Xvw4" resolve="changeEffect" />
-                      </node>
-                      <node concept="liA8E" id="797ZNR2jNuA" role="2OqNvi">
-                        <ref role="37wK5l" node="797ZNR2jK0W" resolve="getInvalidationHint" />
-                      </node>
-                    </node>
-                    <node concept="2es0OD" id="797ZNR2jQsX" role="2OqNvi">
-                      <node concept="1bVj0M" id="797ZNR2jQsZ" role="23t8la">
-                        <node concept="3clFbS" id="797ZNR2jQt0" role="1bW5cS">
-                          <node concept="3clFbF" id="797ZNR2jVNn" role="3cqZAp">
-                            <node concept="2OqwBi" id="797ZNR2jWWe" role="3clFbG">
-                              <node concept="2OqwBi" id="797ZNR2jVY8" role="2Oq$k0">
-                                <node concept="37vLTw" id="797ZNR2jVNl" role="2Oq$k0">
-                                  <ref role="3cqZAo" node="797ZNR2jQt1" resolve="it" />
-                                </node>
-                                <node concept="2qgKlT" id="797ZNR2jWI_" role="2OqNvi">
-                                  <ref role="37wK5l" to="ao0u:2S2eLhiM$ey" resolve="getValueHolderInfo" />
-                                </node>
-                              </node>
-                              <node concept="liA8E" id="797ZNR2jXbM" role="2OqNvi">
-                                <ref role="37wK5l" node="RObVTFmZbg" resolve="invalidate" />
-                                <node concept="37vLTw" id="797ZNR2jXqn" role="37wK5m">
-                                  <ref role="3cqZAo" node="RObVTFnnYE" resolve="_valueSelector" />
-                                </node>
-                                <node concept="2OqwBi" id="797ZNR2kjms" role="37wK5m">
-                                  <node concept="37vLTw" id="797ZNR2kj4w" role="2Oq$k0">
-                                    <ref role="3cqZAo" node="6sjp2R1Xvw4" resolve="changeEffect" />
-                                  </node>
-                                  <node concept="liA8E" id="797ZNR2kjJw" role="2OqNvi">
-                                    <ref role="37wK5l" node="797ZNR2jJms" resolve="getKind" />
-                                  </node>
-                                </node>
-                                <node concept="37vLTw" id="797ZNR2kkQt" role="37wK5m">
-                                  <ref role="3cqZAo" node="797ZNR2kkab" resolve="visitedParticipants" />
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="Rh6nW" id="797ZNR2jQt1" role="1bW2Oz">
-                          <property role="TrG5h" value="it" />
-                          <node concept="2jxLKc" id="797ZNR2jQt2" role="1tU5fm" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="3y3z36" id="ymtTuKAngl" role="3clFbw">
-                <node concept="10Nm6u" id="ymtTuKAnum" role="3uHU7w" />
-                <node concept="2OqwBi" id="ymtTuKAjkF" role="3uHU7B">
-                  <node concept="37vLTw" id="ymtTuKAj5e" role="2Oq$k0">
-                    <ref role="3cqZAo" node="6sjp2R1Xvw4" resolve="changeEffect" />
-                  </node>
-                  <node concept="liA8E" id="ymtTuKAjEH" role="2OqNvi">
+                  <node concept="liA8E" id="797ZNR2jNuA" role="2OqNvi">
                     <ref role="37wK5l" node="797ZNR2jK0W" resolve="getInvalidationHint" />
                   </node>
                 </node>
+                <node concept="2es0OD" id="797ZNR2jQsX" role="2OqNvi">
+                  <node concept="1bVj0M" id="797ZNR2jQsZ" role="23t8la">
+                    <node concept="3clFbS" id="797ZNR2jQt0" role="1bW5cS">
+                      <node concept="3clFbF" id="797ZNR2jVNn" role="3cqZAp">
+                        <node concept="2OqwBi" id="797ZNR2jWWe" role="3clFbG">
+                          <node concept="2OqwBi" id="797ZNR2jVY8" role="2Oq$k0">
+                            <node concept="37vLTw" id="797ZNR2jVNl" role="2Oq$k0">
+                              <ref role="3cqZAo" node="797ZNR2jQt1" resolve="it" />
+                            </node>
+                            <node concept="2qgKlT" id="797ZNR2jWI_" role="2OqNvi">
+                              <ref role="37wK5l" to="ao0u:2S2eLhiM$ey" resolve="getValueHolderInfo" />
+                            </node>
+                          </node>
+                          <node concept="liA8E" id="797ZNR2jXbM" role="2OqNvi">
+                            <ref role="37wK5l" node="RObVTFmZbg" resolve="invalidate" />
+                            <node concept="37vLTw" id="797ZNR2jXqn" role="37wK5m">
+                              <ref role="3cqZAo" node="RObVTFnnYE" resolve="_valueSelector" />
+                            </node>
+                            <node concept="2OqwBi" id="797ZNR2kjms" role="37wK5m">
+                              <node concept="37vLTw" id="797ZNR2kj4w" role="2Oq$k0">
+                                <ref role="3cqZAo" node="6sjp2R1Xvw4" resolve="changeEffect" />
+                              </node>
+                              <node concept="liA8E" id="797ZNR2kjJw" role="2OqNvi">
+                                <ref role="37wK5l" node="797ZNR2jJms" resolve="getKind" />
+                              </node>
+                            </node>
+                            <node concept="37vLTw" id="797ZNR2kkQt" role="37wK5m">
+                              <ref role="3cqZAo" node="797ZNR2kkab" resolve="visitedParticipants" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="Rh6nW" id="797ZNR2jQt1" role="1bW2Oz">
+                      <property role="TrG5h" value="it" />
+                      <node concept="2jxLKc" id="797ZNR2jQt2" role="1tU5fm" />
+                    </node>
+                  </node>
+                </node>
               </node>
             </node>
-            <node concept="3clFbH" id="5nAcTtnbwtr" role="3cqZAp" />
-            <node concept="2Gpval" id="5nAcTtnbygb" role="3cqZAp">
-              <node concept="2GrKxI" id="5nAcTtnbygd" role="2Gsz3X">
-                <property role="TrG5h" value="participant" />
+          </node>
+          <node concept="3y3z36" id="ymtTuKAngl" role="3clFbw">
+            <node concept="10Nm6u" id="ymtTuKAnum" role="3uHU7w" />
+            <node concept="2OqwBi" id="ymtTuKAjkF" role="3uHU7B">
+              <node concept="37vLTw" id="ymtTuKAj5e" role="2Oq$k0">
+                <ref role="3cqZAo" node="6sjp2R1Xvw4" resolve="changeEffect" />
               </node>
-              <node concept="2OqwBi" id="1kbsEhJFqsA" role="2GsD0m">
-                <node concept="37vLTw" id="5nAcTtnbyka" role="2Oq$k0">
-                  <ref role="3cqZAo" node="797ZNR2kkab" resolve="visitedParticipants" />
+              <node concept="liA8E" id="ymtTuKAjEH" role="2OqNvi">
+                <ref role="37wK5l" node="797ZNR2jK0W" resolve="getInvalidationHint" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="5nAcTtnbwtr" role="3cqZAp" />
+        <node concept="2Gpval" id="5nAcTtnbygb" role="3cqZAp">
+          <node concept="2GrKxI" id="5nAcTtnbygd" role="2Gsz3X">
+            <property role="TrG5h" value="participant" />
+          </node>
+          <node concept="2OqwBi" id="1kbsEhJFqsA" role="2GsD0m">
+            <node concept="37vLTw" id="5nAcTtnbyka" role="2Oq$k0">
+              <ref role="3cqZAo" node="797ZNR2kkab" resolve="visitedParticipants" />
+            </node>
+            <node concept="3$u5V9" id="1kbsEhJFrAC" role="2OqNvi">
+              <node concept="1bVj0M" id="1kbsEhJFrAE" role="23t8la">
+                <node concept="3clFbS" id="1kbsEhJFrAF" role="1bW5cS">
+                  <node concept="3clFbF" id="1kbsEhJFrG6" role="3cqZAp">
+                    <node concept="2OqwBi" id="1kbsEhJFrXv" role="3clFbG">
+                      <node concept="37vLTw" id="1kbsEhJFrG5" role="2Oq$k0">
+                        <ref role="3cqZAo" node="1kbsEhJFrAG" resolve="it" />
+                      </node>
+                      <node concept="liA8E" id="1kbsEhJFskH" role="2OqNvi">
+                        <ref role="37wK5l" node="RObVTFnwug" resolve="getValueHolder" />
+                      </node>
+                    </node>
+                  </node>
                 </node>
-                <node concept="3$u5V9" id="1kbsEhJFrAC" role="2OqNvi">
-                  <node concept="1bVj0M" id="1kbsEhJFrAE" role="23t8la">
-                    <node concept="3clFbS" id="1kbsEhJFrAF" role="1bW5cS">
-                      <node concept="3clFbF" id="1kbsEhJFrG6" role="3cqZAp">
-                        <node concept="2OqwBi" id="1kbsEhJFrXv" role="3clFbG">
-                          <node concept="37vLTw" id="1kbsEhJFrG5" role="2Oq$k0">
-                            <ref role="3cqZAo" node="1kbsEhJFrAG" resolve="it" />
+                <node concept="Rh6nW" id="1kbsEhJFrAG" role="1bW2Oz">
+                  <property role="TrG5h" value="it" />
+                  <node concept="2jxLKc" id="1kbsEhJFrAH" role="1tU5fm" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbS" id="5nAcTtnbygh" role="2LFqv$">
+            <node concept="3clFbJ" id="1kbsEhJFmV8" role="3cqZAp">
+              <node concept="3clFbS" id="1kbsEhJFmVa" role="3clFbx">
+                <node concept="3SKdUt" id="3u1dQqyVxyT" role="3cqZAp">
+                  <node concept="3SKdUq" id="3u1dQqyVxyV" role="3SKWNk">
+                    <property role="3SKdUp" value="TODO: EditorComponentHacks does not seem to work? no instances are returned..." />
+                  </node>
+                </node>
+                <node concept="3clFbF" id="4bmM0avMFe_" role="3cqZAp">
+                  <node concept="2OqwBi" id="4bmM0avMFeA" role="3clFbG">
+                    <node concept="2OqwBi" id="4bmM0avMFeB" role="2Oq$k0">
+                      <node concept="2YIFZM" id="5nAcTtnbD$w" role="2Oq$k0">
+                        <ref role="37wK5l" to="kvq8:2WlJ6VKOSU7" resolve="findAllInstances" />
+                        <ref role="1Pybhc" to="kvq8:2WlJ6VKOwRU" resolve="EditorComponentHacks" />
+                      </node>
+                      <node concept="3zZkjj" id="4bmM0avMFeD" role="2OqNvi">
+                        <node concept="1bVj0M" id="4bmM0avMFeE" role="23t8la">
+                          <node concept="3clFbS" id="4bmM0avMFeF" role="1bW5cS">
+                            <node concept="3clFbF" id="4bmM0avMFeG" role="3cqZAp">
+                              <node concept="3clFbC" id="4bmM0avMFeH" role="3clFbG">
+                                <node concept="2OqwBi" id="4bmM0avMFeJ" role="3uHU7B">
+                                  <node concept="2OqwBi" id="4bmM0avMFeK" role="2Oq$k0">
+                                    <node concept="37vLTw" id="4bmM0avMFeL" role="2Oq$k0">
+                                      <ref role="3cqZAo" node="4bmM0avMFeO" resolve="it" />
+                                    </node>
+                                    <node concept="liA8E" id="4bmM0avMFeM" role="2OqNvi">
+                                      <ref role="37wK5l" to="exr9:~EditorComponent.getRootCell():jetbrains.mps.nodeEditor.cells.EditorCell" resolve="getRootCell" />
+                                    </node>
+                                  </node>
+                                  <node concept="liA8E" id="4bmM0avMFeN" role="2OqNvi">
+                                    <ref role="37wK5l" to="f4zo:~EditorCell.getSNode():org.jetbrains.mps.openapi.model.SNode" resolve="getSNode" />
+                                  </node>
+                                </node>
+                                <node concept="2GrUjf" id="3u1dQqyUAO2" role="3uHU7w">
+                                  <ref role="2Gs0qQ" node="5nAcTtnbygd" resolve="participant" />
+                                </node>
+                              </node>
+                            </node>
                           </node>
-                          <node concept="liA8E" id="1kbsEhJFskH" role="2OqNvi">
-                            <ref role="37wK5l" node="RObVTFnwug" resolve="getValueHolder" />
+                          <node concept="Rh6nW" id="4bmM0avMFeO" role="1bW2Oz">
+                            <property role="TrG5h" value="it" />
+                            <node concept="2jxLKc" id="4bmM0avMFeP" role="1tU5fm" />
                           </node>
                         </node>
                       </node>
                     </node>
-                    <node concept="Rh6nW" id="1kbsEhJFrAG" role="1bW2Oz">
-                      <property role="TrG5h" value="it" />
-                      <node concept="2jxLKc" id="1kbsEhJFrAH" role="1tU5fm" />
+                    <node concept="2es0OD" id="4bmM0avMFeQ" role="2OqNvi">
+                      <node concept="1bVj0M" id="4bmM0avMFeR" role="23t8la">
+                        <node concept="3clFbS" id="4bmM0avMFeS" role="1bW5cS">
+                          <node concept="3clFbF" id="4bmM0avMFeT" role="3cqZAp">
+                            <node concept="2OqwBi" id="4bmM0avMFeU" role="3clFbG">
+                              <node concept="37vLTw" id="4bmM0avMFeV" role="2Oq$k0">
+                                <ref role="3cqZAo" node="4bmM0avMFeX" resolve="it" />
+                              </node>
+                              <node concept="liA8E" id="4bmM0avMFeW" role="2OqNvi">
+                                <ref role="37wK5l" to="exr9:~EditorComponent.update():void" resolve="update" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="Rh6nW" id="4bmM0avMFeX" role="1bW2Oz">
+                          <property role="TrG5h" value="it" />
+                          <node concept="2jxLKc" id="4bmM0avMFeY" role="1tU5fm" />
+                        </node>
+                      </node>
                     </node>
                   </node>
                 </node>
               </node>
-              <node concept="3clFbS" id="5nAcTtnbygh" role="2LFqv$">
-                <node concept="3clFbJ" id="1kbsEhJFmV8" role="3cqZAp">
-                  <node concept="3clFbS" id="1kbsEhJFmVa" role="3clFbx">
-                    <node concept="3SKdUt" id="3u1dQqyVxyT" role="3cqZAp">
-                      <node concept="3SKdUq" id="3u1dQqyVxyV" role="3SKWNk">
-                        <property role="3SKdUp" value="TODO: EditorComponentHacks does not seem to work? no instances are returned..." />
-                      </node>
-                    </node>
-                    <node concept="3clFbF" id="4bmM0avMFe_" role="3cqZAp">
-                      <node concept="2OqwBi" id="4bmM0avMFeA" role="3clFbG">
-                        <node concept="2OqwBi" id="4bmM0avMFeB" role="2Oq$k0">
-                          <node concept="2YIFZM" id="5nAcTtnbD$w" role="2Oq$k0">
-                            <ref role="37wK5l" to="kvq8:2WlJ6VKOSU7" resolve="findAllInstances" />
-                            <ref role="1Pybhc" to="kvq8:2WlJ6VKOwRU" resolve="EditorComponentHacks" />
-                          </node>
-                          <node concept="3zZkjj" id="4bmM0avMFeD" role="2OqNvi">
-                            <node concept="1bVj0M" id="4bmM0avMFeE" role="23t8la">
-                              <node concept="3clFbS" id="4bmM0avMFeF" role="1bW5cS">
-                                <node concept="3clFbF" id="4bmM0avMFeG" role="3cqZAp">
-                                  <node concept="3clFbC" id="4bmM0avMFeH" role="3clFbG">
-                                    <node concept="2OqwBi" id="4bmM0avMFeJ" role="3uHU7B">
-                                      <node concept="2OqwBi" id="4bmM0avMFeK" role="2Oq$k0">
-                                        <node concept="37vLTw" id="4bmM0avMFeL" role="2Oq$k0">
-                                          <ref role="3cqZAo" node="4bmM0avMFeO" resolve="it" />
-                                        </node>
-                                        <node concept="liA8E" id="4bmM0avMFeM" role="2OqNvi">
-                                          <ref role="37wK5l" to="exr9:~EditorComponent.getRootCell():jetbrains.mps.nodeEditor.cells.EditorCell" resolve="getRootCell" />
-                                        </node>
-                                      </node>
-                                      <node concept="liA8E" id="4bmM0avMFeN" role="2OqNvi">
-                                        <ref role="37wK5l" to="f4zo:~EditorCell.getSNode():org.jetbrains.mps.openapi.model.SNode" resolve="getSNode" />
-                                      </node>
-                                    </node>
-                                    <node concept="2GrUjf" id="3u1dQqyUAO2" role="3uHU7w">
-                                      <ref role="2Gs0qQ" node="5nAcTtnbygd" resolve="participant" />
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                              <node concept="Rh6nW" id="4bmM0avMFeO" role="1bW2Oz">
-                                <property role="TrG5h" value="it" />
-                                <node concept="2jxLKc" id="4bmM0avMFeP" role="1tU5fm" />
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="2es0OD" id="4bmM0avMFeQ" role="2OqNvi">
-                          <node concept="1bVj0M" id="4bmM0avMFeR" role="23t8la">
-                            <node concept="3clFbS" id="4bmM0avMFeS" role="1bW5cS">
-                              <node concept="3clFbF" id="4bmM0avMFeT" role="3cqZAp">
-                                <node concept="2OqwBi" id="4bmM0avMFeU" role="3clFbG">
-                                  <node concept="37vLTw" id="4bmM0avMFeV" role="2Oq$k0">
-                                    <ref role="3cqZAo" node="4bmM0avMFeX" resolve="it" />
-                                  </node>
-                                  <node concept="liA8E" id="4bmM0avMFeW" role="2OqNvi">
-                                    <ref role="37wK5l" to="exr9:~EditorComponent.update():void" resolve="update" />
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                            <node concept="Rh6nW" id="4bmM0avMFeX" role="1bW2Oz">
-                              <property role="TrG5h" value="it" />
-                              <node concept="2jxLKc" id="4bmM0avMFeY" role="1tU5fm" />
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="2OqwBi" id="1kbsEhJFtm6" role="3clFbw">
-                    <node concept="2GrUjf" id="1kbsEhJFsWq" role="2Oq$k0">
-                      <ref role="2Gs0qQ" node="5nAcTtnbygd" resolve="participant" />
-                    </node>
-                    <node concept="2qgKlT" id="1kbsEhJFtJH" role="2OqNvi">
-                      <ref role="37wK5l" to="ao0u:5nAcTtnb1YA" resolve="isEditorUpdateEnabled" />
-                      <node concept="37vLTw" id="1kbsEhJFtPS" role="37wK5m">
-                        <ref role="3cqZAo" node="RObVTFnnYE" resolve="_valueSelector" />
-                      </node>
-                    </node>
+              <node concept="2OqwBi" id="1kbsEhJFtm6" role="3clFbw">
+                <node concept="2GrUjf" id="1kbsEhJFsWq" role="2Oq$k0">
+                  <ref role="2Gs0qQ" node="5nAcTtnbygd" resolve="participant" />
+                </node>
+                <node concept="2qgKlT" id="1kbsEhJFtJH" role="2OqNvi">
+                  <ref role="37wK5l" to="ao0u:5nAcTtnb1YA" resolve="isEditorUpdateEnabled" />
+                  <node concept="37vLTw" id="1kbsEhJFtPS" role="37wK5m">
+                    <ref role="3cqZAo" node="RObVTFnnYE" resolve="_valueSelector" />
                   </node>
                 </node>
               </node>
@@ -2458,135 +2387,128 @@
       <property role="DiZV1" value="false" />
       <property role="2aFKle" value="false" />
       <node concept="3clFbS" id="2_5DHynEXdY" role="3clF47">
-        <node concept="1HWtB8" id="2YOONxNW2Jb" role="3cqZAp">
-          <node concept="3VsKOn" id="2YOONxNW2Jc" role="1HWFw0">
-            <ref role="3VsUkX" node="7ZWgXq7GlHg" resolve="ValueCache" />
+        <node concept="3cpWs8" id="2_5DHynEZEE" role="3cqZAp">
+          <node concept="3cpWsn" id="2_5DHynEZEF" role="3cpWs9">
+            <property role="TrG5h" value="sb" />
+            <node concept="3uibUv" id="2_5DHynEZEG" role="1tU5fm">
+              <ref role="3uigEE" to="wyt6:~StringBuilder" resolve="StringBuilder" />
+            </node>
+            <node concept="2ShNRf" id="2_5DHynEZMm" role="33vP2m">
+              <node concept="1pGfFk" id="2_5DHynEZZd" role="2ShVmc">
+                <ref role="37wK5l" to="wyt6:~StringBuilder.&lt;init&gt;()" resolve="StringBuilder" />
+              </node>
+            </node>
           </node>
-          <node concept="3clFbS" id="2YOONxNW2Jd" role="1HWHxc">
-            <node concept="3cpWs8" id="2_5DHynEZEE" role="3cqZAp">
-              <node concept="3cpWsn" id="2_5DHynEZEF" role="3cpWs9">
-                <property role="TrG5h" value="sb" />
-                <node concept="3uibUv" id="2_5DHynEZEG" role="1tU5fm">
-                  <ref role="3uigEE" to="wyt6:~StringBuilder" resolve="StringBuilder" />
-                </node>
-                <node concept="2ShNRf" id="2_5DHynEZMm" role="33vP2m">
-                  <node concept="1pGfFk" id="2_5DHynEZZd" role="2ShVmc">
-                    <ref role="37wK5l" to="wyt6:~StringBuilder.&lt;init&gt;()" resolve="StringBuilder" />
-                  </node>
-                </node>
+        </node>
+        <node concept="3clFbF" id="2_5DHynF4CP" role="3cqZAp">
+          <node concept="2OqwBi" id="2_5DHynF53u" role="3clFbG">
+            <node concept="37vLTw" id="2_5DHynF4CN" role="2Oq$k0">
+              <ref role="3cqZAo" node="2_5DHynEZEF" resolve="sb" />
+            </node>
+            <node concept="liA8E" id="2_5DHynF5JA" role="2OqNvi">
+              <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String):java.lang.StringBuilder" resolve="append" />
+              <node concept="Xl_RD" id="2_5DHynF5LD" role="37wK5m">
+                <property role="Xl_RC" value="SOURCES:\n" />
               </node>
             </node>
-            <node concept="3clFbF" id="2_5DHynF4CP" role="3cqZAp">
-              <node concept="2OqwBi" id="2_5DHynF53u" role="3clFbG">
-                <node concept="37vLTw" id="2_5DHynF4CN" role="2Oq$k0">
+          </node>
+        </node>
+        <node concept="2Gpval" id="2_5DHynEZ8H" role="3cqZAp">
+          <node concept="2GrKxI" id="2_5DHynEZ8I" role="2Gsz3X">
+            <property role="TrG5h" value="source" />
+          </node>
+          <node concept="37vLTw" id="2_5DHynEZeZ" role="2GsD0m">
+            <ref role="3cqZAo" node="RObVTFnyV1" resolve="_cachedPropagationSources" />
+          </node>
+          <node concept="3clFbS" id="2_5DHynEZ8K" role="2LFqv$">
+            <node concept="3clFbF" id="2_5DHynF01c" role="3cqZAp">
+              <node concept="2OqwBi" id="2_5DHynF0j8" role="3clFbG">
+                <node concept="37vLTw" id="2_5DHynF01b" role="2Oq$k0">
                   <ref role="3cqZAo" node="2_5DHynEZEF" resolve="sb" />
                 </node>
-                <node concept="liA8E" id="2_5DHynF5JA" role="2OqNvi">
+                <node concept="liA8E" id="2_5DHynF0N3" role="2OqNvi">
                   <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String):java.lang.StringBuilder" resolve="append" />
-                  <node concept="Xl_RD" id="2_5DHynF5LD" role="37wK5m">
-                    <property role="Xl_RC" value="SOURCES:\n" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="2Gpval" id="2_5DHynEZ8H" role="3cqZAp">
-              <node concept="2GrKxI" id="2_5DHynEZ8I" role="2Gsz3X">
-                <property role="TrG5h" value="source" />
-              </node>
-              <node concept="37vLTw" id="2_5DHynEZeZ" role="2GsD0m">
-                <ref role="3cqZAo" node="RObVTFnyV1" resolve="_cachedPropagationSources" />
-              </node>
-              <node concept="3clFbS" id="2_5DHynEZ8K" role="2LFqv$">
-                <node concept="3clFbF" id="2_5DHynF01c" role="3cqZAp">
-                  <node concept="2OqwBi" id="2_5DHynF0j8" role="3clFbG">
-                    <node concept="37vLTw" id="2_5DHynF01b" role="2Oq$k0">
-                      <ref role="3cqZAo" node="2_5DHynEZEF" resolve="sb" />
+                  <node concept="3cpWs3" id="2_5DHynFbiw" role="37wK5m">
+                    <node concept="Xl_RD" id="2_5DHynFcgU" role="3uHU7w">
+                      <property role="Xl_RC" value="\n" />
                     </node>
-                    <node concept="liA8E" id="2_5DHynF0N3" role="2OqNvi">
-                      <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String):java.lang.StringBuilder" resolve="append" />
-                      <node concept="3cpWs3" id="2_5DHynFbiw" role="37wK5m">
-                        <node concept="Xl_RD" id="2_5DHynFcgU" role="3uHU7w">
-                          <property role="Xl_RC" value="\n" />
+                    <node concept="2OqwBi" id="2_5DHynF2Mu" role="3uHU7B">
+                      <node concept="2OqwBi" id="2_5DHynF1EX" role="2Oq$k0">
+                        <node concept="2GrUjf" id="2_5DHynF1$0" role="2Oq$k0">
+                          <ref role="2Gs0qQ" node="2_5DHynEZ8I" resolve="source" />
                         </node>
-                        <node concept="2OqwBi" id="2_5DHynF2Mu" role="3uHU7B">
-                          <node concept="2OqwBi" id="2_5DHynF1EX" role="2Oq$k0">
-                            <node concept="2GrUjf" id="2_5DHynF1$0" role="2Oq$k0">
-                              <ref role="2Gs0qQ" node="2_5DHynEZ8I" resolve="source" />
-                            </node>
-                            <node concept="liA8E" id="2_5DHynF1VX" role="2OqNvi">
-                              <ref role="37wK5l" node="RObVTFnwug" resolve="getValueHolder" />
-                            </node>
-                          </node>
-                          <node concept="2qgKlT" id="2_5DHynF3Qz" role="2OqNvi">
-                            <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
-                          </node>
+                        <node concept="liA8E" id="2_5DHynF1VX" role="2OqNvi">
+                          <ref role="37wK5l" node="RObVTFnwug" resolve="getValueHolder" />
                         </node>
+                      </node>
+                      <node concept="2qgKlT" id="2_5DHynF3Qz" role="2OqNvi">
+                        <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
                       </node>
                     </node>
                   </node>
                 </node>
               </node>
             </node>
-            <node concept="3clFbF" id="2_5DHynFeUX" role="3cqZAp">
-              <node concept="2OqwBi" id="2_5DHynFeUY" role="3clFbG">
-                <node concept="37vLTw" id="2_5DHynFeUZ" role="2Oq$k0">
-                  <ref role="3cqZAo" node="2_5DHynEZEF" resolve="sb" />
-                </node>
-                <node concept="liA8E" id="2_5DHynFeV0" role="2OqNvi">
-                  <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String):java.lang.StringBuilder" resolve="append" />
-                  <node concept="Xl_RD" id="2_5DHynFeV1" role="37wK5m">
-                    <property role="Xl_RC" value="TARGETS:\n" />
-                  </node>
-                </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="2_5DHynFeUX" role="3cqZAp">
+          <node concept="2OqwBi" id="2_5DHynFeUY" role="3clFbG">
+            <node concept="37vLTw" id="2_5DHynFeUZ" role="2Oq$k0">
+              <ref role="3cqZAo" node="2_5DHynEZEF" resolve="sb" />
+            </node>
+            <node concept="liA8E" id="2_5DHynFeV0" role="2OqNvi">
+              <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String):java.lang.StringBuilder" resolve="append" />
+              <node concept="Xl_RD" id="2_5DHynFeV1" role="37wK5m">
+                <property role="Xl_RC" value="TARGETS:\n" />
               </node>
             </node>
-            <node concept="2Gpval" id="2_5DHynFeV2" role="3cqZAp">
-              <node concept="2GrKxI" id="2_5DHynFeV3" role="2Gsz3X">
-                <property role="TrG5h" value="target" />
-              </node>
-              <node concept="37vLTw" id="2_5DHynF$0w" role="2GsD0m">
-                <ref role="3cqZAo" node="RObVTFo4eX" resolve="_cachedPropagationTargets" />
-              </node>
-              <node concept="3clFbS" id="2_5DHynFeV5" role="2LFqv$">
-                <node concept="3clFbF" id="2_5DHynFeV6" role="3cqZAp">
-                  <node concept="2OqwBi" id="2_5DHynFeV7" role="3clFbG">
-                    <node concept="37vLTw" id="2_5DHynFeV8" role="2Oq$k0">
-                      <ref role="3cqZAo" node="2_5DHynEZEF" resolve="sb" />
+          </node>
+        </node>
+        <node concept="2Gpval" id="2_5DHynFeV2" role="3cqZAp">
+          <node concept="2GrKxI" id="2_5DHynFeV3" role="2Gsz3X">
+            <property role="TrG5h" value="target" />
+          </node>
+          <node concept="37vLTw" id="2_5DHynF$0w" role="2GsD0m">
+            <ref role="3cqZAo" node="RObVTFo4eX" resolve="_cachedPropagationTargets" />
+          </node>
+          <node concept="3clFbS" id="2_5DHynFeV5" role="2LFqv$">
+            <node concept="3clFbF" id="2_5DHynFeV6" role="3cqZAp">
+              <node concept="2OqwBi" id="2_5DHynFeV7" role="3clFbG">
+                <node concept="37vLTw" id="2_5DHynFeV8" role="2Oq$k0">
+                  <ref role="3cqZAo" node="2_5DHynEZEF" resolve="sb" />
+                </node>
+                <node concept="liA8E" id="2_5DHynFeV9" role="2OqNvi">
+                  <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String):java.lang.StringBuilder" resolve="append" />
+                  <node concept="3cpWs3" id="2_5DHynFeVa" role="37wK5m">
+                    <node concept="Xl_RD" id="2_5DHynFeVb" role="3uHU7w">
+                      <property role="Xl_RC" value="\n" />
                     </node>
-                    <node concept="liA8E" id="2_5DHynFeV9" role="2OqNvi">
-                      <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String):java.lang.StringBuilder" resolve="append" />
-                      <node concept="3cpWs3" id="2_5DHynFeVa" role="37wK5m">
-                        <node concept="Xl_RD" id="2_5DHynFeVb" role="3uHU7w">
-                          <property role="Xl_RC" value="\n" />
+                    <node concept="2OqwBi" id="2_5DHynFeVc" role="3uHU7B">
+                      <node concept="2OqwBi" id="2_5DHynFeVd" role="2Oq$k0">
+                        <node concept="2GrUjf" id="2_5DHynFeVe" role="2Oq$k0">
+                          <ref role="2Gs0qQ" node="2_5DHynFeV3" resolve="target" />
                         </node>
-                        <node concept="2OqwBi" id="2_5DHynFeVc" role="3uHU7B">
-                          <node concept="2OqwBi" id="2_5DHynFeVd" role="2Oq$k0">
-                            <node concept="2GrUjf" id="2_5DHynFeVe" role="2Oq$k0">
-                              <ref role="2Gs0qQ" node="2_5DHynFeV3" resolve="target" />
-                            </node>
-                            <node concept="liA8E" id="2_5DHynFeVf" role="2OqNvi">
-                              <ref role="37wK5l" node="RObVTFnwug" resolve="getValueHolder" />
-                            </node>
-                          </node>
-                          <node concept="2qgKlT" id="2_5DHynFeVg" role="2OqNvi">
-                            <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
-                          </node>
+                        <node concept="liA8E" id="2_5DHynFeVf" role="2OqNvi">
+                          <ref role="37wK5l" node="RObVTFnwug" resolve="getValueHolder" />
                         </node>
+                      </node>
+                      <node concept="2qgKlT" id="2_5DHynFeVg" role="2OqNvi">
+                        <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
                       </node>
                     </node>
                   </node>
                 </node>
               </node>
             </node>
-            <node concept="3cpWs6" id="2_5DHynF$mB" role="3cqZAp">
-              <node concept="2OqwBi" id="2_5DHynF$Tk" role="3cqZAk">
-                <node concept="37vLTw" id="2_5DHynF$oH" role="2Oq$k0">
-                  <ref role="3cqZAo" node="2_5DHynEZEF" resolve="sb" />
-                </node>
-                <node concept="liA8E" id="2_5DHynFB3H" role="2OqNvi">
-                  <ref role="37wK5l" to="wyt6:~StringBuilder.toString():java.lang.String" resolve="toString" />
-                </node>
-              </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="2_5DHynF$mB" role="3cqZAp">
+          <node concept="2OqwBi" id="2_5DHynF$Tk" role="3cqZAk">
+            <node concept="37vLTw" id="2_5DHynF$oH" role="2Oq$k0">
+              <ref role="3cqZAo" node="2_5DHynEZEF" resolve="sb" />
+            </node>
+            <node concept="liA8E" id="2_5DHynFB3H" role="2OqNvi">
+              <ref role="37wK5l" to="wyt6:~StringBuilder.toString():java.lang.String" resolve="toString" />
             </node>
           </node>
         </node>
@@ -2596,6 +2518,7 @@
         <ref role="3uigEE" to="wyt6:~String" resolve="String" />
       </node>
     </node>
+    <node concept="2tJIrI" id="6sjp2R1WAzf" role="jymVt" />
     <node concept="3Tm1VV" id="7ZWgXq7GlHh" role="1B3o_S" />
   </node>
   <node concept="Qs71p" id="6sjp2R1XhkT">

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.incrementalcomputation/runtime/models/com.mbeddr.mpsutil.incrementalcomputation.runtime.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.incrementalcomputation/runtime/models/com.mbeddr.mpsutil.incrementalcomputation.runtime.mps
@@ -215,6 +215,10 @@
       <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
       </concept>
+      <concept id="1170075670744" name="jetbrains.mps.baseLanguage.structure.SynchronizedStatement" flags="nn" index="1HWtB8">
+        <child id="1170075728144" name="expression" index="1HWFw0" />
+        <child id="1170075736412" name="block" index="1HWHxc" />
+      </concept>
       <concept id="6329021646629104957" name="jetbrains.mps.baseLanguage.structure.TextCommentPart" flags="nn" index="3SKdUq">
         <property id="6329021646629104958" name="text" index="3SKdUp" />
       </concept>
@@ -223,6 +227,9 @@
       </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
       <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
+      <concept id="1116615150612" name="jetbrains.mps.baseLanguage.structure.ClassifierClassExpression" flags="nn" index="3VsKOn">
+        <reference id="1116615189566" name="classifier" index="3VsUkX" />
+      </concept>
       <concept id="1178893518978" name="jetbrains.mps.baseLanguage.structure.ThisConstructorInvocation" flags="nn" index="1VxSAg" />
     </language>
     <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
@@ -1209,92 +1216,99 @@
       <property role="DiZV1" value="false" />
       <property role="2aFKle" value="false" />
       <node concept="3clFbS" id="5YITc37Stks" role="3clF47">
-        <node concept="3cpWs8" id="2wC5sgtDqNw" role="3cqZAp">
-          <node concept="3cpWsn" id="2wC5sgtDqNz" role="3cpWs9">
-            <property role="TrG5h" value="newSources" />
-            <node concept="2OqwBi" id="2NSCtASs85h" role="33vP2m">
-              <node concept="2OqwBi" id="2wC5sgtDqN_" role="2Oq$k0">
-                <node concept="2qgKlT" id="2wC5sgtDqNB" role="2OqNvi">
-                  <ref role="37wK5l" to="ao0u:2S2eLhiMzhL" resolve="getDependencies" />
-                  <node concept="37vLTw" id="2wC5sgtDqNC" role="37wK5m">
-                    <ref role="3cqZAo" node="RObVTFnnYE" resolve="_valueSelector" />
-                  </node>
-                </node>
-                <node concept="37vLTw" id="2NSCtASrFTm" role="2Oq$k0">
-                  <ref role="3cqZAo" node="2NSCtASrCpE" resolve="_valueHolder" />
-                </node>
-              </node>
-              <node concept="3$u5V9" id="2NSCtASsakn" role="2OqNvi">
-                <node concept="1bVj0M" id="2NSCtASsakp" role="23t8la">
-                  <node concept="3clFbS" id="2NSCtASsakq" role="1bW5cS">
-                    <node concept="3clFbF" id="2NSCtASsaPu" role="3cqZAp">
-                      <node concept="2OqwBi" id="2NSCtASsbhH" role="3clFbG">
-                        <node concept="37vLTw" id="2NSCtASsaPt" role="2Oq$k0">
-                          <ref role="3cqZAo" node="2NSCtASsakr" resolve="it" />
-                        </node>
-                        <node concept="2qgKlT" id="2NSCtASsbPI" role="2OqNvi">
-                          <ref role="37wK5l" to="ao0u:2S2eLhiM$ey" resolve="getValueHolderInfo" />
-                        </node>
+        <node concept="1HWtB8" id="2YOONxNV0nJ" role="3cqZAp">
+          <node concept="3VsKOn" id="2YOONxNV2uq" role="1HWFw0">
+            <ref role="3VsUkX" node="7ZWgXq7GlHg" resolve="ValueCache" />
+          </node>
+          <node concept="3clFbS" id="2YOONxNV0nN" role="1HWHxc">
+            <node concept="3cpWs8" id="2wC5sgtDqNw" role="3cqZAp">
+              <node concept="3cpWsn" id="2wC5sgtDqNz" role="3cpWs9">
+                <property role="TrG5h" value="newSources" />
+                <node concept="2OqwBi" id="2NSCtASs85h" role="33vP2m">
+                  <node concept="2OqwBi" id="2wC5sgtDqN_" role="2Oq$k0">
+                    <node concept="2qgKlT" id="2wC5sgtDqNB" role="2OqNvi">
+                      <ref role="37wK5l" to="ao0u:2S2eLhiMzhL" resolve="getDependencies" />
+                      <node concept="37vLTw" id="2wC5sgtDqNC" role="37wK5m">
+                        <ref role="3cqZAo" node="RObVTFnnYE" resolve="_valueSelector" />
                       </node>
                     </node>
+                    <node concept="37vLTw" id="2NSCtASrFTm" role="2Oq$k0">
+                      <ref role="3cqZAo" node="2NSCtASrCpE" resolve="_valueHolder" />
+                    </node>
                   </node>
-                  <node concept="Rh6nW" id="2NSCtASsakr" role="1bW2Oz">
-                    <property role="TrG5h" value="it" />
-                    <node concept="2jxLKc" id="2NSCtASsaks" role="1tU5fm" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="A3Dl8" id="50uWDT$I$gC" role="1tU5fm">
-              <node concept="3uibUv" id="2NSCtASsFmb" role="A3Ik2">
-                <ref role="3uigEE" node="2S2eLhiM$hD" resolve="ValueHolderInfo" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="2wC5sgtDg1R" role="3cqZAp">
-          <node concept="2OqwBi" id="2wC5sgtDhsU" role="3clFbG">
-            <node concept="37vLTw" id="2wC5sgtDsXB" role="2Oq$k0">
-              <ref role="3cqZAo" node="2wC5sgtDqNz" resolve="newSources" />
-            </node>
-            <node concept="2es0OD" id="2wC5sgtDjPt" role="2OqNvi">
-              <node concept="1bVj0M" id="2wC5sgtDjPv" role="23t8la">
-                <node concept="3clFbS" id="2wC5sgtDjPw" role="1bW5cS">
-                  <node concept="3clFbF" id="2wC5sgtDjZT" role="3cqZAp">
-                    <node concept="2OqwBi" id="2NSCtASsPAV" role="3clFbG">
-                      <node concept="37vLTw" id="2wC5sgtDjZS" role="2Oq$k0">
-                        <ref role="3cqZAo" node="2wC5sgtDjPx" resolve="source" />
+                  <node concept="3$u5V9" id="2NSCtASsakn" role="2OqNvi">
+                    <node concept="1bVj0M" id="2NSCtASsakp" role="23t8la">
+                      <node concept="3clFbS" id="2NSCtASsakq" role="1bW5cS">
+                        <node concept="3clFbF" id="2NSCtASsaPu" role="3cqZAp">
+                          <node concept="2OqwBi" id="2NSCtASsbhH" role="3clFbG">
+                            <node concept="37vLTw" id="2NSCtASsaPt" role="2Oq$k0">
+                              <ref role="3cqZAo" node="2NSCtASsakr" resolve="it" />
+                            </node>
+                            <node concept="2qgKlT" id="2NSCtASsbPI" role="2OqNvi">
+                              <ref role="37wK5l" to="ao0u:2S2eLhiM$ey" resolve="getValueHolderInfo" />
+                            </node>
+                          </node>
+                        </node>
                       </node>
-                      <node concept="liA8E" id="2NSCtASsPNP" role="2OqNvi">
-                        <ref role="37wK5l" node="RObVTFoPhX" resolve="addPropagationTarget" />
-                        <node concept="37vLTw" id="2NSCtASsQ9_" role="37wK5m">
-                          <ref role="3cqZAo" node="RObVTFnnYE" resolve="_valueSelector" />
-                        </node>
-                        <node concept="37vLTw" id="2NSCtASsQ9A" role="37wK5m">
-                          <ref role="3cqZAo" node="2NSCtASruBg" resolve="_valueHolderInfo" />
-                        </node>
+                      <node concept="Rh6nW" id="2NSCtASsakr" role="1bW2Oz">
+                        <property role="TrG5h" value="it" />
+                        <node concept="2jxLKc" id="2NSCtASsaks" role="1tU5fm" />
                       </node>
                     </node>
                   </node>
                 </node>
-                <node concept="Rh6nW" id="2wC5sgtDjPx" role="1bW2Oz">
-                  <property role="TrG5h" value="source" />
-                  <node concept="2jxLKc" id="2wC5sgtDjPy" role="1tU5fm" />
+                <node concept="A3Dl8" id="50uWDT$I$gC" role="1tU5fm">
+                  <node concept="3uibUv" id="2NSCtASsFmb" role="A3Ik2">
+                    <ref role="3uigEE" node="2S2eLhiM$hD" resolve="ValueHolderInfo" />
+                  </node>
                 </node>
               </node>
             </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="2wC5sgtDvOA" role="3cqZAp">
-          <node concept="37vLTI" id="2wC5sgtDA02" role="3clFbG">
-            <node concept="2OqwBi" id="50uWDT$I_cC" role="37vLTx">
-              <node concept="37vLTw" id="2wC5sgtDAIk" role="2Oq$k0">
-                <ref role="3cqZAo" node="2wC5sgtDqNz" resolve="newSources" />
+            <node concept="3clFbF" id="2wC5sgtDg1R" role="3cqZAp">
+              <node concept="2OqwBi" id="2wC5sgtDhsU" role="3clFbG">
+                <node concept="37vLTw" id="2wC5sgtDsXB" role="2Oq$k0">
+                  <ref role="3cqZAo" node="2wC5sgtDqNz" resolve="newSources" />
+                </node>
+                <node concept="2es0OD" id="2wC5sgtDjPt" role="2OqNvi">
+                  <node concept="1bVj0M" id="2wC5sgtDjPv" role="23t8la">
+                    <node concept="3clFbS" id="2wC5sgtDjPw" role="1bW5cS">
+                      <node concept="3clFbF" id="2wC5sgtDjZT" role="3cqZAp">
+                        <node concept="2OqwBi" id="2NSCtASsPAV" role="3clFbG">
+                          <node concept="37vLTw" id="2wC5sgtDjZS" role="2Oq$k0">
+                            <ref role="3cqZAo" node="2wC5sgtDjPx" resolve="source" />
+                          </node>
+                          <node concept="liA8E" id="2NSCtASsPNP" role="2OqNvi">
+                            <ref role="37wK5l" node="RObVTFoPhX" resolve="addPropagationTarget" />
+                            <node concept="37vLTw" id="2NSCtASsQ9_" role="37wK5m">
+                              <ref role="3cqZAo" node="RObVTFnnYE" resolve="_valueSelector" />
+                            </node>
+                            <node concept="37vLTw" id="2NSCtASsQ9A" role="37wK5m">
+                              <ref role="3cqZAo" node="2NSCtASruBg" resolve="_valueHolderInfo" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="Rh6nW" id="2wC5sgtDjPx" role="1bW2Oz">
+                      <property role="TrG5h" value="source" />
+                      <node concept="2jxLKc" id="2wC5sgtDjPy" role="1tU5fm" />
+                    </node>
+                  </node>
+                </node>
               </node>
-              <node concept="ANE8D" id="50uWDT$I__H" role="2OqNvi" />
             </node>
-            <node concept="37vLTw" id="2wC5sgtDvO$" role="37vLTJ">
-              <ref role="3cqZAo" node="RObVTFnyV1" resolve="_cachedPropagationSources" />
+            <node concept="3clFbF" id="2wC5sgtDvOA" role="3cqZAp">
+              <node concept="37vLTI" id="2wC5sgtDA02" role="3clFbG">
+                <node concept="2OqwBi" id="50uWDT$I_cC" role="37vLTx">
+                  <node concept="37vLTw" id="2wC5sgtDAIk" role="2Oq$k0">
+                    <ref role="3cqZAo" node="2wC5sgtDqNz" resolve="newSources" />
+                  </node>
+                  <node concept="ANE8D" id="50uWDT$I__H" role="2OqNvi" />
+                </node>
+                <node concept="37vLTw" id="2wC5sgtDvO$" role="37vLTJ">
+                  <ref role="3cqZAo" node="RObVTFnyV1" resolve="_cachedPropagationSources" />
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -1306,7 +1320,6 @@
     <node concept="3clFb_" id="2_5DHynKzeT" role="jymVt">
       <property role="1EzhhJ" value="false" />
       <property role="TrG5h" value="getValueSelector" />
-      <property role="od$2w" value="false" />
       <property role="DiZV1" value="false" />
       <property role="2aFKle" value="false" />
       <node concept="3clFbS" id="2_5DHynKzeW" role="3clF47">
@@ -1336,7 +1349,6 @@
     <node concept="3clFb_" id="KudFejUFph" role="jymVt">
       <property role="1EzhhJ" value="false" />
       <property role="TrG5h" value="getValueHolder" />
-      <property role="od$2w" value="false" />
       <property role="DiZV1" value="false" />
       <property role="2aFKle" value="false" />
       <node concept="3clFbS" id="KudFejUFpk" role="3clF47">
@@ -1366,75 +1378,82 @@
     <node concept="3clFb_" id="2YOONxNCmED" role="jymVt">
       <property role="TrG5h" value="getValue" />
       <node concept="3clFbS" id="2YOONxNCmEF" role="3clF47">
-        <node concept="1gVbGN" id="2YOONxNCmEG" role="3cqZAp">
-          <node concept="3fqX7Q" id="2YOONxNCmEH" role="1gVkn0">
-            <node concept="37vLTw" id="2YOONxNCmEI" role="3fr31v">
-              <ref role="3cqZAo" node="6MN7yMJ7Ell" resolve="_isDisposed" />
+        <node concept="1HWtB8" id="2YOONxNVeXb" role="3cqZAp">
+          <node concept="3VsKOn" id="2YOONxNVgX6" role="1HWFw0">
+            <ref role="3VsUkX" node="7ZWgXq7GlHg" resolve="ValueCache" />
+          </node>
+          <node concept="3clFbS" id="2YOONxNVeXf" role="1HWHxc">
+            <node concept="1gVbGN" id="2YOONxNCmEG" role="3cqZAp">
+              <node concept="3fqX7Q" id="2YOONxNCmEH" role="1gVkn0">
+                <node concept="37vLTw" id="2YOONxNCmEI" role="3fr31v">
+                  <ref role="3cqZAo" node="6MN7yMJ7Ell" resolve="_isDisposed" />
+                </node>
+              </node>
+              <node concept="Xl_RD" id="2YOONxNCmEJ" role="1gVpfI">
+                <property role="Xl_RC" value="cache is disposed" />
+              </node>
             </node>
-          </node>
-          <node concept="Xl_RD" id="2YOONxNCmEJ" role="1gVpfI">
-            <property role="Xl_RC" value="cache is disposed" />
-          </node>
-        </node>
-        <node concept="3clFbH" id="2YOONxNCmEK" role="3cqZAp" />
-        <node concept="3clFbJ" id="2YOONxNCmEL" role="3cqZAp">
-          <node concept="3clFbS" id="2YOONxNCmEM" role="3clFbx">
-            <node concept="3cpWs6" id="2YOONxNCmEN" role="3cqZAp">
-              <node concept="37vLTw" id="2YOONxNCmEO" role="3cqZAk">
+            <node concept="3clFbH" id="2YOONxNCmEK" role="3cqZAp" />
+            <node concept="3clFbJ" id="2YOONxNCmEL" role="3cqZAp">
+              <node concept="3clFbS" id="2YOONxNCmEM" role="3clFbx">
+                <node concept="3cpWs6" id="2YOONxNCmEN" role="3cqZAp">
+                  <node concept="37vLTw" id="2YOONxNCmEO" role="3cqZAk">
+                    <ref role="3cqZAo" node="RObVTFmWn7" resolve="_cachedValue" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3y3z36" id="2YOONxNCmEP" role="3clFbw">
+                <node concept="10Nm6u" id="2YOONxNCmEQ" role="3uHU7w" />
+                <node concept="37vLTw" id="2YOONxNCmER" role="3uHU7B">
+                  <ref role="3cqZAo" node="RObVTFmWn7" resolve="_cachedValue" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbH" id="2YOONxNCmF2" role="3cqZAp" />
+            <node concept="3clFbJ" id="2YOONxNCmF3" role="3cqZAp">
+              <node concept="3clFbS" id="2YOONxNCmF4" role="3clFbx">
+                <node concept="3cpWs6" id="2YOONxNCmF5" role="3cqZAp">
+                  <node concept="10Nm6u" id="2YOONxNCmF6" role="3cqZAk" />
+                </node>
+              </node>
+              <node concept="3fqX7Q" id="2YOONxNEh1U" role="3clFbw">
+                <node concept="2OqwBi" id="2YOONxNEh1W" role="3fr31v">
+                  <node concept="37vLTw" id="2YOONxNEh1X" role="2Oq$k0">
+                    <ref role="3cqZAo" node="2NSCtASrCpE" resolve="_valueHolder" />
+                  </node>
+                  <node concept="2qgKlT" id="2YOONxNEh1Y" role="2OqNvi">
+                    <ref role="37wK5l" to="ao0u:6MPBOWiFIsN" resolve="canCalculate" />
+                    <node concept="37vLTw" id="2YOONxNEh1Z" role="37wK5m">
+                      <ref role="3cqZAo" node="RObVTFnnYE" resolve="_valueSelector" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbH" id="2YOONxNCmFb" role="3cqZAp" />
+            <node concept="3clFbF" id="2YOONxNCmFc" role="3cqZAp">
+              <node concept="37vLTI" id="2YOONxNCmFd" role="3clFbG">
+                <node concept="2OqwBi" id="2YOONxNCmFe" role="37vLTx">
+                  <node concept="37vLTw" id="2YOONxNCmFf" role="2Oq$k0">
+                    <ref role="3cqZAo" node="2NSCtASrCpE" resolve="_valueHolder" />
+                  </node>
+                  <node concept="2qgKlT" id="2YOONxNCmFg" role="2OqNvi">
+                    <ref role="37wK5l" to="ao0u:RObVTFnZ_0" resolve="calculateValue" />
+                    <node concept="37vLTw" id="2YOONxNCmFh" role="37wK5m">
+                      <ref role="3cqZAo" node="RObVTFnnYE" resolve="_valueSelector" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="37vLTw" id="2YOONxNCmFi" role="37vLTJ">
+                  <ref role="3cqZAo" node="RObVTFmWn7" resolve="_cachedValue" />
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs6" id="2YOONxNCmFj" role="3cqZAp">
+              <node concept="37vLTw" id="2YOONxNCmFk" role="3cqZAk">
                 <ref role="3cqZAo" node="RObVTFmWn7" resolve="_cachedValue" />
               </node>
             </node>
-          </node>
-          <node concept="3y3z36" id="2YOONxNCmEP" role="3clFbw">
-            <node concept="10Nm6u" id="2YOONxNCmEQ" role="3uHU7w" />
-            <node concept="37vLTw" id="2YOONxNCmER" role="3uHU7B">
-              <ref role="3cqZAo" node="RObVTFmWn7" resolve="_cachedValue" />
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbH" id="2YOONxNCmF2" role="3cqZAp" />
-        <node concept="3clFbJ" id="2YOONxNCmF3" role="3cqZAp">
-          <node concept="3clFbS" id="2YOONxNCmF4" role="3clFbx">
-            <node concept="3cpWs6" id="2YOONxNCmF5" role="3cqZAp">
-              <node concept="10Nm6u" id="2YOONxNCmF6" role="3cqZAk" />
-            </node>
-          </node>
-          <node concept="3fqX7Q" id="2YOONxNEh1U" role="3clFbw">
-            <node concept="2OqwBi" id="2YOONxNEh1W" role="3fr31v">
-              <node concept="37vLTw" id="2YOONxNEh1X" role="2Oq$k0">
-                <ref role="3cqZAo" node="2NSCtASrCpE" resolve="_valueHolder" />
-              </node>
-              <node concept="2qgKlT" id="2YOONxNEh1Y" role="2OqNvi">
-                <ref role="37wK5l" to="ao0u:6MPBOWiFIsN" resolve="canCalculate" />
-                <node concept="37vLTw" id="2YOONxNEh1Z" role="37wK5m">
-                  <ref role="3cqZAo" node="RObVTFnnYE" resolve="_valueSelector" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbH" id="2YOONxNCmFb" role="3cqZAp" />
-        <node concept="3clFbF" id="2YOONxNCmFc" role="3cqZAp">
-          <node concept="37vLTI" id="2YOONxNCmFd" role="3clFbG">
-            <node concept="2OqwBi" id="2YOONxNCmFe" role="37vLTx">
-              <node concept="37vLTw" id="2YOONxNCmFf" role="2Oq$k0">
-                <ref role="3cqZAo" node="2NSCtASrCpE" resolve="_valueHolder" />
-              </node>
-              <node concept="2qgKlT" id="2YOONxNCmFg" role="2OqNvi">
-                <ref role="37wK5l" to="ao0u:RObVTFnZ_0" resolve="calculateValue" />
-                <node concept="37vLTw" id="2YOONxNCmFh" role="37wK5m">
-                  <ref role="3cqZAo" node="RObVTFnnYE" resolve="_valueSelector" />
-                </node>
-              </node>
-            </node>
-            <node concept="37vLTw" id="2YOONxNCmFi" role="37vLTJ">
-              <ref role="3cqZAo" node="RObVTFmWn7" resolve="_cachedValue" />
-            </node>
-          </node>
-        </node>
-        <node concept="3cpWs6" id="2YOONxNCmFj" role="3cqZAp">
-          <node concept="37vLTw" id="2YOONxNCmFk" role="3cqZAk">
-            <ref role="3cqZAo" node="RObVTFmWn7" resolve="_cachedValue" />
           </node>
         </node>
       </node>
@@ -1449,278 +1468,286 @@
       <property role="TrG5h" value="invalidate" />
       <property role="DiZV1" value="false" />
       <property role="2aFKle" value="false" />
+      <property role="od$2w" value="true" />
       <node concept="3clFbS" id="RObVTFmWkU" role="3clF47">
-        <node concept="3clFbJ" id="48u7VOfNmZd" role="3cqZAp">
-          <node concept="3clFbS" id="48u7VOfNmZf" role="3clFbx">
-            <node concept="3cpWs6" id="48u7VOfNqcN" role="3cqZAp" />
+        <node concept="1HWtB8" id="2YOONxNVku0" role="3cqZAp">
+          <node concept="3VsKOn" id="2YOONxNVmaz" role="1HWFw0">
+            <ref role="3VsUkX" node="7ZWgXq7GlHg" resolve="ValueCache" />
           </node>
-          <node concept="2OqwBi" id="48u7VOfNoLH" role="3clFbw">
-            <node concept="37vLTw" id="48u7VOfNnxH" role="2Oq$k0">
-              <ref role="3cqZAo" node="48u7VOfNi4y" resolve="visitedParticipants" />
-            </node>
-            <node concept="3JPx81" id="48u7VOfNpZF" role="2OqNvi">
-              <node concept="37vLTw" id="2NSCtASt9P8" role="25WWJ7">
-                <ref role="3cqZAo" node="2NSCtASruBg" resolve="_valueHolderInfo" />
+          <node concept="3clFbS" id="2YOONxNVku4" role="1HWHxc">
+            <node concept="3clFbJ" id="48u7VOfNmZd" role="3cqZAp">
+              <node concept="3clFbS" id="48u7VOfNmZf" role="3clFbx">
+                <node concept="3cpWs6" id="48u7VOfNqcN" role="3cqZAp" />
               </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="48u7VOfNqfA" role="3cqZAp">
-          <node concept="2OqwBi" id="48u7VOfNrzw" role="3clFbG">
-            <node concept="37vLTw" id="48u7VOfNqf$" role="2Oq$k0">
-              <ref role="3cqZAo" node="48u7VOfNi4y" resolve="visitedParticipants" />
-            </node>
-            <node concept="TSZUe" id="48u7VOfNHtJ" role="2OqNvi">
-              <node concept="37vLTw" id="2NSCtASt9Y_" role="25WWJ7">
-                <ref role="3cqZAo" node="2NSCtASruBg" resolve="_valueHolderInfo" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbH" id="48u7VOfNt1c" role="3cqZAp" />
-        <node concept="3clFbF" id="RObVTFmWpo" role="3cqZAp">
-          <node concept="37vLTI" id="RObVTFmWXl" role="3clFbG">
-            <node concept="10Nm6u" id="RObVTFmWYF" role="37vLTx" />
-            <node concept="37vLTw" id="RObVTFmWpn" role="37vLTJ">
-              <ref role="3cqZAo" node="RObVTFmWn7" resolve="_cachedValue" />
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbH" id="5YITc37Q0aS" role="3cqZAp" />
-        <node concept="3clFbJ" id="5YITc37PWF4" role="3cqZAp">
-          <node concept="3clFbS" id="5YITc37PWF6" role="3clFbx">
-            <node concept="3clFbF" id="5YITc37PX5p" role="3cqZAp">
-              <node concept="37vLTI" id="5YITc37PXXb" role="3clFbG">
-                <node concept="10Nm6u" id="5YITc37QEVO" role="37vLTx" />
-                <node concept="37vLTw" id="5YITc37PX5n" role="37vLTJ">
-                  <ref role="3cqZAo" node="5YITc37PBWJ" resolve="_cachedHasCycle" />
+              <node concept="2OqwBi" id="48u7VOfNoLH" role="3clFbw">
+                <node concept="37vLTw" id="48u7VOfNnxH" role="2Oq$k0">
+                  <ref role="3cqZAo" node="48u7VOfNi4y" resolve="visitedParticipants" />
+                </node>
+                <node concept="3JPx81" id="48u7VOfNpZF" role="2OqNvi">
+                  <node concept="37vLTw" id="2NSCtASt9P8" role="25WWJ7">
+                    <ref role="3cqZAo" node="2NSCtASruBg" resolve="_valueHolderInfo" />
+                  </node>
                 </node>
               </node>
             </node>
-            <node concept="3cpWs8" id="2wC5sgtCbJE" role="3cqZAp">
-              <node concept="3cpWsn" id="2wC5sgtCbJH" role="3cpWs9">
-                <property role="TrG5h" value="newSources" />
-                <node concept="2OqwBi" id="2NSCtAStj5O" role="33vP2m">
-                  <node concept="2OqwBi" id="2wC5sgtCcnH" role="2Oq$k0">
-                    <node concept="37vLTw" id="2wC5sgtCc75" role="2Oq$k0">
-                      <ref role="3cqZAo" node="2NSCtASrCpE" resolve="_valueHolder" />
-                    </node>
-                    <node concept="2qgKlT" id="2wC5sgtCc$2" role="2OqNvi">
-                      <ref role="37wK5l" to="ao0u:2S2eLhiMzhL" resolve="getDependencies" />
-                      <node concept="37vLTw" id="2wC5sgtCcFC" role="37wK5m">
-                        <ref role="3cqZAo" node="RObVTFnnYE" resolve="_valueSelector" />
-                      </node>
+            <node concept="3clFbF" id="48u7VOfNqfA" role="3cqZAp">
+              <node concept="2OqwBi" id="48u7VOfNrzw" role="3clFbG">
+                <node concept="37vLTw" id="48u7VOfNqf$" role="2Oq$k0">
+                  <ref role="3cqZAo" node="48u7VOfNi4y" resolve="visitedParticipants" />
+                </node>
+                <node concept="TSZUe" id="48u7VOfNHtJ" role="2OqNvi">
+                  <node concept="37vLTw" id="2NSCtASt9Y_" role="25WWJ7">
+                    <ref role="3cqZAo" node="2NSCtASruBg" resolve="_valueHolderInfo" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbH" id="48u7VOfNt1c" role="3cqZAp" />
+            <node concept="3clFbF" id="RObVTFmWpo" role="3cqZAp">
+              <node concept="37vLTI" id="RObVTFmWXl" role="3clFbG">
+                <node concept="10Nm6u" id="RObVTFmWYF" role="37vLTx" />
+                <node concept="37vLTw" id="RObVTFmWpn" role="37vLTJ">
+                  <ref role="3cqZAo" node="RObVTFmWn7" resolve="_cachedValue" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbH" id="5YITc37Q0aS" role="3cqZAp" />
+            <node concept="3clFbJ" id="5YITc37PWF4" role="3cqZAp">
+              <node concept="3clFbS" id="5YITc37PWF6" role="3clFbx">
+                <node concept="3clFbF" id="5YITc37PX5p" role="3cqZAp">
+                  <node concept="37vLTI" id="5YITc37PXXb" role="3clFbG">
+                    <node concept="10Nm6u" id="5YITc37QEVO" role="37vLTx" />
+                    <node concept="37vLTw" id="5YITc37PX5n" role="37vLTJ">
+                      <ref role="3cqZAo" node="5YITc37PBWJ" resolve="_cachedHasCycle" />
                     </node>
                   </node>
-                  <node concept="3$u5V9" id="2NSCtAStltz" role="2OqNvi">
-                    <node concept="1bVj0M" id="2NSCtAStlt_" role="23t8la">
-                      <node concept="3clFbS" id="2NSCtAStltA" role="1bW5cS">
-                        <node concept="3clFbF" id="2NSCtAStm01" role="3cqZAp">
-                          <node concept="2OqwBi" id="2NSCtAStmtY" role="3clFbG">
-                            <node concept="37vLTw" id="2NSCtAStm00" role="2Oq$k0">
-                              <ref role="3cqZAo" node="2NSCtAStltB" resolve="it" />
-                            </node>
-                            <node concept="2qgKlT" id="2NSCtAStn9u" role="2OqNvi">
-                              <ref role="37wK5l" to="ao0u:2S2eLhiM$ey" resolve="getValueHolderInfo" />
-                            </node>
+                </node>
+                <node concept="3cpWs8" id="2wC5sgtCbJE" role="3cqZAp">
+                  <node concept="3cpWsn" id="2wC5sgtCbJH" role="3cpWs9">
+                    <property role="TrG5h" value="newSources" />
+                    <node concept="2OqwBi" id="2NSCtAStj5O" role="33vP2m">
+                      <node concept="2OqwBi" id="2wC5sgtCcnH" role="2Oq$k0">
+                        <node concept="37vLTw" id="2wC5sgtCc75" role="2Oq$k0">
+                          <ref role="3cqZAo" node="2NSCtASrCpE" resolve="_valueHolder" />
+                        </node>
+                        <node concept="2qgKlT" id="2wC5sgtCc$2" role="2OqNvi">
+                          <ref role="37wK5l" to="ao0u:2S2eLhiMzhL" resolve="getDependencies" />
+                          <node concept="37vLTw" id="2wC5sgtCcFC" role="37wK5m">
+                            <ref role="3cqZAo" node="RObVTFnnYE" resolve="_valueSelector" />
                           </node>
                         </node>
                       </node>
-                      <node concept="Rh6nW" id="2NSCtAStltB" role="1bW2Oz">
-                        <property role="TrG5h" value="it" />
-                        <node concept="2jxLKc" id="2NSCtAStltC" role="1tU5fm" />
+                      <node concept="3$u5V9" id="2NSCtAStltz" role="2OqNvi">
+                        <node concept="1bVj0M" id="2NSCtAStlt_" role="23t8la">
+                          <node concept="3clFbS" id="2NSCtAStltA" role="1bW5cS">
+                            <node concept="3clFbF" id="2NSCtAStm01" role="3cqZAp">
+                              <node concept="2OqwBi" id="2NSCtAStmtY" role="3clFbG">
+                                <node concept="37vLTw" id="2NSCtAStm00" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="2NSCtAStltB" resolve="it" />
+                                </node>
+                                <node concept="2qgKlT" id="2NSCtAStn9u" role="2OqNvi">
+                                  <ref role="37wK5l" to="ao0u:2S2eLhiM$ey" resolve="getValueHolderInfo" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="Rh6nW" id="2NSCtAStltB" role="1bW2Oz">
+                            <property role="TrG5h" value="it" />
+                            <node concept="2jxLKc" id="2NSCtAStltC" role="1tU5fm" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="A3Dl8" id="50uWDT$INtP" role="1tU5fm">
+                      <node concept="3uibUv" id="50uWDT$INtR" role="A3Ik2">
+                        <ref role="3uigEE" node="2S2eLhiM$hD" resolve="ValueHolderInfo" />
                       </node>
                     </node>
                   </node>
                 </node>
-                <node concept="A3Dl8" id="50uWDT$INtP" role="1tU5fm">
-                  <node concept="3uibUv" id="50uWDT$INtR" role="A3Ik2">
-                    <ref role="3uigEE" node="2S2eLhiM$hD" resolve="ValueHolderInfo" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbF" id="2wC5sgtCe9p" role="3cqZAp">
-              <node concept="2OqwBi" id="2wC5sgtDcjX" role="3clFbG">
-                <node concept="2OqwBi" id="2wC5sgtCflW" role="2Oq$k0">
-                  <node concept="37vLTw" id="2wC5sgtCe9n" role="2Oq$k0">
-                    <ref role="3cqZAo" node="2wC5sgtCbJH" resolve="newSources" />
-                  </node>
-                  <node concept="3zZkjj" id="2wC5sgtCggS" role="2OqNvi">
-                    <node concept="1bVj0M" id="2wC5sgtCggU" role="23t8la">
-                      <node concept="3clFbS" id="2wC5sgtCggV" role="1bW5cS">
-                        <node concept="3clFbF" id="2wC5sgtCgmm" role="3cqZAp">
-                          <node concept="3fqX7Q" id="2wC5sgtDaky" role="3clFbG">
-                            <node concept="2OqwBi" id="2wC5sgtDak$" role="3fr31v">
-                              <node concept="37vLTw" id="2wC5sgtDak_" role="2Oq$k0">
-                                <ref role="3cqZAo" node="RObVTFnyV1" resolve="_cachedPropagationSources" />
+                <node concept="3clFbF" id="2wC5sgtCe9p" role="3cqZAp">
+                  <node concept="2OqwBi" id="2wC5sgtDcjX" role="3clFbG">
+                    <node concept="2OqwBi" id="2wC5sgtCflW" role="2Oq$k0">
+                      <node concept="37vLTw" id="2wC5sgtCe9n" role="2Oq$k0">
+                        <ref role="3cqZAo" node="2wC5sgtCbJH" resolve="newSources" />
+                      </node>
+                      <node concept="3zZkjj" id="2wC5sgtCggS" role="2OqNvi">
+                        <node concept="1bVj0M" id="2wC5sgtCggU" role="23t8la">
+                          <node concept="3clFbS" id="2wC5sgtCggV" role="1bW5cS">
+                            <node concept="3clFbF" id="2wC5sgtCgmm" role="3cqZAp">
+                              <node concept="3fqX7Q" id="2wC5sgtDaky" role="3clFbG">
+                                <node concept="2OqwBi" id="2wC5sgtDak$" role="3fr31v">
+                                  <node concept="37vLTw" id="2wC5sgtDak_" role="2Oq$k0">
+                                    <ref role="3cqZAo" node="RObVTFnyV1" resolve="_cachedPropagationSources" />
+                                  </node>
+                                  <node concept="3JPx81" id="2wC5sgtDakA" role="2OqNvi">
+                                    <node concept="37vLTw" id="2wC5sgtDaMA" role="25WWJ7">
+                                      <ref role="3cqZAo" node="2wC5sgtCggW" resolve="newSource" />
+                                    </node>
+                                  </node>
+                                </node>
                               </node>
-                              <node concept="3JPx81" id="2wC5sgtDakA" role="2OqNvi">
-                                <node concept="37vLTw" id="2wC5sgtDaMA" role="25WWJ7">
-                                  <ref role="3cqZAo" node="2wC5sgtCggW" resolve="newSource" />
+                            </node>
+                          </node>
+                          <node concept="Rh6nW" id="2wC5sgtCggW" role="1bW2Oz">
+                            <property role="TrG5h" value="newSource" />
+                            <node concept="2jxLKc" id="2wC5sgtCggX" role="1tU5fm" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="2es0OD" id="2wC5sgtDcRT" role="2OqNvi">
+                      <node concept="1bVj0M" id="2wC5sgtDcRV" role="23t8la">
+                        <node concept="3clFbS" id="2wC5sgtDcRW" role="1bW5cS">
+                          <node concept="3clFbF" id="2wC5sgtDddv" role="3cqZAp">
+                            <node concept="2OqwBi" id="2NSCtASttBb" role="3clFbG">
+                              <node concept="37vLTw" id="2wC5sgtDddu" role="2Oq$k0">
+                                <ref role="3cqZAo" node="2wC5sgtDcRX" resolve="newSource" />
+                              </node>
+                              <node concept="liA8E" id="2NSCtAStu2O" role="2OqNvi">
+                                <ref role="37wK5l" node="RObVTFoPhX" resolve="addPropagationTarget" />
+                                <node concept="37vLTw" id="2NSCtASty4d" role="37wK5m">
+                                  <ref role="3cqZAo" node="RObVTFnnYE" resolve="_valueSelector" />
+                                </node>
+                                <node concept="37vLTw" id="2NSCtAStA_D" role="37wK5m">
+                                  <ref role="3cqZAo" node="2NSCtASruBg" resolve="_valueHolderInfo" />
                                 </node>
                               </node>
                             </node>
                           </node>
                         </node>
-                      </node>
-                      <node concept="Rh6nW" id="2wC5sgtCggW" role="1bW2Oz">
-                        <property role="TrG5h" value="newSource" />
-                        <node concept="2jxLKc" id="2wC5sgtCggX" role="1tU5fm" />
+                        <node concept="Rh6nW" id="2wC5sgtDcRX" role="1bW2Oz">
+                          <property role="TrG5h" value="newSource" />
+                          <node concept="2jxLKc" id="2wC5sgtDcRY" role="1tU5fm" />
+                        </node>
                       </node>
                     </node>
                   </node>
                 </node>
-                <node concept="2es0OD" id="2wC5sgtDcRT" role="2OqNvi">
-                  <node concept="1bVj0M" id="2wC5sgtDcRV" role="23t8la">
-                    <node concept="3clFbS" id="2wC5sgtDcRW" role="1bW5cS">
-                      <node concept="3clFbF" id="2wC5sgtDddv" role="3cqZAp">
-                        <node concept="2OqwBi" id="2NSCtASttBb" role="3clFbG">
-                          <node concept="37vLTw" id="2wC5sgtDddu" role="2Oq$k0">
-                            <ref role="3cqZAo" node="2wC5sgtDcRX" resolve="newSource" />
+                <node concept="3clFbF" id="2wC5sgtDDuy" role="3cqZAp">
+                  <node concept="2OqwBi" id="2wC5sgtDMpu" role="3clFbG">
+                    <node concept="2OqwBi" id="2wC5sgtDEN2" role="2Oq$k0">
+                      <node concept="37vLTw" id="2wC5sgtDDuw" role="2Oq$k0">
+                        <ref role="3cqZAo" node="RObVTFnyV1" resolve="_cachedPropagationSources" />
+                      </node>
+                      <node concept="3zZkjj" id="2wC5sgtDGQ$" role="2OqNvi">
+                        <node concept="1bVj0M" id="2wC5sgtDGQA" role="23t8la">
+                          <node concept="3clFbS" id="2wC5sgtDGQB" role="1bW5cS">
+                            <node concept="3clFbF" id="2wC5sgtDH7Z" role="3cqZAp">
+                              <node concept="3fqX7Q" id="2wC5sgtDKLe" role="3clFbG">
+                                <node concept="2OqwBi" id="2wC5sgtDKLg" role="3fr31v">
+                                  <node concept="37vLTw" id="2wC5sgtDKLh" role="2Oq$k0">
+                                    <ref role="3cqZAo" node="2wC5sgtCbJH" resolve="newSources" />
+                                  </node>
+                                  <node concept="3JPx81" id="2wC5sgtDKLi" role="2OqNvi">
+                                    <node concept="37vLTw" id="2wC5sgtDL5d" role="25WWJ7">
+                                      <ref role="3cqZAo" node="2wC5sgtDGQC" resolve="oldSource" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
                           </node>
-                          <node concept="liA8E" id="2NSCtAStu2O" role="2OqNvi">
-                            <ref role="37wK5l" node="RObVTFoPhX" resolve="addPropagationTarget" />
-                            <node concept="37vLTw" id="2NSCtASty4d" role="37wK5m">
-                              <ref role="3cqZAo" node="RObVTFnnYE" resolve="_valueSelector" />
-                            </node>
-                            <node concept="37vLTw" id="2NSCtAStA_D" role="37wK5m">
-                              <ref role="3cqZAo" node="2NSCtASruBg" resolve="_valueHolderInfo" />
-                            </node>
+                          <node concept="Rh6nW" id="2wC5sgtDGQC" role="1bW2Oz">
+                            <property role="TrG5h" value="oldSource" />
+                            <node concept="2jxLKc" id="2wC5sgtDGQD" role="1tU5fm" />
                           </node>
                         </node>
                       </node>
                     </node>
-                    <node concept="Rh6nW" id="2wC5sgtDcRX" role="1bW2Oz">
-                      <property role="TrG5h" value="newSource" />
-                      <node concept="2jxLKc" id="2wC5sgtDcRY" role="1tU5fm" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbF" id="2wC5sgtDDuy" role="3cqZAp">
-              <node concept="2OqwBi" id="2wC5sgtDMpu" role="3clFbG">
-                <node concept="2OqwBi" id="2wC5sgtDEN2" role="2Oq$k0">
-                  <node concept="37vLTw" id="2wC5sgtDDuw" role="2Oq$k0">
-                    <ref role="3cqZAo" node="RObVTFnyV1" resolve="_cachedPropagationSources" />
-                  </node>
-                  <node concept="3zZkjj" id="2wC5sgtDGQ$" role="2OqNvi">
-                    <node concept="1bVj0M" id="2wC5sgtDGQA" role="23t8la">
-                      <node concept="3clFbS" id="2wC5sgtDGQB" role="1bW5cS">
-                        <node concept="3clFbF" id="2wC5sgtDH7Z" role="3cqZAp">
-                          <node concept="3fqX7Q" id="2wC5sgtDKLe" role="3clFbG">
-                            <node concept="2OqwBi" id="2wC5sgtDKLg" role="3fr31v">
-                              <node concept="37vLTw" id="2wC5sgtDKLh" role="2Oq$k0">
-                                <ref role="3cqZAo" node="2wC5sgtCbJH" resolve="newSources" />
+                    <node concept="2es0OD" id="2wC5sgtDMUn" role="2OqNvi">
+                      <node concept="1bVj0M" id="2wC5sgtDMUp" role="23t8la">
+                        <node concept="3clFbS" id="2wC5sgtDMUq" role="1bW5cS">
+                          <node concept="3clFbF" id="2wC5sgtDODz" role="3cqZAp">
+                            <node concept="2OqwBi" id="2NSCtAStvqt" role="3clFbG">
+                              <node concept="37vLTw" id="2wC5sgtDODy" role="2Oq$k0">
+                                <ref role="3cqZAo" node="2wC5sgtDMUr" resolve="oldSource" />
                               </node>
-                              <node concept="3JPx81" id="2wC5sgtDKLi" role="2OqNvi">
-                                <node concept="37vLTw" id="2wC5sgtDL5d" role="25WWJ7">
-                                  <ref role="3cqZAo" node="2wC5sgtDGQC" resolve="oldSource" />
+                              <node concept="liA8E" id="2NSCtAStvQK" role="2OqNvi">
+                                <ref role="37wK5l" node="RObVTFoQPx" resolve="removePropagationTarget" />
+                                <node concept="37vLTw" id="2NSCtAStwCu" role="37wK5m">
+                                  <ref role="3cqZAo" node="RObVTFnnYE" resolve="_valueSelector" />
+                                </node>
+                                <node concept="37vLTw" id="2NSCtAStBYY" role="37wK5m">
+                                  <ref role="3cqZAo" node="2NSCtASruBg" resolve="_valueHolderInfo" />
                                 </node>
                               </node>
                             </node>
                           </node>
                         </node>
-                      </node>
-                      <node concept="Rh6nW" id="2wC5sgtDGQC" role="1bW2Oz">
-                        <property role="TrG5h" value="oldSource" />
-                        <node concept="2jxLKc" id="2wC5sgtDGQD" role="1tU5fm" />
+                        <node concept="Rh6nW" id="2wC5sgtDMUr" role="1bW2Oz">
+                          <property role="TrG5h" value="oldSource" />
+                          <node concept="2jxLKc" id="2wC5sgtDMUs" role="1tU5fm" />
+                        </node>
                       </node>
                     </node>
                   </node>
                 </node>
-                <node concept="2es0OD" id="2wC5sgtDMUn" role="2OqNvi">
-                  <node concept="1bVj0M" id="2wC5sgtDMUp" role="23t8la">
-                    <node concept="3clFbS" id="2wC5sgtDMUq" role="1bW5cS">
-                      <node concept="3clFbF" id="2wC5sgtDODz" role="3cqZAp">
-                        <node concept="2OqwBi" id="2NSCtAStvqt" role="3clFbG">
-                          <node concept="37vLTw" id="2wC5sgtDODy" role="2Oq$k0">
-                            <ref role="3cqZAo" node="2wC5sgtDMUr" resolve="oldSource" />
+                <node concept="3clFbF" id="2wC5sgtDRvI" role="3cqZAp">
+                  <node concept="37vLTI" id="2wC5sgtDY4f" role="3clFbG">
+                    <node concept="2OqwBi" id="50uWDT$IU91" role="37vLTx">
+                      <node concept="37vLTw" id="2wC5sgtDYtf" role="2Oq$k0">
+                        <ref role="3cqZAo" node="2wC5sgtCbJH" resolve="newSources" />
+                      </node>
+                      <node concept="ANE8D" id="50uWDT$IUyf" role="2OqNvi" />
+                    </node>
+                    <node concept="37vLTw" id="2wC5sgtDRvG" role="37vLTJ">
+                      <ref role="3cqZAo" node="RObVTFnyV1" resolve="_cachedPropagationSources" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbC" id="797ZNR2k3Zv" role="3clFbw">
+                <node concept="Rm8GO" id="797ZNR2k4Ca" role="3uHU7w">
+                  <ref role="Rm8GQ" node="6sjp2R1WqzY" resolve="ValueAndDependencies" />
+                  <ref role="1Px2BO" node="6sjp2R1WqtZ" resolve="EChangeEffectKind" />
+                </node>
+                <node concept="37vLTw" id="797ZNR2k2VP" role="3uHU7B">
+                  <ref role="3cqZAo" node="797ZNR2k0QU" resolve="changeEffectKind" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbH" id="2wC5sgtCbq$" role="3cqZAp" />
+            <node concept="3clFbF" id="61NZ8UZnPxS" role="3cqZAp">
+              <node concept="2OqwBi" id="61NZ8UZnRNZ" role="3clFbG">
+                <node concept="2ShNRf" id="61NZ8UZnPxO" role="2Oq$k0">
+                  <node concept="2Jqq0_" id="61NZ8UZo3OI" role="2ShVmc">
+                    <node concept="3uibUv" id="61NZ8UZo40O" role="HW$YZ">
+                      <ref role="3uigEE" node="2S2eLhiM$hD" resolve="ValueHolderInfo" />
+                    </node>
+                    <node concept="37vLTw" id="61NZ8UZo4QK" role="I$8f6">
+                      <ref role="3cqZAo" node="RObVTFo4eX" resolve="_cachedPropagationTargets" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2es0OD" id="61NZ8UZnU5o" role="2OqNvi">
+                  <node concept="1bVj0M" id="61NZ8UZnU5q" role="23t8la">
+                    <node concept="3clFbS" id="61NZ8UZnU5r" role="1bW5cS">
+                      <node concept="3clFbF" id="61NZ8UZnU$k" role="3cqZAp">
+                        <node concept="2OqwBi" id="61NZ8UZnU$l" role="3clFbG">
+                          <node concept="37vLTw" id="61NZ8UZnU$m" role="2Oq$k0">
+                            <ref role="3cqZAo" node="61NZ8UZnU5s" resolve="target" />
                           </node>
-                          <node concept="liA8E" id="2NSCtAStvQK" role="2OqNvi">
-                            <ref role="37wK5l" node="RObVTFoQPx" resolve="removePropagationTarget" />
-                            <node concept="37vLTw" id="2NSCtAStwCu" role="37wK5m">
+                          <node concept="liA8E" id="61NZ8UZnU$n" role="2OqNvi">
+                            <ref role="37wK5l" node="RObVTFmZbg" resolve="invalidate" />
+                            <node concept="37vLTw" id="61NZ8UZnU$o" role="37wK5m">
                               <ref role="3cqZAo" node="RObVTFnnYE" resolve="_valueSelector" />
                             </node>
-                            <node concept="37vLTw" id="2NSCtAStBYY" role="37wK5m">
-                              <ref role="3cqZAo" node="2NSCtASruBg" resolve="_valueHolderInfo" />
+                            <node concept="37vLTw" id="61NZ8UZnU$p" role="37wK5m">
+                              <ref role="3cqZAo" node="797ZNR2k0QU" resolve="changeEffectKind" />
+                            </node>
+                            <node concept="37vLTw" id="61NZ8UZnU$q" role="37wK5m">
+                              <ref role="3cqZAo" node="48u7VOfNi4y" resolve="visitedParticipants" />
                             </node>
                           </node>
                         </node>
                       </node>
                     </node>
-                    <node concept="Rh6nW" id="2wC5sgtDMUr" role="1bW2Oz">
-                      <property role="TrG5h" value="oldSource" />
-                      <node concept="2jxLKc" id="2wC5sgtDMUs" role="1tU5fm" />
+                    <node concept="Rh6nW" id="61NZ8UZnU5s" role="1bW2Oz">
+                      <property role="TrG5h" value="target" />
+                      <node concept="2jxLKc" id="61NZ8UZnU5t" role="1tU5fm" />
                     </node>
                   </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbF" id="2wC5sgtDRvI" role="3cqZAp">
-              <node concept="37vLTI" id="2wC5sgtDY4f" role="3clFbG">
-                <node concept="2OqwBi" id="50uWDT$IU91" role="37vLTx">
-                  <node concept="37vLTw" id="2wC5sgtDYtf" role="2Oq$k0">
-                    <ref role="3cqZAo" node="2wC5sgtCbJH" resolve="newSources" />
-                  </node>
-                  <node concept="ANE8D" id="50uWDT$IUyf" role="2OqNvi" />
-                </node>
-                <node concept="37vLTw" id="2wC5sgtDRvG" role="37vLTJ">
-                  <ref role="3cqZAo" node="RObVTFnyV1" resolve="_cachedPropagationSources" />
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="3clFbC" id="797ZNR2k3Zv" role="3clFbw">
-            <node concept="Rm8GO" id="797ZNR2k4Ca" role="3uHU7w">
-              <ref role="Rm8GQ" node="6sjp2R1WqzY" resolve="ValueAndDependencies" />
-              <ref role="1Px2BO" node="6sjp2R1WqtZ" resolve="EChangeEffectKind" />
-            </node>
-            <node concept="37vLTw" id="797ZNR2k2VP" role="3uHU7B">
-              <ref role="3cqZAo" node="797ZNR2k0QU" resolve="changeEffectKind" />
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbH" id="2wC5sgtCbq$" role="3cqZAp" />
-        <node concept="3clFbF" id="61NZ8UZnPxS" role="3cqZAp">
-          <node concept="2OqwBi" id="61NZ8UZnRNZ" role="3clFbG">
-            <node concept="2ShNRf" id="61NZ8UZnPxO" role="2Oq$k0">
-              <node concept="2Jqq0_" id="61NZ8UZo3OI" role="2ShVmc">
-                <node concept="3uibUv" id="61NZ8UZo40O" role="HW$YZ">
-                  <ref role="3uigEE" node="2S2eLhiM$hD" resolve="ValueHolderInfo" />
-                </node>
-                <node concept="37vLTw" id="61NZ8UZo4QK" role="I$8f6">
-                  <ref role="3cqZAo" node="RObVTFo4eX" resolve="_cachedPropagationTargets" />
-                </node>
-              </node>
-            </node>
-            <node concept="2es0OD" id="61NZ8UZnU5o" role="2OqNvi">
-              <node concept="1bVj0M" id="61NZ8UZnU5q" role="23t8la">
-                <node concept="3clFbS" id="61NZ8UZnU5r" role="1bW5cS">
-                  <node concept="3clFbF" id="61NZ8UZnU$k" role="3cqZAp">
-                    <node concept="2OqwBi" id="61NZ8UZnU$l" role="3clFbG">
-                      <node concept="37vLTw" id="61NZ8UZnU$m" role="2Oq$k0">
-                        <ref role="3cqZAo" node="61NZ8UZnU5s" resolve="target" />
-                      </node>
-                      <node concept="liA8E" id="61NZ8UZnU$n" role="2OqNvi">
-                        <ref role="37wK5l" node="RObVTFmZbg" resolve="invalidate" />
-                        <node concept="37vLTw" id="61NZ8UZnU$o" role="37wK5m">
-                          <ref role="3cqZAo" node="RObVTFnnYE" resolve="_valueSelector" />
-                        </node>
-                        <node concept="37vLTw" id="61NZ8UZnU$p" role="37wK5m">
-                          <ref role="3cqZAo" node="797ZNR2k0QU" resolve="changeEffectKind" />
-                        </node>
-                        <node concept="37vLTw" id="61NZ8UZnU$q" role="37wK5m">
-                          <ref role="3cqZAo" node="48u7VOfNi4y" resolve="visitedParticipants" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="Rh6nW" id="61NZ8UZnU5s" role="1bW2Oz">
-                  <property role="TrG5h" value="target" />
-                  <node concept="2jxLKc" id="61NZ8UZnU5t" role="1tU5fm" />
                 </node>
               </node>
             </node>
@@ -1751,14 +1778,21 @@
       <property role="DiZV1" value="false" />
       <property role="2aFKle" value="false" />
       <node concept="3clFbS" id="RObVTFrQr9" role="3clF47">
-        <node concept="3clFbF" id="RObVTFrUHl" role="3cqZAp">
-          <node concept="2OqwBi" id="RObVTFrW0z" role="3clFbG">
-            <node concept="37vLTw" id="RObVTFrUHk" role="2Oq$k0">
-              <ref role="3cqZAo" node="RObVTFo4eX" resolve="_cachedPropagationTargets" />
-            </node>
-            <node concept="TSZUe" id="RObVTFrYVD" role="2OqNvi">
-              <node concept="37vLTw" id="RObVTFrZgJ" role="25WWJ7">
-                <ref role="3cqZAo" node="RObVTFrSfN" resolve="other" />
+        <node concept="1HWtB8" id="2YOONxNVrzk" role="3cqZAp">
+          <node concept="3VsKOn" id="2YOONxNVs8c" role="1HWFw0">
+            <ref role="3VsUkX" node="7ZWgXq7GlHg" resolve="ValueCache" />
+          </node>
+          <node concept="3clFbS" id="2YOONxNVrzo" role="1HWHxc">
+            <node concept="3clFbF" id="RObVTFrUHl" role="3cqZAp">
+              <node concept="2OqwBi" id="RObVTFrW0z" role="3clFbG">
+                <node concept="37vLTw" id="RObVTFrUHk" role="2Oq$k0">
+                  <ref role="3cqZAo" node="RObVTFo4eX" resolve="_cachedPropagationTargets" />
+                </node>
+                <node concept="TSZUe" id="RObVTFrYVD" role="2OqNvi">
+                  <node concept="37vLTw" id="RObVTFrZgJ" role="25WWJ7">
+                    <ref role="3cqZAo" node="RObVTFrSfN" resolve="other" />
+                  </node>
+                </node>
               </node>
             </node>
           </node>
@@ -1780,14 +1814,21 @@
       <property role="DiZV1" value="false" />
       <property role="2aFKle" value="false" />
       <node concept="3clFbS" id="RObVTFrTIl" role="3clF47">
-        <node concept="3clFbF" id="RObVTFrZDn" role="3cqZAp">
-          <node concept="2OqwBi" id="RObVTFs0WH" role="3clFbG">
-            <node concept="37vLTw" id="RObVTFrZDm" role="2Oq$k0">
-              <ref role="3cqZAo" node="RObVTFo4eX" resolve="_cachedPropagationTargets" />
-            </node>
-            <node concept="3dhRuq" id="RObVTFs3RV" role="2OqNvi">
-              <node concept="37vLTw" id="RObVTFs4Dl" role="25WWJ7">
-                <ref role="3cqZAo" node="RObVTFrTIo" resolve="other" />
+        <node concept="1HWtB8" id="2YOONxNVsJQ" role="3cqZAp">
+          <node concept="3VsKOn" id="2YOONxNVsJR" role="1HWFw0">
+            <ref role="3VsUkX" node="7ZWgXq7GlHg" resolve="ValueCache" />
+          </node>
+          <node concept="3clFbS" id="2YOONxNVsJS" role="1HWHxc">
+            <node concept="3clFbF" id="RObVTFrZDn" role="3cqZAp">
+              <node concept="2OqwBi" id="RObVTFs0WH" role="3clFbG">
+                <node concept="37vLTw" id="RObVTFrZDm" role="2Oq$k0">
+                  <ref role="3cqZAo" node="RObVTFo4eX" resolve="_cachedPropagationTargets" />
+                </node>
+                <node concept="3dhRuq" id="RObVTFs3RV" role="2OqNvi">
+                  <node concept="37vLTw" id="RObVTFs4Dl" role="25WWJ7">
+                    <ref role="3cqZAo" node="RObVTFrTIo" resolve="other" />
+                  </node>
+                </node>
               </node>
             </node>
           </node>
@@ -1809,108 +1850,115 @@
       <property role="DiZV1" value="false" />
       <property role="2aFKle" value="false" />
       <node concept="3clFbS" id="5YITc37MPxu" role="3clF47">
-        <node concept="1gVbGN" id="6MN7yMJ82V1" role="3cqZAp">
-          <node concept="3fqX7Q" id="6MN7yMJ82V2" role="1gVkn0">
-            <node concept="37vLTw" id="6MN7yMJ82V3" role="3fr31v">
-              <ref role="3cqZAo" node="6MN7yMJ7Ell" resolve="_isDisposed" />
-            </node>
+        <node concept="1HWtB8" id="2YOONxNV_1A" role="3cqZAp">
+          <node concept="3VsKOn" id="2YOONxNV_1B" role="1HWFw0">
+            <ref role="3VsUkX" node="7ZWgXq7GlHg" resolve="ValueCache" />
           </node>
-          <node concept="Xl_RD" id="6MN7yMJ82V4" role="1gVpfI">
-            <property role="Xl_RC" value="cache is disposed" />
-          </node>
-        </node>
-        <node concept="3clFbH" id="6MN7yMJ81td" role="3cqZAp" />
-        <node concept="3clFbJ" id="5YITc37QHDg" role="3cqZAp">
-          <node concept="3clFbS" id="5YITc37QHDi" role="3clFbx">
-            <node concept="3cpWs6" id="5YITc37QKQL" role="3cqZAp">
-              <node concept="37vLTw" id="5YITc37QKTf" role="3cqZAk">
-                <ref role="3cqZAo" node="5YITc37PBWJ" resolve="_cachedHasCycle" />
-              </node>
-            </node>
-          </node>
-          <node concept="3y3z36" id="5YITc37QKIn" role="3clFbw">
-            <node concept="10Nm6u" id="5YITc37QKNX" role="3uHU7w" />
-            <node concept="37vLTw" id="5YITc37QJAO" role="3uHU7B">
-              <ref role="3cqZAo" node="5YITc37PBWJ" resolve="_cachedHasCycle" />
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbH" id="5YITc37QOdO" role="3cqZAp" />
-        <node concept="2GUZhq" id="5YITc37QZAg" role="3cqZAp">
-          <node concept="3clFbS" id="5YITc37N3n1" role="2GV8ay">
-            <node concept="3clFbF" id="5YITc37OWoq" role="3cqZAp">
-              <node concept="1rXfSq" id="5YITc37OWos" role="3clFbG">
-                <ref role="37wK5l" node="5YITc37MTr0" resolve="checkForCycle" />
-                <node concept="2ShNRf" id="5YITc37OWot" role="37wK5m">
-                  <node concept="2Jqq0_" id="5YITc37OWou" role="2ShVmc">
-                    <node concept="3Tqbb2" id="5YITc37OWov" role="HW$YZ">
-                      <ref role="ehGHo" to="kzoi:2S2eLhiMx2Q" resolve="IncrementallyComputedValueHolder" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="37vLTw" id="5YITc37OWow" role="37wK5m">
-                  <ref role="3cqZAo" node="2NSCtASrCpE" resolve="_valueHolder" />
+          <node concept="3clFbS" id="2YOONxNV_1C" role="1HWHxc">
+            <node concept="1gVbGN" id="6MN7yMJ82V1" role="3cqZAp">
+              <node concept="3fqX7Q" id="6MN7yMJ82V2" role="1gVkn0">
+                <node concept="37vLTw" id="6MN7yMJ82V3" role="3fr31v">
+                  <ref role="3cqZAo" node="6MN7yMJ7Ell" resolve="_isDisposed" />
                 </node>
               </node>
-            </node>
-            <node concept="3clFbF" id="5YITc37QROb" role="3cqZAp">
-              <node concept="37vLTI" id="5YITc37QVdv" role="3clFbG">
-                <node concept="3clFbT" id="5YITc37QVk5" role="37vLTx">
-                  <property role="3clFbU" value="false" />
-                </node>
-                <node concept="37vLTw" id="5YITc37QRO9" role="37vLTJ">
-                  <ref role="3cqZAo" node="5YITc37PBWJ" resolve="_cachedHasCycle" />
-                </node>
+              <node concept="Xl_RD" id="6MN7yMJ82V4" role="1gVpfI">
+                <property role="Xl_RC" value="cache is disposed" />
               </node>
             </node>
-            <node concept="3clFbF" id="5uCOCQhZggl" role="3cqZAp">
-              <node concept="37vLTI" id="5uCOCQhZh5p" role="3clFbG">
-                <node concept="10Nm6u" id="5uCOCQhZhbR" role="37vLTx" />
-                <node concept="37vLTw" id="5uCOCQhZggj" role="37vLTJ">
-                  <ref role="3cqZAo" node="5uCOCQhZdAO" resolve="_cachedCycle" />
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="TDmWw" id="5YITc37N3n2" role="TEXxN">
-            <node concept="3cpWsn" id="5YITc37N3n4" role="TDEfY">
-              <property role="TrG5h" value="ex" />
-              <node concept="3uibUv" id="5YITc37Oj8Y" role="1tU5fm">
-                <ref role="3uigEE" node="5YITc37Og6w" resolve="CycleDetectedException" />
-              </node>
-            </node>
-            <node concept="3clFbS" id="5YITc37N3n8" role="TDEfX">
-              <node concept="3clFbF" id="5YITc37QY2Q" role="3cqZAp">
-                <node concept="37vLTI" id="5YITc37QY2R" role="3clFbG">
-                  <node concept="3clFbT" id="5YITc37QY2S" role="37vLTx">
-                    <property role="3clFbU" value="true" />
-                  </node>
-                  <node concept="37vLTw" id="5YITc37QY2T" role="37vLTJ">
+            <node concept="3clFbH" id="6MN7yMJ81td" role="3cqZAp" />
+            <node concept="3clFbJ" id="5YITc37QHDg" role="3cqZAp">
+              <node concept="3clFbS" id="5YITc37QHDi" role="3clFbx">
+                <node concept="3cpWs6" id="5YITc37QKQL" role="3cqZAp">
+                  <node concept="37vLTw" id="5YITc37QKTf" role="3cqZAk">
                     <ref role="3cqZAo" node="5YITc37PBWJ" resolve="_cachedHasCycle" />
                   </node>
                 </node>
               </node>
-              <node concept="3clFbF" id="5uCOCQhZhv1" role="3cqZAp">
-                <node concept="37vLTI" id="5uCOCQhZi9w" role="3clFbG">
-                  <node concept="2OqwBi" id="5uCOCQhZiFL" role="37vLTx">
-                    <node concept="37vLTw" id="5uCOCQhZilB" role="2Oq$k0">
-                      <ref role="3cqZAo" node="5YITc37N3n4" resolve="ex" />
-                    </node>
-                    <node concept="liA8E" id="5uCOCQhZjg$" role="2OqNvi">
-                      <ref role="37wK5l" node="5uCOCQhZ80m" resolve="getCycle" />
-                    </node>
-                  </node>
-                  <node concept="37vLTw" id="5uCOCQhZhuZ" role="37vLTJ">
-                    <ref role="3cqZAo" node="5uCOCQhZdAO" resolve="_cachedCycle" />
-                  </node>
+              <node concept="3y3z36" id="5YITc37QKIn" role="3clFbw">
+                <node concept="10Nm6u" id="5YITc37QKNX" role="3uHU7w" />
+                <node concept="37vLTw" id="5YITc37QJAO" role="3uHU7B">
+                  <ref role="3cqZAo" node="5YITc37PBWJ" resolve="_cachedHasCycle" />
                 </node>
               </node>
             </node>
-          </node>
-          <node concept="3clFbS" id="5YITc37QZAj" role="2GVbov">
-            <node concept="3cpWs6" id="5YITc37R1qs" role="3cqZAp">
-              <node concept="37vLTw" id="5YITc37R2rJ" role="3cqZAk">
-                <ref role="3cqZAo" node="5YITc37PBWJ" resolve="_cachedHasCycle" />
+            <node concept="3clFbH" id="5YITc37QOdO" role="3cqZAp" />
+            <node concept="2GUZhq" id="5YITc37QZAg" role="3cqZAp">
+              <node concept="3clFbS" id="5YITc37N3n1" role="2GV8ay">
+                <node concept="3clFbF" id="5YITc37OWoq" role="3cqZAp">
+                  <node concept="1rXfSq" id="5YITc37OWos" role="3clFbG">
+                    <ref role="37wK5l" node="5YITc37MTr0" resolve="checkForCycle" />
+                    <node concept="2ShNRf" id="5YITc37OWot" role="37wK5m">
+                      <node concept="2Jqq0_" id="5YITc37OWou" role="2ShVmc">
+                        <node concept="3Tqbb2" id="5YITc37OWov" role="HW$YZ">
+                          <ref role="ehGHo" to="kzoi:2S2eLhiMx2Q" resolve="IncrementallyComputedValueHolder" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="37vLTw" id="5YITc37OWow" role="37wK5m">
+                      <ref role="3cqZAo" node="2NSCtASrCpE" resolve="_valueHolder" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbF" id="5YITc37QROb" role="3cqZAp">
+                  <node concept="37vLTI" id="5YITc37QVdv" role="3clFbG">
+                    <node concept="3clFbT" id="5YITc37QVk5" role="37vLTx">
+                      <property role="3clFbU" value="false" />
+                    </node>
+                    <node concept="37vLTw" id="5YITc37QRO9" role="37vLTJ">
+                      <ref role="3cqZAo" node="5YITc37PBWJ" resolve="_cachedHasCycle" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbF" id="5uCOCQhZggl" role="3cqZAp">
+                  <node concept="37vLTI" id="5uCOCQhZh5p" role="3clFbG">
+                    <node concept="10Nm6u" id="5uCOCQhZhbR" role="37vLTx" />
+                    <node concept="37vLTw" id="5uCOCQhZggj" role="37vLTJ">
+                      <ref role="3cqZAo" node="5uCOCQhZdAO" resolve="_cachedCycle" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="TDmWw" id="5YITc37N3n2" role="TEXxN">
+                <node concept="3cpWsn" id="5YITc37N3n4" role="TDEfY">
+                  <property role="TrG5h" value="ex" />
+                  <node concept="3uibUv" id="5YITc37Oj8Y" role="1tU5fm">
+                    <ref role="3uigEE" node="5YITc37Og6w" resolve="CycleDetectedException" />
+                  </node>
+                </node>
+                <node concept="3clFbS" id="5YITc37N3n8" role="TDEfX">
+                  <node concept="3clFbF" id="5YITc37QY2Q" role="3cqZAp">
+                    <node concept="37vLTI" id="5YITc37QY2R" role="3clFbG">
+                      <node concept="3clFbT" id="5YITc37QY2S" role="37vLTx">
+                        <property role="3clFbU" value="true" />
+                      </node>
+                      <node concept="37vLTw" id="5YITc37QY2T" role="37vLTJ">
+                        <ref role="3cqZAo" node="5YITc37PBWJ" resolve="_cachedHasCycle" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbF" id="5uCOCQhZhv1" role="3cqZAp">
+                    <node concept="37vLTI" id="5uCOCQhZi9w" role="3clFbG">
+                      <node concept="2OqwBi" id="5uCOCQhZiFL" role="37vLTx">
+                        <node concept="37vLTw" id="5uCOCQhZilB" role="2Oq$k0">
+                          <ref role="3cqZAo" node="5YITc37N3n4" resolve="ex" />
+                        </node>
+                        <node concept="liA8E" id="5uCOCQhZjg$" role="2OqNvi">
+                          <ref role="37wK5l" node="5uCOCQhZ80m" resolve="getCycle" />
+                        </node>
+                      </node>
+                      <node concept="37vLTw" id="5uCOCQhZhuZ" role="37vLTJ">
+                        <ref role="3cqZAo" node="5uCOCQhZdAO" resolve="_cachedCycle" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbS" id="5YITc37QZAj" role="2GVbov">
+                <node concept="3cpWs6" id="5YITc37R1qs" role="3cqZAp">
+                  <node concept="37vLTw" id="5YITc37R2rJ" role="3cqZAk">
+                    <ref role="3cqZAo" node="5YITc37PBWJ" resolve="_cachedHasCycle" />
+                  </node>
+                </node>
               </node>
             </node>
           </node>
@@ -1923,7 +1971,6 @@
     <node concept="3clFb_" id="5uCOCQhZ$YO" role="jymVt">
       <property role="1EzhhJ" value="false" />
       <property role="TrG5h" value="getCycle" />
-      <property role="od$2w" value="false" />
       <property role="DiZV1" value="false" />
       <property role="2aFKle" value="false" />
       <node concept="3clFbS" id="5uCOCQhZ$YR" role="3clF47">
@@ -1942,104 +1989,110 @@
     <node concept="3clFb_" id="5YITc37MTr0" role="jymVt">
       <property role="1EzhhJ" value="false" />
       <property role="TrG5h" value="checkForCycle" />
-      <property role="od$2w" value="false" />
       <property role="DiZV1" value="false" />
       <property role="2aFKle" value="false" />
       <node concept="3clFbS" id="5YITc37MTr1" role="3clF47">
-        <node concept="3clFbJ" id="5YITc37NFbM" role="3cqZAp">
-          <node concept="3clFbS" id="5YITc37NFbO" role="3clFbx">
-            <node concept="3clFbF" id="5uCOCQhZjTA" role="3cqZAp">
-              <node concept="2OqwBi" id="5uCOCQhZkDH" role="3clFbG">
-                <node concept="37vLTw" id="5uCOCQhZjT$" role="2Oq$k0">
+        <node concept="1HWtB8" id="2YOONxNVKym" role="3cqZAp">
+          <node concept="3VsKOn" id="2YOONxNVKyn" role="1HWFw0">
+            <ref role="3VsUkX" node="7ZWgXq7GlHg" resolve="ValueCache" />
+          </node>
+          <node concept="3clFbS" id="2YOONxNVKyo" role="1HWHxc">
+            <node concept="3clFbJ" id="5YITc37NFbM" role="3cqZAp">
+              <node concept="3clFbS" id="5YITc37NFbO" role="3clFbx">
+                <node concept="3clFbF" id="5uCOCQhZjTA" role="3cqZAp">
+                  <node concept="2OqwBi" id="5uCOCQhZkDH" role="3clFbG">
+                    <node concept="37vLTw" id="5uCOCQhZjT$" role="2Oq$k0">
+                      <ref role="3cqZAo" node="5YITc37MTr4" resolve="participantStack" />
+                    </node>
+                    <node concept="2ArzE6" id="5uCOCQhZls7" role="2OqNvi">
+                      <node concept="37vLTw" id="5uCOCQhZlGN" role="25WWJ7">
+                        <ref role="3cqZAo" node="5YITc37NIo3" resolve="participant" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="YS8fn" id="5YITc37NSNw" role="3cqZAp">
+                  <node concept="2ShNRf" id="5YITc37NSOF" role="YScLw">
+                    <node concept="1pGfFk" id="5YITc37NT45" role="2ShVmc">
+                      <ref role="37wK5l" node="5YITc37Og6x" resolve="CycleDetectedException" />
+                      <node concept="2OqwBi" id="5uCOCQhZ9vL" role="37wK5m">
+                        <node concept="37vLTw" id="5uCOCQhZ6_p" role="2Oq$k0">
+                          <ref role="3cqZAo" node="5YITc37MTr4" resolve="participantStack" />
+                        </node>
+                        <node concept="ANE8D" id="5uCOCQhZakr" role="2OqNvi" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="2OqwBi" id="5YITc37NHCX" role="3clFbw">
+                <node concept="37vLTw" id="5YITc37NGFQ" role="2Oq$k0">
                   <ref role="3cqZAo" node="5YITc37MTr4" resolve="participantStack" />
                 </node>
-                <node concept="2ArzE6" id="5uCOCQhZls7" role="2OqNvi">
-                  <node concept="37vLTw" id="5uCOCQhZlGN" role="25WWJ7">
+                <node concept="3JPx81" id="5YITc37NIm1" role="2OqNvi">
+                  <node concept="37vLTw" id="5YITc37NSKV" role="25WWJ7">
                     <ref role="3cqZAo" node="5YITc37NIo3" resolve="participant" />
                   </node>
                 </node>
               </node>
             </node>
-            <node concept="YS8fn" id="5YITc37NSNw" role="3cqZAp">
-              <node concept="2ShNRf" id="5YITc37NSOF" role="YScLw">
-                <node concept="1pGfFk" id="5YITc37NT45" role="2ShVmc">
-                  <ref role="37wK5l" node="5YITc37Og6x" resolve="CycleDetectedException" />
-                  <node concept="2OqwBi" id="5uCOCQhZ9vL" role="37wK5m">
-                    <node concept="37vLTw" id="5uCOCQhZ6_p" role="2Oq$k0">
-                      <ref role="3cqZAo" node="5YITc37MTr4" resolve="participantStack" />
-                    </node>
-                    <node concept="ANE8D" id="5uCOCQhZakr" role="2OqNvi" />
+            <node concept="3clFbH" id="5YITc37Oy6H" role="3cqZAp" />
+            <node concept="3clFbF" id="5YITc37NUKH" role="3cqZAp">
+              <node concept="2OqwBi" id="5YITc37NYJO" role="3clFbG">
+                <node concept="37vLTw" id="5YITc37NXWG" role="2Oq$k0">
+                  <ref role="3cqZAo" node="5YITc37MTr4" resolve="participantStack" />
+                </node>
+                <node concept="2ArzE6" id="5YITc37O096" role="2OqNvi">
+                  <node concept="37vLTw" id="5YITc37O0ng" role="25WWJ7">
+                    <ref role="3cqZAo" node="5YITc37NIo3" resolve="participant" />
                   </node>
                 </node>
               </node>
             </node>
-          </node>
-          <node concept="2OqwBi" id="5YITc37NHCX" role="3clFbw">
-            <node concept="37vLTw" id="5YITc37NGFQ" role="2Oq$k0">
-              <ref role="3cqZAo" node="5YITc37MTr4" resolve="participantStack" />
-            </node>
-            <node concept="3JPx81" id="5YITc37NIm1" role="2OqNvi">
-              <node concept="37vLTw" id="5YITc37NSKV" role="25WWJ7">
-                <ref role="3cqZAo" node="5YITc37NIo3" resolve="participant" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbH" id="5YITc37Oy6H" role="3cqZAp" />
-        <node concept="3clFbF" id="5YITc37NUKH" role="3cqZAp">
-          <node concept="2OqwBi" id="5YITc37NYJO" role="3clFbG">
-            <node concept="37vLTw" id="5YITc37NXWG" role="2Oq$k0">
-              <ref role="3cqZAo" node="5YITc37MTr4" resolve="participantStack" />
-            </node>
-            <node concept="2ArzE6" id="5YITc37O096" role="2OqNvi">
-              <node concept="37vLTw" id="5YITc37O0ng" role="25WWJ7">
-                <ref role="3cqZAo" node="5YITc37NIo3" resolve="participant" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="5YITc37ONuk" role="3cqZAp">
-          <node concept="2OqwBi" id="5YITc37OQCs" role="3clFbG">
-            <node concept="2OqwBi" id="5YITc37ONum" role="2Oq$k0">
-              <node concept="37vLTw" id="5YITc37ONun" role="2Oq$k0">
-                <ref role="3cqZAo" node="5YITc37NIo3" resolve="participant" />
-              </node>
-              <node concept="2qgKlT" id="5YITc37ONuo" role="2OqNvi">
-                <ref role="37wK5l" to="ao0u:2S2eLhiMzhL" resolve="getDependencies" />
-                <node concept="37vLTw" id="5YITc37ONup" role="37wK5m">
-                  <ref role="3cqZAo" node="RObVTFnnYE" resolve="_valueSelector" />
-                </node>
-              </node>
-            </node>
-            <node concept="2es0OD" id="5YITc37OTsH" role="2OqNvi">
-              <node concept="1bVj0M" id="5YITc37OTsJ" role="23t8la">
-                <node concept="3clFbS" id="5YITc37OTsK" role="1bW5cS">
-                  <node concept="3clFbF" id="5YITc37Paiz" role="3cqZAp">
-                    <node concept="1rXfSq" id="5YITc37Paiy" role="3clFbG">
-                      <ref role="37wK5l" node="5YITc37MTr0" resolve="checkForCycle" />
-                      <node concept="37vLTw" id="5YITc37Pauu" role="37wK5m">
-                        <ref role="3cqZAo" node="5YITc37MTr4" resolve="participantStack" />
-                      </node>
-                      <node concept="37vLTw" id="5YITc37PaLo" role="37wK5m">
-                        <ref role="3cqZAo" node="5YITc37OTsL" resolve="it" />
-                      </node>
+            <node concept="3clFbF" id="5YITc37ONuk" role="3cqZAp">
+              <node concept="2OqwBi" id="5YITc37OQCs" role="3clFbG">
+                <node concept="2OqwBi" id="5YITc37ONum" role="2Oq$k0">
+                  <node concept="37vLTw" id="5YITc37ONun" role="2Oq$k0">
+                    <ref role="3cqZAo" node="5YITc37NIo3" resolve="participant" />
+                  </node>
+                  <node concept="2qgKlT" id="5YITc37ONuo" role="2OqNvi">
+                    <ref role="37wK5l" to="ao0u:2S2eLhiMzhL" resolve="getDependencies" />
+                    <node concept="37vLTw" id="5YITc37ONup" role="37wK5m">
+                      <ref role="3cqZAo" node="RObVTFnnYE" resolve="_valueSelector" />
                     </node>
                   </node>
                 </node>
-                <node concept="Rh6nW" id="5YITc37OTsL" role="1bW2Oz">
-                  <property role="TrG5h" value="it" />
-                  <node concept="2jxLKc" id="5YITc37OTsM" role="1tU5fm" />
+                <node concept="2es0OD" id="5YITc37OTsH" role="2OqNvi">
+                  <node concept="1bVj0M" id="5YITc37OTsJ" role="23t8la">
+                    <node concept="3clFbS" id="5YITc37OTsK" role="1bW5cS">
+                      <node concept="3clFbF" id="5YITc37Paiz" role="3cqZAp">
+                        <node concept="1rXfSq" id="5YITc37Paiy" role="3clFbG">
+                          <ref role="37wK5l" node="5YITc37MTr0" resolve="checkForCycle" />
+                          <node concept="37vLTw" id="5YITc37Pauu" role="37wK5m">
+                            <ref role="3cqZAo" node="5YITc37MTr4" resolve="participantStack" />
+                          </node>
+                          <node concept="37vLTw" id="5YITc37PaLo" role="37wK5m">
+                            <ref role="3cqZAo" node="5YITc37OTsL" resolve="it" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="Rh6nW" id="5YITc37OTsL" role="1bW2Oz">
+                      <property role="TrG5h" value="it" />
+                      <node concept="2jxLKc" id="5YITc37OTsM" role="1tU5fm" />
+                    </node>
+                  </node>
                 </node>
               </node>
             </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="5YITc37OBzB" role="3cqZAp">
-          <node concept="2OqwBi" id="5YITc37OF5l" role="3clFbG">
-            <node concept="37vLTw" id="5YITc37OBz_" role="2Oq$k0">
-              <ref role="3cqZAo" node="5YITc37MTr4" resolve="participantStack" />
+            <node concept="3clFbF" id="5YITc37OBzB" role="3cqZAp">
+              <node concept="2OqwBi" id="5YITc37OF5l" role="3clFbG">
+                <node concept="37vLTw" id="5YITc37OBz_" role="2Oq$k0">
+                  <ref role="3cqZAo" node="5YITc37MTr4" resolve="participantStack" />
+                </node>
+                <node concept="2AryhJ" id="5YITc37OG_d" role="2OqNvi" />
+              </node>
             </node>
-            <node concept="2AryhJ" id="5YITc37OG_d" role="2OqNvi" />
           </node>
         </node>
       </node>
@@ -2064,7 +2117,6 @@
     <node concept="3clFb_" id="KudFejWkex" role="jymVt">
       <property role="1EzhhJ" value="false" />
       <property role="TrG5h" value="contentChanged" />
-      <property role="od$2w" value="false" />
       <property role="DiZV1" value="false" />
       <property role="2aFKle" value="false" />
       <node concept="37vLTG" id="KudFejZtIB" role="3clF46">
@@ -2074,20 +2126,27 @@
         </node>
       </node>
       <node concept="3clFbS" id="KudFejWke$" role="3clF47">
-        <node concept="3clFbF" id="KudFejX3if" role="3cqZAp">
-          <node concept="1rXfSq" id="KudFejX3ie" role="3clFbG">
-            <ref role="37wK5l" node="6sjp2R1XpyA" resolve="reactOnChange" />
-            <node concept="2OqwBi" id="KudFejX3_o" role="37wK5m">
-              <node concept="37vLTw" id="KudFejX3nI" role="2Oq$k0">
-                <ref role="3cqZAo" node="2NSCtASrCpE" resolve="_valueHolder" />
-              </node>
-              <node concept="2qgKlT" id="KudFejXa0k" role="2OqNvi">
-                <ref role="37wK5l" to="ao0u:KudFejX3SG" resolve="getChangeEffect" />
-                <node concept="37vLTw" id="KudFejZ$LS" role="37wK5m">
-                  <ref role="3cqZAo" node="KudFejZtIB" resolve="event" />
-                </node>
-                <node concept="37vLTw" id="KudFejYuLw" role="37wK5m">
-                  <ref role="3cqZAo" node="RObVTFnnYE" resolve="_valueSelector" />
+        <node concept="1HWtB8" id="2YOONxNVP3q" role="3cqZAp">
+          <node concept="3VsKOn" id="2YOONxNVP3r" role="1HWFw0">
+            <ref role="3VsUkX" node="7ZWgXq7GlHg" resolve="ValueCache" />
+          </node>
+          <node concept="3clFbS" id="2YOONxNVP3s" role="1HWHxc">
+            <node concept="3clFbF" id="KudFejX3if" role="3cqZAp">
+              <node concept="1rXfSq" id="KudFejX3ie" role="3clFbG">
+                <ref role="37wK5l" node="6sjp2R1XpyA" resolve="reactOnChange" />
+                <node concept="2OqwBi" id="KudFejX3_o" role="37wK5m">
+                  <node concept="37vLTw" id="KudFejX3nI" role="2Oq$k0">
+                    <ref role="3cqZAo" node="2NSCtASrCpE" resolve="_valueHolder" />
+                  </node>
+                  <node concept="2qgKlT" id="KudFejXa0k" role="2OqNvi">
+                    <ref role="37wK5l" to="ao0u:KudFejX3SG" resolve="getChangeEffect" />
+                    <node concept="37vLTw" id="KudFejZ$LS" role="37wK5m">
+                      <ref role="3cqZAo" node="KudFejZtIB" resolve="event" />
+                    </node>
+                    <node concept="37vLTw" id="KudFejYuLw" role="37wK5m">
+                      <ref role="3cqZAo" node="RObVTFnnYE" resolve="_valueSelector" />
+                    </node>
+                  </node>
                 </node>
               </node>
             </node>
@@ -2101,34 +2160,40 @@
     <node concept="3clFb_" id="7CsrqpZonfx" role="jymVt">
       <property role="1EzhhJ" value="false" />
       <property role="TrG5h" value="dispose" />
-      <property role="od$2w" value="false" />
       <property role="DiZV1" value="false" />
       <property role="2aFKle" value="false" />
       <node concept="3clFbS" id="7CsrqpZonf$" role="3clF47">
-        <node concept="3clFbF" id="6MN7yMJ7Gf$" role="3cqZAp">
-          <node concept="37vLTI" id="6MN7yMJ7G_Y" role="3clFbG">
-            <node concept="3clFbT" id="6MN7yMJ7GFb" role="37vLTx">
-              <property role="3clFbU" value="true" />
-            </node>
-            <node concept="37vLTw" id="6MN7yMJ7Gfy" role="37vLTJ">
-              <ref role="3cqZAo" node="6MN7yMJ7Ell" resolve="_isDisposed" />
-            </node>
+        <node concept="1HWtB8" id="2YOONxNVSop" role="3cqZAp">
+          <node concept="3VsKOn" id="2YOONxNVSoq" role="1HWFw0">
+            <ref role="3VsUkX" node="7ZWgXq7GlHg" resolve="ValueCache" />
           </node>
-        </node>
-        <node concept="3clFbF" id="7CsrqpZoweS" role="3cqZAp">
-          <node concept="2OqwBi" id="7CsrqpZozVw" role="3clFbG">
-            <node concept="2JrnkZ" id="7CsrqpZozxo" role="2Oq$k0">
-              <node concept="37vLTw" id="7CsrqpZoweQ" role="2JrQYb">
-                <ref role="3cqZAo" node="2NSCtASrCpE" resolve="_valueHolder" />
+          <node concept="3clFbS" id="2YOONxNVSor" role="1HWHxc">
+            <node concept="3clFbF" id="6MN7yMJ7Gf$" role="3cqZAp">
+              <node concept="37vLTI" id="6MN7yMJ7G_Y" role="3clFbG">
+                <node concept="3clFbT" id="6MN7yMJ7GFb" role="37vLTx">
+                  <property role="3clFbU" value="true" />
+                </node>
+                <node concept="37vLTw" id="6MN7yMJ7Gfy" role="37vLTJ">
+                  <ref role="3cqZAo" node="6MN7yMJ7Ell" resolve="_isDisposed" />
+                </node>
               </node>
             </node>
-            <node concept="liA8E" id="7CsrqpZo$cw" role="2OqNvi">
-              <ref role="37wK5l" to="mhbf:~SNode.putUserObject(java.lang.Object,java.lang.Object):void" resolve="putUserObject" />
-              <node concept="10M0yZ" id="3mJtqpyRjq3" role="37wK5m">
-                <ref role="3cqZAo" node="3mJtqpyRiaj" resolve="USER_OBJECT_ID" />
-                <ref role="1PxDUh" node="2S2eLhiM$hD" resolve="ValueHolderInfo" />
+            <node concept="3clFbF" id="7CsrqpZoweS" role="3cqZAp">
+              <node concept="2OqwBi" id="7CsrqpZozVw" role="3clFbG">
+                <node concept="2JrnkZ" id="7CsrqpZozxo" role="2Oq$k0">
+                  <node concept="37vLTw" id="7CsrqpZoweQ" role="2JrQYb">
+                    <ref role="3cqZAo" node="2NSCtASrCpE" resolve="_valueHolder" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="7CsrqpZo$cw" role="2OqNvi">
+                  <ref role="37wK5l" to="mhbf:~SNode.putUserObject(java.lang.Object,java.lang.Object):void" resolve="putUserObject" />
+                  <node concept="10M0yZ" id="3mJtqpyRjq3" role="37wK5m">
+                    <ref role="3cqZAo" node="3mJtqpyRiaj" resolve="USER_OBJECT_ID" />
+                    <ref role="1PxDUh" node="2S2eLhiM$hD" resolve="ValueHolderInfo" />
+                  </node>
+                  <node concept="10Nm6u" id="7CsrqpZoAUQ" role="37wK5m" />
+                </node>
               </node>
-              <node concept="10Nm6u" id="7CsrqpZoAUQ" role="37wK5m" />
             </node>
           </node>
         </node>
@@ -2140,230 +2205,236 @@
     <node concept="3clFb_" id="6sjp2R1XpyA" role="jymVt">
       <property role="1EzhhJ" value="false" />
       <property role="TrG5h" value="reactOnChange" />
-      <property role="od$2w" value="false" />
       <property role="DiZV1" value="false" />
       <property role="2aFKle" value="false" />
       <node concept="3clFbS" id="6sjp2R1XpyD" role="3clF47">
-        <node concept="3clFbJ" id="797ZNR2jQA2" role="3cqZAp">
-          <node concept="3clFbS" id="797ZNR2jQA4" role="3clFbx">
-            <node concept="3cpWs6" id="797ZNR2jSz7" role="3cqZAp" />
+        <node concept="1HWtB8" id="2YOONxNVVq7" role="3cqZAp">
+          <node concept="3VsKOn" id="2YOONxNVVq8" role="1HWFw0">
+            <ref role="3VsUkX" node="7ZWgXq7GlHg" resolve="ValueCache" />
           </node>
-          <node concept="3clFbC" id="797ZNR2kqtC" role="3clFbw">
-            <node concept="10Nm6u" id="797ZNR2kqLi" role="3uHU7w" />
-            <node concept="37vLTw" id="797ZNR2kq65" role="3uHU7B">
-              <ref role="3cqZAo" node="6sjp2R1Xvw4" resolve="changeEffect" />
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbH" id="797ZNR2jSzk" role="3cqZAp" />
-        <node concept="3cpWs8" id="797ZNR2kka8" role="3cqZAp">
-          <node concept="3cpWsn" id="797ZNR2kkab" role="3cpWs9">
-            <property role="TrG5h" value="visitedParticipants" />
-            <node concept="_YKpA" id="797ZNR2kka4" role="1tU5fm">
-              <node concept="3uibUv" id="797ZNR2kkrE" role="_ZDj9">
-                <ref role="3uigEE" node="2S2eLhiM$hD" resolve="ValueHolderInfo" />
+          <node concept="3clFbS" id="2YOONxNVVq9" role="1HWHxc">
+            <node concept="3clFbJ" id="797ZNR2jQA2" role="3cqZAp">
+              <node concept="3clFbS" id="797ZNR2jQA4" role="3clFbx">
+                <node concept="3cpWs6" id="797ZNR2jSz7" role="3cqZAp" />
               </node>
-            </node>
-            <node concept="2ShNRf" id="797ZNR2kkwW" role="33vP2m">
-              <node concept="2Jqq0_" id="797ZNR2kkwX" role="2ShVmc">
-                <node concept="3uibUv" id="797ZNR2kkwY" role="HW$YZ">
-                  <ref role="3uigEE" node="2S2eLhiM$hD" resolve="ValueHolderInfo" />
+              <node concept="3clFbC" id="797ZNR2kqtC" role="3clFbw">
+                <node concept="10Nm6u" id="797ZNR2kqLi" role="3uHU7w" />
+                <node concept="37vLTw" id="797ZNR2kq65" role="3uHU7B">
+                  <ref role="3cqZAo" node="6sjp2R1Xvw4" resolve="changeEffect" />
                 </node>
               </node>
             </node>
-          </node>
-        </node>
-        <node concept="3clFbH" id="7QXl$ZOIJu5" role="3cqZAp" />
-        <node concept="3clFbF" id="ymtTuKAgNy" role="3cqZAp">
-          <node concept="1rXfSq" id="ymtTuKAgNw" role="3clFbG">
-            <ref role="37wK5l" node="RObVTFmWkR" resolve="invalidate" />
-            <node concept="2OqwBi" id="ymtTuKAhCS" role="37wK5m">
-              <node concept="37vLTw" id="ymtTuKAhr6" role="2Oq$k0">
-                <ref role="3cqZAo" node="6sjp2R1Xvw4" resolve="changeEffect" />
-              </node>
-              <node concept="liA8E" id="ymtTuKAhTg" role="2OqNvi">
-                <ref role="37wK5l" node="797ZNR2jJms" resolve="getKind" />
+            <node concept="3clFbH" id="797ZNR2jSzk" role="3cqZAp" />
+            <node concept="3cpWs8" id="797ZNR2kka8" role="3cqZAp">
+              <node concept="3cpWsn" id="797ZNR2kkab" role="3cpWs9">
+                <property role="TrG5h" value="visitedParticipants" />
+                <node concept="_YKpA" id="797ZNR2kka4" role="1tU5fm">
+                  <node concept="3uibUv" id="797ZNR2kkrE" role="_ZDj9">
+                    <ref role="3uigEE" node="2S2eLhiM$hD" resolve="ValueHolderInfo" />
+                  </node>
+                </node>
+                <node concept="2ShNRf" id="797ZNR2kkwW" role="33vP2m">
+                  <node concept="2Jqq0_" id="797ZNR2kkwX" role="2ShVmc">
+                    <node concept="3uibUv" id="797ZNR2kkwY" role="HW$YZ">
+                      <ref role="3uigEE" node="2S2eLhiM$hD" resolve="ValueHolderInfo" />
+                    </node>
+                  </node>
+                </node>
               </node>
             </node>
-            <node concept="37vLTw" id="ymtTuKAifV" role="37wK5m">
-              <ref role="3cqZAo" node="797ZNR2kkab" resolve="visitedParticipants" />
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbH" id="7QXl$ZOIJfV" role="3cqZAp" />
-        <node concept="3clFbJ" id="ymtTuKAiPZ" role="3cqZAp">
-          <node concept="3clFbS" id="ymtTuKAiQ1" role="3clFbx">
-            <node concept="3clFbF" id="797ZNR2jNaq" role="3cqZAp">
-              <node concept="2OqwBi" id="797ZNR2jOz4" role="3clFbG">
-                <node concept="2OqwBi" id="797ZNR2jNiU" role="2Oq$k0">
-                  <node concept="37vLTw" id="797ZNR2jNao" role="2Oq$k0">
+            <node concept="3clFbH" id="7QXl$ZOIJu5" role="3cqZAp" />
+            <node concept="3clFbF" id="ymtTuKAgNy" role="3cqZAp">
+              <node concept="1rXfSq" id="ymtTuKAgNw" role="3clFbG">
+                <ref role="37wK5l" node="RObVTFmWkR" resolve="invalidate" />
+                <node concept="2OqwBi" id="ymtTuKAhCS" role="37wK5m">
+                  <node concept="37vLTw" id="ymtTuKAhr6" role="2Oq$k0">
                     <ref role="3cqZAo" node="6sjp2R1Xvw4" resolve="changeEffect" />
                   </node>
-                  <node concept="liA8E" id="797ZNR2jNuA" role="2OqNvi">
+                  <node concept="liA8E" id="ymtTuKAhTg" role="2OqNvi">
+                    <ref role="37wK5l" node="797ZNR2jJms" resolve="getKind" />
+                  </node>
+                </node>
+                <node concept="37vLTw" id="ymtTuKAifV" role="37wK5m">
+                  <ref role="3cqZAo" node="797ZNR2kkab" resolve="visitedParticipants" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbH" id="7QXl$ZOIJfV" role="3cqZAp" />
+            <node concept="3clFbJ" id="ymtTuKAiPZ" role="3cqZAp">
+              <node concept="3clFbS" id="ymtTuKAiQ1" role="3clFbx">
+                <node concept="3clFbF" id="797ZNR2jNaq" role="3cqZAp">
+                  <node concept="2OqwBi" id="797ZNR2jOz4" role="3clFbG">
+                    <node concept="2OqwBi" id="797ZNR2jNiU" role="2Oq$k0">
+                      <node concept="37vLTw" id="797ZNR2jNao" role="2Oq$k0">
+                        <ref role="3cqZAo" node="6sjp2R1Xvw4" resolve="changeEffect" />
+                      </node>
+                      <node concept="liA8E" id="797ZNR2jNuA" role="2OqNvi">
+                        <ref role="37wK5l" node="797ZNR2jK0W" resolve="getInvalidationHint" />
+                      </node>
+                    </node>
+                    <node concept="2es0OD" id="797ZNR2jQsX" role="2OqNvi">
+                      <node concept="1bVj0M" id="797ZNR2jQsZ" role="23t8la">
+                        <node concept="3clFbS" id="797ZNR2jQt0" role="1bW5cS">
+                          <node concept="3clFbF" id="797ZNR2jVNn" role="3cqZAp">
+                            <node concept="2OqwBi" id="797ZNR2jWWe" role="3clFbG">
+                              <node concept="2OqwBi" id="797ZNR2jVY8" role="2Oq$k0">
+                                <node concept="37vLTw" id="797ZNR2jVNl" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="797ZNR2jQt1" resolve="it" />
+                                </node>
+                                <node concept="2qgKlT" id="797ZNR2jWI_" role="2OqNvi">
+                                  <ref role="37wK5l" to="ao0u:2S2eLhiM$ey" resolve="getValueHolderInfo" />
+                                </node>
+                              </node>
+                              <node concept="liA8E" id="797ZNR2jXbM" role="2OqNvi">
+                                <ref role="37wK5l" node="RObVTFmZbg" resolve="invalidate" />
+                                <node concept="37vLTw" id="797ZNR2jXqn" role="37wK5m">
+                                  <ref role="3cqZAo" node="RObVTFnnYE" resolve="_valueSelector" />
+                                </node>
+                                <node concept="2OqwBi" id="797ZNR2kjms" role="37wK5m">
+                                  <node concept="37vLTw" id="797ZNR2kj4w" role="2Oq$k0">
+                                    <ref role="3cqZAo" node="6sjp2R1Xvw4" resolve="changeEffect" />
+                                  </node>
+                                  <node concept="liA8E" id="797ZNR2kjJw" role="2OqNvi">
+                                    <ref role="37wK5l" node="797ZNR2jJms" resolve="getKind" />
+                                  </node>
+                                </node>
+                                <node concept="37vLTw" id="797ZNR2kkQt" role="37wK5m">
+                                  <ref role="3cqZAo" node="797ZNR2kkab" resolve="visitedParticipants" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="Rh6nW" id="797ZNR2jQt1" role="1bW2Oz">
+                          <property role="TrG5h" value="it" />
+                          <node concept="2jxLKc" id="797ZNR2jQt2" role="1tU5fm" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3y3z36" id="ymtTuKAngl" role="3clFbw">
+                <node concept="10Nm6u" id="ymtTuKAnum" role="3uHU7w" />
+                <node concept="2OqwBi" id="ymtTuKAjkF" role="3uHU7B">
+                  <node concept="37vLTw" id="ymtTuKAj5e" role="2Oq$k0">
+                    <ref role="3cqZAo" node="6sjp2R1Xvw4" resolve="changeEffect" />
+                  </node>
+                  <node concept="liA8E" id="ymtTuKAjEH" role="2OqNvi">
                     <ref role="37wK5l" node="797ZNR2jK0W" resolve="getInvalidationHint" />
                   </node>
                 </node>
-                <node concept="2es0OD" id="797ZNR2jQsX" role="2OqNvi">
-                  <node concept="1bVj0M" id="797ZNR2jQsZ" role="23t8la">
-                    <node concept="3clFbS" id="797ZNR2jQt0" role="1bW5cS">
-                      <node concept="3clFbF" id="797ZNR2jVNn" role="3cqZAp">
-                        <node concept="2OqwBi" id="797ZNR2jWWe" role="3clFbG">
-                          <node concept="2OqwBi" id="797ZNR2jVY8" role="2Oq$k0">
-                            <node concept="37vLTw" id="797ZNR2jVNl" role="2Oq$k0">
-                              <ref role="3cqZAo" node="797ZNR2jQt1" resolve="it" />
-                            </node>
-                            <node concept="2qgKlT" id="797ZNR2jWI_" role="2OqNvi">
-                              <ref role="37wK5l" to="ao0u:2S2eLhiM$ey" resolve="getValueHolderInfo" />
-                            </node>
+              </node>
+            </node>
+            <node concept="3clFbH" id="5nAcTtnbwtr" role="3cqZAp" />
+            <node concept="2Gpval" id="5nAcTtnbygb" role="3cqZAp">
+              <node concept="2GrKxI" id="5nAcTtnbygd" role="2Gsz3X">
+                <property role="TrG5h" value="participant" />
+              </node>
+              <node concept="2OqwBi" id="1kbsEhJFqsA" role="2GsD0m">
+                <node concept="37vLTw" id="5nAcTtnbyka" role="2Oq$k0">
+                  <ref role="3cqZAo" node="797ZNR2kkab" resolve="visitedParticipants" />
+                </node>
+                <node concept="3$u5V9" id="1kbsEhJFrAC" role="2OqNvi">
+                  <node concept="1bVj0M" id="1kbsEhJFrAE" role="23t8la">
+                    <node concept="3clFbS" id="1kbsEhJFrAF" role="1bW5cS">
+                      <node concept="3clFbF" id="1kbsEhJFrG6" role="3cqZAp">
+                        <node concept="2OqwBi" id="1kbsEhJFrXv" role="3clFbG">
+                          <node concept="37vLTw" id="1kbsEhJFrG5" role="2Oq$k0">
+                            <ref role="3cqZAo" node="1kbsEhJFrAG" resolve="it" />
                           </node>
-                          <node concept="liA8E" id="797ZNR2jXbM" role="2OqNvi">
-                            <ref role="37wK5l" node="RObVTFmZbg" resolve="invalidate" />
-                            <node concept="37vLTw" id="797ZNR2jXqn" role="37wK5m">
-                              <ref role="3cqZAo" node="RObVTFnnYE" resolve="_valueSelector" />
-                            </node>
-                            <node concept="2OqwBi" id="797ZNR2kjms" role="37wK5m">
-                              <node concept="37vLTw" id="797ZNR2kj4w" role="2Oq$k0">
-                                <ref role="3cqZAo" node="6sjp2R1Xvw4" resolve="changeEffect" />
-                              </node>
-                              <node concept="liA8E" id="797ZNR2kjJw" role="2OqNvi">
-                                <ref role="37wK5l" node="797ZNR2jJms" resolve="getKind" />
-                              </node>
-                            </node>
-                            <node concept="37vLTw" id="797ZNR2kkQt" role="37wK5m">
-                              <ref role="3cqZAo" node="797ZNR2kkab" resolve="visitedParticipants" />
-                            </node>
+                          <node concept="liA8E" id="1kbsEhJFskH" role="2OqNvi">
+                            <ref role="37wK5l" node="RObVTFnwug" resolve="getValueHolder" />
                           </node>
                         </node>
                       </node>
                     </node>
-                    <node concept="Rh6nW" id="797ZNR2jQt1" role="1bW2Oz">
+                    <node concept="Rh6nW" id="1kbsEhJFrAG" role="1bW2Oz">
                       <property role="TrG5h" value="it" />
-                      <node concept="2jxLKc" id="797ZNR2jQt2" role="1tU5fm" />
+                      <node concept="2jxLKc" id="1kbsEhJFrAH" role="1tU5fm" />
                     </node>
                   </node>
                 </node>
               </node>
-            </node>
-          </node>
-          <node concept="3y3z36" id="ymtTuKAngl" role="3clFbw">
-            <node concept="10Nm6u" id="ymtTuKAnum" role="3uHU7w" />
-            <node concept="2OqwBi" id="ymtTuKAjkF" role="3uHU7B">
-              <node concept="37vLTw" id="ymtTuKAj5e" role="2Oq$k0">
-                <ref role="3cqZAo" node="6sjp2R1Xvw4" resolve="changeEffect" />
-              </node>
-              <node concept="liA8E" id="ymtTuKAjEH" role="2OqNvi">
-                <ref role="37wK5l" node="797ZNR2jK0W" resolve="getInvalidationHint" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbH" id="5nAcTtnbwtr" role="3cqZAp" />
-        <node concept="2Gpval" id="5nAcTtnbygb" role="3cqZAp">
-          <node concept="2GrKxI" id="5nAcTtnbygd" role="2Gsz3X">
-            <property role="TrG5h" value="participant" />
-          </node>
-          <node concept="2OqwBi" id="1kbsEhJFqsA" role="2GsD0m">
-            <node concept="37vLTw" id="5nAcTtnbyka" role="2Oq$k0">
-              <ref role="3cqZAo" node="797ZNR2kkab" resolve="visitedParticipants" />
-            </node>
-            <node concept="3$u5V9" id="1kbsEhJFrAC" role="2OqNvi">
-              <node concept="1bVj0M" id="1kbsEhJFrAE" role="23t8la">
-                <node concept="3clFbS" id="1kbsEhJFrAF" role="1bW5cS">
-                  <node concept="3clFbF" id="1kbsEhJFrG6" role="3cqZAp">
-                    <node concept="2OqwBi" id="1kbsEhJFrXv" role="3clFbG">
-                      <node concept="37vLTw" id="1kbsEhJFrG5" role="2Oq$k0">
-                        <ref role="3cqZAo" node="1kbsEhJFrAG" resolve="it" />
-                      </node>
-                      <node concept="liA8E" id="1kbsEhJFskH" role="2OqNvi">
-                        <ref role="37wK5l" node="RObVTFnwug" resolve="getValueHolder" />
+              <node concept="3clFbS" id="5nAcTtnbygh" role="2LFqv$">
+                <node concept="3clFbJ" id="1kbsEhJFmV8" role="3cqZAp">
+                  <node concept="3clFbS" id="1kbsEhJFmVa" role="3clFbx">
+                    <node concept="3SKdUt" id="3u1dQqyVxyT" role="3cqZAp">
+                      <node concept="3SKdUq" id="3u1dQqyVxyV" role="3SKWNk">
+                        <property role="3SKdUp" value="TODO: EditorComponentHacks does not seem to work? no instances are returned..." />
                       </node>
                     </node>
-                  </node>
-                </node>
-                <node concept="Rh6nW" id="1kbsEhJFrAG" role="1bW2Oz">
-                  <property role="TrG5h" value="it" />
-                  <node concept="2jxLKc" id="1kbsEhJFrAH" role="1tU5fm" />
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="3clFbS" id="5nAcTtnbygh" role="2LFqv$">
-            <node concept="3clFbJ" id="1kbsEhJFmV8" role="3cqZAp">
-              <node concept="3clFbS" id="1kbsEhJFmVa" role="3clFbx">
-                <node concept="3SKdUt" id="3u1dQqyVxyT" role="3cqZAp">
-                  <node concept="3SKdUq" id="3u1dQqyVxyV" role="3SKWNk">
-                    <property role="3SKdUp" value="TODO: EditorComponentHacks does not seem to work? no instances are returned..." />
-                  </node>
-                </node>
-                <node concept="3clFbF" id="4bmM0avMFe_" role="3cqZAp">
-                  <node concept="2OqwBi" id="4bmM0avMFeA" role="3clFbG">
-                    <node concept="2OqwBi" id="4bmM0avMFeB" role="2Oq$k0">
-                      <node concept="2YIFZM" id="5nAcTtnbD$w" role="2Oq$k0">
-                        <ref role="37wK5l" to="kvq8:2WlJ6VKOSU7" resolve="findAllInstances" />
-                        <ref role="1Pybhc" to="kvq8:2WlJ6VKOwRU" resolve="EditorComponentHacks" />
-                      </node>
-                      <node concept="3zZkjj" id="4bmM0avMFeD" role="2OqNvi">
-                        <node concept="1bVj0M" id="4bmM0avMFeE" role="23t8la">
-                          <node concept="3clFbS" id="4bmM0avMFeF" role="1bW5cS">
-                            <node concept="3clFbF" id="4bmM0avMFeG" role="3cqZAp">
-                              <node concept="3clFbC" id="4bmM0avMFeH" role="3clFbG">
-                                <node concept="2OqwBi" id="4bmM0avMFeJ" role="3uHU7B">
-                                  <node concept="2OqwBi" id="4bmM0avMFeK" role="2Oq$k0">
-                                    <node concept="37vLTw" id="4bmM0avMFeL" role="2Oq$k0">
-                                      <ref role="3cqZAo" node="4bmM0avMFeO" resolve="it" />
+                    <node concept="3clFbF" id="4bmM0avMFe_" role="3cqZAp">
+                      <node concept="2OqwBi" id="4bmM0avMFeA" role="3clFbG">
+                        <node concept="2OqwBi" id="4bmM0avMFeB" role="2Oq$k0">
+                          <node concept="2YIFZM" id="5nAcTtnbD$w" role="2Oq$k0">
+                            <ref role="37wK5l" to="kvq8:2WlJ6VKOSU7" resolve="findAllInstances" />
+                            <ref role="1Pybhc" to="kvq8:2WlJ6VKOwRU" resolve="EditorComponentHacks" />
+                          </node>
+                          <node concept="3zZkjj" id="4bmM0avMFeD" role="2OqNvi">
+                            <node concept="1bVj0M" id="4bmM0avMFeE" role="23t8la">
+                              <node concept="3clFbS" id="4bmM0avMFeF" role="1bW5cS">
+                                <node concept="3clFbF" id="4bmM0avMFeG" role="3cqZAp">
+                                  <node concept="3clFbC" id="4bmM0avMFeH" role="3clFbG">
+                                    <node concept="2OqwBi" id="4bmM0avMFeJ" role="3uHU7B">
+                                      <node concept="2OqwBi" id="4bmM0avMFeK" role="2Oq$k0">
+                                        <node concept="37vLTw" id="4bmM0avMFeL" role="2Oq$k0">
+                                          <ref role="3cqZAo" node="4bmM0avMFeO" resolve="it" />
+                                        </node>
+                                        <node concept="liA8E" id="4bmM0avMFeM" role="2OqNvi">
+                                          <ref role="37wK5l" to="exr9:~EditorComponent.getRootCell():jetbrains.mps.nodeEditor.cells.EditorCell" resolve="getRootCell" />
+                                        </node>
+                                      </node>
+                                      <node concept="liA8E" id="4bmM0avMFeN" role="2OqNvi">
+                                        <ref role="37wK5l" to="f4zo:~EditorCell.getSNode():org.jetbrains.mps.openapi.model.SNode" resolve="getSNode" />
+                                      </node>
                                     </node>
-                                    <node concept="liA8E" id="4bmM0avMFeM" role="2OqNvi">
-                                      <ref role="37wK5l" to="exr9:~EditorComponent.getRootCell():jetbrains.mps.nodeEditor.cells.EditorCell" resolve="getRootCell" />
+                                    <node concept="2GrUjf" id="3u1dQqyUAO2" role="3uHU7w">
+                                      <ref role="2Gs0qQ" node="5nAcTtnbygd" resolve="participant" />
                                     </node>
                                   </node>
-                                  <node concept="liA8E" id="4bmM0avMFeN" role="2OqNvi">
-                                    <ref role="37wK5l" to="f4zo:~EditorCell.getSNode():org.jetbrains.mps.openapi.model.SNode" resolve="getSNode" />
-                                  </node>
-                                </node>
-                                <node concept="2GrUjf" id="3u1dQqyUAO2" role="3uHU7w">
-                                  <ref role="2Gs0qQ" node="5nAcTtnbygd" resolve="participant" />
                                 </node>
                               </node>
-                            </node>
-                          </node>
-                          <node concept="Rh6nW" id="4bmM0avMFeO" role="1bW2Oz">
-                            <property role="TrG5h" value="it" />
-                            <node concept="2jxLKc" id="4bmM0avMFeP" role="1tU5fm" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="2es0OD" id="4bmM0avMFeQ" role="2OqNvi">
-                      <node concept="1bVj0M" id="4bmM0avMFeR" role="23t8la">
-                        <node concept="3clFbS" id="4bmM0avMFeS" role="1bW5cS">
-                          <node concept="3clFbF" id="4bmM0avMFeT" role="3cqZAp">
-                            <node concept="2OqwBi" id="4bmM0avMFeU" role="3clFbG">
-                              <node concept="37vLTw" id="4bmM0avMFeV" role="2Oq$k0">
-                                <ref role="3cqZAo" node="4bmM0avMFeX" resolve="it" />
-                              </node>
-                              <node concept="liA8E" id="4bmM0avMFeW" role="2OqNvi">
-                                <ref role="37wK5l" to="exr9:~EditorComponent.update():void" resolve="update" />
+                              <node concept="Rh6nW" id="4bmM0avMFeO" role="1bW2Oz">
+                                <property role="TrG5h" value="it" />
+                                <node concept="2jxLKc" id="4bmM0avMFeP" role="1tU5fm" />
                               </node>
                             </node>
                           </node>
                         </node>
-                        <node concept="Rh6nW" id="4bmM0avMFeX" role="1bW2Oz">
-                          <property role="TrG5h" value="it" />
-                          <node concept="2jxLKc" id="4bmM0avMFeY" role="1tU5fm" />
+                        <node concept="2es0OD" id="4bmM0avMFeQ" role="2OqNvi">
+                          <node concept="1bVj0M" id="4bmM0avMFeR" role="23t8la">
+                            <node concept="3clFbS" id="4bmM0avMFeS" role="1bW5cS">
+                              <node concept="3clFbF" id="4bmM0avMFeT" role="3cqZAp">
+                                <node concept="2OqwBi" id="4bmM0avMFeU" role="3clFbG">
+                                  <node concept="37vLTw" id="4bmM0avMFeV" role="2Oq$k0">
+                                    <ref role="3cqZAo" node="4bmM0avMFeX" resolve="it" />
+                                  </node>
+                                  <node concept="liA8E" id="4bmM0avMFeW" role="2OqNvi">
+                                    <ref role="37wK5l" to="exr9:~EditorComponent.update():void" resolve="update" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="Rh6nW" id="4bmM0avMFeX" role="1bW2Oz">
+                              <property role="TrG5h" value="it" />
+                              <node concept="2jxLKc" id="4bmM0avMFeY" role="1tU5fm" />
+                            </node>
+                          </node>
                         </node>
                       </node>
                     </node>
                   </node>
-                </node>
-              </node>
-              <node concept="2OqwBi" id="1kbsEhJFtm6" role="3clFbw">
-                <node concept="2GrUjf" id="1kbsEhJFsWq" role="2Oq$k0">
-                  <ref role="2Gs0qQ" node="5nAcTtnbygd" resolve="participant" />
-                </node>
-                <node concept="2qgKlT" id="1kbsEhJFtJH" role="2OqNvi">
-                  <ref role="37wK5l" to="ao0u:5nAcTtnb1YA" resolve="isEditorUpdateEnabled" />
-                  <node concept="37vLTw" id="1kbsEhJFtPS" role="37wK5m">
-                    <ref role="3cqZAo" node="RObVTFnnYE" resolve="_valueSelector" />
+                  <node concept="2OqwBi" id="1kbsEhJFtm6" role="3clFbw">
+                    <node concept="2GrUjf" id="1kbsEhJFsWq" role="2Oq$k0">
+                      <ref role="2Gs0qQ" node="5nAcTtnbygd" resolve="participant" />
+                    </node>
+                    <node concept="2qgKlT" id="1kbsEhJFtJH" role="2OqNvi">
+                      <ref role="37wK5l" to="ao0u:5nAcTtnb1YA" resolve="isEditorUpdateEnabled" />
+                      <node concept="37vLTw" id="1kbsEhJFtPS" role="37wK5m">
+                        <ref role="3cqZAo" node="RObVTFnnYE" resolve="_valueSelector" />
+                      </node>
+                    </node>
                   </node>
                 </node>
               </node>
@@ -2387,128 +2458,135 @@
       <property role="DiZV1" value="false" />
       <property role="2aFKle" value="false" />
       <node concept="3clFbS" id="2_5DHynEXdY" role="3clF47">
-        <node concept="3cpWs8" id="2_5DHynEZEE" role="3cqZAp">
-          <node concept="3cpWsn" id="2_5DHynEZEF" role="3cpWs9">
-            <property role="TrG5h" value="sb" />
-            <node concept="3uibUv" id="2_5DHynEZEG" role="1tU5fm">
-              <ref role="3uigEE" to="wyt6:~StringBuilder" resolve="StringBuilder" />
-            </node>
-            <node concept="2ShNRf" id="2_5DHynEZMm" role="33vP2m">
-              <node concept="1pGfFk" id="2_5DHynEZZd" role="2ShVmc">
-                <ref role="37wK5l" to="wyt6:~StringBuilder.&lt;init&gt;()" resolve="StringBuilder" />
+        <node concept="1HWtB8" id="2YOONxNW2Jb" role="3cqZAp">
+          <node concept="3VsKOn" id="2YOONxNW2Jc" role="1HWFw0">
+            <ref role="3VsUkX" node="7ZWgXq7GlHg" resolve="ValueCache" />
+          </node>
+          <node concept="3clFbS" id="2YOONxNW2Jd" role="1HWHxc">
+            <node concept="3cpWs8" id="2_5DHynEZEE" role="3cqZAp">
+              <node concept="3cpWsn" id="2_5DHynEZEF" role="3cpWs9">
+                <property role="TrG5h" value="sb" />
+                <node concept="3uibUv" id="2_5DHynEZEG" role="1tU5fm">
+                  <ref role="3uigEE" to="wyt6:~StringBuilder" resolve="StringBuilder" />
+                </node>
+                <node concept="2ShNRf" id="2_5DHynEZMm" role="33vP2m">
+                  <node concept="1pGfFk" id="2_5DHynEZZd" role="2ShVmc">
+                    <ref role="37wK5l" to="wyt6:~StringBuilder.&lt;init&gt;()" resolve="StringBuilder" />
+                  </node>
+                </node>
               </node>
             </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="2_5DHynF4CP" role="3cqZAp">
-          <node concept="2OqwBi" id="2_5DHynF53u" role="3clFbG">
-            <node concept="37vLTw" id="2_5DHynF4CN" role="2Oq$k0">
-              <ref role="3cqZAo" node="2_5DHynEZEF" resolve="sb" />
-            </node>
-            <node concept="liA8E" id="2_5DHynF5JA" role="2OqNvi">
-              <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String):java.lang.StringBuilder" resolve="append" />
-              <node concept="Xl_RD" id="2_5DHynF5LD" role="37wK5m">
-                <property role="Xl_RC" value="SOURCES:\n" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="2Gpval" id="2_5DHynEZ8H" role="3cqZAp">
-          <node concept="2GrKxI" id="2_5DHynEZ8I" role="2Gsz3X">
-            <property role="TrG5h" value="source" />
-          </node>
-          <node concept="37vLTw" id="2_5DHynEZeZ" role="2GsD0m">
-            <ref role="3cqZAo" node="RObVTFnyV1" resolve="_cachedPropagationSources" />
-          </node>
-          <node concept="3clFbS" id="2_5DHynEZ8K" role="2LFqv$">
-            <node concept="3clFbF" id="2_5DHynF01c" role="3cqZAp">
-              <node concept="2OqwBi" id="2_5DHynF0j8" role="3clFbG">
-                <node concept="37vLTw" id="2_5DHynF01b" role="2Oq$k0">
+            <node concept="3clFbF" id="2_5DHynF4CP" role="3cqZAp">
+              <node concept="2OqwBi" id="2_5DHynF53u" role="3clFbG">
+                <node concept="37vLTw" id="2_5DHynF4CN" role="2Oq$k0">
                   <ref role="3cqZAo" node="2_5DHynEZEF" resolve="sb" />
                 </node>
-                <node concept="liA8E" id="2_5DHynF0N3" role="2OqNvi">
+                <node concept="liA8E" id="2_5DHynF5JA" role="2OqNvi">
                   <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String):java.lang.StringBuilder" resolve="append" />
-                  <node concept="3cpWs3" id="2_5DHynFbiw" role="37wK5m">
-                    <node concept="Xl_RD" id="2_5DHynFcgU" role="3uHU7w">
-                      <property role="Xl_RC" value="\n" />
+                  <node concept="Xl_RD" id="2_5DHynF5LD" role="37wK5m">
+                    <property role="Xl_RC" value="SOURCES:\n" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="2Gpval" id="2_5DHynEZ8H" role="3cqZAp">
+              <node concept="2GrKxI" id="2_5DHynEZ8I" role="2Gsz3X">
+                <property role="TrG5h" value="source" />
+              </node>
+              <node concept="37vLTw" id="2_5DHynEZeZ" role="2GsD0m">
+                <ref role="3cqZAo" node="RObVTFnyV1" resolve="_cachedPropagationSources" />
+              </node>
+              <node concept="3clFbS" id="2_5DHynEZ8K" role="2LFqv$">
+                <node concept="3clFbF" id="2_5DHynF01c" role="3cqZAp">
+                  <node concept="2OqwBi" id="2_5DHynF0j8" role="3clFbG">
+                    <node concept="37vLTw" id="2_5DHynF01b" role="2Oq$k0">
+                      <ref role="3cqZAo" node="2_5DHynEZEF" resolve="sb" />
                     </node>
-                    <node concept="2OqwBi" id="2_5DHynF2Mu" role="3uHU7B">
-                      <node concept="2OqwBi" id="2_5DHynF1EX" role="2Oq$k0">
-                        <node concept="2GrUjf" id="2_5DHynF1$0" role="2Oq$k0">
-                          <ref role="2Gs0qQ" node="2_5DHynEZ8I" resolve="source" />
+                    <node concept="liA8E" id="2_5DHynF0N3" role="2OqNvi">
+                      <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String):java.lang.StringBuilder" resolve="append" />
+                      <node concept="3cpWs3" id="2_5DHynFbiw" role="37wK5m">
+                        <node concept="Xl_RD" id="2_5DHynFcgU" role="3uHU7w">
+                          <property role="Xl_RC" value="\n" />
                         </node>
-                        <node concept="liA8E" id="2_5DHynF1VX" role="2OqNvi">
-                          <ref role="37wK5l" node="RObVTFnwug" resolve="getValueHolder" />
+                        <node concept="2OqwBi" id="2_5DHynF2Mu" role="3uHU7B">
+                          <node concept="2OqwBi" id="2_5DHynF1EX" role="2Oq$k0">
+                            <node concept="2GrUjf" id="2_5DHynF1$0" role="2Oq$k0">
+                              <ref role="2Gs0qQ" node="2_5DHynEZ8I" resolve="source" />
+                            </node>
+                            <node concept="liA8E" id="2_5DHynF1VX" role="2OqNvi">
+                              <ref role="37wK5l" node="RObVTFnwug" resolve="getValueHolder" />
+                            </node>
+                          </node>
+                          <node concept="2qgKlT" id="2_5DHynF3Qz" role="2OqNvi">
+                            <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+                          </node>
                         </node>
-                      </node>
-                      <node concept="2qgKlT" id="2_5DHynF3Qz" role="2OqNvi">
-                        <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
                       </node>
                     </node>
                   </node>
                 </node>
               </node>
             </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="2_5DHynFeUX" role="3cqZAp">
-          <node concept="2OqwBi" id="2_5DHynFeUY" role="3clFbG">
-            <node concept="37vLTw" id="2_5DHynFeUZ" role="2Oq$k0">
-              <ref role="3cqZAo" node="2_5DHynEZEF" resolve="sb" />
-            </node>
-            <node concept="liA8E" id="2_5DHynFeV0" role="2OqNvi">
-              <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String):java.lang.StringBuilder" resolve="append" />
-              <node concept="Xl_RD" id="2_5DHynFeV1" role="37wK5m">
-                <property role="Xl_RC" value="TARGETS:\n" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="2Gpval" id="2_5DHynFeV2" role="3cqZAp">
-          <node concept="2GrKxI" id="2_5DHynFeV3" role="2Gsz3X">
-            <property role="TrG5h" value="target" />
-          </node>
-          <node concept="37vLTw" id="2_5DHynF$0w" role="2GsD0m">
-            <ref role="3cqZAo" node="RObVTFo4eX" resolve="_cachedPropagationTargets" />
-          </node>
-          <node concept="3clFbS" id="2_5DHynFeV5" role="2LFqv$">
-            <node concept="3clFbF" id="2_5DHynFeV6" role="3cqZAp">
-              <node concept="2OqwBi" id="2_5DHynFeV7" role="3clFbG">
-                <node concept="37vLTw" id="2_5DHynFeV8" role="2Oq$k0">
+            <node concept="3clFbF" id="2_5DHynFeUX" role="3cqZAp">
+              <node concept="2OqwBi" id="2_5DHynFeUY" role="3clFbG">
+                <node concept="37vLTw" id="2_5DHynFeUZ" role="2Oq$k0">
                   <ref role="3cqZAo" node="2_5DHynEZEF" resolve="sb" />
                 </node>
-                <node concept="liA8E" id="2_5DHynFeV9" role="2OqNvi">
+                <node concept="liA8E" id="2_5DHynFeV0" role="2OqNvi">
                   <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String):java.lang.StringBuilder" resolve="append" />
-                  <node concept="3cpWs3" id="2_5DHynFeVa" role="37wK5m">
-                    <node concept="Xl_RD" id="2_5DHynFeVb" role="3uHU7w">
-                      <property role="Xl_RC" value="\n" />
+                  <node concept="Xl_RD" id="2_5DHynFeV1" role="37wK5m">
+                    <property role="Xl_RC" value="TARGETS:\n" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="2Gpval" id="2_5DHynFeV2" role="3cqZAp">
+              <node concept="2GrKxI" id="2_5DHynFeV3" role="2Gsz3X">
+                <property role="TrG5h" value="target" />
+              </node>
+              <node concept="37vLTw" id="2_5DHynF$0w" role="2GsD0m">
+                <ref role="3cqZAo" node="RObVTFo4eX" resolve="_cachedPropagationTargets" />
+              </node>
+              <node concept="3clFbS" id="2_5DHynFeV5" role="2LFqv$">
+                <node concept="3clFbF" id="2_5DHynFeV6" role="3cqZAp">
+                  <node concept="2OqwBi" id="2_5DHynFeV7" role="3clFbG">
+                    <node concept="37vLTw" id="2_5DHynFeV8" role="2Oq$k0">
+                      <ref role="3cqZAo" node="2_5DHynEZEF" resolve="sb" />
                     </node>
-                    <node concept="2OqwBi" id="2_5DHynFeVc" role="3uHU7B">
-                      <node concept="2OqwBi" id="2_5DHynFeVd" role="2Oq$k0">
-                        <node concept="2GrUjf" id="2_5DHynFeVe" role="2Oq$k0">
-                          <ref role="2Gs0qQ" node="2_5DHynFeV3" resolve="target" />
+                    <node concept="liA8E" id="2_5DHynFeV9" role="2OqNvi">
+                      <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String):java.lang.StringBuilder" resolve="append" />
+                      <node concept="3cpWs3" id="2_5DHynFeVa" role="37wK5m">
+                        <node concept="Xl_RD" id="2_5DHynFeVb" role="3uHU7w">
+                          <property role="Xl_RC" value="\n" />
                         </node>
-                        <node concept="liA8E" id="2_5DHynFeVf" role="2OqNvi">
-                          <ref role="37wK5l" node="RObVTFnwug" resolve="getValueHolder" />
+                        <node concept="2OqwBi" id="2_5DHynFeVc" role="3uHU7B">
+                          <node concept="2OqwBi" id="2_5DHynFeVd" role="2Oq$k0">
+                            <node concept="2GrUjf" id="2_5DHynFeVe" role="2Oq$k0">
+                              <ref role="2Gs0qQ" node="2_5DHynFeV3" resolve="target" />
+                            </node>
+                            <node concept="liA8E" id="2_5DHynFeVf" role="2OqNvi">
+                              <ref role="37wK5l" node="RObVTFnwug" resolve="getValueHolder" />
+                            </node>
+                          </node>
+                          <node concept="2qgKlT" id="2_5DHynFeVg" role="2OqNvi">
+                            <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+                          </node>
                         </node>
-                      </node>
-                      <node concept="2qgKlT" id="2_5DHynFeVg" role="2OqNvi">
-                        <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
                       </node>
                     </node>
                   </node>
                 </node>
               </node>
             </node>
-          </node>
-        </node>
-        <node concept="3cpWs6" id="2_5DHynF$mB" role="3cqZAp">
-          <node concept="2OqwBi" id="2_5DHynF$Tk" role="3cqZAk">
-            <node concept="37vLTw" id="2_5DHynF$oH" role="2Oq$k0">
-              <ref role="3cqZAo" node="2_5DHynEZEF" resolve="sb" />
-            </node>
-            <node concept="liA8E" id="2_5DHynFB3H" role="2OqNvi">
-              <ref role="37wK5l" to="wyt6:~StringBuilder.toString():java.lang.String" resolve="toString" />
+            <node concept="3cpWs6" id="2_5DHynF$mB" role="3cqZAp">
+              <node concept="2OqwBi" id="2_5DHynF$Tk" role="3cqZAk">
+                <node concept="37vLTw" id="2_5DHynF$oH" role="2Oq$k0">
+                  <ref role="3cqZAo" node="2_5DHynEZEF" resolve="sb" />
+                </node>
+                <node concept="liA8E" id="2_5DHynFB3H" role="2OqNvi">
+                  <ref role="37wK5l" to="wyt6:~StringBuilder.toString():java.lang.String" resolve="toString" />
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -2518,7 +2596,6 @@
         <ref role="3uigEE" to="wyt6:~String" resolve="String" />
       </node>
     </node>
-    <node concept="2tJIrI" id="6sjp2R1WAzf" role="jymVt" />
     <node concept="3Tm1VV" id="7ZWgXq7GlHh" role="1B3o_S" />
   </node>
   <node concept="Qs71p" id="6sjp2R1XhkT">

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.incrementalcomputation/runtime/models/com.mbeddr.mpsutil.incrementalcomputation.runtime.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.incrementalcomputation/runtime/models/com.mbeddr.mpsutil.incrementalcomputation.runtime.mps
@@ -232,8 +232,12 @@
       </concept>
     </language>
     <language id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc">
+      <concept id="5858074156537516430" name="jetbrains.mps.baseLanguage.javadoc.structure.ReturnBlockDocTag" flags="ng" index="x79VA">
+        <property id="5858074156537516431" name="text" index="x79VB" />
+      </concept>
       <concept id="5349172909345501395" name="jetbrains.mps.baseLanguage.javadoc.structure.BaseDocComment" flags="ng" index="P$AiS">
         <child id="8465538089690331502" name="body" index="TZ5H$" />
+        <child id="5383422241790532083" name="tags" index="3nqlJM" />
       </concept>
       <concept id="5349172909345532724" name="jetbrains.mps.baseLanguage.javadoc.structure.MethodDocComment" flags="ng" index="P$JXv" />
       <concept id="8465538089690331500" name="jetbrains.mps.baseLanguage.javadoc.structure.CommentLine" flags="ng" index="TZ5HA">
@@ -526,6 +530,16 @@
           </node>
         </node>
       </node>
+      <node concept="P$JXv" id="6MPBOWiFLIL" role="lGtFl">
+        <node concept="TZ5HA" id="6MPBOWiFLIM" role="TZ5H$">
+          <node concept="1dT_AC" id="6MPBOWiFLIN" role="1dT_Ay">
+            <property role="1dT_AB" value="Return all cycles, including those that don't disturb calculation" />
+          </node>
+        </node>
+        <node concept="x79VA" id="6MPBOWiFLIO" role="3nqlJM">
+          <property role="x79VB" value="a sequence of tuples of valueSelector and the sequence of propagation participants that are part of the cycle" />
+        </node>
+      </node>
     </node>
     <node concept="2tJIrI" id="QuEk0ZL_4i" role="jymVt" />
     <node concept="3clFb_" id="QuEk0ZLA6V" role="jymVt">
@@ -581,7 +595,7 @@
               </node>
             </node>
             <node concept="liA8E" id="7ZWgXq7GHub" role="2OqNvi">
-              <ref role="37wK5l" node="7ZWgXq7GFy8" resolve="getValue" />
+              <ref role="37wK5l" node="2YOONxNCmED" resolve="getValue" />
             </node>
           </node>
         </node>
@@ -1192,7 +1206,6 @@
     <node concept="3clFb_" id="5YITc37Stkp" role="jymVt">
       <property role="1EzhhJ" value="false" />
       <property role="TrG5h" value="init" />
-      <property role="od$2w" value="false" />
       <property role="DiZV1" value="false" />
       <property role="2aFKle" value="false" />
       <node concept="3clFbS" id="5YITc37Stks" role="3clF47">
@@ -1350,106 +1363,111 @@
       </node>
     </node>
     <node concept="2tJIrI" id="7ZWgXq7GFxo" role="jymVt" />
-    <node concept="3clFb_" id="7ZWgXq7GFy8" role="jymVt">
-      <property role="1EzhhJ" value="false" />
+    <node concept="3clFb_" id="2YOONxNCmED" role="jymVt">
       <property role="TrG5h" value="getValue" />
-      <property role="od$2w" value="false" />
-      <property role="DiZV1" value="false" />
-      <property role="2aFKle" value="false" />
-      <node concept="3clFbS" id="7ZWgXq7GFyb" role="3clF47">
-        <node concept="1gVbGN" id="6MN7yMJ7Wb5" role="3cqZAp">
-          <node concept="3fqX7Q" id="6MN7yMJ7Wb6" role="1gVkn0">
-            <node concept="37vLTw" id="6MN7yMJ7Wb7" role="3fr31v">
+      <node concept="3clFbS" id="2YOONxNCmEF" role="3clF47">
+        <node concept="1gVbGN" id="2YOONxNCmEG" role="3cqZAp">
+          <node concept="3fqX7Q" id="2YOONxNCmEH" role="1gVkn0">
+            <node concept="37vLTw" id="2YOONxNCmEI" role="3fr31v">
               <ref role="3cqZAo" node="6MN7yMJ7Ell" resolve="_isDisposed" />
             </node>
           </node>
-          <node concept="Xl_RD" id="6MN7yMJ7Wb8" role="1gVpfI">
+          <node concept="Xl_RD" id="2YOONxNCmEJ" role="1gVpfI">
             <property role="Xl_RC" value="cache is disposed" />
           </node>
         </node>
-        <node concept="3clFbH" id="6MN7yMJ7UwA" role="3cqZAp" />
-        <node concept="3clFbJ" id="RObVTFmX1K" role="3cqZAp">
-          <node concept="3clFbS" id="RObVTFmX1M" role="3clFbx">
-            <node concept="3cpWs6" id="RObVTFmXGP" role="3cqZAp">
-              <node concept="37vLTw" id="RObVTFmXH_" role="3cqZAk">
+        <node concept="3clFbH" id="2YOONxNCmEK" role="3cqZAp" />
+        <node concept="3clFbJ" id="2YOONxNCmEL" role="3cqZAp">
+          <node concept="3clFbS" id="2YOONxNCmEM" role="3clFbx">
+            <node concept="3cpWs6" id="2YOONxNCmEN" role="3cqZAp">
+              <node concept="37vLTw" id="2YOONxNCmEO" role="3cqZAk">
                 <ref role="3cqZAo" node="RObVTFmWn7" resolve="_cachedValue" />
               </node>
             </node>
           </node>
-          <node concept="3y3z36" id="RObVTFmXDE" role="3clFbw">
-            <node concept="10Nm6u" id="RObVTFmXFl" role="3uHU7w" />
-            <node concept="37vLTw" id="RObVTFmX41" role="3uHU7B">
+          <node concept="3y3z36" id="2YOONxNCmEP" role="3clFbw">
+            <node concept="10Nm6u" id="2YOONxNCmEQ" role="3uHU7w" />
+            <node concept="37vLTw" id="2YOONxNCmER" role="3uHU7B">
               <ref role="3cqZAo" node="RObVTFmWn7" resolve="_cachedValue" />
             </node>
           </node>
         </node>
-        <node concept="3clFbH" id="5nAcTtn9DRM" role="3cqZAp" />
-        <node concept="3clFbJ" id="5nAcTtn9FwX" role="3cqZAp">
-          <node concept="3clFbS" id="5nAcTtn9FwZ" role="3clFbx">
-            <node concept="3cpWs6" id="5nAcTtn9MQ1" role="3cqZAp">
-              <node concept="10Nm6u" id="5nAcTtn9MRI" role="3cqZAk" />
+        <node concept="3clFbH" id="2YOONxNCmES" role="3cqZAp" />
+        <node concept="3clFbJ" id="2YOONxNCmET" role="3cqZAp">
+          <node concept="3clFbS" id="2YOONxNCmEU" role="3clFbx">
+            <node concept="3cpWs6" id="2YOONxNCmEV" role="3cqZAp">
+              <node concept="10Nm6u" id="2YOONxNCmEW" role="3cqZAk" />
             </node>
           </node>
-          <node concept="3fqX7Q" id="5nAcTtn9MFN" role="3clFbw">
-            <node concept="2OqwBi" id="5nAcTtn9MFP" role="3fr31v">
-              <node concept="37vLTw" id="5nAcTtn9MFQ" role="2Oq$k0">
+          <node concept="3fqX7Q" id="2YOONxNCmEX" role="3clFbw">
+            <node concept="2OqwBi" id="2YOONxNCmEY" role="3fr31v">
+              <node concept="37vLTw" id="2YOONxNCmEZ" role="2Oq$k0">
                 <ref role="3cqZAo" node="2NSCtASrCpE" resolve="_valueHolder" />
               </node>
-              <node concept="2qgKlT" id="5nAcTtn9MFR" role="2OqNvi">
+              <node concept="2qgKlT" id="2YOONxNCmF0" role="2OqNvi">
                 <ref role="37wK5l" to="ao0u:5nAcTtn9HEK" resolve="isActive" />
-                <node concept="37vLTw" id="5nAcTtn9MFS" role="37wK5m">
+                <node concept="37vLTw" id="2YOONxNCmF1" role="37wK5m">
                   <ref role="3cqZAo" node="RObVTFnnYE" resolve="_valueSelector" />
                 </node>
               </node>
             </node>
           </node>
         </node>
-        <node concept="3clFbH" id="5YITc37Pt5W" role="3cqZAp" />
-        <node concept="3clFbJ" id="5YITc37PeX3" role="3cqZAp">
-          <node concept="3clFbS" id="5YITc37PeX5" role="3clFbx">
-            <node concept="3cpWs6" id="5YITc37PjjW" role="3cqZAp">
-              <node concept="10Nm6u" id="5YITc37Pjl3" role="3cqZAk" />
+        <node concept="3clFbH" id="2YOONxNCmF2" role="3cqZAp" />
+        <node concept="3clFbJ" id="2YOONxNCmF3" role="3cqZAp">
+          <node concept="3clFbS" id="2YOONxNCmF4" role="3clFbx">
+            <node concept="3cpWs6" id="2YOONxNCmF5" role="3cqZAp">
+              <node concept="10Nm6u" id="2YOONxNCmF6" role="3cqZAk" />
             </node>
           </node>
-          <node concept="1rXfSq" id="5YITc37Phwd" role="3clFbw">
-            <ref role="37wK5l" node="5YITc37MPxr" resolve="hasCycle" />
-          </node>
-        </node>
-        <node concept="3clFbH" id="5YITc37Py_w" role="3cqZAp" />
-        <node concept="3clFbF" id="RObVTFp3i7" role="3cqZAp">
-          <node concept="37vLTI" id="RObVTFp4it" role="3clFbG">
-            <node concept="2OqwBi" id="RObVTFp4vL" role="37vLTx">
-              <node concept="37vLTw" id="RObVTFp4lT" role="2Oq$k0">
+          <node concept="3fqX7Q" id="2YOONxNEh1U" role="3clFbw">
+            <node concept="2OqwBi" id="2YOONxNEh1W" role="3fr31v">
+              <node concept="37vLTw" id="2YOONxNEh1X" role="2Oq$k0">
                 <ref role="3cqZAo" node="2NSCtASrCpE" resolve="_valueHolder" />
               </node>
-              <node concept="2qgKlT" id="RObVTFp4FH" role="2OqNvi">
-                <ref role="37wK5l" to="ao0u:RObVTFnZ_0" resolve="calculateValue" />
-                <node concept="37vLTw" id="RObVTFp4KT" role="37wK5m">
+              <node concept="2qgKlT" id="2YOONxNEh1Y" role="2OqNvi">
+                <ref role="37wK5l" to="ao0u:6MPBOWiFIsN" resolve="canCalculate" />
+                <node concept="37vLTw" id="2YOONxNEh1Z" role="37wK5m">
                   <ref role="3cqZAo" node="RObVTFnnYE" resolve="_valueSelector" />
                 </node>
               </node>
             </node>
-            <node concept="37vLTw" id="RObVTFp3i5" role="37vLTJ">
+          </node>
+        </node>
+        <node concept="3clFbH" id="2YOONxNCmFb" role="3cqZAp" />
+        <node concept="3clFbF" id="2YOONxNCmFc" role="3cqZAp">
+          <node concept="37vLTI" id="2YOONxNCmFd" role="3clFbG">
+            <node concept="2OqwBi" id="2YOONxNCmFe" role="37vLTx">
+              <node concept="37vLTw" id="2YOONxNCmFf" role="2Oq$k0">
+                <ref role="3cqZAo" node="2NSCtASrCpE" resolve="_valueHolder" />
+              </node>
+              <node concept="2qgKlT" id="2YOONxNCmFg" role="2OqNvi">
+                <ref role="37wK5l" to="ao0u:RObVTFnZ_0" resolve="calculateValue" />
+                <node concept="37vLTw" id="2YOONxNCmFh" role="37wK5m">
+                  <ref role="3cqZAo" node="RObVTFnnYE" resolve="_valueSelector" />
+                </node>
+              </node>
+            </node>
+            <node concept="37vLTw" id="2YOONxNCmFi" role="37vLTJ">
               <ref role="3cqZAo" node="RObVTFmWn7" resolve="_cachedValue" />
             </node>
           </node>
         </node>
-        <node concept="3cpWs6" id="RObVTFp5oK" role="3cqZAp">
-          <node concept="37vLTw" id="RObVTFp5Qr" role="3cqZAk">
+        <node concept="3cpWs6" id="2YOONxNCmFj" role="3cqZAp">
+          <node concept="37vLTw" id="2YOONxNCmFk" role="3cqZAk">
             <ref role="3cqZAo" node="RObVTFmWn7" resolve="_cachedValue" />
           </node>
         </node>
       </node>
-      <node concept="3Tm1VV" id="7ZWgXq7GFxL" role="1B3o_S" />
-      <node concept="3uibUv" id="50uWDT$KYnx" role="3clF45">
+      <node concept="3uibUv" id="2YOONxNCmFl" role="3clF45">
         <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
       </node>
+      <node concept="3Tm1VV" id="2YOONxNCmFm" role="1B3o_S" />
     </node>
     <node concept="2tJIrI" id="RObVTFn2t1" role="jymVt" />
     <node concept="3clFb_" id="RObVTFmWkR" role="jymVt">
       <property role="1EzhhJ" value="false" />
       <property role="TrG5h" value="invalidate" />
-      <property role="od$2w" value="false" />
       <property role="DiZV1" value="false" />
       <property role="2aFKle" value="false" />
       <node concept="3clFbS" id="RObVTFmWkU" role="3clF47">
@@ -1751,7 +1769,6 @@
     <node concept="3clFb_" id="RObVTFrQr6" role="jymVt">
       <property role="1EzhhJ" value="false" />
       <property role="TrG5h" value="addPropagationTarget" />
-      <property role="od$2w" value="false" />
       <property role="DiZV1" value="false" />
       <property role="2aFKle" value="false" />
       <node concept="3clFbS" id="RObVTFrQr9" role="3clF47">
@@ -1781,7 +1798,6 @@
     <node concept="3clFb_" id="RObVTFrTIk" role="jymVt">
       <property role="1EzhhJ" value="false" />
       <property role="TrG5h" value="removePropagationTarget" />
-      <property role="od$2w" value="false" />
       <property role="DiZV1" value="false" />
       <property role="2aFKle" value="false" />
       <node concept="3clFbS" id="RObVTFrTIl" role="3clF47">
@@ -1811,7 +1827,6 @@
     <node concept="3clFb_" id="5YITc37MPxr" role="jymVt">
       <property role="1EzhhJ" value="false" />
       <property role="TrG5h" value="hasCycle" />
-      <property role="od$2w" value="false" />
       <property role="DiZV1" value="false" />
       <property role="2aFKle" value="false" />
       <node concept="3clFbS" id="5YITc37MPxu" role="3clF47">
@@ -2390,7 +2405,6 @@
     <node concept="3clFb_" id="2_5DHynEXdV" role="jymVt">
       <property role="1EzhhJ" value="false" />
       <property role="TrG5h" value="getDebugInfo" />
-      <property role="od$2w" value="false" />
       <property role="DiZV1" value="false" />
       <property role="2aFKle" value="false" />
       <node concept="3clFbS" id="2_5DHynEXdY" role="3clF47">

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.incrementalcomputation/runtime/models/com.mbeddr.mpsutil.incrementalcomputation.runtime.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.incrementalcomputation/runtime/models/com.mbeddr.mpsutil.incrementalcomputation.runtime.mps
@@ -1392,27 +1392,6 @@
             </node>
           </node>
         </node>
-        <node concept="3clFbH" id="2YOONxNCmES" role="3cqZAp" />
-        <node concept="3clFbJ" id="2YOONxNCmET" role="3cqZAp">
-          <node concept="3clFbS" id="2YOONxNCmEU" role="3clFbx">
-            <node concept="3cpWs6" id="2YOONxNCmEV" role="3cqZAp">
-              <node concept="10Nm6u" id="2YOONxNCmEW" role="3cqZAk" />
-            </node>
-          </node>
-          <node concept="3fqX7Q" id="2YOONxNCmEX" role="3clFbw">
-            <node concept="2OqwBi" id="2YOONxNCmEY" role="3fr31v">
-              <node concept="37vLTw" id="2YOONxNCmEZ" role="2Oq$k0">
-                <ref role="3cqZAo" node="2NSCtASrCpE" resolve="_valueHolder" />
-              </node>
-              <node concept="2qgKlT" id="2YOONxNCmF0" role="2OqNvi">
-                <ref role="37wK5l" to="ao0u:5nAcTtn9HEK" resolve="isActive" />
-                <node concept="37vLTw" id="2YOONxNCmF1" role="37wK5m">
-                  <ref role="3cqZAo" node="RObVTFnnYE" resolve="_valueSelector" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
         <node concept="3clFbH" id="2YOONxNCmF2" role="3cqZAp" />
         <node concept="3clFbJ" id="2YOONxNCmF3" role="3cqZAp">
           <node concept="3clFbS" id="2YOONxNCmF4" role="3clFbx">

--- a/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.asynccell/README.md
+++ b/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.asynccell/README.md
@@ -38,6 +38,10 @@ cell provider:
 
 As example, see `com.mbeddr.mpsutil.asynccell.sandbox`.
 
+# Errors
+
+If the query callback raises an exception, the exception will be logged to stdout, the value will be set to `ERR` and the cell will stop calling it (until the next editor update).
+
 # State
 It contains automated tests and a sandbox for manual tests.
 So far, only used in Security Analyst.

--- a/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.asynccell/models/plugin.mps
+++ b/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.asynccell/models/plugin.mps
@@ -22,6 +22,7 @@
     <import index="hox0" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.style(MPS.Editor/)" />
     <import index="lui2" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.module(MPS.OpenAPI/)" />
     <import index="hyam" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt.event(JDK/)" />
+    <import index="5ueo" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.editor.runtime.style(MPS.Editor/)" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
   </imports>
   <registry>
@@ -2095,6 +2096,11 @@
                               </node>
                               <node concept="TDmWw" id="3anL894Mo0F" role="TEbGg">
                                 <node concept="3clFbS" id="3anL894Mo0G" role="TDEfX">
+                                  <node concept="3SKdUt" id="4BfR_zSgRHm" role="3cqZAp">
+                                    <node concept="3SKdUq" id="4BfR_zSgRHo" role="3SKWNk">
+                                      <property role="3SKdUp" value="print" />
+                                    </node>
+                                  </node>
                                   <node concept="3clFbF" id="3anL894Mo0H" role="3cqZAp">
                                     <node concept="2OqwBi" id="3anL894Mo0I" role="3clFbG">
                                       <node concept="37vLTw" id="3anL894Mo0J" role="2Oq$k0">
@@ -2102,6 +2108,60 @@
                                       </node>
                                       <node concept="liA8E" id="3anL894Mo0K" role="2OqNvi">
                                         <ref role="37wK5l" to="wyt6:~Throwable.printStackTrace():void" resolve="printStackTrace" />
+                                      </node>
+                                    </node>
+                                  </node>
+                                  <node concept="3SKdUt" id="7ZJOHLTFv82" role="3cqZAp">
+                                    <node concept="3SKdUq" id="7ZJOHLTFv84" role="3SKWNk">
+                                      <property role="3SKdUp" value="show error" />
+                                    </node>
+                                  </node>
+                                  <node concept="3cpWs8" id="7ZJOHLTGvUy" role="3cqZAp">
+                                    <node concept="3cpWsn" id="7ZJOHLTGvUz" role="3cpWs9">
+                                      <property role="TrG5h" value="impl" />
+                                      <node concept="3uibUv" id="7ZJOHLTGvUx" role="1tU5fm">
+                                        <ref role="3uigEE" to="5ueo:~StyleImpl" resolve="StyleImpl" />
+                                      </node>
+                                      <node concept="2ShNRf" id="7ZJOHLTGvU$" role="33vP2m">
+                                        <node concept="1pGfFk" id="7ZJOHLTGvU_" role="2ShVmc">
+                                          <ref role="37wK5l" to="5ueo:~StyleImpl.&lt;init&gt;()" resolve="StyleImpl" />
+                                        </node>
+                                      </node>
+                                    </node>
+                                  </node>
+                                  <node concept="3clFbF" id="2YOONxNTwUS" role="3cqZAp">
+                                    <node concept="37vLTI" id="2YOONxNTxt0" role="3clFbG">
+                                      <node concept="37vLTw" id="2YOONxNTwUQ" role="37vLTJ">
+                                        <ref role="3cqZAo" node="3anL894Mo0i" resolve="result" />
+                                      </node>
+                                      <node concept="2ShNRf" id="7ZJOHLTFByJ" role="37vLTx">
+                                        <node concept="1pGfFk" id="7ZJOHLTFT7g" role="2ShVmc">
+                                          <ref role="37wK5l" node="5HPe_Jxcpw8" resolve="AsyncCellValue" />
+                                          <node concept="Xl_RD" id="7ZJOHLTFUgx" role="37wK5m">
+                                            <property role="Xl_RC" value="ERR" />
+                                          </node>
+                                          <node concept="37vLTw" id="7ZJOHLTGvUA" role="37wK5m">
+                                            <ref role="3cqZAo" node="7ZJOHLTGvUz" resolve="impl" />
+                                          </node>
+                                        </node>
+                                      </node>
+                                    </node>
+                                  </node>
+                                  <node concept="3SKdUt" id="4BfR_zSgQLn" role="3cqZAp">
+                                    <node concept="3SKdUq" id="4BfR_zSgQLo" role="3SKWNk">
+                                      <property role="3SKdUp" value="and forget about it immediately to prevent spamming" />
+                                    </node>
+                                  </node>
+                                  <node concept="3clFbF" id="4BfR_zSgQLp" role="3cqZAp">
+                                    <node concept="2OqwBi" id="4BfR_zSgQLq" role="3clFbG">
+                                      <node concept="37vLTw" id="4BfR_zSgQLr" role="2Oq$k0">
+                                        <ref role="3cqZAo" node="5HPe_JwXHEl" resolve="_cellManager" />
+                                      </node>
+                                      <node concept="liA8E" id="4BfR_zSgQLs" role="2OqNvi">
+                                        <ref role="37wK5l" node="5HPe_JwZDXR" resolve="removeAsyncCell" />
+                                        <node concept="2GrUjf" id="4BfR_zSgQLt" role="37wK5m">
+                                          <ref role="2Gs0qQ" node="3anL894Mo04" resolve="cell" />
+                                        </node>
                                       </node>
                                     </node>
                                   </node>

--- a/code/languages/com.mbeddr.mpsutil/tests/test.com.mbeddr.mpsutil.incrementalcomputation.runtime/models/test@tests.mps
+++ b/code/languages/com.mbeddr.mpsutil/tests/test.com.mbeddr.mpsutil.incrementalcomputation.runtime/models/test@tests.mps
@@ -1,0 +1,609 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:59847a09-8774-43f1-90c9-0742c82175e1(test.com.mbeddr.mpsutil.incrementalcomputation.runtime.test@tests)">
+  <persistence version="9" />
+  <languages>
+    <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="2" />
+    <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="1" />
+    <use id="654422bf-e75f-44dc-936d-188890a746ce" name="de.slisson.mps.reflection" version="0" />
+    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="13" />
+    <use id="aee9cad2-acd4-4608-aef2-0004f6a1cdbd" name="jetbrains.mps.lang.actions" version="4" />
+    <use id="63650c59-16c8-498a-99c8-005c7ee9515d" name="jetbrains.mps.lang.access" version="0" />
+    <use id="d08b386d-5ef3-4be0-9f84-dbefaf9e37f4" name="test.com.mbeddr.mpsutil.incrementalcomputation.utils" version="0" />
+  </languages>
+  <imports>
+    <import index="hz0z" ref="r:9bb90129-d2fe-48c5-b554-41fc26889d83(com.mbeddr.mpsutil.incrementalcomputation.runtime)" />
+    <import index="w1kc" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel(MPS.Core/)" />
+    <import index="kzoi" ref="r:644d327d-a4dc-4e49-b137-5aa4630bcd32(com.mbeddr.mpsutil.incrementalcomputation.structure)" />
+    <import index="s5lw" ref="r:7a356a35-b452-4ebe-818c-de36ace053d9(test.com.mbeddr.mpsutil.incrementalcomputation.utils.structure)" />
+    <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" />
+    <import index="lui2" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.module(MPS.OpenAPI/)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
+        <child id="1068498886297" name="rValue" index="37vLTx" />
+        <child id="1068498886295" name="lValue" index="37vLTJ" />
+      </concept>
+      <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1197029447546" name="jetbrains.mps.baseLanguage.structure.FieldReferenceOperation" flags="nn" index="2OwXpG">
+        <reference id="1197029500499" name="fieldDeclaration" index="2Oxat5" />
+      </concept>
+      <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
+        <child id="1145553007750" name="creator" index="2ShVmc" />
+      </concept>
+      <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
+        <child id="1137022507850" name="body" index="2VODD2" />
+      </concept>
+      <concept id="1070475354124" name="jetbrains.mps.baseLanguage.structure.ThisExpression" flags="nn" index="Xjq3P" />
+      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
+        <property id="1070475926801" name="value" index="Xl_RC" />
+      </concept>
+      <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
+        <reference id="1144433194310" name="classConcept" index="1Pybhc" />
+      </concept>
+      <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
+      <concept id="1068390468200" name="jetbrains.mps.baseLanguage.structure.FieldDeclaration" flags="ig" index="312cEg" />
+      <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
+        <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
+        <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
+      </concept>
+      <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
+      <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
+        <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
+      <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
+        <child id="1068580123133" name="returnType" index="3clF45" />
+        <child id="1068580123135" name="body" index="3clF47" />
+      </concept>
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT">
+        <property id="1068580123138" name="value" index="3clFbU" />
+      </concept>
+      <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
+        <property id="1068580320021" name="value" index="3cmrfH" />
+      </concept>
+      <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
+        <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
+      </concept>
+      <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
+      <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
+      </concept>
+      <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk" />
+      <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
+        <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
+      </concept>
+      <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
+        <reference id="1107535924139" name="classifier" index="3uigEE" />
+      </concept>
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
+        <child id="1178549979242" name="visibility" index="1B3o_S" />
+      </concept>
+      <concept id="6329021646629104957" name="jetbrains.mps.baseLanguage.structure.TextCommentPart" flags="nn" index="3SKdUq">
+        <property id="6329021646629104958" name="text" index="3SKdUp" />
+      </concept>
+      <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="nn" index="3SKdUt">
+        <child id="6329021646629175155" name="commentPart" index="3SKWNk" />
+      </concept>
+      <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
+    </language>
+    <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
+      <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
+        <child id="1199569916463" name="body" index="1bW5cS" />
+      </concept>
+    </language>
+    <language id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest">
+      <concept id="1171931690126" name="jetbrains.mps.baseLanguage.unitTest.structure.TestMethod" flags="ig" index="3s$Bmu">
+        <property id="1171931690128" name="methodName" index="3s$Bm0" />
+      </concept>
+      <concept id="1171931851043" name="jetbrains.mps.baseLanguage.unitTest.structure.BTestCase" flags="ig" index="3s_ewN">
+        <property id="1171931851045" name="testCaseName" index="3s_ewP" />
+        <child id="1171931851044" name="testMethodList" index="3s_ewO" />
+        <child id="8243879142738613220" name="afterTest" index="1KhZu3" />
+        <child id="8243879142738613219" name="beforeTest" index="1KhZu4" />
+      </concept>
+      <concept id="1171931858461" name="jetbrains.mps.baseLanguage.unitTest.structure.TestMethodList" flags="ng" index="3s_gsd">
+        <child id="1171931858462" name="testMethod" index="3s_gse" />
+      </concept>
+      <concept id="8427750732757990717" name="jetbrains.mps.baseLanguage.unitTest.structure.BinaryAssert" flags="nn" index="3tpDYu">
+        <child id="8427750732757990725" name="actual" index="3tpDZA" />
+        <child id="8427750732757990724" name="expected" index="3tpDZB" />
+      </concept>
+      <concept id="1171978097730" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertEquals" flags="nn" index="3vlDli" />
+      <concept id="1172069869612" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertThrows" flags="nn" index="3$NI$W">
+        <child id="1172070029086" name="statement" index="3$Oloe" />
+        <child id="1172070532815" name="exceptionType" index="3$Qgvv" />
+      </concept>
+      <concept id="1172073500303" name="jetbrains.mps.baseLanguage.unitTest.structure.Message" flags="ng" index="3_1$Yv">
+        <child id="1172073511101" name="message" index="3_1BAH" />
+      </concept>
+      <concept id="1172075514136" name="jetbrains.mps.baseLanguage.unitTest.structure.MessageHolder" flags="ng" index="3_9gw8">
+        <child id="1172075534298" name="message" index="3_9lra" />
+      </concept>
+      <concept id="8243879142738608185" name="jetbrains.mps.baseLanguage.unitTest.structure.BeforeTest" flags="in" index="1KhYhu" />
+      <concept id="8243879142738613213" name="jetbrains.mps.baseLanguage.unitTest.structure.AfterTest" flags="in" index="1KhZuU" />
+    </language>
+    <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1180636770613" name="jetbrains.mps.lang.smodel.structure.SNodeCreator" flags="nn" index="3zrR0B">
+        <child id="1180636770616" name="createdType" index="3zrR0E" />
+      </concept>
+      <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
+        <reference id="1138405853777" name="concept" index="ehGHo" />
+      </concept>
+      <concept id="1138056022639" name="jetbrains.mps.lang.smodel.structure.SPropertyAccess" flags="nn" index="3TrcHB">
+        <reference id="1138056395725" name="property" index="3TsBF5" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="3s_ewN" id="2YOONxNHqck">
+    <property role="3s_ewP" value="ValueCache_getValue" />
+    <node concept="312cEg" id="2YOONxNHqVj" role="jymVt">
+      <property role="TrG5h" value="cache" />
+      <node concept="3uibUv" id="2YOONxNHqUU" role="1tU5fm">
+        <ref role="3uigEE" to="hz0z:7ZWgXq7GlHg" resolve="ValueCache" />
+      </node>
+    </node>
+    <node concept="312cEg" id="2YOONxNHywt" role="jymVt">
+      <property role="TrG5h" value="myValueSelector" />
+      <node concept="3uibUv" id="2YOONxNHyts" role="1tU5fm">
+        <ref role="3uigEE" to="wyt6:~String" resolve="String" />
+      </node>
+      <node concept="Xl_RD" id="2YOONxNHyyi" role="33vP2m">
+        <property role="Xl_RC" value="selector" />
+      </node>
+    </node>
+    <node concept="312cEg" id="2YOONxNIu1W" role="jymVt">
+      <property role="TrG5h" value="valueHolder" />
+      <node concept="3Tqbb2" id="2YOONxNIu1V" role="1tU5fm">
+        <ref role="ehGHo" to="s5lw:2YOONxNIuVt" resolve="SimpleIncrementalComputationMock" />
+      </node>
+    </node>
+    <node concept="3Tm1VV" id="2YOONxNHqcl" role="1B3o_S" />
+    <node concept="3s_gsd" id="2YOONxNHqcm" role="3s_ewO">
+      <node concept="3s$Bmu" id="2YOONxNH$cE" role="3s_gse">
+        <property role="3s$Bm0" value="getValue_calculate" />
+        <node concept="3cqZAl" id="2YOONxNH$cF" role="3clF45" />
+        <node concept="3Tm1VV" id="2YOONxNH$cG" role="1B3o_S" />
+        <node concept="3clFbS" id="2YOONxNH$cH" role="3clF47">
+          <node concept="3SKdUt" id="2YOONxNKju0" role="3cqZAp">
+            <node concept="3SKdUq" id="2YOONxNKju2" role="3SKWNk">
+              <property role="3SKdUp" value="given I have a new cache" />
+            </node>
+          </node>
+          <node concept="3clFbF" id="2YOONxNJUam" role="3cqZAp">
+            <node concept="37vLTI" id="2YOONxNJYOQ" role="3clFbG">
+              <node concept="3clFbT" id="2YOONxNJYUr" role="37vLTx">
+                <property role="3clFbU" value="true" />
+              </node>
+              <node concept="2OqwBi" id="2YOONxNJV3A" role="37vLTJ">
+                <node concept="37vLTw" id="2YOONxNJUak" role="2Oq$k0">
+                  <ref role="3cqZAo" node="2YOONxNIu1W" resolve="valueHolder" />
+                </node>
+                <node concept="3TrcHB" id="2YOONxNJVqi" role="2OqNvi">
+                  <ref role="3TsBF5" to="s5lw:2YOONxNJAg_" resolve="canCalculate_return" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="2YOONxNKipT" role="3cqZAp">
+            <node concept="37vLTI" id="2YOONxNKipU" role="3clFbG">
+              <node concept="Xl_RD" id="2YOONxNKiPi" role="37vLTx">
+                <property role="Xl_RC" value="myCalculatedValue" />
+              </node>
+              <node concept="2OqwBi" id="2YOONxNKipW" role="37vLTJ">
+                <node concept="37vLTw" id="2YOONxNKipX" role="2Oq$k0">
+                  <ref role="3cqZAo" node="2YOONxNIu1W" resolve="valueHolder" />
+                </node>
+                <node concept="3TrcHB" id="2YOONxNKiG$" role="2OqNvi">
+                  <ref role="3TsBF5" to="s5lw:2YOONxNKfVz" resolve="calculateValue_return" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbH" id="2YOONxNKjhb" role="3cqZAp" />
+          <node concept="3SKdUt" id="2YOONxNKj_K" role="3cqZAp">
+            <node concept="3SKdUq" id="2YOONxNKj_M" role="3SKWNk">
+              <property role="3SKdUp" value="when I let the value be calculated" />
+            </node>
+          </node>
+          <node concept="3cpWs8" id="2YOONxNK3il" role="3cqZAp">
+            <node concept="3cpWsn" id="2YOONxNK3im" role="3cpWs9">
+              <property role="TrG5h" value="returnedValue" />
+              <node concept="3uibUv" id="2YOONxNK3ik" role="1tU5fm">
+                <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+              </node>
+              <node concept="2OqwBi" id="2YOONxNK3in" role="33vP2m">
+                <node concept="37vLTw" id="2YOONxNK3io" role="2Oq$k0">
+                  <ref role="3cqZAo" node="2YOONxNHqVj" resolve="cache" />
+                </node>
+                <node concept="liA8E" id="2YOONxNK3ip" role="2OqNvi">
+                  <ref role="37wK5l" to="hz0z:2YOONxNCmED" resolve="getValue" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbH" id="2YOONxNKjXj" role="3cqZAp" />
+          <node concept="3SKdUt" id="2YOONxNKkam" role="3cqZAp">
+            <node concept="3SKdUq" id="2YOONxNKkao" role="3SKWNk">
+              <property role="3SKdUp" value="then it returns the calculated value" />
+            </node>
+          </node>
+          <node concept="3vlDli" id="2YOONxNKljJ" role="3cqZAp">
+            <node concept="Xl_RD" id="2YOONxNKl$C" role="3tpDZB">
+              <property role="Xl_RC" value="myCalculatedValue" />
+            </node>
+            <node concept="37vLTw" id="2YOONxNKlJe" role="3tpDZA">
+              <ref role="3cqZAo" node="2YOONxNK3im" resolve="returnedValue" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3s$Bmu" id="2YOONxNLb0W" role="3s_gse">
+        <property role="3s$Bm0" value="getValue_cached" />
+        <node concept="3cqZAl" id="2YOONxNLb0X" role="3clF45" />
+        <node concept="3Tm1VV" id="2YOONxNLb0Y" role="1B3o_S" />
+        <node concept="3clFbS" id="2YOONxNLb0Z" role="3clF47">
+          <node concept="3SKdUt" id="2YOONxNLb10" role="3cqZAp">
+            <node concept="3SKdUq" id="2YOONxNLb11" role="3SKWNk">
+              <property role="3SKdUp" value="given I have a new cache" />
+            </node>
+          </node>
+          <node concept="3clFbF" id="2YOONxNLb12" role="3cqZAp">
+            <node concept="37vLTI" id="2YOONxNLb13" role="3clFbG">
+              <node concept="3clFbT" id="2YOONxNLb14" role="37vLTx">
+                <property role="3clFbU" value="true" />
+              </node>
+              <node concept="2OqwBi" id="2YOONxNLb15" role="37vLTJ">
+                <node concept="37vLTw" id="2YOONxNLb16" role="2Oq$k0">
+                  <ref role="3cqZAo" node="2YOONxNIu1W" resolve="valueHolder" />
+                </node>
+                <node concept="3TrcHB" id="2YOONxNLb17" role="2OqNvi">
+                  <ref role="3TsBF5" to="s5lw:2YOONxNJAg_" resolve="canCalculate_return" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="2YOONxNLb18" role="3cqZAp">
+            <node concept="37vLTI" id="2YOONxNLb19" role="3clFbG">
+              <node concept="Xl_RD" id="2YOONxNLb1a" role="37vLTx">
+                <property role="Xl_RC" value="myCalculatedValue" />
+              </node>
+              <node concept="2OqwBi" id="2YOONxNLb1b" role="37vLTJ">
+                <node concept="37vLTw" id="2YOONxNLb1c" role="2Oq$k0">
+                  <ref role="3cqZAo" node="2YOONxNIu1W" resolve="valueHolder" />
+                </node>
+                <node concept="3TrcHB" id="2YOONxNLb1d" role="2OqNvi">
+                  <ref role="3TsBF5" to="s5lw:2YOONxNKfVz" resolve="calculateValue_return" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbH" id="2YOONxNLb1e" role="3cqZAp" />
+          <node concept="3SKdUt" id="2YOONxNLb1f" role="3cqZAp">
+            <node concept="3SKdUq" id="2YOONxNLb1g" role="3SKWNk">
+              <property role="3SKdUp" value="when I let the value be calculated" />
+            </node>
+          </node>
+          <node concept="3clFbF" id="2YOONxNLdOc" role="3cqZAp">
+            <node concept="2OqwBi" id="2YOONxNLb1k" role="3clFbG">
+              <node concept="37vLTw" id="2YOONxNLb1l" role="2Oq$k0">
+                <ref role="3cqZAo" node="2YOONxNHqVj" resolve="cache" />
+              </node>
+              <node concept="liA8E" id="2YOONxNLb1m" role="2OqNvi">
+                <ref role="37wK5l" to="hz0z:2YOONxNCmED" resolve="getValue" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbH" id="2YOONxNMd0N" role="3cqZAp" />
+          <node concept="3SKdUt" id="2YOONxNMdbn" role="3cqZAp">
+            <node concept="3SKdUq" id="2YOONxNMdbp" role="3SKWNk">
+              <property role="3SKdUp" value="then it asked for calculation" />
+            </node>
+          </node>
+          <node concept="3vlDli" id="2YOONxNMdGE" role="3cqZAp">
+            <node concept="2OqwBi" id="2YOONxNMdGF" role="3tpDZA">
+              <node concept="37vLTw" id="2YOONxNMdGG" role="2Oq$k0">
+                <ref role="3cqZAo" node="2YOONxNIu1W" resolve="valueHolder" />
+              </node>
+              <node concept="3TrcHB" id="2YOONxNMdGH" role="2OqNvi">
+                <ref role="3TsBF5" to="s5lw:2YOONxNJAgD" resolve="calculateValue_calledTimes" />
+              </node>
+            </node>
+            <node concept="3cmrfG" id="2YOONxNMdGI" role="3tpDZB">
+              <property role="3cmrfH" value="1" />
+            </node>
+          </node>
+          <node concept="3clFbH" id="2YOONxNLeyw" role="3cqZAp" />
+          <node concept="3SKdUt" id="2YOONxNLeNj" role="3cqZAp">
+            <node concept="3SKdUq" id="2YOONxNLeNl" role="3SKWNk">
+              <property role="3SKdUp" value="when I get the value again" />
+            </node>
+          </node>
+          <node concept="3cpWs8" id="2YOONxNLbZu" role="3cqZAp">
+            <node concept="3cpWsn" id="2YOONxNLbZv" role="3cpWs9">
+              <property role="TrG5h" value="returnedValue" />
+              <node concept="3uibUv" id="2YOONxNLbZw" role="1tU5fm">
+                <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+              </node>
+              <node concept="2OqwBi" id="2YOONxNLbZx" role="33vP2m">
+                <node concept="37vLTw" id="2YOONxNLbZy" role="2Oq$k0">
+                  <ref role="3cqZAo" node="2YOONxNHqVj" resolve="cache" />
+                </node>
+                <node concept="liA8E" id="2YOONxNLbZz" role="2OqNvi">
+                  <ref role="37wK5l" to="hz0z:2YOONxNCmED" resolve="getValue" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbH" id="2YOONxNLb1n" role="3cqZAp" />
+          <node concept="3SKdUt" id="2YOONxNLb1o" role="3cqZAp">
+            <node concept="3SKdUq" id="2YOONxNLb1p" role="3SKWNk">
+              <property role="3SKdUp" value="then it returns the cached value" />
+            </node>
+          </node>
+          <node concept="3vlDli" id="2YOONxNLb1q" role="3cqZAp">
+            <node concept="Xl_RD" id="2YOONxNLb1r" role="3tpDZB">
+              <property role="Xl_RC" value="myCalculatedValue" />
+            </node>
+            <node concept="37vLTw" id="2YOONxNLgLG" role="3tpDZA">
+              <ref role="3cqZAo" node="2YOONxNLbZv" resolve="returnedValue" />
+            </node>
+          </node>
+          <node concept="3clFbH" id="2YOONxNMa_v" role="3cqZAp" />
+          <node concept="3SKdUt" id="2YOONxNMaRf" role="3cqZAp">
+            <node concept="3SKdUq" id="2YOONxNMaRh" role="3SKWNk">
+              <property role="3SKdUp" value="and it didn't ask for calculation again" />
+            </node>
+          </node>
+          <node concept="3vlDli" id="2YOONxNMbSr" role="3cqZAp">
+            <node concept="2OqwBi" id="2YOONxNMbSt" role="3tpDZA">
+              <node concept="37vLTw" id="2YOONxNMbSu" role="2Oq$k0">
+                <ref role="3cqZAo" node="2YOONxNIu1W" resolve="valueHolder" />
+              </node>
+              <node concept="3TrcHB" id="2YOONxNMbSv" role="2OqNvi">
+                <ref role="3TsBF5" to="s5lw:2YOONxNJAgD" resolve="calculateValue_calledTimes" />
+              </node>
+            </node>
+            <node concept="3cmrfG" id="2YOONxNMc24" role="3tpDZB">
+              <property role="3cmrfH" value="1" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3s$Bmu" id="2YOONxNLEoK" role="3s_gse">
+        <property role="3s$Bm0" value="getValue_cannotCalculate" />
+        <node concept="3cqZAl" id="2YOONxNLEoL" role="3clF45" />
+        <node concept="3Tm1VV" id="2YOONxNLEoM" role="1B3o_S" />
+        <node concept="3clFbS" id="2YOONxNLEoN" role="3clF47">
+          <node concept="3SKdUt" id="2YOONxNLEoO" role="3cqZAp">
+            <node concept="3SKdUq" id="2YOONxNLEoP" role="3SKWNk">
+              <property role="3SKdUp" value="given I have a new cache that cannot be filled" />
+            </node>
+          </node>
+          <node concept="3clFbF" id="2YOONxNLEoQ" role="3cqZAp">
+            <node concept="37vLTI" id="2YOONxNLEoR" role="3clFbG">
+              <node concept="3clFbT" id="2YOONxNLEoS" role="37vLTx" />
+              <node concept="2OqwBi" id="2YOONxNLEoT" role="37vLTJ">
+                <node concept="37vLTw" id="2YOONxNLEoU" role="2Oq$k0">
+                  <ref role="3cqZAo" node="2YOONxNIu1W" resolve="valueHolder" />
+                </node>
+                <node concept="3TrcHB" id="2YOONxNLEoV" role="2OqNvi">
+                  <ref role="3TsBF5" to="s5lw:2YOONxNJAg_" resolve="canCalculate_return" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="2YOONxNLHSA" role="3cqZAp">
+            <node concept="37vLTI" id="2YOONxNLHSB" role="3clFbG">
+              <node concept="Xl_RD" id="2YOONxNLHSC" role="37vLTx">
+                <property role="Xl_RC" value="thisShouldNeverBeRead" />
+              </node>
+              <node concept="2OqwBi" id="2YOONxNLHSD" role="37vLTJ">
+                <node concept="37vLTw" id="2YOONxNLHSE" role="2Oq$k0">
+                  <ref role="3cqZAo" node="2YOONxNIu1W" resolve="valueHolder" />
+                </node>
+                <node concept="3TrcHB" id="2YOONxNLHSF" role="2OqNvi">
+                  <ref role="3TsBF5" to="s5lw:2YOONxNKfVz" resolve="calculateValue_return" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbH" id="2YOONxNLHMw" role="3cqZAp" />
+          <node concept="3SKdUt" id="2YOONxNLEpj" role="3cqZAp">
+            <node concept="3SKdUq" id="2YOONxNLEpk" role="3SKWNk">
+              <property role="3SKdUp" value="when I get the value" />
+            </node>
+          </node>
+          <node concept="3cpWs8" id="2YOONxNLEpl" role="3cqZAp">
+            <node concept="3cpWsn" id="2YOONxNLEpm" role="3cpWs9">
+              <property role="TrG5h" value="returnedValue" />
+              <node concept="3uibUv" id="2YOONxNLEpn" role="1tU5fm">
+                <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+              </node>
+              <node concept="2OqwBi" id="2YOONxNLEpo" role="33vP2m">
+                <node concept="37vLTw" id="2YOONxNLEpp" role="2Oq$k0">
+                  <ref role="3cqZAo" node="2YOONxNHqVj" resolve="cache" />
+                </node>
+                <node concept="liA8E" id="2YOONxNLEpq" role="2OqNvi">
+                  <ref role="37wK5l" to="hz0z:2YOONxNCmED" resolve="getValue" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbH" id="2YOONxNLEpr" role="3cqZAp" />
+          <node concept="3SKdUt" id="2YOONxNLEps" role="3cqZAp">
+            <node concept="3SKdUq" id="2YOONxNLEpt" role="3SKWNk">
+              <property role="3SKdUp" value="then it returns no value" />
+            </node>
+          </node>
+          <node concept="3vlDli" id="2YOONxNLEpu" role="3cqZAp">
+            <node concept="10Nm6u" id="2YOONxNLHbX" role="3tpDZB" />
+            <node concept="37vLTw" id="2YOONxNLEpw" role="3tpDZA">
+              <ref role="3cqZAo" node="2YOONxNLEpm" resolve="returnedValue" />
+            </node>
+          </node>
+          <node concept="3clFbH" id="2YOONxNM8jH" role="3cqZAp" />
+          <node concept="3SKdUt" id="2YOONxNM8xo" role="3cqZAp">
+            <node concept="3SKdUq" id="2YOONxNM8xq" role="3SKWNk">
+              <property role="3SKdUp" value="and didn't call calculateValue" />
+            </node>
+          </node>
+          <node concept="3vlDli" id="2YOONxNM9$t" role="3cqZAp">
+            <node concept="3cmrfG" id="2YOONxNM9Vq" role="3tpDZB">
+              <property role="3cmrfH" value="0" />
+            </node>
+            <node concept="2OqwBi" id="2YOONxNMa3Q" role="3tpDZA">
+              <node concept="37vLTw" id="2YOONxNM9VJ" role="2Oq$k0">
+                <ref role="3cqZAo" node="2YOONxNIu1W" resolve="valueHolder" />
+              </node>
+              <node concept="3TrcHB" id="2YOONxNMaxZ" role="2OqNvi">
+                <ref role="3TsBF5" to="s5lw:2YOONxNJAgD" resolve="calculateValue_calledTimes" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3s$Bmu" id="2YOONxNMIBA" role="3s_gse">
+        <property role="3s$Bm0" value="getValue_disposed" />
+        <node concept="3cqZAl" id="2YOONxNMIBB" role="3clF45" />
+        <node concept="3Tm1VV" id="2YOONxNMIBC" role="1B3o_S" />
+        <node concept="3clFbS" id="2YOONxNMIBD" role="3clF47">
+          <node concept="3SKdUt" id="2YOONxNMIBE" role="3cqZAp">
+            <node concept="3SKdUq" id="2YOONxNMIBF" role="3SKWNk">
+              <property role="3SKdUp" value="given I have a disposed cache" />
+            </node>
+          </node>
+          <node concept="3clFbF" id="2YOONxNMJNX" role="3cqZAp">
+            <node concept="2OqwBi" id="2YOONxNMJYt" role="3clFbG">
+              <node concept="37vLTw" id="2YOONxNMJNV" role="2Oq$k0">
+                <ref role="3cqZAo" node="2YOONxNHqVj" resolve="cache" />
+              </node>
+              <node concept="liA8E" id="2YOONxNMLOS" role="2OqNvi">
+                <ref role="37wK5l" to="hz0z:7CsrqpZonfx" resolve="dispose" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbH" id="2YOONxNMIBS" role="3cqZAp" />
+          <node concept="3SKdUt" id="2YOONxNMIBT" role="3cqZAp">
+            <node concept="3SKdUq" id="2YOONxNMIBU" role="3SKWNk">
+              <property role="3SKdUp" value="then getting the value should throw an error" />
+            </node>
+          </node>
+          <node concept="3$NI$W" id="2YOONxNMUVM" role="3cqZAp">
+            <node concept="3uibUv" id="2YOONxNMVaj" role="3$Qgvv">
+              <ref role="3uigEE" to="wyt6:~AssertionError" resolve="AssertionError" />
+            </node>
+            <node concept="3clFbF" id="2YOONxNMV4c" role="3$Oloe">
+              <node concept="2OqwBi" id="2YOONxNMV4e" role="3clFbG">
+                <node concept="37vLTw" id="2YOONxNMV4f" role="2Oq$k0">
+                  <ref role="3cqZAo" node="2YOONxNHqVj" resolve="cache" />
+                </node>
+                <node concept="liA8E" id="2YOONxNMV4g" role="2OqNvi">
+                  <ref role="37wK5l" to="hz0z:2YOONxNCmED" resolve="getValue" />
+                </node>
+              </node>
+            </node>
+            <node concept="3_1$Yv" id="2YOONxNMVRs" role="3_9lra">
+              <node concept="Xl_RD" id="2YOONxNMWYl" role="3_1BAH">
+                <property role="Xl_RC" value="cache is disposed" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1KhYhu" id="2YOONxNHqV_" role="1KhZu4">
+      <node concept="3clFbS" id="2YOONxNHqVA" role="2VODD2">
+        <node concept="3clFbF" id="2YOONxNUJpQ" role="3cqZAp">
+          <node concept="2OqwBi" id="2YOONxNUJGC" role="3clFbG">
+            <node concept="2YIFZM" id="2YOONxNUJvK" role="2Oq$k0">
+              <ref role="37wK5l" to="w1kc:~ModelAccess.instance():jetbrains.mps.smodel.ModelAccess" resolve="instance" />
+              <ref role="1Pybhc" to="w1kc:~ModelAccess" resolve="ModelAccess" />
+            </node>
+            <node concept="liA8E" id="2YOONxNUKll" role="2OqNvi">
+              <ref role="37wK5l" to="lui2:~ModelAccess.runReadAction(java.lang.Runnable):void" resolve="runReadAction" />
+              <node concept="1bVj0M" id="2YOONxNUKmG" role="37wK5m">
+                <node concept="3clFbS" id="2YOONxNUKmH" role="1bW5cS">
+                  <node concept="3clFbF" id="2YOONxNIu25" role="3cqZAp">
+                    <node concept="37vLTI" id="2YOONxNIu26" role="3clFbG">
+                      <node concept="2OqwBi" id="2YOONxNIu27" role="37vLTJ">
+                        <node concept="Xjq3P" id="2YOONxNIu28" role="2Oq$k0" />
+                        <node concept="2OwXpG" id="2YOONxNIu29" role="2OqNvi">
+                          <ref role="2Oxat5" node="2YOONxNIu1W" resolve="valueHolder" />
+                        </node>
+                      </node>
+                      <node concept="2ShNRf" id="2YOONxNIu2a" role="37vLTx">
+                        <node concept="3zrR0B" id="2YOONxNIu2b" role="2ShVmc">
+                          <node concept="3Tqbb2" id="2YOONxNIu2c" role="3zrR0E">
+                            <ref role="ehGHo" to="s5lw:2YOONxNIuVt" resolve="SimpleIncrementalComputationMock" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbF" id="2YOONxNHqWl" role="3cqZAp">
+                    <node concept="37vLTI" id="2YOONxNHr5y" role="3clFbG">
+                      <node concept="2ShNRf" id="2YOONxNHr8h" role="37vLTx">
+                        <node concept="1pGfFk" id="2YOONxNHr6Y" role="2ShVmc">
+                          <ref role="37wK5l" to="hz0z:7ZWgXq7GDUc" resolve="ValueCache" />
+                          <node concept="2ShNRf" id="2YOONxNHxCy" role="37wK5m">
+                            <node concept="1pGfFk" id="2YOONxNHxJX" role="2ShVmc">
+                              <ref role="37wK5l" to="hz0z:2S2eLhiMJT4" resolve="ValueHolderInfo" />
+                              <node concept="37vLTw" id="2YOONxNIuJF" role="37wK5m">
+                                <ref role="3cqZAo" node="2YOONxNIu1W" resolve="valueHolder" />
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="37vLTw" id="2YOONxNHyAI" role="37wK5m">
+                            <ref role="3cqZAo" node="2YOONxNHywt" resolve="myValueSelector" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="37vLTw" id="2YOONxNHqWk" role="37vLTJ">
+                        <ref role="3cqZAo" node="2YOONxNHqVj" resolve="cache" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1KhZuU" id="2YOONxNHzgz" role="1KhZu3">
+      <node concept="3clFbS" id="2YOONxNHzg$" role="2VODD2">
+        <node concept="3clFbF" id="2YOONxNHzlM" role="3cqZAp">
+          <node concept="2OqwBi" id="2YOONxNHzoa" role="3clFbG">
+            <node concept="37vLTw" id="2YOONxNHzlL" role="2Oq$k0">
+              <ref role="3cqZAo" node="2YOONxNHqVj" resolve="cache" />
+            </node>
+            <node concept="liA8E" id="2YOONxNHz_c" role="2OqNvi">
+              <ref role="37wK5l" to="hz0z:7CsrqpZonfx" resolve="dispose" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/code/languages/com.mbeddr.mpsutil/tests/test.com.mbeddr.mpsutil.incrementalcomputation.runtime/test.com.mbeddr.mpsutil.incrementalcomputation.runtime.msd
+++ b/code/languages/com.mbeddr.mpsutil/tests/test.com.mbeddr.mpsutil.incrementalcomputation.runtime/test.com.mbeddr.mpsutil.incrementalcomputation.runtime.msd
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<solution name="test.com.mbeddr.mpsutil.incrementalcomputation.runtime" uuid="fa260a45-d02c-4dc2-bb84-e976ff916c98" moduleVersion="0" compileInMPS="true">
+  <models>
+    <modelRoot contentPath="${module}" type="default">
+      <sourceRoot location="models" />
+    </modelRoot>
+  </models>
+  <sourcePath />
+  <dependencies>
+    <dependency reexport="false">0fdbe445-2f40-47cb-beff-b44f4f5ffde0(com.mbeddr.mpsutil.incrementalcomputation.runtime)</dependency>
+    <dependency reexport="false">6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)</dependency>
+    <dependency reexport="false">d08b386d-5ef3-4be0-9f84-dbefaf9e37f4(test.com.mbeddr.mpsutil.incrementalcomputation.utils)</dependency>
+    <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
+  </dependencies>
+  <languageVersions>
+    <language slang="l:fca4b687-11d4-461f-9cd4-f00968145931:com.mbeddr.mpsutil.incrementalcomputation" version="0" />
+    <language slang="l:654422bf-e75f-44dc-936d-188890a746ce:de.slisson.mps.reflection" version="0" />
+    <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="8" />
+    <language slang="l:443f4c36-fcf5-4eb6-9500-8d06ed259e3e:jetbrains.mps.baseLanguage.classifiers" version="0" />
+    <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
+    <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
+    <language slang="l:f61473f9-130f-42f6-b98d-6c438812c2f6:jetbrains.mps.baseLanguage.unitTest" version="1" />
+    <language slang="l:63650c59-16c8-498a-99c8-005c7ee9515d:jetbrains.mps.lang.access" version="0" />
+    <language slang="l:aee9cad2-acd4-4608-aef2-0004f6a1cdbd:jetbrains.mps.lang.actions" version="4" />
+    <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="1" />
+    <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
+    <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="13" />
+    <language slang="l:c72da2b9-7cce-4447-8389-f407dc1158b7:jetbrains.mps.lang.structure" version="7" />
+    <language slang="l:8585453e-6bfb-4d80-98de-b16074f1d86c:jetbrains.mps.lang.test" version="2" />
+    <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
+    <language slang="l:d08b386d-5ef3-4be0-9f84-dbefaf9e37f4:test.com.mbeddr.mpsutil.incrementalcomputation.utils" version="0" />
+  </languageVersions>
+  <dependencyVersions>
+    <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
+    <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
+    <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
+    <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
+    <module reference="fca4b687-11d4-461f-9cd4-f00968145931(com.mbeddr.mpsutil.incrementalcomputation)" version="0" />
+    <module reference="0fdbe445-2f40-47cb-beff-b44f4f5ffde0(com.mbeddr.mpsutil.incrementalcomputation.runtime)" version="0" />
+    <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
+    <module reference="fa260a45-d02c-4dc2-bb84-e976ff916c98(test.com.mbeddr.mpsutil.incrementalcomputation.runtime)" version="0" />
+    <module reference="d08b386d-5ef3-4be0-9f84-dbefaf9e37f4(test.com.mbeddr.mpsutil.incrementalcomputation.utils)" version="0" />
+  </dependencyVersions>
+</solution>
+

--- a/code/languages/com.mbeddr.mpsutil/tests/test.com.mbeddr.mpsutil.incrementalcomputation.utils/generator/template/main@generator.mps
+++ b/code/languages/com.mbeddr.mpsutil/tests/test.com.mbeddr.mpsutil.incrementalcomputation.utils/generator/template/main@generator.mps
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:211ad5c9-bd38-4f54-9477-c00101d111d5(main@generator)">
+  <persistence version="9" />
+  <languages>
+    <devkit ref="a2eb3a43-fcc2-4200-80dc-c60110c4862d(jetbrains.mps.devkit.templates)" />
+  </languages>
+  <imports>
+    <import index="s5lw" ref="r:7a356a35-b452-4ebe-818c-de36ace053d9(test.com.mbeddr.mpsutil.incrementalcomputation.utils.structure)" />
+  </imports>
+  <registry>
+    <language id="b401a680-8325-4110-8fd3-84331ff25bef" name="jetbrains.mps.lang.generator">
+      <concept id="1095416546421" name="jetbrains.mps.lang.generator.structure.MappingConfiguration" flags="ig" index="bUwia" />
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="bUwia" id="2YOONxNIuVs">
+    <property role="TrG5h" value="main" />
+  </node>
+</model>
+

--- a/code/languages/com.mbeddr.mpsutil/tests/test.com.mbeddr.mpsutil.incrementalcomputation.utils/models/behavior.mps
+++ b/code/languages/com.mbeddr.mpsutil/tests/test.com.mbeddr.mpsutil.incrementalcomputation.utils/models/behavior.mps
@@ -1,0 +1,284 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:2f025e8d-47fd-4b1c-b7cc-e1f2d9fcae51(test.com.mbeddr.mpsutil.incrementalcomputation.utils.behavior)">
+  <persistence version="9" />
+  <languages>
+    <use id="af65afd8-f0dd-4942-87d9-63a55f2a9db1" name="jetbrains.mps.lang.behavior" version="2" />
+    <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
+  </languages>
+  <imports>
+    <import index="ao0u" ref="r:1a144811-e678-4458-87d0-b30274644955(com.mbeddr.mpsutil.incrementalcomputation.behavior)" />
+    <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" />
+    <import index="kzoi" ref="r:644d327d-a4dc-4e49-b137-5aa4630bcd32(com.mbeddr.mpsutil.incrementalcomputation.structure)" />
+    <import index="hz0z" ref="r:9bb90129-d2fe-48c5-b554-41fc26889d83(com.mbeddr.mpsutil.incrementalcomputation.runtime)" />
+    <import index="n4y8" ref="9414e29c-0c8d-4bc7-b251-f312597fb993/java:org.mockito(org.mockito/)" />
+    <import index="s5lw" ref="r:7a356a35-b452-4ebe-818c-de36ace053d9(test.com.mbeddr.mpsutil.incrementalcomputation.utils.structure)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="a247e09e-2435-45ba-b8d2-07e93feba96a" name="jetbrains.mps.baseLanguage.tuples">
+      <concept id="1238852151516" name="jetbrains.mps.baseLanguage.tuples.structure.IndexedTupleType" flags="in" index="1LlUBW">
+        <child id="1238852204892" name="componentType" index="1Lm7xW" />
+      </concept>
+    </language>
+    <language id="af65afd8-f0dd-4942-87d9-63a55f2a9db1" name="jetbrains.mps.lang.behavior">
+      <concept id="1225194240794" name="jetbrains.mps.lang.behavior.structure.ConceptBehavior" flags="ng" index="13h7C7">
+        <reference id="1225194240799" name="concept" index="13h7C2" />
+        <child id="1225194240805" name="method" index="13h7CS" />
+        <child id="1225194240801" name="constructor" index="13h7CW" />
+      </concept>
+      <concept id="1225194413805" name="jetbrains.mps.lang.behavior.structure.ConceptConstructorDeclaration" flags="in" index="13hLZK" />
+      <concept id="1225194472830" name="jetbrains.mps.lang.behavior.structure.ConceptMethodDeclaration" flags="ng" index="13i0hz">
+        <reference id="1225194472831" name="overriddenMethod" index="13i0hy" />
+      </concept>
+      <concept id="1225194628440" name="jetbrains.mps.lang.behavior.structure.SuperNodeExpression" flags="nn" index="13iAh5">
+        <reference id="5299096511375896640" name="superConcept" index="3eA5LN" />
+      </concept>
+      <concept id="1225194691553" name="jetbrains.mps.lang.behavior.structure.ThisNodeExpression" flags="nn" index="13iPFW" />
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1239714755177" name="jetbrains.mps.baseLanguage.structure.AbstractUnaryNumberOperation" flags="nn" index="2$Kvd9">
+        <child id="1239714902950" name="expression" index="2$L3a6" />
+      </concept>
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
+        <child id="1137022507850" name="body" index="2VODD2" />
+      </concept>
+      <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
+      <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
+      <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
+        <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
+      </concept>
+      <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
+      <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
+        <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
+      <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
+        <child id="1068580123133" name="returnType" index="3clF45" />
+        <child id="1068580123134" name="parameter" index="3clF46" />
+        <child id="1068580123135" name="body" index="3clF47" />
+      </concept>
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
+        <child id="1068581517676" name="expression" index="3cqZAk" />
+      </concept>
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
+      </concept>
+      <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
+        <reference id="1107535924139" name="classifier" index="3uigEE" />
+      </concept>
+      <concept id="1214918800624" name="jetbrains.mps.baseLanguage.structure.PostfixIncrementExpression" flags="nn" index="3uNrnE" />
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
+        <child id="1178549979242" name="visibility" index="1B3o_S" />
+      </concept>
+      <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
+    </language>
+    <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
+      <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
+        <reference id="1138405853777" name="concept" index="ehGHo" />
+      </concept>
+      <concept id="1138056022639" name="jetbrains.mps.lang.smodel.structure.SPropertyAccess" flags="nn" index="3TrcHB">
+        <reference id="1138056395725" name="property" index="3TsBF5" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+    <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
+      <concept id="1151689724996" name="jetbrains.mps.baseLanguage.collections.structure.SequenceType" flags="in" index="A3Dl8">
+        <child id="1151689745422" name="elementType" index="A3Ik2" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="13h7C7" id="2YOONxNIVp0">
+    <ref role="13h7C2" to="s5lw:2YOONxNIuVt" resolve="SimpleIncrementalComputationMock" />
+    <node concept="13hLZK" id="2YOONxNIVp1" role="13h7CW">
+      <node concept="3clFbS" id="2YOONxNIVp2" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="2YOONxNJkhV" role="13h7CS">
+      <property role="TrG5h" value="getValueSelectorsToUpdate" />
+      <ref role="13i0hy" to="ao0u:7rpuqnf_WYv" resolve="getValueSelectorsToUpdate" />
+      <node concept="3Tm1VV" id="2YOONxNJkhW" role="1B3o_S" />
+      <node concept="3clFbS" id="2YOONxNJki3" role="3clF47">
+        <node concept="3clFbF" id="2YOONxNJJIm" role="3cqZAp">
+          <node concept="10Nm6u" id="2YOONxNJJIl" role="3clFbG" />
+        </node>
+      </node>
+      <node concept="A3Dl8" id="2YOONxNJki4" role="3clF45">
+        <node concept="3uibUv" id="2YOONxNJki5" role="A3Ik2">
+          <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+        </node>
+      </node>
+    </node>
+    <node concept="13i0hz" id="2YOONxNJki6" role="13h7CS">
+      <property role="TrG5h" value="getDependencies" />
+      <ref role="13i0hy" to="ao0u:2S2eLhiMzhL" resolve="getDependencies" />
+      <node concept="3Tm1VV" id="2YOONxNJki9" role="1B3o_S" />
+      <node concept="3clFbS" id="2YOONxNJkig" role="3clF47">
+        <node concept="3clFbF" id="2YOONxNJJIJ" role="3cqZAp">
+          <node concept="10Nm6u" id="2YOONxNJJII" role="3clFbG" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="2YOONxNJkih" role="3clF46">
+        <property role="TrG5h" value="valueSelector" />
+        <node concept="3uibUv" id="2YOONxNJkii" role="1tU5fm">
+          <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+        </node>
+      </node>
+      <node concept="A3Dl8" id="2YOONxNJkij" role="3clF45">
+        <node concept="3Tqbb2" id="2YOONxNJkik" role="A3Ik2">
+          <ref role="ehGHo" to="kzoi:2S2eLhiMx2Q" resolve="IncrementallyComputedValueHolder" />
+        </node>
+      </node>
+    </node>
+    <node concept="13i0hz" id="2YOONxNJkil" role="13h7CS">
+      <property role="TrG5h" value="calculateValue" />
+      <ref role="13i0hy" to="ao0u:RObVTFnZ_0" resolve="calculateValue" />
+      <node concept="3Tm1VV" id="2YOONxNJkio" role="1B3o_S" />
+      <node concept="3clFbS" id="2YOONxNJkiy" role="3clF47">
+        <node concept="3clFbF" id="2YOONxNJGg3" role="3cqZAp">
+          <node concept="3uNrnE" id="2YOONxNJIv5" role="3clFbG">
+            <node concept="2OqwBi" id="2YOONxNJIv7" role="2$L3a6">
+              <node concept="13iPFW" id="2YOONxNJIv8" role="2Oq$k0" />
+              <node concept="3TrcHB" id="2YOONxNJIv9" role="2OqNvi">
+                <ref role="3TsBF5" to="s5lw:2YOONxNJAgD" resolve="calculateValue_calledTimes" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="2YOONxNKfoh" role="3cqZAp" />
+        <node concept="3cpWs6" id="2YOONxNKfJ4" role="3cqZAp">
+          <node concept="2OqwBi" id="2YOONxNKhTL" role="3cqZAk">
+            <node concept="13iPFW" id="2YOONxNKhG4" role="2Oq$k0" />
+            <node concept="3TrcHB" id="2YOONxNKiaW" role="2OqNvi">
+              <ref role="3TsBF5" to="s5lw:2YOONxNKfVz" resolve="calculateValue_return" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="2YOONxNJkiz" role="3clF46">
+        <property role="TrG5h" value="valueSelector" />
+        <node concept="3uibUv" id="2YOONxNJki$" role="1tU5fm">
+          <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+        </node>
+      </node>
+      <node concept="3uibUv" id="2YOONxNJki_" role="3clF45">
+        <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+      </node>
+    </node>
+    <node concept="13i0hz" id="2YOONxNJkiC" role="13h7CS">
+      <property role="TrG5h" value="getChangeEffect" />
+      <ref role="13i0hy" to="ao0u:KudFejX3SG" resolve="getChangeEffect" />
+      <node concept="3Tm1VV" id="2YOONxNJkiH" role="1B3o_S" />
+      <node concept="3clFbS" id="2YOONxNJkiQ" role="3clF47">
+        <node concept="3cpWs6" id="2YOONxNJkiX" role="3cqZAp">
+          <node concept="10Nm6u" id="2YOONxNJkiW" role="3cqZAk" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="2YOONxNJkiR" role="3clF46">
+        <property role="TrG5h" value="event" />
+        <node concept="3uibUv" id="2YOONxNJkiS" role="1tU5fm">
+          <ref role="3uigEE" to="hz0z:KudFejZbfb" resolve="ContentChangedEvent" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="2YOONxNJkiT" role="3clF46">
+        <property role="TrG5h" value="valueSelector" />
+        <node concept="3uibUv" id="2YOONxNJkiU" role="1tU5fm">
+          <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+        </node>
+      </node>
+      <node concept="3uibUv" id="2YOONxNJkiV" role="3clF45">
+        <ref role="3uigEE" to="hz0z:797ZNR2jylR" resolve="ChangeEffect" />
+      </node>
+    </node>
+    <node concept="13i0hz" id="2YOONxNJkiY" role="13h7CS">
+      <property role="TrG5h" value="isEditorUpdateEnabled" />
+      <ref role="13i0hy" to="ao0u:5nAcTtnb1YA" resolve="isEditorUpdateEnabled" />
+      <node concept="3Tm1VV" id="2YOONxNJkj1" role="1B3o_S" />
+      <node concept="3clFbS" id="2YOONxNJkjb" role="3clF47">
+        <node concept="3cpWs6" id="2YOONxNJkjj" role="3cqZAp">
+          <node concept="2OqwBi" id="2YOONxNJkjg" role="3cqZAk">
+            <node concept="13iAh5" id="2YOONxNJkjh" role="2Oq$k0">
+              <ref role="3eA5LN" to="kzoi:2S2eLhiMx2Q" resolve="IncrementallyComputedValueHolder" />
+            </node>
+            <node concept="2qgKlT" id="2YOONxNJkji" role="2OqNvi">
+              <ref role="37wK5l" to="ao0u:5nAcTtnb1YA" resolve="isEditorUpdateEnabled" />
+              <node concept="37vLTw" id="2YOONxNJkjf" role="37wK5m">
+                <ref role="3cqZAo" node="2YOONxNJkjc" resolve="valueSelector" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="2YOONxNJkjc" role="3clF46">
+        <property role="TrG5h" value="valueSelector" />
+        <node concept="3uibUv" id="2YOONxNJkjd" role="1tU5fm">
+          <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+        </node>
+      </node>
+      <node concept="10P_77" id="2YOONxNJkje" role="3clF45" />
+    </node>
+    <node concept="13i0hz" id="2YOONxNJkjk" role="13h7CS">
+      <property role="TrG5h" value="canCalculate" />
+      <ref role="13i0hy" to="ao0u:6MPBOWiFIsN" resolve="canCalculate" />
+      <node concept="3Tm1VV" id="2YOONxNJkjl" role="1B3o_S" />
+      <node concept="3clFbS" id="2YOONxNJkjx" role="3clF47">
+        <node concept="3cpWs6" id="2YOONxNJJlu" role="3cqZAp">
+          <node concept="2OqwBi" id="2YOONxNJJw$" role="3cqZAk">
+            <node concept="13iPFW" id="2YOONxNJJm4" role="2Oq$k0" />
+            <node concept="3TrcHB" id="2YOONxNJJFT" role="2OqNvi">
+              <ref role="3TsBF5" to="s5lw:2YOONxNJAg_" resolve="canCalculate_return" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="2YOONxNJkjy" role="3clF46">
+        <property role="TrG5h" value="valueSelector" />
+        <node concept="3uibUv" id="2YOONxNJkjz" role="1tU5fm">
+          <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+        </node>
+      </node>
+      <node concept="10P_77" id="2YOONxNJkj$" role="3clF45" />
+    </node>
+    <node concept="13i0hz" id="2YOONxNJkjE" role="13h7CS">
+      <property role="TrG5h" value="getAllCycles" />
+      <ref role="13i0hy" to="ao0u:5YITc37Rtfk" resolve="getAllCycles" />
+      <node concept="3Tm1VV" id="2YOONxNJkjF" role="1B3o_S" />
+      <node concept="3clFbS" id="2YOONxNJkjT" role="3clF47">
+        <node concept="3cpWs6" id="2YOONxNJkk2" role="3cqZAp">
+          <node concept="2OqwBi" id="2YOONxNJkjZ" role="3cqZAk">
+            <node concept="13iAh5" id="2YOONxNJkk0" role="2Oq$k0">
+              <ref role="3eA5LN" to="kzoi:2S2eLhiMx2Q" resolve="IncrementallyComputedValueHolder" />
+            </node>
+            <node concept="2qgKlT" id="2YOONxNJkk1" role="2OqNvi">
+              <ref role="37wK5l" to="ao0u:5YITc37Rtfk" resolve="getAllCycles" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="A3Dl8" id="2YOONxNJkjU" role="3clF45">
+        <node concept="1LlUBW" id="2YOONxNJkjV" role="A3Ik2">
+          <node concept="3uibUv" id="2YOONxNJkjW" role="1Lm7xW">
+            <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+          </node>
+          <node concept="A3Dl8" id="2YOONxNJkjX" role="1Lm7xW">
+            <node concept="3Tqbb2" id="2YOONxNJkjY" role="A3Ik2" />
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/code/languages/com.mbeddr.mpsutil/tests/test.com.mbeddr.mpsutil.incrementalcomputation.utils/models/constraints.mps
+++ b/code/languages/com.mbeddr.mpsutil/tests/test.com.mbeddr.mpsutil.incrementalcomputation.utils/models/constraints.mps
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:a39cdc2e-3a55-4e0e-912b-042335bff594(test.com.mbeddr.mpsutil.incrementalcomputation.utils.constraints)">
+  <persistence version="9" />
+  <languages>
+    <use id="3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1" name="jetbrains.mps.lang.constraints" version="4" />
+    <devkit ref="00000000-0000-4000-0000-5604ebd4f22c(jetbrains.mps.devkit.aspect.constraints)" />
+  </languages>
+  <imports />
+  <registry />
+</model>
+

--- a/code/languages/com.mbeddr.mpsutil/tests/test.com.mbeddr.mpsutil.incrementalcomputation.utils/models/editor.mps
+++ b/code/languages/com.mbeddr.mpsutil/tests/test.com.mbeddr.mpsutil.incrementalcomputation.utils/models/editor.mps
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:1e682189-c2c6-4db0-90e4-2f44b3636f9d(test.com.mbeddr.mpsutil.incrementalcomputation.utils.editor)">
+  <persistence version="9" />
+  <languages>
+    <use id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor" version="12" />
+    <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
+  </languages>
+  <imports />
+  <registry />
+</model>
+

--- a/code/languages/com.mbeddr.mpsutil/tests/test.com.mbeddr.mpsutil.incrementalcomputation.utils/models/structure.mps
+++ b/code/languages/com.mbeddr.mpsutil/tests/test.com.mbeddr.mpsutil.incrementalcomputation.utils/models/structure.mps
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:7a356a35-b452-4ebe-818c-de36ace053d9(test.com.mbeddr.mpsutil.incrementalcomputation.utils.structure)">
+  <persistence version="9" />
+  <languages>
+    <use id="c72da2b9-7cce-4447-8389-f407dc1158b7" name="jetbrains.mps.lang.structure" version="7" />
+    <devkit ref="78434eb8-b0e5-444b-850d-e7c4ad2da9ab(jetbrains.mps.devkit.aspect.structure)" />
+  </languages>
+  <imports>
+    <import index="kzoi" ref="r:644d327d-a4dc-4e49-b137-5aa4630bcd32(com.mbeddr.mpsutil.incrementalcomputation.structure)" />
+    <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="c72da2b9-7cce-4447-8389-f407dc1158b7" name="jetbrains.mps.lang.structure">
+      <concept id="1169125787135" name="jetbrains.mps.lang.structure.structure.AbstractConceptDeclaration" flags="ig" index="PkWjJ">
+        <property id="6714410169261853888" name="conceptId" index="EcuMT" />
+        <child id="1071489727084" name="propertyDeclaration" index="1TKVEl" />
+      </concept>
+      <concept id="1169127622168" name="jetbrains.mps.lang.structure.structure.InterfaceConceptReference" flags="ig" index="PrWs8">
+        <reference id="1169127628841" name="intfc" index="PrY4T" />
+      </concept>
+      <concept id="1071489090640" name="jetbrains.mps.lang.structure.structure.ConceptDeclaration" flags="ig" index="1TIwiD">
+        <child id="1169129564478" name="implements" index="PzmwI" />
+      </concept>
+      <concept id="1071489288299" name="jetbrains.mps.lang.structure.structure.PropertyDeclaration" flags="ig" index="1TJgyi">
+        <property id="241647608299431129" name="propertyId" index="IQ2nx" />
+        <reference id="1082985295845" name="dataType" index="AX2Wp" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="1TIwiD" id="2YOONxNIuVt">
+    <property role="EcuMT" value="3437604655003725533" />
+    <property role="TrG5h" value="SimpleIncrementalComputationMock" />
+    <node concept="PrWs8" id="2YOONxNIVoz" role="PzmwI">
+      <ref role="PrY4T" to="kzoi:2S2eLhiMx2Q" resolve="IncrementallyComputedValueHolder" />
+    </node>
+    <node concept="1TJgyi" id="2YOONxNJAg_" role="1TKVEl">
+      <property role="IQ2nx" value="3437604655004017701" />
+      <property role="TrG5h" value="canCalculate_return" />
+      <ref role="AX2Wp" to="tpck:fKAQMTB" resolve="boolean" />
+    </node>
+    <node concept="1TJgyi" id="2YOONxNJAgD" role="1TKVEl">
+      <property role="IQ2nx" value="3437604655004017705" />
+      <property role="TrG5h" value="calculateValue_calledTimes" />
+      <ref role="AX2Wp" to="tpck:fKAQMTA" resolve="integer" />
+    </node>
+    <node concept="1TJgyi" id="2YOONxNKfVz" role="1TKVEl">
+      <property role="IQ2nx" value="3437604655004188387" />
+      <property role="TrG5h" value="calculateValue_return" />
+      <ref role="AX2Wp" to="tpck:fKAOsGN" resolve="string" />
+    </node>
+  </node>
+</model>
+

--- a/code/languages/com.mbeddr.mpsutil/tests/test.com.mbeddr.mpsutil.incrementalcomputation.utils/models/typesystem.mps
+++ b/code/languages/com.mbeddr.mpsutil/tests/test.com.mbeddr.mpsutil.incrementalcomputation.utils/models/typesystem.mps
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:8cd14b5a-e742-400f-a13b-1c9c9179725e(test.com.mbeddr.mpsutil.incrementalcomputation.utils.typesystem)">
+  <persistence version="9" />
+  <languages>
+    <use id="7a5dda62-9140-4668-ab76-d5ed1746f2b2" name="jetbrains.mps.lang.typesystem" version="1" />
+    <devkit ref="00000000-0000-4000-0000-1de82b3a4936(jetbrains.mps.devkit.aspect.typesystem)" />
+  </languages>
+  <imports />
+  <registry />
+</model>
+

--- a/code/languages/com.mbeddr.mpsutil/tests/test.com.mbeddr.mpsutil.incrementalcomputation.utils/test.com.mbeddr.mpsutil.incrementalcomputation.utils.mpl
+++ b/code/languages/com.mbeddr.mpsutil/tests/test.com.mbeddr.mpsutil.incrementalcomputation.utils/test.com.mbeddr.mpsutil.incrementalcomputation.utils.mpl
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<language namespace="test.com.mbeddr.mpsutil.incrementalcomputation.utils" uuid="d08b386d-5ef3-4be0-9f84-dbefaf9e37f4" languageVersion="0" moduleVersion="0">
+  <models>
+    <modelRoot contentPath="${module}" type="default">
+      <sourceRoot location="models" />
+    </modelRoot>
+  </models>
+  <accessoryModels />
+  <generators>
+    <generator alias="main" namespace="test.com.mbeddr.mpsutil.incrementalcomputation.utils#01" uuid="3b1aa90d-19b5-40ad-a942-37a00114aa1f">
+      <models>
+        <modelRoot contentPath="${module}/generator/template" type="default">
+          <sourceRoot location="." />
+        </modelRoot>
+      </models>
+      <external-templates />
+      <languageVersions>
+        <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="8" />
+        <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
+        <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
+        <language slang="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" version="2" />
+        <language slang="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" version="0" />
+        <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
+        <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="1" />
+        <language slang="l:b401a680-8325-4110-8fd3-84331ff25bef:jetbrains.mps.lang.generator" version="2" />
+        <language slang="l:d7706f63-9be2-479c-a3da-ae92af1e64d5:jetbrains.mps.lang.generator.generationContext" version="0" />
+        <language slang="l:289fcc83-6543-41e8-a5ca-768235715ce4:jetbrains.mps.lang.generator.generationParameters" version="0" />
+        <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
+        <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="0" />
+        <language slang="l:13744753-c81f-424a-9c1b-cf8943bf4e86:jetbrains.mps.lang.sharedConcepts" version="0" />
+        <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="13" />
+        <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
+        <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
+      </languageVersions>
+      <dependencyVersions>
+        <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
+        <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
+        <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
+        <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
+        <module reference="fca4b687-11d4-461f-9cd4-f00968145931(com.mbeddr.mpsutil.incrementalcomputation)" version="0" />
+        <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
+        <module reference="d08b386d-5ef3-4be0-9f84-dbefaf9e37f4(test.com.mbeddr.mpsutil.incrementalcomputation.utils)" version="0" />
+        <module reference="3b1aa90d-19b5-40ad-a942-37a00114aa1f(test.com.mbeddr.mpsutil.incrementalcomputation.utils#01)" version="0" />
+      </dependencyVersions>
+      <mapping-priorities />
+    </generator>
+  </generators>
+  <sourcePath />
+  <dependencies>
+    <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
+    <dependency reexport="false">0fdbe445-2f40-47cb-beff-b44f4f5ffde0(com.mbeddr.mpsutil.incrementalcomputation.runtime)</dependency>
+    <dependency reexport="false">9414e29c-0c8d-4bc7-b251-f312597fb993(org.mockito)</dependency>
+  </dependencies>
+  <languageVersions>
+    <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="8" />
+    <language slang="l:443f4c36-fcf5-4eb6-9500-8d06ed259e3e:jetbrains.mps.baseLanguage.classifiers" version="0" />
+    <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
+    <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
+    <language slang="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" version="2" />
+    <language slang="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" version="0" />
+    <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
+    <language slang="l:aee9cad2-acd4-4608-aef2-0004f6a1cdbd:jetbrains.mps.lang.actions" version="4" />
+    <language slang="l:af65afd8-f0dd-4942-87d9-63a55f2a9db1:jetbrains.mps.lang.behavior" version="2" />
+    <language slang="l:3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1:jetbrains.mps.lang.constraints" version="4" />
+    <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="1" />
+    <language slang="l:f4ad079d-bc71-4ffb-9600-9328705cf998:jetbrains.mps.lang.descriptor" version="0" />
+    <language slang="l:18bc6592-03a6-4e29-a83a-7ff23bde13ba:jetbrains.mps.lang.editor" version="12" />
+    <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
+    <language slang="l:d4615e3b-d671-4ba9-af01-2b78369b0ba7:jetbrains.mps.lang.pattern" version="1" />
+    <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="0" />
+    <language slang="l:982eb8df-2c96-4bd7-9963-11712ea622e5:jetbrains.mps.lang.resources" version="2" />
+    <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="13" />
+    <language slang="l:c72da2b9-7cce-4447-8389-f407dc1158b7:jetbrains.mps.lang.structure" version="7" />
+    <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
+    <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
+    <language slang="l:7a5dda62-9140-4668-ab76-d5ed1746f2b2:jetbrains.mps.lang.typesystem" version="1" />
+  </languageVersions>
+  <dependencyVersions>
+    <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
+    <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
+    <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
+    <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
+    <module reference="fca4b687-11d4-461f-9cd4-f00968145931(com.mbeddr.mpsutil.incrementalcomputation)" version="0" />
+    <module reference="0fdbe445-2f40-47cb-beff-b44f4f5ffde0(com.mbeddr.mpsutil.incrementalcomputation.runtime)" version="0" />
+    <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
+    <module reference="a9e4c532-c5f5-4bb7-99ef-42abb73bbb70(jetbrains.mps.lang.descriptor.aspects)" version="0" />
+    <module reference="9414e29c-0c8d-4bc7-b251-f312597fb993(org.mockito)" version="0" />
+    <module reference="d08b386d-5ef3-4be0-9f84-dbefaf9e37f4(test.com.mbeddr.mpsutil.incrementalcomputation.utils)" version="0" />
+  </dependencyVersions>
+  <extendedLanguages>
+    <extendedLanguage>fca4b687-11d4-461f-9cd4-f00968145931(com.mbeddr.mpsutil.incrementalcomputation)</extendedLanguage>
+  </extendedLanguages>
+</language>
+


### PR DESCRIPTION
- incrementalComputation: replaced `#isActive()` with `#canCalculate()` and inlined check for having cycles into it (in order to allow API clients to opt into running the calculation even though there are cycles) (needed to fix [SECA-872](https://intern.itemis.de/jira/browse/SECA-872))
- incrementalComputation: automated test for ValueCache
- incrementalComputation: only one thread at a time can enter any ValueCache method to prevent race conditions that may be the causing [SECA-822](https://intern.itemis.de/jira/browse/SECA-822)
- incrementalComputation: added README.md
- asynccell: if calculation raises an error, don't rerun it until the editor is updated and display `ERR` instead