### PR TITLE
Illegal argument exception pops up during code completion of macro folder and file picker

### DIFF
--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.filepicker/models/behavior.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.filepicker/models/behavior.mps
@@ -109,6 +109,7 @@
       <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
       <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
       <concept id="1225271369338" name="jetbrains.mps.baseLanguage.structure.IsEmptyOperation" flags="nn" index="17RlXB" />
+      <concept id="1225271408483" name="jetbrains.mps.baseLanguage.structure.IsNotEmptyOperation" flags="nn" index="17RvpY" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
       </concept>
@@ -2197,18 +2198,42 @@
       <ref role="13i0hy" node="5lKnBeAIfOh" resolve="getPrefix" />
       <node concept="3Tm1VV" id="7c_RIoB8IKt" role="1B3o_S" />
       <node concept="3clFbS" id="7c_RIoB8IKw" role="3clF47">
-        <node concept="3cpWs6" id="HgIalQMxED" role="3cqZAp">
-          <node concept="2OqwBi" id="HgIalQMxEE" role="3cqZAk">
-            <node concept="2YIFZM" id="HgIalQMxEF" role="2Oq$k0">
-              <ref role="1Pybhc" to="z1c3:~PathMacros" resolve="PathMacros" />
-              <ref role="37wK5l" to="z1c3:~PathMacros.getInstance():jetbrains.mps.project.PathMacros" resolve="getInstance" />
+        <node concept="3cpWs8" id="1dVB_FSXQst" role="3cqZAp">
+          <node concept="3cpWsn" id="1dVB_FSXQsu" role="3cpWs9">
+            <property role="TrG5h" value="pathMacros" />
+            <node concept="3uibUv" id="1dVB_FSXQsv" role="1tU5fm">
+              <ref role="3uigEE" to="z1c3:~PathMacros" resolve="PathMacros" />
             </node>
-            <node concept="liA8E" id="HgIalQMxEG" role="2OqNvi">
-              <ref role="37wK5l" to="z1c3:~PathMacros.getValue(java.lang.String):java.lang.String" resolve="getValue" />
-              <node concept="2OqwBi" id="HgIalQMxEH" role="37wK5m">
-                <node concept="13iPFW" id="HgIalQMxEI" role="2Oq$k0" />
-                <node concept="3TrcHB" id="HgIalQMxEJ" role="2OqNvi">
+            <node concept="2ShNRf" id="1dVB_FSXQsw" role="33vP2m">
+              <node concept="1pGfFk" id="1dVB_FSXQsx" role="2ShVmc">
+                <ref role="37wK5l" to="z1c3:~PathMacros.&lt;init&gt;()" resolve="PathMacros" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="1dVB_FSXQsy" role="3cqZAp">
+          <node concept="3K4zz7" id="1dVB_FSXQsz" role="3cqZAk">
+            <node concept="10Nm6u" id="1dVB_FSXQs$" role="3K4GZi" />
+            <node concept="2OqwBi" id="1dVB_FSXQs_" role="3K4Cdx">
+              <node concept="2OqwBi" id="1dVB_FSXQsA" role="2Oq$k0">
+                <node concept="13iPFW" id="1dVB_FSXQsB" role="2Oq$k0" />
+                <node concept="3TrcHB" id="1dVB_FSXQsC" role="2OqNvi">
                   <ref role="3TsBF5" to="68mc:7c_RIoB8OqH" resolve="macro" />
+                </node>
+              </node>
+              <node concept="17RvpY" id="1dVB_FSXQsD" role="2OqNvi" />
+            </node>
+            <node concept="2OqwBi" id="1dVB_FSXQsE" role="3K4E3e">
+              <node concept="37vLTw" id="1dVB_FSXQsF" role="2Oq$k0">
+                <ref role="3cqZAo" node="1dVB_FSXQsu" resolve="pathMacros" />
+              </node>
+              <node concept="liA8E" id="1dVB_FSXQsG" role="2OqNvi">
+                <ref role="37wK5l" to="z1c3:~PathMacros.getValue(java.lang.String):java.lang.String" resolve="getValue" />
+                <node concept="2OqwBi" id="1dVB_FSXQsH" role="37wK5m">
+                  <node concept="13iPFW" id="1dVB_FSXQsI" role="2Oq$k0" />
+                  <node concept="3TrcHB" id="1dVB_FSXQsJ" role="2OqNvi">
+                    <ref role="3TsBF5" to="68mc:7c_RIoB8OqH" resolve="macro" />
+                  </node>
                 </node>
               </node>
             </node>
@@ -2352,18 +2377,42 @@
       <ref role="13i0hy" node="5lKnBeAIfOh" resolve="getPrefix" />
       <node concept="3Tm1VV" id="4eXJ6EOa6Di" role="1B3o_S" />
       <node concept="3clFbS" id="4eXJ6EOa6Dj" role="3clF47">
-        <node concept="3cpWs6" id="6M3J7P6$Cz5" role="3cqZAp">
-          <node concept="2OqwBi" id="6M3J7P6$Cz6" role="3cqZAk">
-            <node concept="2YIFZM" id="6M3J7P6$Cz7" role="2Oq$k0">
-              <ref role="37wK5l" to="z1c3:~PathMacros.getInstance():jetbrains.mps.project.PathMacros" resolve="getInstance" />
-              <ref role="1Pybhc" to="z1c3:~PathMacros" resolve="PathMacros" />
+        <node concept="3cpWs8" id="1dVB_FSVVuJ" role="3cqZAp">
+          <node concept="3cpWsn" id="1dVB_FSVVuK" role="3cpWs9">
+            <property role="TrG5h" value="pathMacros" />
+            <node concept="3uibUv" id="1dVB_FSVVuL" role="1tU5fm">
+              <ref role="3uigEE" to="z1c3:~PathMacros" resolve="PathMacros" />
             </node>
-            <node concept="liA8E" id="6M3J7P6$Cz8" role="2OqNvi">
-              <ref role="37wK5l" to="z1c3:~PathMacros.getValue(java.lang.String):java.lang.String" resolve="getValue" />
-              <node concept="2OqwBi" id="6M3J7P6$Cz9" role="37wK5m">
-                <node concept="13iPFW" id="6M3J7P6$Cza" role="2Oq$k0" />
-                <node concept="3TrcHB" id="6M3J7P6$Czb" role="2OqNvi">
+            <node concept="2ShNRf" id="1dVB_FSVVFw" role="33vP2m">
+              <node concept="1pGfFk" id="1dVB_FSVVFv" role="2ShVmc">
+                <ref role="37wK5l" to="z1c3:~PathMacros.&lt;init&gt;()" resolve="PathMacros" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="6M3J7P6$Cz5" role="3cqZAp">
+          <node concept="3K4zz7" id="4LIuw56Edtf" role="3cqZAk">
+            <node concept="10Nm6u" id="4LIuw56Ed_F" role="3K4GZi" />
+            <node concept="2OqwBi" id="4LIuw56EbjN" role="3K4Cdx">
+              <node concept="2OqwBi" id="4LIuw56E9v8" role="2Oq$k0">
+                <node concept="13iPFW" id="4LIuw56E9i5" role="2Oq$k0" />
+                <node concept="3TrcHB" id="4LIuw56E9Os" role="2OqNvi">
                   <ref role="3TsBF5" to="68mc:4eXJ6EO9ZKy" resolve="macro" />
+                </node>
+              </node>
+              <node concept="17RvpY" id="4LIuw56Ecq1" role="2OqNvi" />
+            </node>
+            <node concept="2OqwBi" id="1dVB_FSVW6C" role="3K4E3e">
+              <node concept="37vLTw" id="1dVB_FSVVSt" role="2Oq$k0">
+                <ref role="3cqZAo" node="1dVB_FSVVuK" resolve="pathMacros" />
+              </node>
+              <node concept="liA8E" id="1dVB_FSVWqe" role="2OqNvi">
+                <ref role="37wK5l" to="z1c3:~PathMacros.getValue(java.lang.String):java.lang.String" resolve="getValue" />
+                <node concept="2OqwBi" id="1dVB_FSVWJa" role="37wK5m">
+                  <node concept="13iPFW" id="1dVB_FSVWuU" role="2Oq$k0" />
+                  <node concept="3TrcHB" id="1dVB_FSVX9L" role="2OqNvi">
+                    <ref role="3TsBF5" to="68mc:4eXJ6EO9ZKy" resolve="macro" />
+                  </node>
                 </node>
               </node>
             </node>


### PR DESCRIPTION
In the 'getPrefix()' method of the macro folder and file picker behaviour, getValue() method is called to evaluate and get the value of the macro.When the macro is null the function getValue() throws argument cannot be null exception.
Added a null check so that it calls the method getValue() only when the macro is not null.

Kindly review the changes and merge with milestone.

Regards ,

Vignesh M