### PR TITLE
build:thirdparty: updated jdk version according to mps 2019.1

### DIFF
--- a/build/thirdparty/jdk/build.gradle
+++ b/build/thirdparty/jdk/build.gradle
@@ -1,7 +1,7 @@
 import de.undercouch.gradle.tasks.download.Download
 
 group 'com.jetbrains.jdk'
-version '8u152b1343.26'
+version '8u202b1483.21'
 
 for (platform in ['osx', 'windows', 'linux']) {
     String capitalizedPlatform = platform.capitalize()


### PR DESCRIPTION
The latest jdk version available in nexus is: 8u152b1136.39 which was required for MPS 2018.3.

This PR increases the version to 8u202b1483.21.