### PR TITLE
Restored VersionFixer in SPreferenceUtil class to avoid migration pop-up window dialog

### DIFF
--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.spreferences/generator/template/main@generator.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.spreferences/generator/template/main@generator.mps
@@ -720,6 +720,9 @@
                                             <property role="3rM5sR" value="f3061a53-9226-4cc5-a443-f952ceaf5816" />
                                             <node concept="29HgVG" id="1MMv7XpBoGJ" role="lGtFl" />
                                           </node>
+                                          <node concept="37vLTw" id="1a9tAsKGbC$" role="37wK5m">
+                                            <ref role="3cqZAo" node="1m7X3OECMUP" resolve="mpsProject" />
+                                          </node>
                                         </node>
                                         <node concept="1WS0z7" id="1MMv7XpBoUZ" role="lGtFl">
                                           <node concept="3JmXsc" id="1MMv7XpBoV1" role="3Jn$fo">

--- a/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.spreferences.runtime/models/com/mbeddr/mpsutil/spreferences/runtime.mps
+++ b/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.spreferences.runtime/models/com/mbeddr/mpsutil/spreferences/runtime.mps
@@ -336,13 +336,6 @@
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
-      <concept id="709746936026466394" name="jetbrains.mps.lang.core.structure.ChildAttribute" flags="ng" index="3VBwX9">
-        <property id="709746936026609031" name="linkId" index="3V$3ak" />
-        <property id="709746936026609029" name="role_DebugInfo" index="3V$3am" />
-      </concept>
-      <concept id="4452961908202556907" name="jetbrains.mps.lang.core.structure.BaseCommentAttribute" flags="ng" index="1X3_iC">
-        <child id="3078666699043039389" name="commentedNode" index="8Wnug" />
-      </concept>
     </language>
     <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
       <concept id="1204796164442" name="jetbrains.mps.baseLanguage.collections.structure.InternalSequenceOperation" flags="nn" index="23sCx2">
@@ -6281,6 +6274,9 @@
                 <ref role="3cqZAo" node="1MMv7Xp_Wly" resolve="language" />
               </node>
             </node>
+            <node concept="37vLTw" id="1a9tAsKGafW" role="37wK5m">
+              <ref role="3cqZAo" node="1a9tAsKG9$N" resolve="project" />
+            </node>
           </node>
         </node>
       </node>
@@ -6294,6 +6290,12 @@
         <property role="TrG5h" value="language" />
         <node concept="3uibUv" id="1MMv7XpAfb4" role="1tU5fm">
           <ref role="3uigEE" to="lui2:~SModuleReference" resolve="SModuleReference" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="1a9tAsKG9$N" role="3clF46">
+        <property role="TrG5h" value="project" />
+        <node concept="3uibUv" id="1a9tAsKHp3I" role="1tU5fm">
+          <ref role="3uigEE" to="z1c3:~Project" resolve="Project" />
         </node>
       </node>
       <node concept="3cqZAl" id="1MMv7Xp_Wc6" role="3clF45" />
@@ -6366,51 +6368,39 @@
             </node>
           </node>
         </node>
-        <node concept="1X3_iC" id="7xmEYdpCr_K" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3cpWs8" id="4g2jb9OpVwx" role="8Wnug">
-            <node concept="3cpWsn" id="4g2jb9OpVwy" role="3cpWs9">
-              <property role="TrG5h" value="fixer" />
-              <node concept="3uibUv" id="4g2jb9OpVwp" role="1tU5fm">
-                <ref role="3uigEE" to="6f4m:5gIiJF05pHn" resolve="VersionFixer" />
-              </node>
-              <node concept="2ShNRf" id="4g2jb9OpVwz" role="33vP2m">
-                <node concept="1pGfFk" id="4g2jb9OpVw$" role="2ShVmc">
-                  <ref role="37wK5l" to="6f4m:5gIiJF05pI8" resolve="VersionFixer" />
-                  <node concept="2OqwBi" id="75ZZgo2xa4g" role="37wK5m">
-                    <node concept="37vLTw" id="75ZZgo2x8de" role="2Oq$k0">
-                      <ref role="3cqZAo" node="7AF3xowMHyf" resolve="model" />
-                    </node>
-                    <node concept="liA8E" id="75ZZgo2xavg" role="2OqNvi">
-                      <ref role="37wK5l" to="mhbf:~SModel.getRepository():org.jetbrains.mps.openapi.module.SRepository" resolve="getRepository" />
-                    </node>
-                  </node>
-                  <node concept="2OqwBi" id="75ZZgo2xbjM" role="37wK5m">
-                    <node concept="37vLTw" id="75ZZgo2xaQ5" role="2Oq$k0">
-                      <ref role="3cqZAo" node="7AF3xowMHyf" resolve="model" />
-                    </node>
-                    <node concept="liA8E" id="75ZZgo2xbqI" role="2OqNvi">
-                      <ref role="37wK5l" to="mhbf:~SModel.getModule():org.jetbrains.mps.openapi.module.SModule" resolve="getModule" />
-                    </node>
-                  </node>
-                  <node concept="3clFbT" id="7xmEYdpCrgG" role="37wK5m" />
+        <node concept="3clFbH" id="1a9tAsKFCH3" role="3cqZAp" />
+        <node concept="3cpWs8" id="4g2jb9OpVwx" role="3cqZAp">
+          <node concept="3cpWsn" id="4g2jb9OpVwy" role="3cpWs9">
+            <property role="TrG5h" value="fixer" />
+            <node concept="3uibUv" id="4g2jb9OpVwp" role="1tU5fm">
+              <ref role="3uigEE" to="6f4m:5gIiJF05pHn" resolve="VersionFixer" />
+            </node>
+            <node concept="2ShNRf" id="4g2jb9OpVwz" role="33vP2m">
+              <node concept="1pGfFk" id="4g2jb9OpVw$" role="2ShVmc">
+                <ref role="37wK5l" to="6f4m:5gIiJF05pI8" resolve="VersionFixer" />
+                <node concept="37vLTw" id="1a9tAsKG8H3" role="37wK5m">
+                  <ref role="3cqZAo" node="1a9tAsKG7vO" resolve="project" />
                 </node>
+                <node concept="2OqwBi" id="75ZZgo2xbjM" role="37wK5m">
+                  <node concept="37vLTw" id="75ZZgo2xaQ5" role="2Oq$k0">
+                    <ref role="3cqZAo" node="7AF3xowMHyf" resolve="model" />
+                  </node>
+                  <node concept="liA8E" id="75ZZgo2xbqI" role="2OqNvi">
+                    <ref role="37wK5l" to="mhbf:~SModel.getModule():org.jetbrains.mps.openapi.module.SModule" resolve="getModule" />
+                  </node>
+                </node>
+                <node concept="3clFbT" id="7xmEYdpCrgG" role="37wK5m" />
               </node>
             </node>
           </node>
         </node>
-        <node concept="1X3_iC" id="7xmEYdpCr_L" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="4g2jb9Op_Td" role="8Wnug">
-            <node concept="2OqwBi" id="4g2jb9OpGK0" role="3clFbG">
-              <node concept="37vLTw" id="4g2jb9OpVwD" role="2Oq$k0">
-                <ref role="3cqZAo" node="4g2jb9OpVwy" resolve="fixer" />
-              </node>
-              <node concept="liA8E" id="4g2jb9OpH$y" role="2OqNvi">
-                <ref role="37wK5l" to="6f4m:2V3ml1v0Uym" resolve="updateImportVersions" />
-              </node>
+        <node concept="3clFbF" id="4g2jb9Op_Td" role="3cqZAp">
+          <node concept="2OqwBi" id="4g2jb9OpGK0" role="3clFbG">
+            <node concept="37vLTw" id="4g2jb9OpVwD" role="2Oq$k0">
+              <ref role="3cqZAo" node="4g2jb9OpVwy" resolve="fixer" />
+            </node>
+            <node concept="liA8E" id="4g2jb9OpH$y" role="2OqNvi">
+              <ref role="37wK5l" to="6f4m:2V3ml1v0Uym" resolve="updateImportVersions" />
             </node>
           </node>
         </node>
@@ -6426,6 +6416,12 @@
         <property role="TrG5h" value="language" />
         <node concept="3uibUv" id="7AF3xowMPQY" role="1tU5fm">
           <ref role="3uigEE" to="c17a:~SLanguage" resolve="SLanguage" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="1a9tAsKG7vO" role="3clF46">
+        <property role="TrG5h" value="project" />
+        <node concept="3uibUv" id="1a9tAsKHpo0" role="1tU5fm">
+          <ref role="3uigEE" to="z1c3:~Project" resolve="Project" />
         </node>
       </node>
       <node concept="3cqZAl" id="7AF3xowMHyj" role="3clF45" />
@@ -6449,6 +6445,9 @@
                 <ref role="3cqZAo" node="1MMv7XpAVT0" resolve="language" />
               </node>
             </node>
+            <node concept="37vLTw" id="1a9tAsKG9uO" role="37wK5m">
+              <ref role="3cqZAo" node="1a9tAsKG960" resolve="project" />
+            </node>
           </node>
         </node>
       </node>
@@ -6462,6 +6461,12 @@
         <property role="TrG5h" value="language" />
         <node concept="3uibUv" id="1MMv7XpAWhD" role="1tU5fm">
           <ref role="3uigEE" to="w1kc:~Language" resolve="Language" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="1a9tAsKG960" role="3clF46">
+        <property role="TrG5h" value="project" />
+        <node concept="3uibUv" id="1a9tAsKHoCL" role="1tU5fm">
+          <ref role="3uigEE" to="z1c3:~Project" resolve="Project" />
         </node>
       </node>
       <node concept="3cqZAl" id="1MMv7XpAVT2" role="3clF45" />


### PR DESCRIPTION
Hello All,

https://github.com/mbeddr/mbeddr.core/pull/1982

As part of the above issue, version fixer is added to SPreferenceUtil class to avoid the migration pop-up dialog. But due to recent migration to MPS 2018.3 the code has been commented as there was a minor change in the function signature of VersionFixer constructor. So I have uncommented the code and changed the constructor to take the project as an argument from the PreferencePageDescription root template.

Please review the changes and merge them with milestone/v19.2_20183.

Kind Regards,
Aswin Sugumaran