### PR TITLE
Improve json text gen and editors

### DIFF
--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.json/models/com.mbeddr.mpsutil.json.editor.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.json/models/com.mbeddr.mpsutil.json.editor.mps
@@ -33,6 +33,7 @@
       <concept id="1237307900041" name="jetbrains.mps.lang.editor.structure.IndentLayoutIndentStyleClassItem" flags="ln" index="lj46D" />
       <concept id="1237308012275" name="jetbrains.mps.lang.editor.structure.IndentLayoutNewLineStyleClassItem" flags="ln" index="ljvvj" />
       <concept id="709996738298806197" name="jetbrains.mps.lang.editor.structure.QueryFunction_SeparatorText" flags="in" index="2o9xnK" />
+      <concept id="1142886811589" name="jetbrains.mps.lang.editor.structure.ConceptFunctionParameter_node" flags="nn" index="pncrf" />
       <concept id="1237385578942" name="jetbrains.mps.lang.editor.structure.IndentLayoutOnNewLineStyleClassItem" flags="ln" index="pVoyu" />
       <concept id="1233148810477" name="jetbrains.mps.lang.editor.structure.InlineStyleDeclaration" flags="ng" index="tppnM" />
       <concept id="1177327570013" name="jetbrains.mps.lang.editor.structure.QueryFunction_SubstituteMenu_Substitute" flags="in" index="ucgPf" />
@@ -65,6 +66,7 @@
       <concept id="1186404549998" name="jetbrains.mps.lang.editor.structure.ForegroundColorStyleClassItem" flags="ln" index="VechU" />
       <concept id="1186414536763" name="jetbrains.mps.lang.editor.structure.BooleanStyleSheetItem" flags="ln" index="VOi$J">
         <property id="1186414551515" name="flag" index="VOm3f" />
+        <child id="1223387335081" name="query" index="3n$kyP" />
       </concept>
       <concept id="1186414949600" name="jetbrains.mps.lang.editor.structure.AutoDeletableStyleClassItem" flags="ln" index="VPRnO" />
       <concept id="1630016958697344083" name="jetbrains.mps.lang.editor.structure.IMenu_Concept" flags="ng" index="2ZABuq">
@@ -92,9 +94,15 @@
       <concept id="1236262245656" name="jetbrains.mps.lang.editor.structure.MatchingLabelStyleClassItem" flags="ln" index="3mYdg7">
         <property id="1238091709220" name="labelName" index="1413C4" />
       </concept>
+      <concept id="1223387125302" name="jetbrains.mps.lang.editor.structure.QueryFunction_Boolean" flags="in" index="3nzxsE" />
       <concept id="3308396621974580100" name="jetbrains.mps.lang.editor.structure.SubstituteMenu_Default" flags="ng" index="3p36aQ" />
       <concept id="1139848536355" name="jetbrains.mps.lang.editor.structure.CellModel_WithRole" flags="ng" index="1$h60E">
+        <property id="1214560368769" name="emptyNoTargetText" index="39s7Ar" />
+        <property id="1140114345053" name="allowEmptyText" index="1O74Pk" />
         <reference id="1140103550593" name="relationDeclaration" index="1NtTu8" />
+      </concept>
+      <concept id="1073389214265" name="jetbrains.mps.lang.editor.structure.EditorCellModel" flags="ng" index="3EYTF0">
+        <property id="1130859485024" name="attractsFocus" index="1cu_pB" />
       </concept>
       <concept id="1073389446423" name="jetbrains.mps.lang.editor.structure.CellModel_Collection" flags="sn" stub="3013115976261988961" index="3EZMnI">
         <child id="1106270802874" name="cellLayout" index="2iSdaV" />
@@ -188,11 +196,17 @@
       <concept id="1138056022639" name="jetbrains.mps.lang.smodel.structure.SPropertyAccess" flags="nn" index="3TrcHB">
         <reference id="1138056395725" name="property" index="3TsBF5" />
       </concept>
+      <concept id="1138056282393" name="jetbrains.mps.lang.smodel.structure.SLinkListAccess" flags="nn" index="3Tsc0h">
+        <reference id="1138056546658" name="link" index="3TtcxE" />
+      </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
+    </language>
+    <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
+      <concept id="1176501494711" name="jetbrains.mps.baseLanguage.collections.structure.IsNotEmptyOperation" flags="nn" index="3GX2aA" />
     </language>
   </registry>
   <node concept="24kQdi" id="3L4lRB2Gdmi">
@@ -244,6 +258,8 @@
         </node>
       </node>
       <node concept="3F0A7n" id="3L4lRB2Gdsx" role="3EZMnx">
+        <property role="1O74Pk" value="true" />
+        <property role="39s7Ar" value="true" />
         <ref role="1NtTu8" to="21pk:3L4lRB2Gdre" resolve="value" />
       </node>
       <node concept="3F0ifn" id="3L4lRB2GdsD" role="3EZMnx">
@@ -289,15 +305,48 @@
       </node>
       <node concept="3F2HdR" id="3L4lRB2Gduv" role="3EZMnx">
         <property role="Q2I2d" value="punctuation" />
+        <property role="1cu_pB" value="0" />
         <ref role="1NtTu8" to="21pk:3L4lRB2GdnM" resolve="values" />
         <node concept="l2Vlx" id="1F5R5ewJC2F" role="2czzBx" />
         <node concept="pVoyu" id="3L4lRB2GnqV" role="3F10Kt">
           <property role="VOm3f" value="true" />
+          <node concept="3nzxsE" id="4gPdtuDx93D" role="3n$kyP">
+            <node concept="3clFbS" id="4gPdtuDx93E" role="2VODD2">
+              <node concept="3clFbF" id="4gPdtuDx93F" role="3cqZAp">
+                <node concept="2OqwBi" id="4gPdtuDx93G" role="3clFbG">
+                  <node concept="2OqwBi" id="4gPdtuDx93H" role="2Oq$k0">
+                    <node concept="pncrf" id="4gPdtuDx93I" role="2Oq$k0" />
+                    <node concept="3Tsc0h" id="4gPdtuDx93J" role="2OqNvi">
+                      <ref role="3TtcxE" to="21pk:3L4lRB2GdnM" resolve="values" />
+                    </node>
+                  </node>
+                  <node concept="3GX2aA" id="4gPdtuDx93K" role="2OqNvi" />
+                </node>
+              </node>
+            </node>
+          </node>
         </node>
         <node concept="lj46D" id="3L4lRB2GnqX" role="3F10Kt">
           <property role="VOm3f" value="true" />
+          <node concept="3nzxsE" id="4gPdtuDwLD2" role="3n$kyP">
+            <node concept="3clFbS" id="4gPdtuDwLD3" role="2VODD2">
+              <node concept="3clFbF" id="4gPdtuDwLKe" role="3cqZAp">
+                <node concept="2OqwBi" id="4gPdtuDwNHp" role="3clFbG">
+                  <node concept="2OqwBi" id="4gPdtuDwLVG" role="2Oq$k0">
+                    <node concept="pncrf" id="4gPdtuDwLKd" role="2Oq$k0" />
+                    <node concept="3Tsc0h" id="4gPdtuDwMl2" role="2OqNvi">
+                      <ref role="3TtcxE" to="21pk:3L4lRB2GdnM" resolve="values" />
+                    </node>
+                  </node>
+                  <node concept="3GX2aA" id="4gPdtuDwQnR" role="2OqNvi" />
+                </node>
+              </node>
+            </node>
+          </node>
         </node>
-        <node concept="3F0ifn" id="3L4lRB2GqSP" role="2czzBI" />
+        <node concept="3F0ifn" id="3L4lRB2GqSP" role="2czzBI">
+          <property role="1cu_pB" value="1" />
+        </node>
         <node concept="2o9xnK" id="1F5R5ewJmtK" role="2gpyvW">
           <node concept="3clFbS" id="1F5R5ewJmtL" role="2VODD2">
             <node concept="3clFbF" id="1F5R5ewJmAe" role="3cqZAp">
@@ -317,6 +366,21 @@
         <property role="3F0ifm" value="]" />
         <node concept="pVoyu" id="3L4lRB2Gdv7" role="3F10Kt">
           <property role="VOm3f" value="true" />
+          <node concept="3nzxsE" id="4gPdtuDwZ_L" role="3n$kyP">
+            <node concept="3clFbS" id="4gPdtuDwZ_M" role="2VODD2">
+              <node concept="3clFbF" id="4gPdtuDwZ_N" role="3cqZAp">
+                <node concept="2OqwBi" id="4gPdtuDwZ_O" role="3clFbG">
+                  <node concept="2OqwBi" id="4gPdtuDwZ_P" role="2Oq$k0">
+                    <node concept="pncrf" id="4gPdtuDwZ_Q" role="2Oq$k0" />
+                    <node concept="3Tsc0h" id="4gPdtuDwZ_R" role="2OqNvi">
+                      <ref role="3TtcxE" to="21pk:3L4lRB2GdnM" resolve="values" />
+                    </node>
+                  </node>
+                  <node concept="3GX2aA" id="4gPdtuDwZ_S" role="2OqNvi" />
+                </node>
+              </node>
+            </node>
+          </node>
         </node>
         <node concept="3mYdg7" id="1F5R5ewLQyc" role="3F10Kt">
           <property role="1413C4" value="arr" />
@@ -340,12 +404,43 @@
         <node concept="l2Vlx" id="1F5R5ewKww5" role="2czzBx" />
         <node concept="lj46D" id="3L4lRB2Gl9E" role="3F10Kt">
           <property role="VOm3f" value="true" />
+          <node concept="3nzxsE" id="4gPdtuDz3MF" role="3n$kyP">
+            <node concept="3clFbS" id="4gPdtuDz3MG" role="2VODD2">
+              <node concept="3clFbF" id="4gPdtuDz3MH" role="3cqZAp">
+                <node concept="2OqwBi" id="4gPdtuDz3MI" role="3clFbG">
+                  <node concept="2OqwBi" id="4gPdtuDz3MJ" role="2Oq$k0">
+                    <node concept="pncrf" id="4gPdtuDz3MK" role="2Oq$k0" />
+                    <node concept="3Tsc0h" id="4gPdtuDz3ML" role="2OqNvi">
+                      <ref role="3TtcxE" to="21pk:3L4lRB2Gdr9" resolve="variables" />
+                    </node>
+                  </node>
+                  <node concept="3GX2aA" id="4gPdtuDz3MM" role="2OqNvi" />
+                </node>
+              </node>
+            </node>
+          </node>
         </node>
         <node concept="pVoyu" id="1F5R5ewKDgN" role="3F10Kt">
           <property role="VOm3f" value="true" />
+          <node concept="3nzxsE" id="4gPdtuDz44a" role="3n$kyP">
+            <node concept="3clFbS" id="4gPdtuDz44b" role="2VODD2">
+              <node concept="3clFbF" id="4gPdtuDz44c" role="3cqZAp">
+                <node concept="2OqwBi" id="4gPdtuDz44d" role="3clFbG">
+                  <node concept="2OqwBi" id="4gPdtuDz44e" role="2Oq$k0">
+                    <node concept="pncrf" id="4gPdtuDz44f" role="2Oq$k0" />
+                    <node concept="3Tsc0h" id="4gPdtuDz44g" role="2OqNvi">
+                      <ref role="3TtcxE" to="21pk:3L4lRB2Gdr9" resolve="variables" />
+                    </node>
+                  </node>
+                  <node concept="3GX2aA" id="4gPdtuDz44h" role="2OqNvi" />
+                </node>
+              </node>
+            </node>
+          </node>
         </node>
         <node concept="3F0ifn" id="3L4lRB2GrFN" role="2czzBI">
           <property role="3F0ifm" value="" />
+          <property role="1cu_pB" value="1" />
         </node>
         <node concept="tppnM" id="1F5R5ewKww8" role="sWeuL">
           <node concept="ljvvj" id="1F5R5ewKwwa" role="3F10Kt">
@@ -357,6 +452,21 @@
         <property role="3F0ifm" value="}" />
         <node concept="pVoyu" id="3L4lRB2Gl9N" role="3F10Kt">
           <property role="VOm3f" value="true" />
+          <node concept="3nzxsE" id="4gPdtuDyXtO" role="3n$kyP">
+            <node concept="3clFbS" id="4gPdtuDyXtP" role="2VODD2">
+              <node concept="3clFbF" id="4gPdtuDyX_0" role="3cqZAp">
+                <node concept="2OqwBi" id="4gPdtuDyZUP" role="3clFbG">
+                  <node concept="2OqwBi" id="4gPdtuDyXKu" role="2Oq$k0">
+                    <node concept="pncrf" id="4gPdtuDyX$Z" role="2Oq$k0" />
+                    <node concept="3Tsc0h" id="4gPdtuDyY5u" role="2OqNvi">
+                      <ref role="3TtcxE" to="21pk:3L4lRB2Gdr9" resolve="variables" />
+                    </node>
+                  </node>
+                  <node concept="3GX2aA" id="4gPdtuDz3xv" role="2OqNvi" />
+                </node>
+              </node>
+            </node>
+          </node>
         </node>
         <node concept="3mYdg7" id="1F5R5ewLHNp" role="3F10Kt">
           <property role="1413C4" value="obj" />

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.json/models/com.mbeddr.mpsutil.json.structure.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.json/models/com.mbeddr.mpsutil.json.structure.mps
@@ -104,7 +104,7 @@
     <node concept="1TJgyj" id="3L4lRB2GdnM" role="1TKVEi">
       <property role="20lmBu" value="aggregation" />
       <property role="20kJfa" value="values" />
-      <property role="20lbJX" value="1..n" />
+      <property role="20lbJX" value="0..n" />
       <property role="IQ2ns" value="4342692121161029106" />
       <ref role="20lvS9" node="3L4lRB2GdnB" resolve="IValue" />
     </node>

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.json/models/com.mbeddr.mpsutil.json.textGen.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.json/models/com.mbeddr.mpsutil.json.textGen.mps
@@ -26,7 +26,6 @@
       <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
         <property id="1070475926801" name="value" index="Xl_RC" />
       </concept>
-      <concept id="1068580123152" name="jetbrains.mps.baseLanguage.structure.EqualsExpression" flags="nn" index="3clFbC" />
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
@@ -38,22 +37,11 @@
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
       </concept>
-      <concept id="1079359253375" name="jetbrains.mps.baseLanguage.structure.ParenthesizedExpression" flags="nn" index="1eOMI4">
-        <child id="1079359253376" name="expression" index="1eOMHV" />
-      </concept>
-      <concept id="1081516740877" name="jetbrains.mps.baseLanguage.structure.NotExpression" flags="nn" index="3fqX7Q">
-        <child id="1081516765348" name="expression" index="3fr31v" />
-      </concept>
-      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
-        <child id="1081773367579" name="rightExpression" index="3uHU7w" />
-        <child id="1081773367580" name="leftExpression" index="3uHU7B" />
-      </concept>
     </language>
     <language id="b83431fe-5c8f-40bc-8a36-65e25f4dd253" name="jetbrains.mps.lang.textGen">
       <concept id="8931911391946696733" name="jetbrains.mps.lang.textGen.structure.ExtensionDeclaration" flags="in" index="9MYSb" />
       <concept id="1237305208784" name="jetbrains.mps.lang.textGen.structure.NewLineAppendPart" flags="ng" index="l8MVK" />
       <concept id="1237305334312" name="jetbrains.mps.lang.textGen.structure.NodeAppendPart" flags="ng" index="l9hG8">
-        <property id="1237306318654" name="withIndent" index="ld1Su" />
         <child id="1237305790512" name="value" index="lb14g" />
       </concept>
       <concept id="1237305557638" name="jetbrains.mps.lang.textGen.structure.ConstantStringAppendPart" flags="ng" index="la8eA">
@@ -62,6 +50,7 @@
       <concept id="1237306079178" name="jetbrains.mps.lang.textGen.structure.AppendOperation" flags="nn" index="lc7rE">
         <child id="1237306115446" name="part" index="lcghm" />
       </concept>
+      <concept id="4357423944233036906" name="jetbrains.mps.lang.textGen.structure.IndentPart" flags="ng" index="2BGw6n" />
       <concept id="1233670071145" name="jetbrains.mps.lang.textGen.structure.ConceptTextGenDeclaration" flags="ig" index="WtQ9Q">
         <reference id="1233670257997" name="conceptDeclaration" index="WuzLi" />
         <child id="1233749296504" name="textGenBlock" index="11c4hB" />
@@ -69,12 +58,13 @@
       </concept>
       <concept id="1233748055915" name="jetbrains.mps.lang.textGen.structure.NodeParameter" flags="nn" index="117lpO" />
       <concept id="1233749247888" name="jetbrains.mps.lang.textGen.structure.GenerateTextDeclaration" flags="in" index="11bSqf" />
-      <concept id="1233920501193" name="jetbrains.mps.lang.textGen.structure.IndentBufferOperation" flags="nn" index="1bpajm" />
       <concept id="1236188139846" name="jetbrains.mps.lang.textGen.structure.WithIndentOperation" flags="nn" index="3izx1p">
         <child id="1236188238861" name="list" index="3izTki" />
       </concept>
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1143512015885" name="jetbrains.mps.lang.smodel.structure.Node_GetNextSiblingOperation" flags="nn" index="YCak7" />
+      <concept id="1172008320231" name="jetbrains.mps.lang.smodel.structure.Node_IsNotNullOperation" flags="nn" index="3x8VRR" />
       <concept id="1138056022639" name="jetbrains.mps.lang.smodel.structure.SPropertyAccess" flags="nn" index="3TrcHB">
         <reference id="1138056395725" name="property" index="3TsBF5" />
       </concept>
@@ -99,7 +89,7 @@
       <concept id="1153944233411" name="jetbrains.mps.baseLanguage.collections.structure.ForEachVariableReference" flags="nn" index="2GrUjf">
         <reference id="1153944258490" name="variable" index="2Gs0qQ" />
       </concept>
-      <concept id="1165595910856" name="jetbrains.mps.baseLanguage.collections.structure.GetLastOperation" flags="nn" index="1yVyf7" />
+      <concept id="1176501494711" name="jetbrains.mps.baseLanguage.collections.structure.IsNotEmptyOperation" flags="nn" index="3GX2aA" />
     </language>
   </registry>
   <node concept="WtQ9Q" id="3L4lRB2Gv5B">
@@ -136,7 +126,6 @@
           <node concept="la8eA" id="3L4lRB2Gwr$" role="lcghm">
             <property role="lacIc" value="{" />
           </node>
-          <node concept="l8MVK" id="3L4lRB2Gws5" role="lcghm" />
         </node>
         <node concept="3izx1p" id="fIiyXFEO0A" role="3cqZAp">
           <node concept="3clFbS" id="fIiyXFEO0C" role="3izTki">
@@ -146,8 +135,9 @@
               </node>
               <node concept="3clFbS" id="3L4lRB2GEBl" role="2LFqv$">
                 <node concept="lc7rE" id="3L4lRB2GHfl" role="3cqZAp">
+                  <node concept="l8MVK" id="4gPdtuDyTZT" role="lcghm" />
+                  <node concept="2BGw6n" id="4gPdtuDySCm" role="lcghm" />
                   <node concept="l9hG8" id="3L4lRB2GHfz" role="lcghm">
-                    <property role="ld1Su" value="true" />
                     <node concept="2GrUjf" id="3L4lRB2GHgj" role="lb14g">
                       <ref role="2Gs0qQ" node="3L4lRB2GEBj" resolve="var" />
                     </node>
@@ -161,27 +151,15 @@
                       </node>
                     </node>
                   </node>
-                  <node concept="3fqX7Q" id="3L4lRB2GEJV" role="3clFbw">
-                    <node concept="1eOMI4" id="3L4lRB2GEJX" role="3fr31v">
-                      <node concept="3clFbC" id="3L4lRB2GEMB" role="1eOMHV">
-                        <node concept="2OqwBi" id="3L4lRB2GFyj" role="3uHU7w">
-                          <node concept="2OqwBi" id="3L4lRB2GEQW" role="2Oq$k0">
-                            <node concept="117lpO" id="3L4lRB2GENW" role="2Oq$k0" />
-                            <node concept="3Tsc0h" id="3L4lRB2GEZ9" role="2OqNvi">
-                              <ref role="3TtcxE" to="21pk:3L4lRB2Gdr9" resolve="variables" />
-                            </node>
-                          </node>
-                          <node concept="1yVyf7" id="3L4lRB2GHdb" role="2OqNvi" />
-                        </node>
-                        <node concept="2GrUjf" id="3L4lRB2GEKn" role="3uHU7B">
-                          <ref role="2Gs0qQ" node="3L4lRB2GEBj" resolve="var" />
-                        </node>
+                  <node concept="2OqwBi" id="4gPdtuDyIjA" role="3clFbw">
+                    <node concept="2OqwBi" id="4gPdtuDyHH8" role="2Oq$k0">
+                      <node concept="2GrUjf" id="4gPdtuDyHvv" role="2Oq$k0">
+                        <ref role="2Gs0qQ" node="3L4lRB2GEBj" resolve="var" />
                       </node>
+                      <node concept="YCak7" id="4gPdtuDyI47" role="2OqNvi" />
                     </node>
+                    <node concept="3x8VRR" id="4gPdtuDyI$1" role="2OqNvi" />
                   </node>
-                </node>
-                <node concept="lc7rE" id="3L4lRB2GHsf" role="3cqZAp">
-                  <node concept="l8MVK" id="3L4lRB2GHva" role="lcghm" />
                 </node>
               </node>
               <node concept="2OqwBi" id="3L4lRB2GEEP" role="2GsD0m">
@@ -193,7 +171,23 @@
             </node>
           </node>
         </node>
-        <node concept="1bpajm" id="fIiyXFFopd" role="3cqZAp" />
+        <node concept="3clFbJ" id="4gPdtuDyIBU" role="3cqZAp">
+          <node concept="2OqwBi" id="4gPdtuDyKOA" role="3clFbw">
+            <node concept="2OqwBi" id="4gPdtuDyIS4" role="2Oq$k0">
+              <node concept="117lpO" id="4gPdtuDyIKd" role="2Oq$k0" />
+              <node concept="3Tsc0h" id="4gPdtuDyJ8e" role="2OqNvi">
+                <ref role="3TtcxE" to="21pk:3L4lRB2Gdr9" resolve="variables" />
+              </node>
+            </node>
+            <node concept="3GX2aA" id="4gPdtuDyNxr" role="2OqNvi" />
+          </node>
+          <node concept="3clFbS" id="4gPdtuDyIBW" role="3clFbx">
+            <node concept="lc7rE" id="4gPdtuDyNBw" role="3cqZAp">
+              <node concept="l8MVK" id="4gPdtuDyNBT" role="lcghm" />
+              <node concept="2BGw6n" id="4gPdtuDyUjc" role="lcghm" />
+            </node>
+          </node>
+        </node>
         <node concept="lc7rE" id="3L4lRB2Gw$x" role="3cqZAp">
           <node concept="la8eA" id="3L4lRB2Gw_r" role="lcghm">
             <property role="lacIc" value="}" />
@@ -222,7 +216,7 @@
             <property role="lacIc" value="&quot;" />
           </node>
           <node concept="la8eA" id="3L4lRB2GwZg" role="lcghm">
-            <property role="lacIc" value=":" />
+            <property role="lacIc" value=": " />
           </node>
           <node concept="l9hG8" id="3L4lRB2Gx1x" role="lcghm">
             <node concept="2OqwBi" id="3L4lRB2Gx5d" role="lb14g">
@@ -244,7 +238,6 @@
           <node concept="la8eA" id="3L4lRB2Gxiv" role="lcghm">
             <property role="lacIc" value="[" />
           </node>
-          <node concept="l8MVK" id="3L4lRB2GxjR" role="lcghm" />
         </node>
         <node concept="3izx1p" id="fIiyXFEQCF" role="3cqZAp">
           <node concept="3clFbS" id="fIiyXFEQCH" role="3izTki">
@@ -253,8 +246,9 @@
                 <property role="TrG5h" value="entry" />
               </node>
               <node concept="3clFbS" id="3L4lRB2GxJG" role="2LFqv$">
-                <node concept="1bpajm" id="2CRkjehLm9x" role="3cqZAp" />
                 <node concept="lc7rE" id="3L4lRB2G_pl" role="3cqZAp">
+                  <node concept="l8MVK" id="4gPdtuDyVPC" role="lcghm" />
+                  <node concept="2BGw6n" id="4gPdtuDyVOU" role="lcghm" />
                   <node concept="l9hG8" id="3L4lRB2G_s6" role="lcghm">
                     <node concept="2GrUjf" id="3L4lRB2G_sT" role="lb14g">
                       <ref role="2Gs0qQ" node="3L4lRB2GxJE" resolve="entry" />
@@ -269,27 +263,15 @@
                       </node>
                     </node>
                   </node>
-                  <node concept="3fqX7Q" id="3L4lRB2G_f$" role="3clFbw">
-                    <node concept="1eOMI4" id="3L4lRB2G_m7" role="3fr31v">
-                      <node concept="3clFbC" id="3L4lRB2G_fA" role="1eOMHV">
-                        <node concept="2OqwBi" id="3L4lRB2G_fC" role="3uHU7B">
-                          <node concept="2OqwBi" id="3L4lRB2G_fD" role="2Oq$k0">
-                            <node concept="117lpO" id="3L4lRB2G_fE" role="2Oq$k0" />
-                            <node concept="3Tsc0h" id="3L4lRB2G_fF" role="2OqNvi">
-                              <ref role="3TtcxE" to="21pk:3L4lRB2GdnM" resolve="values" />
-                            </node>
-                          </node>
-                          <node concept="1yVyf7" id="3L4lRB2G_fG" role="2OqNvi" />
-                        </node>
-                        <node concept="2GrUjf" id="3L4lRB2G_fB" role="3uHU7w">
-                          <ref role="2Gs0qQ" node="3L4lRB2GxJE" resolve="entry" />
-                        </node>
+                  <node concept="2OqwBi" id="4gPdtuDwc4X" role="3clFbw">
+                    <node concept="2OqwBi" id="4gPdtuDwbo6" role="2Oq$k0">
+                      <node concept="2GrUjf" id="3L4lRB2G_fB" role="2Oq$k0">
+                        <ref role="2Gs0qQ" node="3L4lRB2GxJE" resolve="entry" />
                       </node>
+                      <node concept="YCak7" id="4gPdtuDwbJv" role="2OqNvi" />
                     </node>
+                    <node concept="3x8VRR" id="4gPdtuDwcp0" role="2OqNvi" />
                   </node>
-                </node>
-                <node concept="lc7rE" id="3L4lRB2GxSq" role="3cqZAp">
-                  <node concept="l8MVK" id="3L4lRB2GxVN" role="lcghm" />
                 </node>
               </node>
               <node concept="2OqwBi" id="3L4lRB2GxNt" role="2GsD0m">
@@ -301,7 +283,23 @@
             </node>
           </node>
         </node>
-        <node concept="1bpajm" id="fIiyXFFuqt" role="3cqZAp" />
+        <node concept="3clFbJ" id="4gPdtuDxjzj" role="3cqZAp">
+          <node concept="3clFbS" id="4gPdtuDxjzl" role="3clFbx">
+            <node concept="lc7rE" id="4gPdtuDxnij" role="3cqZAp">
+              <node concept="l8MVK" id="4gPdtuDxniF" role="lcghm" />
+              <node concept="2BGw6n" id="4gPdtuDyVU2" role="lcghm" />
+            </node>
+          </node>
+          <node concept="2OqwBi" id="4gPdtuDxlir" role="3clFbw">
+            <node concept="2OqwBi" id="4gPdtuDxjMT" role="2Oq$k0">
+              <node concept="117lpO" id="4gPdtuDxjF2" role="2Oq$k0" />
+              <node concept="3Tsc0h" id="4gPdtuDxk33" role="2OqNvi">
+                <ref role="3TtcxE" to="21pk:3L4lRB2GdnM" resolve="values" />
+              </node>
+            </node>
+            <node concept="3GX2aA" id="4gPdtuDxnfs" role="2OqNvi" />
+          </node>
+        </node>
         <node concept="lc7rE" id="3L4lRB2GxAU" role="3cqZAp">
           <node concept="la8eA" id="3L4lRB2GxBO" role="lcghm">
             <property role="lacIc" value="]" />

--- a/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.json.sandbox/models/com.mbeddr.mpsutil.json.sandbox.model.mps
+++ b/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.json.sandbox/models/com.mbeddr.mpsutil.json.sandbox.model.mps
@@ -76,6 +76,18 @@
                   <property role="2xKZ1a" value="1.232E+231231" />
                 </node>
               </node>
+              <node concept="3YX88e" id="4gPdtuDwz7P" role="3YX86K">
+                <property role="TrG5h" value="empty array" />
+                <node concept="3YX8am" id="4gPdtuDyCnr" role="3YX8ah" />
+              </node>
+              <node concept="3YX88e" id="4gPdtuDyD96" role="3YX86K">
+                <property role="TrG5h" value="empty object" />
+                <node concept="3YX88f" id="4gPdtuDzC$z" role="3YX8ah" />
+              </node>
+              <node concept="3YX88e" id="4gPdtuDzmkU" role="3YX86K">
+                <property role="TrG5h" value="empty string" />
+                <node concept="3YX86M" id="4gPdtuDzvB4" role="3YX8ah" />
+              </node>
             </node>
           </node>
         </node>


### PR DESCRIPTION
This PR includes couple of minor improvements in the text gen and editors of json language:

- arrays: allow empty arrays and print brackets on single line for empty arrays
- objects: print parenthesis for empty objects on single line
- variables: add space after colon in text gen
- arrays/objects: set focus between the brackets/parenthesis on creation
- strings: allow empty strings in the editor