### PR TITLE
Macro picker functionality completely broken as macro value is returned null 

### DIFF
--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.filepicker/models/behavior.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.filepicker/models/behavior.mps
@@ -13,13 +13,14 @@
     <import index="guwi" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.io(JDK/)" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" />
     <import index="z60i" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt(JDK/)" />
-    <import index="z1c3" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.project(MPS.Core/)" />
     <import index="mhbf" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.model(MPS.OpenAPI/)" />
     <import index="lui2" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.module(MPS.OpenAPI/)" />
     <import index="3ju5" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.vfs(MPS.Core/)" />
     <import index="g3l6" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.extapi.model(MPS.Core/)" />
     <import index="fwk" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.textgen.trace(MPS.Core/)" />
     <import index="ni5j" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util.regex(JDK/)" />
+    <import index="bd8o" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.application(MPS.IDEA/)" />
+    <import index="z1c3" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.project(MPS.Core/)" implicit="true" />
   </imports>
   <registry>
     <language id="af65afd8-f0dd-4942-87d9-63a55f2a9db1" name="jetbrains.mps.lang.behavior">
@@ -2198,19 +2199,6 @@
       <ref role="13i0hy" node="5lKnBeAIfOh" resolve="getPrefix" />
       <node concept="3Tm1VV" id="7c_RIoB8IKt" role="1B3o_S" />
       <node concept="3clFbS" id="7c_RIoB8IKw" role="3clF47">
-        <node concept="3cpWs8" id="1dVB_FSXQst" role="3cqZAp">
-          <node concept="3cpWsn" id="1dVB_FSXQsu" role="3cpWs9">
-            <property role="TrG5h" value="pathMacros" />
-            <node concept="3uibUv" id="1dVB_FSXQsv" role="1tU5fm">
-              <ref role="3uigEE" to="z1c3:~PathMacros" resolve="PathMacros" />
-            </node>
-            <node concept="2ShNRf" id="1dVB_FSXQsw" role="33vP2m">
-              <node concept="1pGfFk" id="1dVB_FSXQsx" role="2ShVmc">
-                <ref role="37wK5l" to="z1c3:~PathMacros.&lt;init&gt;()" resolve="PathMacros" />
-              </node>
-            </node>
-          </node>
-        </node>
         <node concept="3cpWs6" id="1dVB_FSXQsy" role="3cqZAp">
           <node concept="3K4zz7" id="1dVB_FSXQsz" role="3cqZAk">
             <node concept="10Nm6u" id="1dVB_FSXQs$" role="3K4GZi" />
@@ -2224,11 +2212,12 @@
               <node concept="17RvpY" id="1dVB_FSXQsD" role="2OqNvi" />
             </node>
             <node concept="2OqwBi" id="1dVB_FSXQsE" role="3K4E3e">
-              <node concept="37vLTw" id="1dVB_FSXQsF" role="2Oq$k0">
-                <ref role="3cqZAo" node="1dVB_FSXQsu" resolve="pathMacros" />
+              <node concept="2YIFZM" id="4I0qSQE6m3G" role="2Oq$k0">
+                <ref role="37wK5l" to="bd8o:~PathMacros.getInstance():com.intellij.openapi.application.PathMacros" resolve="getInstance" />
+                <ref role="1Pybhc" to="bd8o:~PathMacros" resolve="PathMacros" />
               </node>
               <node concept="liA8E" id="1dVB_FSXQsG" role="2OqNvi">
-                <ref role="37wK5l" to="z1c3:~PathMacros.getValue(java.lang.String):java.lang.String" resolve="getValue" />
+                <ref role="37wK5l" to="bd8o:~PathMacros.getValue(java.lang.String):java.lang.String" resolve="getValue" />
                 <node concept="2OqwBi" id="1dVB_FSXQsH" role="37wK5m">
                   <node concept="13iPFW" id="1dVB_FSXQsI" role="2Oq$k0" />
                   <node concept="3TrcHB" id="1dVB_FSXQsJ" role="2OqNvi">
@@ -2377,40 +2366,28 @@
       <ref role="13i0hy" node="5lKnBeAIfOh" resolve="getPrefix" />
       <node concept="3Tm1VV" id="4eXJ6EOa6Di" role="1B3o_S" />
       <node concept="3clFbS" id="4eXJ6EOa6Dj" role="3clF47">
-        <node concept="3cpWs8" id="1dVB_FSVVuJ" role="3cqZAp">
-          <node concept="3cpWsn" id="1dVB_FSVVuK" role="3cpWs9">
-            <property role="TrG5h" value="pathMacros" />
-            <node concept="3uibUv" id="1dVB_FSVVuL" role="1tU5fm">
-              <ref role="3uigEE" to="z1c3:~PathMacros" resolve="PathMacros" />
-            </node>
-            <node concept="2ShNRf" id="1dVB_FSVVFw" role="33vP2m">
-              <node concept="1pGfFk" id="1dVB_FSVVFv" role="2ShVmc">
-                <ref role="37wK5l" to="z1c3:~PathMacros.&lt;init&gt;()" resolve="PathMacros" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3cpWs6" id="6M3J7P6$Cz5" role="3cqZAp">
-          <node concept="3K4zz7" id="4LIuw56Edtf" role="3cqZAk">
-            <node concept="10Nm6u" id="4LIuw56Ed_F" role="3K4GZi" />
-            <node concept="2OqwBi" id="4LIuw56EbjN" role="3K4Cdx">
-              <node concept="2OqwBi" id="4LIuw56E9v8" role="2Oq$k0">
-                <node concept="13iPFW" id="4LIuw56E9i5" role="2Oq$k0" />
-                <node concept="3TrcHB" id="4LIuw56E9Os" role="2OqNvi">
+        <node concept="3cpWs6" id="4I0qSQE6mrV" role="3cqZAp">
+          <node concept="3K4zz7" id="4I0qSQE6mrW" role="3cqZAk">
+            <node concept="10Nm6u" id="4I0qSQE6mrX" role="3K4GZi" />
+            <node concept="2OqwBi" id="4I0qSQE6mrY" role="3K4Cdx">
+              <node concept="2OqwBi" id="4I0qSQE6mrZ" role="2Oq$k0">
+                <node concept="13iPFW" id="4I0qSQE6ms0" role="2Oq$k0" />
+                <node concept="3TrcHB" id="4I0qSQE6ms1" role="2OqNvi">
                   <ref role="3TsBF5" to="68mc:4eXJ6EO9ZKy" resolve="macro" />
                 </node>
               </node>
-              <node concept="17RvpY" id="4LIuw56Ecq1" role="2OqNvi" />
+              <node concept="17RvpY" id="4I0qSQE6ms2" role="2OqNvi" />
             </node>
-            <node concept="2OqwBi" id="1dVB_FSVW6C" role="3K4E3e">
-              <node concept="37vLTw" id="1dVB_FSVVSt" role="2Oq$k0">
-                <ref role="3cqZAo" node="1dVB_FSVVuK" resolve="pathMacros" />
+            <node concept="2OqwBi" id="4I0qSQE6ms3" role="3K4E3e">
+              <node concept="2YIFZM" id="4I0qSQE6ms4" role="2Oq$k0">
+                <ref role="37wK5l" to="bd8o:~PathMacros.getInstance():com.intellij.openapi.application.PathMacros" resolve="getInstance" />
+                <ref role="1Pybhc" to="bd8o:~PathMacros" resolve="PathMacros" />
               </node>
-              <node concept="liA8E" id="1dVB_FSVWqe" role="2OqNvi">
-                <ref role="37wK5l" to="z1c3:~PathMacros.getValue(java.lang.String):java.lang.String" resolve="getValue" />
-                <node concept="2OqwBi" id="1dVB_FSVWJa" role="37wK5m">
-                  <node concept="13iPFW" id="1dVB_FSVWuU" role="2Oq$k0" />
-                  <node concept="3TrcHB" id="1dVB_FSVX9L" role="2OqNvi">
+              <node concept="liA8E" id="4I0qSQE6ms5" role="2OqNvi">
+                <ref role="37wK5l" to="bd8o:~PathMacros.getValue(java.lang.String):java.lang.String" resolve="getValue" />
+                <node concept="2OqwBi" id="4I0qSQE6ms6" role="37wK5m">
+                  <node concept="13iPFW" id="4I0qSQE6ms7" role="2Oq$k0" />
+                  <node concept="3TrcHB" id="4I0qSQE6ms8" role="2OqNvi">
                     <ref role="3TsBF5" to="68mc:4eXJ6EO9ZKy" resolve="macro" />
                   </node>
                 </node>


### PR DESCRIPTION
When the 'getValue()' method inside the 'PathMacros' class ,is called by creating a non-static
object ,value of the macro is returned as null and also the static method (getInstance()) is deprecated. So used the 'PathMacros' class from intellij inside MPS.Idea solution. 

Please review the changes and merge with milestone.

Regards ,

Vignesh M