### PR TITLE
mpstutil.smodule: fixed GlobalModelAccess usage in addModelOperation

### DIFF
--- a/code/languages/com.mbeddr.build/solutions/com.mbeddr.platform/models/com/mbeddr/platform/build.mps
+++ b/code/languages/com.mbeddr.build/solutions/com.mbeddr.platform/models/com/mbeddr/platform/build.mps
@@ -7355,6 +7355,11 @@
             </node>
           </node>
         </node>
+        <node concept="1SiIV0" id="2rFgM0FWDQ7" role="3bR37C">
+          <node concept="3bR9La" id="2rFgM0FWDQ8" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
+          </node>
+        </node>
       </node>
     </node>
     <node concept="2G$12M" id="3quoVcnPcDz" role="3989C9">

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.smodule/generator/template/main@generator.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.smodule/generator/template/main@generator.mps
@@ -55,11 +55,16 @@
       <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
         <reference id="1107535924139" name="classifier" index="3uigEE" />
       </concept>
+      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
+        <child id="1081773367579" name="rightExpression" index="3uHU7w" />
+        <child id="1081773367580" name="leftExpression" index="3uHU7B" />
+      </concept>
       <concept id="1163668896201" name="jetbrains.mps.baseLanguage.structure.TernaryOperatorExpression" flags="nn" index="3K4zz7">
         <child id="1163668914799" name="condition" index="3K4Cdx" />
         <child id="1163668922816" name="ifTrue" index="3K4E3e" />
         <child id="1163668934364" name="ifFalse" index="3K4GZi" />
       </concept>
+      <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
     </language>
     <language id="b401a680-8325-4110-8fd3-84331ff25bef" name="jetbrains.mps.lang.generator">
       <concept id="1114706874351" name="jetbrains.mps.lang.generator.structure.CopySrcNodeMacro" flags="ln" index="29HgVG">
@@ -155,6 +160,7 @@
       <concept id="4040588429969021681" name="jetbrains.mps.lang.smodel.structure.ModuleReferenceExpression" flags="nn" index="3rM5sP">
         <property id="4040588429969021683" name="moduleId" index="3rM5sR" />
       </concept>
+      <concept id="1171999116870" name="jetbrains.mps.lang.smodel.structure.Node_IsNullOperation" flags="nn" index="3w_OXm" />
       <concept id="1172008320231" name="jetbrains.mps.lang.smodel.structure.Node_IsNotNullOperation" flags="nn" index="3x8VRR" />
       <concept id="1140137987495" name="jetbrains.mps.lang.smodel.structure.SNodeTypeCastExpression" flags="nn" index="1PxgMI" />
       <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
@@ -746,16 +752,298 @@
       <node concept="30G5F_" id="7Ynnt_Oi$ys" role="30HLyM">
         <node concept="3clFbS" id="7Ynnt_Oi$yt" role="2VODD2">
           <node concept="3clFbF" id="7Ynnt_Oi$$Z" role="3cqZAp">
-            <node concept="2OqwBi" id="7Ynnt_Oi_rc" role="3clFbG">
-              <node concept="2OqwBi" id="7Ynnt_Oi$Ee" role="2Oq$k0">
-                <node concept="30H73N" id="7Ynnt_Oi$$Y" role="2Oq$k0" />
-                <node concept="3TrEf2" id="7Ynnt_Oi_6t" role="2OqNvi">
-                  <ref role="3Tt5mk" to="tpee:hqOqNr4" resolve="operation" />
+            <node concept="1Wc70l" id="2rFgM0FVTBU" role="3clFbG">
+              <node concept="2OqwBi" id="2rFgM0FVVVN" role="3uHU7w">
+                <node concept="2OqwBi" id="2rFgM0FVVhR" role="2Oq$k0">
+                  <node concept="1PxgMI" id="2rFgM0FVUMd" role="2Oq$k0">
+                    <node concept="chp4Y" id="2rFgM0FVV03" role="3oSUPX">
+                      <ref role="cht4Q" to="gt8j:3d01KqFhiz2" resolve="AddModelOperation" />
+                    </node>
+                    <node concept="2OqwBi" id="2rFgM0FVUfE" role="1m5AlR">
+                      <node concept="30H73N" id="2rFgM0FVTOR" role="2Oq$k0" />
+                      <node concept="3TrEf2" id="2rFgM0FVWNH" role="2OqNvi">
+                        <ref role="3Tt5mk" to="tpee:hqOqNr4" resolve="operation" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3TrEf2" id="2rFgM0FVVC5" role="2OqNvi">
+                    <ref role="3Tt5mk" to="gt8j:7bwMmZeYmBk" resolve="repo" />
+                  </node>
+                </node>
+                <node concept="3w_OXm" id="2rFgM0FVWkS" role="2OqNvi" />
+              </node>
+              <node concept="2OqwBi" id="7Ynnt_Oi_rc" role="3uHU7B">
+                <node concept="2OqwBi" id="7Ynnt_Oi$Ee" role="2Oq$k0">
+                  <node concept="30H73N" id="7Ynnt_Oi$$Y" role="2Oq$k0" />
+                  <node concept="3TrEf2" id="7Ynnt_Oi_6t" role="2OqNvi">
+                    <ref role="3Tt5mk" to="tpee:hqOqNr4" resolve="operation" />
+                  </node>
+                </node>
+                <node concept="1mIQ4w" id="7Ynnt_OiA1X" role="2OqNvi">
+                  <node concept="chp4Y" id="7Ynnt_OiA8j" role="cj9EA">
+                    <ref role="cht4Q" to="gt8j:3d01KqFhiz2" resolve="AddModelOperation" />
+                  </node>
                 </node>
               </node>
-              <node concept="1mIQ4w" id="7Ynnt_OiA1X" role="2OqNvi">
-                <node concept="chp4Y" id="7Ynnt_OiA8j" role="cj9EA">
-                  <ref role="cht4Q" to="gt8j:3d01KqFhiz2" resolve="AddModelOperation" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3aamgX" id="2rFgM0FVX7g" role="3acgRq">
+      <ref role="30HIoZ" to="tpee:hqOqwz4" resolve="DotExpression" />
+      <node concept="gft3U" id="2rFgM0FVX7h" role="1lVwrX">
+        <node concept="2YIFZM" id="2rFgM0FVYSi" role="gfFT$">
+          <ref role="1Pybhc" to="8tyk:7Ynnt_OamsD" resolve="ModelHelper" />
+          <ref role="37wK5l" to="8tyk:2rFgM0FVwtY" resolve="createModel" />
+          <node concept="10Nm6u" id="2rFgM0FVYSj" role="37wK5m">
+            <node concept="29HgVG" id="2rFgM0FVYSk" role="lGtFl">
+              <node concept="3NFfHV" id="2rFgM0FVYSl" role="3NFExx">
+                <node concept="3clFbS" id="2rFgM0FVYSm" role="2VODD2">
+                  <node concept="3clFbF" id="2rFgM0FVYSn" role="3cqZAp">
+                    <node concept="2OqwBi" id="2rFgM0FVYSo" role="3clFbG">
+                      <node concept="3TrEf2" id="2rFgM0FVYSp" role="2OqNvi">
+                        <ref role="3Tt5mk" to="tpee:hqOq$gm" resolve="operand" />
+                      </node>
+                      <node concept="30H73N" id="2rFgM0FVYSq" role="2Oq$k0" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="Xl_RD" id="2rFgM0FVYSr" role="37wK5m">
+            <property role="Xl_RC" value="" />
+            <node concept="1sPUBX" id="2rFgM0FVYSs" role="lGtFl">
+              <ref role="v9R2y" node="7Ynnt_OiDam" resolve="switch_StorageType" />
+              <node concept="3NFfHV" id="2rFgM0FVYSt" role="1sPUBK">
+                <node concept="3clFbS" id="2rFgM0FVYSu" role="2VODD2">
+                  <node concept="3clFbF" id="2rFgM0FVYSv" role="3cqZAp">
+                    <node concept="2OqwBi" id="2rFgM0FVYSw" role="3clFbG">
+                      <node concept="2OqwBi" id="2rFgM0FVYSx" role="2Oq$k0">
+                        <node concept="1iwH7S" id="2rFgM0FVYSy" role="2Oq$k0" />
+                        <node concept="1psM6Z" id="2rFgM0FW111" role="2OqNvi">
+                          <ref role="1psM6Y" node="2rFgM0FVYTw" resolve="operation" />
+                        </node>
+                      </node>
+                      <node concept="3TrEf2" id="2rFgM0FW267" role="2OqNvi">
+                        <ref role="3Tt5mk" to="gt8j:7Ynnt_OiBVL" resolve="storageType" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="Xl_RD" id="2rFgM0FVYS_" role="37wK5m">
+            <property role="Xl_RC" value="name" />
+            <node concept="29HgVG" id="2rFgM0FVYSA" role="lGtFl">
+              <node concept="3NFfHV" id="2rFgM0FVYSB" role="3NFExx">
+                <node concept="3clFbS" id="2rFgM0FVYSC" role="2VODD2">
+                  <node concept="3clFbF" id="2rFgM0FVYSD" role="3cqZAp">
+                    <node concept="2OqwBi" id="2rFgM0FVYSE" role="3clFbG">
+                      <node concept="2OqwBi" id="2rFgM0FVYSF" role="2Oq$k0">
+                        <node concept="1iwH7S" id="2rFgM0FVYSG" role="2Oq$k0" />
+                        <node concept="1psM6Z" id="2rFgM0FW0Pb" role="2OqNvi">
+                          <ref role="1psM6Y" node="2rFgM0FVYTw" resolve="operation" />
+                        </node>
+                      </node>
+                      <node concept="3TrEf2" id="2rFgM0FW2ns" role="2OqNvi">
+                        <ref role="3Tt5mk" to="gt8j:lse_ua3yy7" resolve="name" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2ShNRf" id="2rFgM0FVYSJ" role="37wK5m">
+            <node concept="Tc6Ow" id="2rFgM0FVYSK" role="2ShVmc">
+              <node concept="3uibUv" id="2rFgM0FVYSL" role="HW$YZ">
+                <ref role="3uigEE" to="z1c3:~DevKit" resolve="DevKit" />
+              </node>
+              <node concept="10Nm6u" id="2rFgM0FVYSM" role="HW$Y0">
+                <node concept="2b32R4" id="2rFgM0FVYSN" role="lGtFl">
+                  <node concept="3JmXsc" id="2rFgM0FVYSO" role="2P8S$">
+                    <node concept="3clFbS" id="2rFgM0FVYSP" role="2VODD2">
+                      <node concept="3clFbF" id="2rFgM0FVYSQ" role="3cqZAp">
+                        <node concept="2OqwBi" id="2rFgM0FVYSR" role="3clFbG">
+                          <node concept="2OqwBi" id="2rFgM0FVYSS" role="2Oq$k0">
+                            <node concept="2OqwBi" id="2rFgM0FVYST" role="2Oq$k0">
+                              <node concept="1iwH7S" id="2rFgM0FVYSU" role="2Oq$k0" />
+                              <node concept="1psM6Z" id="2rFgM0FW1cL" role="2OqNvi">
+                                <ref role="1psM6Y" node="2rFgM0FVYTw" resolve="operation" />
+                              </node>
+                            </node>
+                            <node concept="3Tsc0h" id="2rFgM0FW2ct" role="2OqNvi">
+                              <ref role="3TtcxE" to="gt8j:3d01KqFhi$c" resolve="with" />
+                            </node>
+                          </node>
+                          <node concept="v3k3i" id="2rFgM0FVYSX" role="2OqNvi">
+                            <node concept="chp4Y" id="2rFgM0FVYSY" role="v3oSu">
+                              <ref role="cht4Q" to="gt8j:3d01KqF6Q9C" resolve="DevKitRef" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2ShNRf" id="2rFgM0FVYSZ" role="37wK5m">
+            <node concept="Tc6Ow" id="2rFgM0FVYT0" role="2ShVmc">
+              <node concept="3uibUv" id="2rFgM0FVYT1" role="HW$YZ">
+                <ref role="3uigEE" to="c17a:~SLanguage" resolve="SLanguage" />
+              </node>
+              <node concept="10Nm6u" id="2rFgM0FVYT2" role="HW$Y0">
+                <node concept="2b32R4" id="2rFgM0FVYT3" role="lGtFl">
+                  <node concept="3JmXsc" id="2rFgM0FVYT4" role="2P8S$">
+                    <node concept="3clFbS" id="2rFgM0FVYT5" role="2VODD2">
+                      <node concept="3clFbF" id="2rFgM0FVYT6" role="3cqZAp">
+                        <node concept="2OqwBi" id="2rFgM0FVYT7" role="3clFbG">
+                          <node concept="2OqwBi" id="2rFgM0FVYT8" role="2Oq$k0">
+                            <node concept="2OqwBi" id="2rFgM0FVYT9" role="2Oq$k0">
+                              <node concept="1iwH7S" id="2rFgM0FVYTa" role="2Oq$k0" />
+                              <node concept="1psM6Z" id="2rFgM0FW1lO" role="2OqNvi">
+                                <ref role="1psM6Y" node="2rFgM0FVYTw" resolve="operation" />
+                              </node>
+                            </node>
+                            <node concept="3Tsc0h" id="2rFgM0FW1O_" role="2OqNvi">
+                              <ref role="3TtcxE" to="gt8j:3d01KqFhi$c" resolve="with" />
+                            </node>
+                          </node>
+                          <node concept="v3k3i" id="2rFgM0FVYTd" role="2OqNvi">
+                            <node concept="chp4Y" id="2rFgM0FVYTe" role="v3oSu">
+                              <ref role="cht4Q" to="gt8j:3d01KqFgAKr" resolve="LanguageRef" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2ShNRf" id="2rFgM0FVYTf" role="37wK5m">
+            <node concept="Tc6Ow" id="2rFgM0FVYTg" role="2ShVmc">
+              <node concept="3uibUv" id="2rFgM0FVYTh" role="HW$YZ">
+                <ref role="3uigEE" to="mhbf:~SModel" resolve="SModel" />
+              </node>
+              <node concept="10Nm6u" id="2rFgM0FVYTi" role="HW$Y0">
+                <node concept="2b32R4" id="2rFgM0FVYTj" role="lGtFl">
+                  <node concept="3JmXsc" id="2rFgM0FVYTk" role="2P8S$">
+                    <node concept="3clFbS" id="2rFgM0FVYTl" role="2VODD2">
+                      <node concept="3clFbF" id="2rFgM0FVYTm" role="3cqZAp">
+                        <node concept="2OqwBi" id="2rFgM0FVYTn" role="3clFbG">
+                          <node concept="2OqwBi" id="2rFgM0FVYTo" role="2Oq$k0">
+                            <node concept="2OqwBi" id="2rFgM0FVYTp" role="2Oq$k0">
+                              <node concept="1iwH7S" id="2rFgM0FVYTq" role="2Oq$k0" />
+                              <node concept="1psM6Z" id="2rFgM0FW1Ra" role="2OqNvi">
+                                <ref role="1psM6Y" node="2rFgM0FVYTw" resolve="operation" />
+                              </node>
+                            </node>
+                            <node concept="3Tsc0h" id="2rFgM0FW23j" role="2OqNvi">
+                              <ref role="3TtcxE" to="gt8j:3d01KqFhi$c" resolve="with" />
+                            </node>
+                          </node>
+                          <node concept="v3k3i" id="2rFgM0FVYTt" role="2OqNvi">
+                            <node concept="chp4Y" id="2rFgM0FVYTu" role="v3oSu">
+                              <ref role="cht4Q" to="gt8j:3d01KqFhj1T" resolve="MyModelRefExpression" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="10Nm6u" id="2rFgM0FW0i_" role="37wK5m">
+            <node concept="29HgVG" id="2rFgM0FW0_M" role="lGtFl">
+              <node concept="3NFfHV" id="2rFgM0FW2sq" role="3NFExx">
+                <node concept="3clFbS" id="2rFgM0FW2sr" role="2VODD2">
+                  <node concept="3clFbF" id="2rFgM0FW2sx" role="3cqZAp">
+                    <node concept="2OqwBi" id="2rFgM0FW2sz" role="3clFbG">
+                      <node concept="2OqwBi" id="2rFgM0FW2s$" role="2Oq$k0">
+                        <node concept="1iwH7S" id="2rFgM0FW2s_" role="2Oq$k0" />
+                        <node concept="1psM6Z" id="2rFgM0FW2sA" role="2OqNvi">
+                          <ref role="1psM6Y" node="2rFgM0FVYTw" resolve="operation" />
+                        </node>
+                      </node>
+                      <node concept="3TrEf2" id="2rFgM0FW3jR" role="2OqNvi">
+                        <ref role="3Tt5mk" to="gt8j:7bwMmZeYmBk" resolve="repo" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1ps_y7" id="2rFgM0FVYTv" role="lGtFl">
+            <node concept="1ps_xZ" id="2rFgM0FVYTw" role="1ps_xO">
+              <property role="TrG5h" value="operation" />
+              <node concept="3Tqbb2" id="2rFgM0FVYTx" role="1ps_xK">
+                <ref role="ehGHo" to="gt8j:3d01KqFhiz2" resolve="AddModelOperation" />
+              </node>
+              <node concept="2jfdEK" id="2rFgM0FVYTy" role="1ps_xN">
+                <node concept="3clFbS" id="2rFgM0FVYTz" role="2VODD2">
+                  <node concept="3clFbF" id="2rFgM0FVYT$" role="3cqZAp">
+                    <node concept="1PxgMI" id="2rFgM0FVYT_" role="3clFbG">
+                      <node concept="2OqwBi" id="2rFgM0FVYTA" role="1m5AlR">
+                        <node concept="30H73N" id="2rFgM0FVYTB" role="2Oq$k0" />
+                        <node concept="3TrEf2" id="2rFgM0FVYTC" role="2OqNvi">
+                          <ref role="3Tt5mk" to="tpee:hqOqNr4" resolve="operation" />
+                        </node>
+                      </node>
+                      <node concept="chp4Y" id="2rFgM0FVYTD" role="3oSUPX">
+                        <ref role="cht4Q" to="gt8j:3d01KqFhiz2" resolve="AddModelOperation" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="30G5F_" id="2rFgM0FVX8E" role="30HLyM">
+        <node concept="3clFbS" id="2rFgM0FVX8F" role="2VODD2">
+          <node concept="3clFbF" id="2rFgM0FVX8G" role="3cqZAp">
+            <node concept="1Wc70l" id="2rFgM0FVX8H" role="3clFbG">
+              <node concept="2OqwBi" id="2rFgM0FVX8I" role="3uHU7w">
+                <node concept="2OqwBi" id="2rFgM0FVX8J" role="2Oq$k0">
+                  <node concept="1PxgMI" id="2rFgM0FVX8K" role="2Oq$k0">
+                    <node concept="chp4Y" id="2rFgM0FVX8L" role="3oSUPX">
+                      <ref role="cht4Q" to="gt8j:3d01KqFhiz2" resolve="AddModelOperation" />
+                    </node>
+                    <node concept="2OqwBi" id="2rFgM0FVX8M" role="1m5AlR">
+                      <node concept="30H73N" id="2rFgM0FVX8N" role="2Oq$k0" />
+                      <node concept="3TrEf2" id="2rFgM0FVX8O" role="2OqNvi">
+                        <ref role="3Tt5mk" to="tpee:hqOqNr4" resolve="operation" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3TrEf2" id="2rFgM0FVX8P" role="2OqNvi">
+                    <ref role="3Tt5mk" to="gt8j:7bwMmZeYmBk" resolve="repo" />
+                  </node>
+                </node>
+                <node concept="3x8VRR" id="2rFgM0FVY$r" role="2OqNvi" />
+              </node>
+              <node concept="2OqwBi" id="2rFgM0FVX8R" role="3uHU7B">
+                <node concept="2OqwBi" id="2rFgM0FVX8S" role="2Oq$k0">
+                  <node concept="30H73N" id="2rFgM0FVX8T" role="2Oq$k0" />
+                  <node concept="3TrEf2" id="2rFgM0FVX8U" role="2OqNvi">
+                    <ref role="3Tt5mk" to="tpee:hqOqNr4" resolve="operation" />
+                  </node>
+                </node>
+                <node concept="1mIQ4w" id="2rFgM0FVX8V" role="2OqNvi">
+                  <node concept="chp4Y" id="2rFgM0FVX8W" role="cj9EA">
+                    <ref role="cht4Q" to="gt8j:3d01KqFhiz2" resolve="AddModelOperation" />
+                  </node>
                 </node>
               </node>
             </node>

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.smodule/languageModels/editor.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.smodule/languageModels/editor.mps
@@ -50,6 +50,7 @@
         <reference id="1381004262292426837" name="parentStyleClass" index="1k5W1q" />
       </concept>
       <concept id="1139848536355" name="jetbrains.mps.lang.editor.structure.CellModel_WithRole" flags="ng" index="1$h60E">
+        <property id="1139852716018" name="noTargetText" index="1$x2rV" />
         <reference id="1140103550593" name="relationDeclaration" index="1NtTu8" />
       </concept>
       <concept id="1073389214265" name="jetbrains.mps.lang.editor.structure.EditorCellModel" flags="ng" index="3EYTF0">
@@ -278,6 +279,13 @@
       <node concept="3F1sOY" id="lse_ua3yTF" role="3EZMnx">
         <ref role="1NtTu8" to="gt8j:lse_ua3yy7" resolve="name" />
         <ref role="1ERwB7" node="3d01KqFjaW7" resolve="addModelActions" />
+      </node>
+      <node concept="3F0ifn" id="2rFgM0FVbER" role="3EZMnx">
+        <property role="3F0ifm" value="," />
+      </node>
+      <node concept="3F1sOY" id="2rFgM0FVc2g" role="3EZMnx">
+        <property role="1$x2rV" value="repository" />
+        <ref role="1NtTu8" to="gt8j:7bwMmZeYmBk" resolve="repo" />
       </node>
       <node concept="3F0ifn" id="3d01KqFhjaM" role="3EZMnx">
         <property role="3F0ifm" value=", with" />

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.smodule/languageModels/structure.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.smodule/languageModels/structure.mps
@@ -174,6 +174,12 @@
       <property role="IQ2ns" value="386247815699769479" />
       <ref role="20lvS9" to="tpee:fz3vP1J" resolve="Expression" />
     </node>
+    <node concept="1TJgyj" id="7bwMmZeYmBk" role="1TKVEi">
+      <property role="IQ2ns" value="8277837597157976532" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="repo" />
+      <ref role="20lvS9" to="tpee:fz3vP1J" resolve="Expression" />
+    </node>
   </node>
   <node concept="PlHQZ" id="3d01KqFhj1P">
     <property role="TrG5h" value="IModelWithContent" />

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.smodule/languageModels/typesystem.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.smodule/languageModels/typesystem.mps
@@ -11,6 +11,7 @@
     <import index="z1c4" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.project(MPS.Platform/)" />
     <import index="w1kc" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel(MPS.Core/)" />
     <import index="mhbf" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.model(MPS.OpenAPI/)" />
+    <import index="lui2" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.module(MPS.OpenAPI/)" />
     <import index="tp25" ref="r:00000000-0000-4000-0000-011c89590301(jetbrains.mps.lang.smodel.structure)" implicit="true" />
   </imports>
   <registry>
@@ -24,6 +25,9 @@
       </concept>
       <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
         <child id="1145553007750" name="creator" index="2ShVmc" />
+      </concept>
+      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
+        <property id="1070475926801" name="value" index="Xl_RC" />
       </concept>
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
@@ -62,8 +66,18 @@
         <child id="1175147624276" name="body" index="2sgrp5" />
       </concept>
       <concept id="1175147670730" name="jetbrains.mps.lang.typesystem.structure.SubtypingRule" flags="ig" index="2sgARr" />
+      <concept id="1175517400280" name="jetbrains.mps.lang.typesystem.structure.AssertStatement" flags="nn" index="2Mj0R9">
+        <child id="1175517761460" name="condition" index="2MkoU_" />
+      </concept>
+      <concept id="1175517767210" name="jetbrains.mps.lang.typesystem.structure.ReportErrorStatement" flags="nn" index="2MkqsV">
+        <child id="1175517851849" name="errorString" index="2MkJ7o" />
+      </concept>
       <concept id="1195213580585" name="jetbrains.mps.lang.typesystem.structure.AbstractCheckingRule" flags="ig" index="18hYwZ">
         <child id="1195213635060" name="body" index="18ibNy" />
+      </concept>
+      <concept id="1195214364922" name="jetbrains.mps.lang.typesystem.structure.NonTypesystemRule" flags="ig" index="18kY7G" />
+      <concept id="3937244445246642777" name="jetbrains.mps.lang.typesystem.structure.AbstractReportStatement" flags="ng" index="1urrMJ">
+        <child id="3937244445246642781" name="nodeToReport" index="1urrMF" />
       </concept>
       <concept id="1174642788531" name="jetbrains.mps.lang.typesystem.structure.ConceptReference" flags="ig" index="1YaCAy">
         <reference id="1174642800329" name="concept" index="1YaFvo" />
@@ -87,6 +101,7 @@
       <concept id="1174663118805" name="jetbrains.mps.lang.typesystem.structure.CreateLessThanInequationStatement" flags="nn" index="1ZobV4" />
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1172008320231" name="jetbrains.mps.lang.smodel.structure.Node_IsNotNullOperation" flags="nn" index="3x8VRR" />
       <concept id="1180636770613" name="jetbrains.mps.lang.smodel.structure.SNodeCreator" flags="nn" index="3zrR0B">
         <child id="1180636770616" name="createdType" index="3zrR0E" />
       </concept>
@@ -265,6 +280,33 @@
           </node>
         </node>
       </node>
+      <node concept="1ZobV4" id="7bwMmZeYwax" role="3cqZAp">
+        <node concept="mw_s8" id="7bwMmZeYwaX" role="1ZfhK$">
+          <node concept="1Z2H0r" id="7bwMmZeYwaT" role="mwGJk">
+            <node concept="2OqwBi" id="7bwMmZeYwlQ" role="1Z2MuG">
+              <node concept="1YBJjd" id="7bwMmZeYwbe" role="2Oq$k0">
+                <ref role="1YBMHb" node="3d01KqFjELB" resolve="addModelOperation" />
+              </node>
+              <node concept="3TrEf2" id="7bwMmZeYwrB" role="2OqNvi">
+                <ref role="3Tt5mk" to="gt8j:7bwMmZeYmBk" resolve="repo" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="mw_s8" id="4N6D1IQ0OS4" role="1ZfhKB">
+          <node concept="2pJPEk" id="4N6D1IQ0OS5" role="mwGJk">
+            <node concept="2pJPED" id="4N6D1IQ0OS6" role="2pJPEn">
+              <ref role="2pJxaS" to="tpee:g7uibYu" resolve="ClassifierType" />
+              <node concept="2pIpSj" id="4N6D1IQ0OS7" role="2pJxcM">
+                <ref role="2pIpSl" to="tpee:g7uigIF" resolve="classifier" />
+                <node concept="36bGnv" id="4N6D1IQ0OS8" role="28nt2d">
+                  <ref role="36bGnp" to="lui2:~SRepository" resolve="SRepository" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
       <node concept="1ZobV4" id="lse_ua3$RQ" role="3cqZAp">
         <node concept="mw_s8" id="lse_ua3$Sm" role="1ZfhKB">
           <node concept="2ShNRf" id="lse_ua3$Si" role="mwGJk">
@@ -382,6 +424,34 @@
     <node concept="1YaCAy" id="2gGfLsWUgzt" role="1YuTPh">
       <property role="TrG5h" value="addDependencyOperation" />
       <ref role="1YaFvo" to="gt8j:3d01KqFgWkj" resolve="AddDependencyOperation" />
+    </node>
+  </node>
+  <node concept="18kY7G" id="7bwMmZeYy4X">
+    <property role="TrG5h" value="check_AddModelOperation" />
+    <node concept="3clFbS" id="7bwMmZeYy4Y" role="18ibNy">
+      <node concept="2Mj0R9" id="7bwMmZeYy59" role="3cqZAp">
+        <node concept="2OqwBi" id="7bwMmZeYylG" role="2MkoU_">
+          <node concept="2OqwBi" id="7bwMmZeYyak" role="2Oq$k0">
+            <node concept="1YBJjd" id="7bwMmZeYy5z" role="2Oq$k0">
+              <ref role="1YBMHb" node="7bwMmZeYy50" resolve="addModelOperation" />
+            </node>
+            <node concept="3TrEf2" id="2rFgM0FVpsn" role="2OqNvi">
+              <ref role="3Tt5mk" to="gt8j:7bwMmZeYmBk" resolve="repo" />
+            </node>
+          </node>
+          <node concept="3x8VRR" id="7bwMmZeYyyf" role="2OqNvi" />
+        </node>
+        <node concept="Xl_RD" id="7bwMmZeYyA5" role="2MkJ7o">
+          <property role="Xl_RC" value="Add model requires the project repository to be specified" />
+        </node>
+        <node concept="1YBJjd" id="7bwMmZeYyHP" role="1urrMF">
+          <ref role="1YBMHb" node="7bwMmZeYy50" resolve="addModelOperation" />
+        </node>
+      </node>
+    </node>
+    <node concept="1YaCAy" id="7bwMmZeYy50" role="1YuTPh">
+      <property role="TrG5h" value="addModelOperation" />
+      <ref role="1YaFvo" to="gt8j:3d01KqFhiz2" resolve="AddModelOperation" />
     </node>
   </node>
 </model>

--- a/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.smodule.runtime/com.mbeddr.mpsutil.smodule.runtime.msd
+++ b/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.smodule.runtime/com.mbeddr.mpsutil.smodule.runtime.msd
@@ -14,6 +14,7 @@
   <dependencies>
     <dependency reexport="true">6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)</dependency>
     <dependency reexport="false">019b622b-0aef-4dd3-86d0-4eef01f3f6bb(jetbrains.mps.ide)</dependency>
+    <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:fc9fa859-9e8c-4b5f-8a23-d3ba09424d0f:com.mbeddr.mpsutil.uniquenames" version="0" />

--- a/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.smodule.runtime/models/com/mbeddr/mpsutil/smodule/runtime/lib.mps
+++ b/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.smodule.runtime/models/com/mbeddr/mpsutil/smodule/runtime/lib.mps
@@ -25,6 +25,8 @@
     <import index="z1c4" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.project(MPS.Platform/)" />
     <import index="alof" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.ide.project(MPS.Platform/)" />
     <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
+    <import index="mhfm" ref="3f233e7f-b8a6-46d2-a57f-795d56775243/java:org.jetbrains.annotations(Annotations/)" />
+    <import index="yzht" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:org.jetbrains.concurrency(MPS.IDEA/)" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
     <import index="31cb" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.extapi.module(MPS.Core/)" implicit="true" />
   </imports>
@@ -106,6 +108,7 @@
       <concept id="1068580123165" name="jetbrains.mps.baseLanguage.structure.InstanceMethodDeclaration" flags="ig" index="3clFb_">
         <property id="1178608670077" name="isAbstract" index="1EzhhJ" />
       </concept>
+      <concept id="1068580123152" name="jetbrains.mps.baseLanguage.structure.EqualsExpression" flags="nn" index="3clFbC" />
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
@@ -215,7 +218,6 @@
     <language id="760a0a8c-eabb-4521-8bfd-65db761a9ba3" name="jetbrains.mps.baseLanguage.logging">
       <concept id="2034914114981261497" name="jetbrains.mps.baseLanguage.logging.structure.LogLowLevelStatement" flags="ng" index="RRSsy">
         <property id="2034914114981261751" name="severity" index="RRSoG" />
-        <child id="2034914114981261755" name="throwable" index="RRSow" />
         <child id="2034914114981261753" name="message" index="RRSoy" />
       </concept>
     </language>
@@ -692,9 +694,6 @@
             <node concept="37vLTw" id="2rFgM0FVLBk" role="37wK5m">
               <ref role="3cqZAo" node="7Ynnt_OibxO" resolve="module" />
             </node>
-            <node concept="37vLTw" id="2rFgM0FVMyH" role="37wK5m">
-              <ref role="3cqZAo" node="7Ynnt_Oi8_r" resolve="storageType" />
-            </node>
             <node concept="37vLTw" id="2rFgM0FVNkX" role="37wK5m">
               <ref role="3cqZAo" node="7Ynnt_OidYh" resolve="name" />
             </node>
@@ -806,6 +805,9 @@
       <node concept="2AHcQZ" id="2rFgM0FVy4o" role="2AJF6D">
         <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
       </node>
+      <node concept="2AHcQZ" id="6V$9xNdTZdF" role="2AJF6D">
+        <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
+      </node>
     </node>
     <node concept="2tJIrI" id="2rFgM0FWs$$" role="jymVt" />
     <node concept="2YIFZL" id="2rFgM0FVwtY" role="jymVt">
@@ -814,27 +816,7 @@
       <property role="DiZV1" value="false" />
       <property role="2aFKle" value="false" />
       <node concept="3clFbS" id="2rFgM0FVwtZ" role="3clF47">
-        <node concept="3cpWs8" id="2rFgM0FVwu0" role="3cqZAp">
-          <node concept="3cpWsn" id="2rFgM0FVwu1" role="3cpWs9">
-            <property role="TrG5h" value="modelFactory" />
-            <property role="3TUv4t" value="true" />
-            <node concept="3uibUv" id="2rFgM0FVwu2" role="1tU5fm">
-              <ref role="3uigEE" to="dush:~ModelFactory" resolve="ModelFactory" />
-            </node>
-            <node concept="2OqwBi" id="2rFgM0FVwu3" role="33vP2m">
-              <node concept="2YIFZM" id="2rFgM0FVwu4" role="2Oq$k0">
-                <ref role="1Pybhc" to="dush:~PersistenceFacade" resolve="PersistenceFacade" />
-                <ref role="37wK5l" to="dush:~PersistenceFacade.getInstance()" resolve="getInstance" />
-              </node>
-              <node concept="liA8E" id="2rFgM0FVwu5" role="2OqNvi">
-                <ref role="37wK5l" to="dush:~PersistenceFacade.getModelFactory(java.lang.String)" resolve="getModelFactory" />
-                <node concept="37vLTw" id="2rFgM0FVwu6" role="37wK5m">
-                  <ref role="3cqZAo" node="2rFgM0FVwvB" resolve="storageType" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
+        <node concept="3clFbH" id="6V$9xNdUvzI" role="3cqZAp" />
         <node concept="3cpWs8" id="2rFgM0FVwu7" role="3cqZAp">
           <node concept="3cpWsn" id="2rFgM0FVwu8" role="3cpWs9">
             <property role="TrG5h" value="mr" />
@@ -852,20 +834,19 @@
           </node>
         </node>
         <node concept="3clFbH" id="2rFgM0FVwuc" role="3cqZAp" />
-        <node concept="3cpWs8" id="2rFgM0FVwud" role="3cqZAp">
-          <node concept="3cpWsn" id="2rFgM0FVwue" role="3cpWs9">
+        <node concept="3cpWs8" id="6V$9xNdU9DP" role="3cqZAp">
+          <node concept="3cpWsn" id="6V$9xNdU9DQ" role="3cpWs9">
             <property role="TrG5h" value="res" />
-            <property role="3TUv4t" value="true" />
-            <node concept="3uibUv" id="2rFgM0FVwuf" role="1tU5fm">
-              <ref role="3uigEE" to="zn9m:~AsyncResult" resolve="AsyncResult" />
-              <node concept="3uibUv" id="2rFgM0FVwug" role="11_B2D">
+            <node concept="3uibUv" id="6V$9xNdU9DN" role="1tU5fm">
+              <ref role="3uigEE" to="yzht:~AsyncPromise" resolve="AsyncPromise" />
+              <node concept="3uibUv" id="6V$9xNdUbfy" role="11_B2D">
                 <ref role="3uigEE" to="mhbf:~SModel" resolve="SModel" />
               </node>
             </node>
-            <node concept="2ShNRf" id="2rFgM0FVwuh" role="33vP2m">
-              <node concept="1pGfFk" id="2rFgM0FVwui" role="2ShVmc">
-                <ref role="37wK5l" to="zn9m:~AsyncResult.&lt;init&gt;()" resolve="AsyncResult" />
-                <node concept="3uibUv" id="2rFgM0FVwuj" role="1pMfVU">
+            <node concept="2ShNRf" id="6V$9xNdUcv8" role="33vP2m">
+              <node concept="1pGfFk" id="6V$9xNdUcqo" role="2ShVmc">
+                <ref role="37wK5l" to="yzht:~AsyncPromise.&lt;init&gt;()" resolve="AsyncPromise" />
+                <node concept="3uibUv" id="6V$9xNdUcqp" role="1pMfVU">
                   <ref role="3uigEE" to="mhbf:~SModel" resolve="SModel" />
                 </node>
               </node>
@@ -884,57 +865,56 @@
                       <node concept="3cpWs8" id="2rFgM0FVwur" role="3cqZAp">
                         <node concept="3cpWsn" id="2rFgM0FVwus" role="3cpWs9">
                           <property role="TrG5h" value="model" />
-                          <node concept="10Nm6u" id="2rFgM0FVwut" role="33vP2m" />
                           <node concept="3uibUv" id="2rFgM0FVwuu" role="1tU5fm">
                             <ref role="3uigEE" to="mhbf:~EditableSModel" resolve="EditableSModel" />
                           </node>
                         </node>
                       </node>
-                      <node concept="SfApY" id="2rFgM0FVwuv" role="3cqZAp">
-                        <node concept="3clFbS" id="2rFgM0FVwuw" role="SfCbr">
-                          <node concept="3clFbF" id="2rFgM0FVwux" role="3cqZAp">
-                            <node concept="37vLTI" id="2rFgM0FVwuy" role="3clFbG">
-                              <node concept="2YIFZM" id="2rFgM0FVwuz" role="37vLTx">
-                                <ref role="37wK5l" to="z1c3:~SModuleOperations.createModelWithAdjustments(java.lang.String,org.jetbrains.mps.openapi.persistence.ModelRoot,org.jetbrains.mps.openapi.persistence.ModelFactoryType)" resolve="createModelWithAdjustments" />
-                                <ref role="1Pybhc" to="z1c3:~SModuleOperations" resolve="SModuleOperations" />
-                                <node concept="37vLTw" id="2rFgM0FVwu$" role="37wK5m">
-                                  <ref role="3cqZAo" node="2rFgM0FVwvD" resolve="name" />
-                                </node>
-                                <node concept="37vLTw" id="2rFgM0FVwu_" role="37wK5m">
-                                  <ref role="3cqZAo" node="2rFgM0FVwu8" resolve="mr" />
-                                </node>
-                                <node concept="2OqwBi" id="2rFgM0FVwuA" role="37wK5m">
-                                  <node concept="37vLTw" id="2rFgM0FVwuB" role="2Oq$k0">
-                                    <ref role="3cqZAo" node="2rFgM0FVwu1" resolve="modelFactory" />
-                                  </node>
-                                  <node concept="liA8E" id="2rFgM0FVwuC" role="2OqNvi">
-                                    <ref role="37wK5l" to="dush:~ModelFactory.getType()" resolve="getType" />
-                                  </node>
-                                </node>
-                              </node>
-                              <node concept="37vLTw" id="2rFgM0FVwuD" role="37vLTJ">
-                                <ref role="3cqZAo" node="2rFgM0FVwus" resolve="model" />
-                              </node>
+                      <node concept="3clFbF" id="2rFgM0FVwux" role="3cqZAp">
+                        <node concept="37vLTI" id="2rFgM0FVwuy" role="3clFbG">
+                          <node concept="2YIFZM" id="2rFgM0FVwuz" role="37vLTx">
+                            <ref role="1Pybhc" to="z1c3:~SModuleOperations" resolve="SModuleOperations" />
+                            <ref role="37wK5l" to="z1c3:~SModuleOperations.createModelWithAdjustments(java.lang.String,org.jetbrains.mps.openapi.persistence.ModelRoot)" resolve="createModelWithAdjustments" />
+                            <node concept="37vLTw" id="2rFgM0FVwu$" role="37wK5m">
+                              <ref role="3cqZAo" node="2rFgM0FVwvD" resolve="name" />
                             </node>
+                            <node concept="37vLTw" id="2rFgM0FVwu_" role="37wK5m">
+                              <ref role="3cqZAo" node="2rFgM0FVwu8" resolve="mr" />
+                            </node>
+                          </node>
+                          <node concept="37vLTw" id="2rFgM0FVwuD" role="37vLTJ">
+                            <ref role="3cqZAo" node="2rFgM0FVwus" resolve="model" />
                           </node>
                         </node>
-                        <node concept="TDmWw" id="2rFgM0FVwuE" role="TEbGg">
-                          <node concept="3cpWsn" id="2rFgM0FVwuF" role="TDEfY">
-                            <property role="TrG5h" value="e" />
-                            <node concept="3uibUv" id="2rFgM0FVwuG" role="1tU5fm">
-                              <ref role="3uigEE" to="pa15:~ModelCannotBeCreatedException" resolve="ModelCannotBeCreatedException" />
+                      </node>
+                      <node concept="3clFbH" id="6V$9xNdTU$Y" role="3cqZAp" />
+                      <node concept="3clFbJ" id="6V$9xNdTV3W" role="3cqZAp">
+                        <node concept="3clFbS" id="6V$9xNdTV3Y" role="3clFbx">
+                          <node concept="RRSsy" id="2rFgM0FVwuI" role="3cqZAp">
+                            <property role="RRSoG" value="gZ5fh_4/error" />
+                            <node concept="Xl_RD" id="2rFgM0FVwuJ" role="RRSoy">
+                              <property role="Xl_RC" value="Can't create model" />
                             </node>
                           </node>
-                          <node concept="3clFbS" id="2rFgM0FVwuH" role="TDEfX">
-                            <node concept="RRSsy" id="2rFgM0FVwuI" role="3cqZAp">
-                              <property role="RRSoG" value="gZ5fh_4/error" />
-                              <node concept="Xl_RD" id="2rFgM0FVwuJ" role="RRSoy">
-                                <property role="Xl_RC" value="Can't create model" />
+                          <node concept="3clFbF" id="6V$9xNdU5I4" role="3cqZAp">
+                            <node concept="2OqwBi" id="6V$9xNdU65j" role="3clFbG">
+                              <node concept="37vLTw" id="6V$9xNdUhG$" role="2Oq$k0">
+                                <ref role="3cqZAo" node="6V$9xNdU9DQ" resolve="res" />
                               </node>
-                              <node concept="37vLTw" id="2rFgM0FVwuK" role="RRSow">
-                                <ref role="3cqZAo" node="2rFgM0FVwuF" resolve="e" />
+                              <node concept="liA8E" id="6V$9xNdUiHo" role="2OqNvi">
+                                <ref role="37wK5l" to="yzht:~AsyncPromise.setError(java.lang.String)" resolve="setError" />
+                                <node concept="Xl_RD" id="6V$9xNdUiVy" role="37wK5m">
+                                  <property role="Xl_RC" value="Can't create model" />
+                                </node>
                               </node>
                             </node>
+                          </node>
+                          <node concept="3cpWs6" id="6V$9xNdU5o0" role="3cqZAp" />
+                        </node>
+                        <node concept="3clFbC" id="6V$9xNdTVLk" role="3clFbw">
+                          <node concept="10Nm6u" id="6V$9xNdTW31" role="3uHU7w" />
+                          <node concept="37vLTw" id="6V$9xNdTVnZ" role="3uHU7B">
+                            <ref role="3cqZAo" node="2rFgM0FVwus" resolve="model" />
                           </node>
                         </node>
                       </node>
@@ -1035,11 +1015,11 @@
                       </node>
                       <node concept="3clFbF" id="2rFgM0FVwvm" role="3cqZAp">
                         <node concept="2OqwBi" id="2rFgM0FVwvn" role="3clFbG">
-                          <node concept="37vLTw" id="2rFgM0FVwvo" role="2Oq$k0">
-                            <ref role="3cqZAo" node="2rFgM0FVwue" resolve="res" />
+                          <node concept="37vLTw" id="6V$9xNdUjfr" role="2Oq$k0">
+                            <ref role="3cqZAo" node="6V$9xNdU9DQ" resolve="res" />
                           </node>
                           <node concept="liA8E" id="2rFgM0FVwvp" role="2OqNvi">
-                            <ref role="37wK5l" to="zn9m:~AsyncResult.setDone(java.lang.Object)" resolve="setDone" />
+                            <ref role="37wK5l" to="yzht:~AsyncPromise.setResult(java.lang.Object)" resolve="setResult" />
                             <node concept="37vLTw" id="2rFgM0FVwvq" role="37wK5m">
                               <ref role="3cqZAo" node="2rFgM0FVwus" resolve="model" />
                             </node>
@@ -1059,11 +1039,11 @@
         <node concept="3clFbH" id="2rFgM0FVwvu" role="3cqZAp" />
         <node concept="3cpWs6" id="2rFgM0FVwvv" role="3cqZAp">
           <node concept="2OqwBi" id="2rFgM0FVwvw" role="3cqZAk">
-            <node concept="37vLTw" id="2rFgM0FVwvx" role="2Oq$k0">
-              <ref role="3cqZAo" node="2rFgM0FVwue" resolve="res" />
+            <node concept="37vLTw" id="6V$9xNdUjSU" role="2Oq$k0">
+              <ref role="3cqZAo" node="6V$9xNdU9DQ" resolve="res" />
             </node>
-            <node concept="liA8E" id="2rFgM0FVwvy" role="2OqNvi">
-              <ref role="37wK5l" to="zn9m:~AsyncResult.getResultSync()" resolve="getResultSync" />
+            <node concept="liA8E" id="6V$9xNdUkWA" role="2OqNvi">
+              <ref role="37wK5l" to="yzht:~AsyncPromise.get()" resolve="get" />
             </node>
           </node>
         </node>
@@ -1077,15 +1057,17 @@
         <node concept="3uibUv" id="2rFgM0FVwvA" role="1tU5fm">
           <ref role="3uigEE" to="z1c3:~AbstractModule" resolve="AbstractModule" />
         </node>
-      </node>
-      <node concept="37vLTG" id="2rFgM0FVwvB" role="3clF46">
-        <property role="TrG5h" value="storageType" />
-        <node concept="17QB3L" id="2rFgM0FVwvC" role="1tU5fm" />
+        <node concept="2AHcQZ" id="6V$9xNdUm1w" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
       </node>
       <node concept="37vLTG" id="2rFgM0FVwvD" role="3clF46">
         <property role="TrG5h" value="name" />
         <property role="3TUv4t" value="true" />
         <node concept="17QB3L" id="2rFgM0FVwvE" role="1tU5fm" />
+        <node concept="2AHcQZ" id="6V$9xNdUofk" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
       </node>
       <node concept="37vLTG" id="2rFgM0FVwvF" role="3clF46">
         <property role="TrG5h" value="devkits" />
@@ -1094,6 +1076,9 @@
           <node concept="3uibUv" id="2rFgM0FVwvH" role="_ZDj9">
             <ref role="3uigEE" to="z1c3:~DevKit" resolve="DevKit" />
           </node>
+        </node>
+        <node concept="2AHcQZ" id="6V$9xNdUppD" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
         </node>
       </node>
       <node concept="37vLTG" id="2rFgM0FVwvI" role="3clF46">
@@ -1104,6 +1089,9 @@
             <ref role="3uigEE" to="c17a:~SLanguage" resolve="SLanguage" />
           </node>
         </node>
+        <node concept="2AHcQZ" id="6V$9xNdUr7J" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
       </node>
       <node concept="37vLTG" id="2rFgM0FVwvL" role="3clF46">
         <property role="TrG5h" value="dependencies" />
@@ -1113,12 +1101,21 @@
             <ref role="3uigEE" to="mhbf:~SModel" resolve="SModel" />
           </node>
         </node>
+        <node concept="2AHcQZ" id="6V$9xNdUsOI" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
       </node>
       <node concept="37vLTG" id="2rFgM0FV$Rm" role="3clF46">
         <property role="TrG5h" value="repository" />
         <node concept="3uibUv" id="2rFgM0FV_IL" role="1tU5fm">
           <ref role="3uigEE" to="lui2:~SRepository" resolve="SRepository" />
         </node>
+        <node concept="2AHcQZ" id="6V$9xNdUuhN" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="6V$9xNdTXc_" role="2AJF6D">
+        <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
       </node>
     </node>
     <node concept="2YIFZL" id="sa5eTsu7F9" role="jymVt">

--- a/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.smodule.runtime/models/com/mbeddr/mpsutil/smodule/runtime/lib.mps
+++ b/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.smodule.runtime/models/com/mbeddr/mpsutil/smodule/runtime/lib.mps
@@ -23,8 +23,10 @@
     <import index="3a50" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.ide(MPS.Platform/)" />
     <import index="pa15" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.persistence(MPS.Core/)" />
     <import index="z1c4" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.project(MPS.Platform/)" />
-    <import index="31cb" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.extapi.module(MPS.Core/)" implicit="true" />
+    <import index="alof" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.ide.project(MPS.Platform/)" />
+    <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
+    <import index="31cb" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.extapi.module(MPS.Core/)" implicit="true" />
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
@@ -35,6 +37,12 @@
       <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
       <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="ng" index="2tJIrI" />
+      <concept id="1188207840427" name="jetbrains.mps.baseLanguage.structure.AnnotationInstance" flags="nn" index="2AHcQZ">
+        <reference id="1188208074048" name="annotation" index="2AI5Lk" />
+      </concept>
+      <concept id="1188208481402" name="jetbrains.mps.baseLanguage.structure.HasAnnotation" flags="ng" index="2AJDlI">
+        <child id="1188208488637" name="annotation" index="2AJF6D" />
+      </concept>
       <concept id="1154032098014" name="jetbrains.mps.baseLanguage.structure.AbstractLoopStatement" flags="nn" index="2LF5Ji">
         <child id="1154032183016" name="body" index="2LFqv$" />
       </concept>
@@ -112,6 +120,9 @@
       <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT">
         <property id="1068580123138" name="value" index="3clFbU" />
       </concept>
+      <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
+        <property id="1068580320021" name="value" index="3cmrfH" />
+      </concept>
       <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
       <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
         <child id="1068581517676" name="expression" index="3cqZAk" />
@@ -182,10 +193,20 @@
     <language id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc">
       <concept id="5349172909345501395" name="jetbrains.mps.baseLanguage.javadoc.structure.BaseDocComment" flags="ng" index="P$AiS">
         <child id="8465538089690331502" name="body" index="TZ5H$" />
+        <child id="5383422241790532083" name="tags" index="3nqlJM" />
       </concept>
       <concept id="5349172909345532724" name="jetbrains.mps.baseLanguage.javadoc.structure.MethodDocComment" flags="ng" index="P$JXv" />
       <concept id="8465538089690331500" name="jetbrains.mps.baseLanguage.javadoc.structure.CommentLine" flags="ng" index="TZ5HA">
         <child id="8970989240999019149" name="part" index="1dT_Ay" />
+      </concept>
+      <concept id="8465538089690331492" name="jetbrains.mps.baseLanguage.javadoc.structure.DeprecatedBlockDocTag" flags="ng" index="TZ5HI">
+        <child id="2667874559098216723" name="text" index="3HnX3l" />
+      </concept>
+      <concept id="2217234381367190443" name="jetbrains.mps.baseLanguage.javadoc.structure.SeeBlockDocTag" flags="ng" index="VUp57">
+        <child id="2217234381367190458" name="reference" index="VUp5m" />
+      </concept>
+      <concept id="2217234381367530195" name="jetbrains.mps.baseLanguage.javadoc.structure.MethodDocReference" flags="ng" index="VXe0Z">
+        <reference id="2217234381367530196" name="methodDeclaration" index="VXe0S" />
       </concept>
       <concept id="8970989240999019143" name="jetbrains.mps.baseLanguage.javadoc.structure.TextCommentLinePart" flags="ng" index="1dT_AC">
         <property id="8970989240999019144" name="text" index="1dT_AB" />
@@ -635,262 +656,59 @@
       <property role="DiZV1" value="false" />
       <property role="2aFKle" value="false" />
       <node concept="3clFbS" id="7Ynnt_OhWsc" role="3clF47">
-        <node concept="3cpWs8" id="7Ynnt_Oi8MC" role="3cqZAp">
-          <node concept="3cpWsn" id="7Ynnt_Oi8MD" role="3cpWs9">
-            <property role="TrG5h" value="modelFactory" />
-            <property role="3TUv4t" value="true" />
-            <node concept="3uibUv" id="7Ynnt_Oi8M_" role="1tU5fm">
-              <ref role="3uigEE" to="dush:~ModelFactory" resolve="ModelFactory" />
+        <node concept="3cpWs8" id="2rFgM0FVKxD" role="3cqZAp">
+          <node concept="3cpWsn" id="2rFgM0FVKxE" role="3cpWs9">
+            <property role="TrG5h" value="repository" />
+            <node concept="3uibUv" id="2rFgM0FVKuc" role="1tU5fm">
+              <ref role="3uigEE" to="lui2:~SRepository" resolve="SRepository" />
             </node>
-            <node concept="2OqwBi" id="7Ynnt_Oi8ME" role="33vP2m">
-              <node concept="2YIFZM" id="7Ynnt_Oi8MF" role="2Oq$k0">
-                <ref role="1Pybhc" to="dush:~PersistenceFacade" resolve="PersistenceFacade" />
-                <ref role="37wK5l" to="dush:~PersistenceFacade.getInstance()" resolve="getInstance" />
-              </node>
-              <node concept="liA8E" id="7Ynnt_Oi8MG" role="2OqNvi">
-                <ref role="37wK5l" to="dush:~PersistenceFacade.getModelFactory(java.lang.String)" resolve="getModelFactory" />
-                <node concept="37vLTw" id="7Ynnt_Oi8MH" role="37wK5m">
-                  <ref role="3cqZAo" node="7Ynnt_Oi8_r" resolve="storageType" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3cpWs8" id="7Ynnt_OikS0" role="3cqZAp">
-          <node concept="3cpWsn" id="7Ynnt_OikS1" role="3cpWs9">
-            <property role="TrG5h" value="mr" />
-            <property role="3TUv4t" value="true" />
-            <node concept="3uibUv" id="7Ynnt_OikS2" role="1tU5fm">
-              <ref role="3uigEE" to="dush:~ModelRoot" resolve="ModelRoot" />
-            </node>
-            <node concept="2YIFZM" id="sa5eTsu7Fi" role="33vP2m">
-              <ref role="1Pybhc" node="7Ynnt_OamsD" resolve="ModelHelper" />
-              <ref role="37wK5l" node="sa5eTsu7F9" resolve="getMR" />
-              <node concept="37vLTw" id="sa5eTsu7Fh" role="37wK5m">
-                <ref role="3cqZAo" node="7Ynnt_OibxO" resolve="module" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbH" id="7Ynnt_OidZb" role="3cqZAp" />
-        <node concept="3cpWs8" id="1B5fOaAWlsR" role="3cqZAp">
-          <node concept="3cpWsn" id="1B5fOaAWlsS" role="3cpWs9">
-            <property role="TrG5h" value="res" />
-            <property role="3TUv4t" value="true" />
-            <node concept="3uibUv" id="1B5fOaAWlsT" role="1tU5fm">
-              <ref role="3uigEE" to="zn9m:~AsyncResult" resolve="AsyncResult" />
-              <node concept="3uibUv" id="1B5fOaAWlsU" role="11_B2D">
-                <ref role="3uigEE" to="mhbf:~SModel" resolve="SModel" />
-              </node>
-            </node>
-            <node concept="2ShNRf" id="1B5fOaAWlsV" role="33vP2m">
-              <node concept="1pGfFk" id="1B5fOaAWlsW" role="2ShVmc">
-                <ref role="37wK5l" to="zn9m:~AsyncResult.&lt;init&gt;()" resolve="AsyncResult" />
-                <node concept="3uibUv" id="1B5fOaAWlsX" role="1pMfVU">
-                  <ref role="3uigEE" to="mhbf:~SModel" resolve="SModel" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbH" id="4rHwORqAEnb" role="3cqZAp" />
-        <node concept="3clFbF" id="4rHwORqAJ0T" role="3cqZAp">
-          <node concept="2YIFZM" id="4rHwORqAJbl" role="3clFbG">
-            <ref role="37wK5l" to="3a50:~ThreadUtils.runInUIThreadNoWait(java.lang.Runnable)" resolve="runInUIThreadNoWait" />
-            <ref role="1Pybhc" to="3a50:~ThreadUtils" resolve="ThreadUtils" />
-            <node concept="1bVj0M" id="4rHwORqAFRv" role="37wK5m">
-              <node concept="3clFbS" id="4rHwORqAFRx" role="1bW5cS">
-                <node concept="1QHqEO" id="4rHwORqAFTq" role="3cqZAp">
-                  <node concept="1QHqEC" id="4rHwORqAFTr" role="1QHqEI">
-                    <node concept="3clFbS" id="4rHwORqAFTs" role="1bW5cS">
-                      <node concept="3cpWs8" id="4rHwORqAFTt" role="3cqZAp">
-                        <node concept="3cpWsn" id="4rHwORqAFTu" role="3cpWs9">
-                          <property role="TrG5h" value="model" />
-                          <node concept="10Nm6u" id="4oSomgtPOmN" role="33vP2m" />
-                          <node concept="3uibUv" id="4rHwORqAFTv" role="1tU5fm">
-                            <ref role="3uigEE" to="mhbf:~EditableSModel" resolve="EditableSModel" />
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="SfApY" id="4oSomgtPHLA" role="3cqZAp">
-                        <node concept="3clFbS" id="4oSomgtPHLC" role="SfCbr">
-                          <node concept="3clFbF" id="4oSomgtPI$O" role="3cqZAp">
-                            <node concept="37vLTI" id="4oSomgtPI$Q" role="3clFbG">
-                              <node concept="2YIFZM" id="4oSomgtPnGP" role="37vLTx">
-                                <ref role="37wK5l" to="z1c3:~SModuleOperations.createModelWithAdjustments(java.lang.String,org.jetbrains.mps.openapi.persistence.ModelRoot,org.jetbrains.mps.openapi.persistence.ModelFactoryType)" resolve="createModelWithAdjustments" />
-                                <ref role="1Pybhc" to="z1c3:~SModuleOperations" resolve="SModuleOperations" />
-                                <node concept="37vLTw" id="4oSomgtPnGQ" role="37wK5m">
-                                  <ref role="3cqZAo" node="7Ynnt_OidYh" resolve="name" />
-                                </node>
-                                <node concept="37vLTw" id="4oSomgtPnGR" role="37wK5m">
-                                  <ref role="3cqZAo" node="7Ynnt_OikS1" resolve="mr" />
-                                </node>
-                                <node concept="2OqwBi" id="4oSomgtPo86" role="37wK5m">
-                                  <node concept="37vLTw" id="4oSomgtPnGS" role="2Oq$k0">
-                                    <ref role="3cqZAo" node="7Ynnt_Oi8MD" resolve="modelFactory" />
-                                  </node>
-                                  <node concept="liA8E" id="4oSomgtPoqE" role="2OqNvi">
-                                    <ref role="37wK5l" to="dush:~ModelFactory.getType()" resolve="getType" />
-                                  </node>
-                                </node>
-                              </node>
-                              <node concept="37vLTw" id="4oSomgtPI$U" role="37vLTJ">
-                                <ref role="3cqZAo" node="4rHwORqAFTu" resolve="model" />
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="TDmWw" id="4oSomgtPHLD" role="TEbGg">
-                          <node concept="3cpWsn" id="4oSomgtPHLF" role="TDEfY">
-                            <property role="TrG5h" value="e" />
-                            <node concept="3uibUv" id="4oSomgtPMpL" role="1tU5fm">
-                              <ref role="3uigEE" to="pa15:~ModelCannotBeCreatedException" resolve="ModelCannotBeCreatedException" />
-                            </node>
-                          </node>
-                          <node concept="3clFbS" id="4oSomgtPHLJ" role="TDEfX">
-                            <node concept="RRSsy" id="42VTAcDfnNY" role="3cqZAp">
-                              <property role="RRSoG" value="gZ5fh_4/error" />
-                              <node concept="Xl_RD" id="4oSomgtPMRf" role="RRSoy">
-                                <property role="Xl_RC" value="Can't create model" />
-                              </node>
-                              <node concept="37vLTw" id="4oSomgtPMRh" role="RRSow">
-                                <ref role="3cqZAo" node="4oSomgtPHLF" resolve="e" />
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="3cpWs8" id="4rHwORqALms" role="3cqZAp">
-                        <node concept="3cpWsn" id="4rHwORqALmt" role="3cpWs9">
-                          <property role="TrG5h" value="mi" />
-                          <node concept="3uibUv" id="4rHwORqALmu" role="1tU5fm">
-                            <ref role="3uigEE" to="w1kc:~ModelImports" resolve="ModelImports" />
-                          </node>
-                          <node concept="2ShNRf" id="4rHwORqALRY" role="33vP2m">
-                            <node concept="1pGfFk" id="4rHwORqAS7O" role="2ShVmc">
-                              <ref role="37wK5l" to="w1kc:~ModelImports.&lt;init&gt;(org.jetbrains.mps.openapi.model.SModel)" resolve="ModelImports" />
-                              <node concept="37vLTw" id="4rHwORqASsn" role="37wK5m">
-                                <ref role="3cqZAo" node="4rHwORqAFTu" resolve="model" />
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="2Gpval" id="4rHwORqAFT$" role="3cqZAp">
-                        <node concept="2GrKxI" id="4rHwORqAFT_" role="2Gsz3X">
-                          <property role="TrG5h" value="kit" />
-                        </node>
-                        <node concept="3clFbS" id="4rHwORqAFTA" role="2LFqv$">
-                          <node concept="3clFbF" id="4rHwORqAFTB" role="3cqZAp">
-                            <node concept="2OqwBi" id="4rHwORqAFTC" role="3clFbG">
-                              <node concept="37vLTw" id="6B58x5zXwDn" role="2Oq$k0">
-                                <ref role="3cqZAo" node="4rHwORqALmt" resolve="mi" />
-                              </node>
-                              <node concept="liA8E" id="4rHwORqAFTH" role="2OqNvi">
-                                <ref role="37wK5l" to="w1kc:~ModelImports.addUsedDevKit(org.jetbrains.mps.openapi.module.SModuleReference)" resolve="addUsedDevKit" />
-                                <node concept="2OqwBi" id="4rHwORqAFTI" role="37wK5m">
-                                  <node concept="2GrUjf" id="4rHwORqAFTJ" role="2Oq$k0">
-                                    <ref role="2Gs0qQ" node="4rHwORqAFT_" resolve="kit" />
-                                  </node>
-                                  <node concept="liA8E" id="4rHwORqAFTK" role="2OqNvi">
-                                    <ref role="37wK5l" to="z1c3:~AbstractModule.getModuleReference()" resolve="getModuleReference" />
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="37vLTw" id="4rHwORqAFTL" role="2GsD0m">
-                          <ref role="3cqZAo" node="7Ynnt_Oimwi" resolve="devkits" />
-                        </node>
-                      </node>
-                      <node concept="2Gpval" id="4rHwORqAFTM" role="3cqZAp">
-                        <node concept="2GrKxI" id="4rHwORqAFTN" role="2Gsz3X">
-                          <property role="TrG5h" value="lang" />
-                        </node>
-                        <node concept="3clFbS" id="4rHwORqAFTO" role="2LFqv$">
-                          <node concept="3clFbF" id="4rHwORqAFTP" role="3cqZAp">
-                            <node concept="2OqwBi" id="4rHwORqAFTQ" role="3clFbG">
-                              <node concept="37vLTw" id="6B58x5zXx5k" role="2Oq$k0">
-                                <ref role="3cqZAo" node="4rHwORqALmt" resolve="mi" />
-                              </node>
-                              <node concept="liA8E" id="4rHwORqAFTV" role="2OqNvi">
-                                <ref role="37wK5l" to="w1kc:~ModelImports.addUsedLanguage(org.jetbrains.mps.openapi.language.SLanguage)" resolve="addUsedLanguage" />
-                                <node concept="2GrUjf" id="4rHwORqAFTW" role="37wK5m">
-                                  <ref role="2Gs0qQ" node="4rHwORqAFTN" resolve="lang" />
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="37vLTw" id="4rHwORqAFTX" role="2GsD0m">
-                          <ref role="3cqZAo" node="7Ynnt_Oim_w" resolve="languages" />
-                        </node>
-                      </node>
-                      <node concept="2Gpval" id="4rHwORqAFTY" role="3cqZAp">
-                        <node concept="2GrKxI" id="4rHwORqAFTZ" role="2Gsz3X">
-                          <property role="TrG5h" value="dep" />
-                        </node>
-                        <node concept="3clFbS" id="4rHwORqAFU0" role="2LFqv$">
-                          <node concept="3clFbF" id="4rHwORqASXM" role="3cqZAp">
-                            <node concept="2OqwBi" id="4rHwORqATf_" role="3clFbG">
-                              <node concept="37vLTw" id="4rHwORqASXK" role="2Oq$k0">
-                                <ref role="3cqZAo" node="4rHwORqALmt" resolve="mi" />
-                              </node>
-                              <node concept="liA8E" id="4rHwORqATtG" role="2OqNvi">
-                                <ref role="37wK5l" to="w1kc:~ModelImports.addModelImport(org.jetbrains.mps.openapi.model.SModelReference)" resolve="addModelImport" />
-                                <node concept="2OqwBi" id="4rHwORqATOW" role="37wK5m">
-                                  <node concept="2GrUjf" id="4rHwORqATFy" role="2Oq$k0">
-                                    <ref role="2Gs0qQ" node="4rHwORqAFTZ" resolve="dep" />
-                                  </node>
-                                  <node concept="liA8E" id="4rHwORqAUd3" role="2OqNvi">
-                                    <ref role="37wK5l" to="mhbf:~SModel.getReference()" resolve="getReference" />
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="37vLTw" id="4rHwORqAFUc" role="2GsD0m">
-                          <ref role="3cqZAo" node="7Ynnt_OimHj" resolve="dependencies" />
-                        </node>
-                      </node>
-                      <node concept="3clFbF" id="4rHwORqAFUd" role="3cqZAp">
-                        <node concept="2OqwBi" id="4rHwORqAFUe" role="3clFbG">
-                          <node concept="37vLTw" id="4rHwORqAFUf" role="2Oq$k0">
-                            <ref role="3cqZAo" node="1B5fOaAWlsS" resolve="res" />
-                          </node>
-                          <node concept="liA8E" id="4rHwORqAFUg" role="2OqNvi">
-                            <ref role="37wK5l" to="zn9m:~AsyncResult.setDone(java.lang.Object)" resolve="setDone" />
-                            <node concept="37vLTw" id="4rHwORqAFUh" role="37wK5m">
-                              <ref role="3cqZAo" node="4rHwORqAFTu" resolve="model" />
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
+            <node concept="2OqwBi" id="2rFgM0FVKxF" role="33vP2m">
+              <node concept="2OqwBi" id="2rFgM0FVKxG" role="2Oq$k0">
+                <node concept="2OqwBi" id="2rFgM0FVKxH" role="2Oq$k0">
+                  <node concept="2YIFZM" id="2rFgM0FVKxI" role="2Oq$k0">
+                    <ref role="37wK5l" to="z1c3:~ProjectManager.getInstance()" resolve="getInstance" />
+                    <ref role="1Pybhc" to="z1c3:~ProjectManager" resolve="ProjectManager" />
                   </node>
-                  <node concept="2OqwBi" id="3HHdT04kCnq" role="ukAjM">
-                    <node concept="37vLTw" id="3HHdT04kB_L" role="2Oq$k0">
-                      <ref role="3cqZAo" node="7Ynnt_OibxO" resolve="module" />
-                    </node>
-                    <node concept="liA8E" id="3HHdT04kD27" role="2OqNvi">
-                      <ref role="37wK5l" to="31cb:~SModuleBase.getRepository()" resolve="getRepository" />
-                    </node>
+                  <node concept="liA8E" id="2rFgM0FVKxJ" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~ProjectManager.getOpenedProjects()" resolve="getOpenedProjects" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="2rFgM0FVKxK" role="2OqNvi">
+                  <ref role="37wK5l" to="33ny:~List.get(int)" resolve="get" />
+                  <node concept="3cmrfG" id="2rFgM0FVKxL" role="37wK5m">
+                    <property role="3cmrfH" value="0" />
                   </node>
                 </node>
               </node>
+              <node concept="liA8E" id="2rFgM0FVKxM" role="2OqNvi">
+                <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+              </node>
             </node>
           </node>
         </node>
-        <node concept="3clFbH" id="5fqMIVnv_bC" role="3cqZAp" />
-        <node concept="3cpWs6" id="7Ynnt_OiuzI" role="3cqZAp">
-          <node concept="2OqwBi" id="1B5fOaAWm$i" role="3cqZAk">
-            <node concept="37vLTw" id="1B5fOaAWm$j" role="2Oq$k0">
-              <ref role="3cqZAo" node="1B5fOaAWlsS" resolve="res" />
+        <node concept="3clFbF" id="2rFgM0FV$ce" role="3cqZAp">
+          <node concept="1rXfSq" id="2rFgM0FV$cd" role="3clFbG">
+            <ref role="37wK5l" node="2rFgM0FVwtY" resolve="createModel" />
+            <node concept="37vLTw" id="2rFgM0FVLBk" role="37wK5m">
+              <ref role="3cqZAo" node="7Ynnt_OibxO" resolve="module" />
             </node>
-            <node concept="liA8E" id="1B5fOaAWm$k" role="2OqNvi">
-              <ref role="37wK5l" to="zn9m:~AsyncResult.getResultSync()" resolve="getResultSync" />
+            <node concept="37vLTw" id="2rFgM0FVMyH" role="37wK5m">
+              <ref role="3cqZAo" node="7Ynnt_Oi8_r" resolve="storageType" />
+            </node>
+            <node concept="37vLTw" id="2rFgM0FVNkX" role="37wK5m">
+              <ref role="3cqZAo" node="7Ynnt_OidYh" resolve="name" />
+            </node>
+            <node concept="37vLTw" id="2rFgM0FVO5q" role="37wK5m">
+              <ref role="3cqZAo" node="7Ynnt_Oimwi" resolve="devkits" />
+            </node>
+            <node concept="37vLTw" id="2rFgM0FVOU6" role="37wK5m">
+              <ref role="3cqZAo" node="7Ynnt_Oim_w" resolve="languages" />
+            </node>
+            <node concept="37vLTw" id="2rFgM0FVPJq" role="37wK5m">
+              <ref role="3cqZAo" node="7Ynnt_OimHj" resolve="dependencies" />
+            </node>
+            <node concept="37vLTw" id="2rFgM0FVRwf" role="37wK5m">
+              <ref role="3cqZAo" node="2rFgM0FVKxE" resolve="repository" />
             </node>
           </node>
         </node>
@@ -939,6 +757,367 @@
           <node concept="3uibUv" id="7Ynnt_OimLX" role="_ZDj9">
             <ref role="3uigEE" to="mhbf:~SModel" resolve="SModel" />
           </node>
+        </node>
+      </node>
+      <node concept="P$JXv" id="2rFgM0FVy4l" role="lGtFl">
+        <node concept="TZ5HI" id="2rFgM0FWxn3" role="3nqlJM">
+          <node concept="TZ5HA" id="2rFgM0FWxn4" role="3HnX3l">
+            <node concept="1dT_AC" id="2rFgM0FWybU" role="1dT_Ay">
+              <property role="1dT_AB" value="" />
+            </node>
+          </node>
+        </node>
+        <node concept="VUp57" id="2rFgM0FWkES" role="3nqlJM">
+          <node concept="VXe0Z" id="2rFgM0FWrN8" role="VUp5m">
+            <ref role="VXe0S" node="2rFgM0FVwtY" resolve="createModel" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="2rFgM0FWyps" role="TZ5H$">
+          <node concept="1dT_AC" id="2rFgM0FWypt" role="1dT_Ay">
+            <property role="1dT_AB" value="As GlobalModelAccess has no idea how to run commands we need to provide a project repository." />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="2rFgM0FWyzY" role="TZ5H$">
+          <node concept="1dT_AC" id="2rFgM0FWyzZ" role="1dT_Ay">
+            <property role="1dT_AB" value="" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="2rFgM0FWyBm" role="TZ5H$">
+          <node concept="1dT_AC" id="2rFgM0FWyBn" role="1dT_Ay">
+            <property role="1dT_AB" value="For not breaking all of the existing usages we for now try to get the project repository from" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="2rFgM0FWyIj" role="TZ5H$">
+          <node concept="1dT_AC" id="2rFgM0FWyIk" role="1dT_Ay">
+            <property role="1dT_AB" value="the opened projects." />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="2rFgM0FWyLJ" role="TZ5H$">
+          <node concept="1dT_AC" id="2rFgM0FWyLK" role="1dT_Ay">
+            <property role="1dT_AB" value="" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="2rFgM0FWyLV" role="TZ5H$">
+          <node concept="1dT_AC" id="2rFgM0FWyLW" role="1dT_Ay">
+            <property role="1dT_AB" value="New implementations should use the createModel() that takes a repository as parameter." />
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="2rFgM0FVy4o" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="2rFgM0FWs$$" role="jymVt" />
+    <node concept="2YIFZL" id="2rFgM0FVwtY" role="jymVt">
+      <property role="TrG5h" value="createModel" />
+      <property role="od$2w" value="false" />
+      <property role="DiZV1" value="false" />
+      <property role="2aFKle" value="false" />
+      <node concept="3clFbS" id="2rFgM0FVwtZ" role="3clF47">
+        <node concept="3cpWs8" id="2rFgM0FVwu0" role="3cqZAp">
+          <node concept="3cpWsn" id="2rFgM0FVwu1" role="3cpWs9">
+            <property role="TrG5h" value="modelFactory" />
+            <property role="3TUv4t" value="true" />
+            <node concept="3uibUv" id="2rFgM0FVwu2" role="1tU5fm">
+              <ref role="3uigEE" to="dush:~ModelFactory" resolve="ModelFactory" />
+            </node>
+            <node concept="2OqwBi" id="2rFgM0FVwu3" role="33vP2m">
+              <node concept="2YIFZM" id="2rFgM0FVwu4" role="2Oq$k0">
+                <ref role="1Pybhc" to="dush:~PersistenceFacade" resolve="PersistenceFacade" />
+                <ref role="37wK5l" to="dush:~PersistenceFacade.getInstance()" resolve="getInstance" />
+              </node>
+              <node concept="liA8E" id="2rFgM0FVwu5" role="2OqNvi">
+                <ref role="37wK5l" to="dush:~PersistenceFacade.getModelFactory(java.lang.String)" resolve="getModelFactory" />
+                <node concept="37vLTw" id="2rFgM0FVwu6" role="37wK5m">
+                  <ref role="3cqZAo" node="2rFgM0FVwvB" resolve="storageType" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="2rFgM0FVwu7" role="3cqZAp">
+          <node concept="3cpWsn" id="2rFgM0FVwu8" role="3cpWs9">
+            <property role="TrG5h" value="mr" />
+            <property role="3TUv4t" value="true" />
+            <node concept="3uibUv" id="2rFgM0FVwu9" role="1tU5fm">
+              <ref role="3uigEE" to="dush:~ModelRoot" resolve="ModelRoot" />
+            </node>
+            <node concept="2YIFZM" id="2rFgM0FVwua" role="33vP2m">
+              <ref role="1Pybhc" node="7Ynnt_OamsD" resolve="ModelHelper" />
+              <ref role="37wK5l" node="sa5eTsu7F9" resolve="getMR" />
+              <node concept="37vLTw" id="2rFgM0FVwub" role="37wK5m">
+                <ref role="3cqZAo" node="2rFgM0FVwv_" resolve="module" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="2rFgM0FVwuc" role="3cqZAp" />
+        <node concept="3cpWs8" id="2rFgM0FVwud" role="3cqZAp">
+          <node concept="3cpWsn" id="2rFgM0FVwue" role="3cpWs9">
+            <property role="TrG5h" value="res" />
+            <property role="3TUv4t" value="true" />
+            <node concept="3uibUv" id="2rFgM0FVwuf" role="1tU5fm">
+              <ref role="3uigEE" to="zn9m:~AsyncResult" resolve="AsyncResult" />
+              <node concept="3uibUv" id="2rFgM0FVwug" role="11_B2D">
+                <ref role="3uigEE" to="mhbf:~SModel" resolve="SModel" />
+              </node>
+            </node>
+            <node concept="2ShNRf" id="2rFgM0FVwuh" role="33vP2m">
+              <node concept="1pGfFk" id="2rFgM0FVwui" role="2ShVmc">
+                <ref role="37wK5l" to="zn9m:~AsyncResult.&lt;init&gt;()" resolve="AsyncResult" />
+                <node concept="3uibUv" id="2rFgM0FVwuj" role="1pMfVU">
+                  <ref role="3uigEE" to="mhbf:~SModel" resolve="SModel" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="2rFgM0FVwuk" role="3cqZAp">
+          <node concept="2YIFZM" id="2rFgM0FVwul" role="3clFbG">
+            <ref role="37wK5l" to="3a50:~ThreadUtils.runInUIThreadNoWait(java.lang.Runnable)" resolve="runInUIThreadNoWait" />
+            <ref role="1Pybhc" to="3a50:~ThreadUtils" resolve="ThreadUtils" />
+            <node concept="1bVj0M" id="2rFgM0FVwum" role="37wK5m">
+              <node concept="3clFbS" id="2rFgM0FVwun" role="1bW5cS">
+                <node concept="1QHqEO" id="2rFgM0FVwuo" role="3cqZAp">
+                  <node concept="1QHqEC" id="2rFgM0FVwup" role="1QHqEI">
+                    <node concept="3clFbS" id="2rFgM0FVwuq" role="1bW5cS">
+                      <node concept="3cpWs8" id="2rFgM0FVwur" role="3cqZAp">
+                        <node concept="3cpWsn" id="2rFgM0FVwus" role="3cpWs9">
+                          <property role="TrG5h" value="model" />
+                          <node concept="10Nm6u" id="2rFgM0FVwut" role="33vP2m" />
+                          <node concept="3uibUv" id="2rFgM0FVwuu" role="1tU5fm">
+                            <ref role="3uigEE" to="mhbf:~EditableSModel" resolve="EditableSModel" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="SfApY" id="2rFgM0FVwuv" role="3cqZAp">
+                        <node concept="3clFbS" id="2rFgM0FVwuw" role="SfCbr">
+                          <node concept="3clFbF" id="2rFgM0FVwux" role="3cqZAp">
+                            <node concept="37vLTI" id="2rFgM0FVwuy" role="3clFbG">
+                              <node concept="2YIFZM" id="2rFgM0FVwuz" role="37vLTx">
+                                <ref role="37wK5l" to="z1c3:~SModuleOperations.createModelWithAdjustments(java.lang.String,org.jetbrains.mps.openapi.persistence.ModelRoot,org.jetbrains.mps.openapi.persistence.ModelFactoryType)" resolve="createModelWithAdjustments" />
+                                <ref role="1Pybhc" to="z1c3:~SModuleOperations" resolve="SModuleOperations" />
+                                <node concept="37vLTw" id="2rFgM0FVwu$" role="37wK5m">
+                                  <ref role="3cqZAo" node="2rFgM0FVwvD" resolve="name" />
+                                </node>
+                                <node concept="37vLTw" id="2rFgM0FVwu_" role="37wK5m">
+                                  <ref role="3cqZAo" node="2rFgM0FVwu8" resolve="mr" />
+                                </node>
+                                <node concept="2OqwBi" id="2rFgM0FVwuA" role="37wK5m">
+                                  <node concept="37vLTw" id="2rFgM0FVwuB" role="2Oq$k0">
+                                    <ref role="3cqZAo" node="2rFgM0FVwu1" resolve="modelFactory" />
+                                  </node>
+                                  <node concept="liA8E" id="2rFgM0FVwuC" role="2OqNvi">
+                                    <ref role="37wK5l" to="dush:~ModelFactory.getType()" resolve="getType" />
+                                  </node>
+                                </node>
+                              </node>
+                              <node concept="37vLTw" id="2rFgM0FVwuD" role="37vLTJ">
+                                <ref role="3cqZAo" node="2rFgM0FVwus" resolve="model" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="TDmWw" id="2rFgM0FVwuE" role="TEbGg">
+                          <node concept="3cpWsn" id="2rFgM0FVwuF" role="TDEfY">
+                            <property role="TrG5h" value="e" />
+                            <node concept="3uibUv" id="2rFgM0FVwuG" role="1tU5fm">
+                              <ref role="3uigEE" to="pa15:~ModelCannotBeCreatedException" resolve="ModelCannotBeCreatedException" />
+                            </node>
+                          </node>
+                          <node concept="3clFbS" id="2rFgM0FVwuH" role="TDEfX">
+                            <node concept="RRSsy" id="2rFgM0FVwuI" role="3cqZAp">
+                              <property role="RRSoG" value="gZ5fh_4/error" />
+                              <node concept="Xl_RD" id="2rFgM0FVwuJ" role="RRSoy">
+                                <property role="Xl_RC" value="Can't create model" />
+                              </node>
+                              <node concept="37vLTw" id="2rFgM0FVwuK" role="RRSow">
+                                <ref role="3cqZAo" node="2rFgM0FVwuF" resolve="e" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3cpWs8" id="2rFgM0FVwuL" role="3cqZAp">
+                        <node concept="3cpWsn" id="2rFgM0FVwuM" role="3cpWs9">
+                          <property role="TrG5h" value="mi" />
+                          <node concept="3uibUv" id="2rFgM0FVwuN" role="1tU5fm">
+                            <ref role="3uigEE" to="w1kc:~ModelImports" resolve="ModelImports" />
+                          </node>
+                          <node concept="2ShNRf" id="2rFgM0FVwuO" role="33vP2m">
+                            <node concept="1pGfFk" id="2rFgM0FVwuP" role="2ShVmc">
+                              <ref role="37wK5l" to="w1kc:~ModelImports.&lt;init&gt;(org.jetbrains.mps.openapi.model.SModel)" resolve="ModelImports" />
+                              <node concept="37vLTw" id="2rFgM0FVwuQ" role="37wK5m">
+                                <ref role="3cqZAo" node="2rFgM0FVwus" resolve="model" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="2Gpval" id="2rFgM0FVwuR" role="3cqZAp">
+                        <node concept="2GrKxI" id="2rFgM0FVwuS" role="2Gsz3X">
+                          <property role="TrG5h" value="kit" />
+                        </node>
+                        <node concept="3clFbS" id="2rFgM0FVwuT" role="2LFqv$">
+                          <node concept="3clFbF" id="2rFgM0FVwuU" role="3cqZAp">
+                            <node concept="2OqwBi" id="2rFgM0FVwuV" role="3clFbG">
+                              <node concept="37vLTw" id="2rFgM0FVwuW" role="2Oq$k0">
+                                <ref role="3cqZAo" node="2rFgM0FVwuM" resolve="mi" />
+                              </node>
+                              <node concept="liA8E" id="2rFgM0FVwuX" role="2OqNvi">
+                                <ref role="37wK5l" to="w1kc:~ModelImports.addUsedDevKit(org.jetbrains.mps.openapi.module.SModuleReference)" resolve="addUsedDevKit" />
+                                <node concept="2OqwBi" id="2rFgM0FVwuY" role="37wK5m">
+                                  <node concept="2GrUjf" id="2rFgM0FVwuZ" role="2Oq$k0">
+                                    <ref role="2Gs0qQ" node="2rFgM0FVwuS" resolve="kit" />
+                                  </node>
+                                  <node concept="liA8E" id="2rFgM0FVwv0" role="2OqNvi">
+                                    <ref role="37wK5l" to="z1c3:~AbstractModule.getModuleReference()" resolve="getModuleReference" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="37vLTw" id="2rFgM0FVwv1" role="2GsD0m">
+                          <ref role="3cqZAo" node="2rFgM0FVwvF" resolve="devkits" />
+                        </node>
+                      </node>
+                      <node concept="2Gpval" id="2rFgM0FVwv2" role="3cqZAp">
+                        <node concept="2GrKxI" id="2rFgM0FVwv3" role="2Gsz3X">
+                          <property role="TrG5h" value="lang" />
+                        </node>
+                        <node concept="3clFbS" id="2rFgM0FVwv4" role="2LFqv$">
+                          <node concept="3clFbF" id="2rFgM0FVwv5" role="3cqZAp">
+                            <node concept="2OqwBi" id="2rFgM0FVwv6" role="3clFbG">
+                              <node concept="37vLTw" id="2rFgM0FVwv7" role="2Oq$k0">
+                                <ref role="3cqZAo" node="2rFgM0FVwuM" resolve="mi" />
+                              </node>
+                              <node concept="liA8E" id="2rFgM0FVwv8" role="2OqNvi">
+                                <ref role="37wK5l" to="w1kc:~ModelImports.addUsedLanguage(org.jetbrains.mps.openapi.language.SLanguage)" resolve="addUsedLanguage" />
+                                <node concept="2GrUjf" id="2rFgM0FVwv9" role="37wK5m">
+                                  <ref role="2Gs0qQ" node="2rFgM0FVwv3" resolve="lang" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="37vLTw" id="2rFgM0FVwva" role="2GsD0m">
+                          <ref role="3cqZAo" node="2rFgM0FVwvI" resolve="languages" />
+                        </node>
+                      </node>
+                      <node concept="2Gpval" id="2rFgM0FVwvb" role="3cqZAp">
+                        <node concept="2GrKxI" id="2rFgM0FVwvc" role="2Gsz3X">
+                          <property role="TrG5h" value="dep" />
+                        </node>
+                        <node concept="3clFbS" id="2rFgM0FVwvd" role="2LFqv$">
+                          <node concept="3clFbF" id="2rFgM0FVwve" role="3cqZAp">
+                            <node concept="2OqwBi" id="2rFgM0FVwvf" role="3clFbG">
+                              <node concept="37vLTw" id="2rFgM0FVwvg" role="2Oq$k0">
+                                <ref role="3cqZAo" node="2rFgM0FVwuM" resolve="mi" />
+                              </node>
+                              <node concept="liA8E" id="2rFgM0FVwvh" role="2OqNvi">
+                                <ref role="37wK5l" to="w1kc:~ModelImports.addModelImport(org.jetbrains.mps.openapi.model.SModelReference)" resolve="addModelImport" />
+                                <node concept="2OqwBi" id="2rFgM0FVwvi" role="37wK5m">
+                                  <node concept="2GrUjf" id="2rFgM0FVwvj" role="2Oq$k0">
+                                    <ref role="2Gs0qQ" node="2rFgM0FVwvc" resolve="dep" />
+                                  </node>
+                                  <node concept="liA8E" id="2rFgM0FVwvk" role="2OqNvi">
+                                    <ref role="37wK5l" to="mhbf:~SModel.getReference()" resolve="getReference" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="37vLTw" id="2rFgM0FVwvl" role="2GsD0m">
+                          <ref role="3cqZAo" node="2rFgM0FVwvL" resolve="dependencies" />
+                        </node>
+                      </node>
+                      <node concept="3clFbF" id="2rFgM0FVwvm" role="3cqZAp">
+                        <node concept="2OqwBi" id="2rFgM0FVwvn" role="3clFbG">
+                          <node concept="37vLTw" id="2rFgM0FVwvo" role="2Oq$k0">
+                            <ref role="3cqZAo" node="2rFgM0FVwue" resolve="res" />
+                          </node>
+                          <node concept="liA8E" id="2rFgM0FVwvp" role="2OqNvi">
+                            <ref role="37wK5l" to="zn9m:~AsyncResult.setDone(java.lang.Object)" resolve="setDone" />
+                            <node concept="37vLTw" id="2rFgM0FVwvq" role="37wK5m">
+                              <ref role="3cqZAo" node="2rFgM0FVwus" resolve="model" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="37vLTw" id="2rFgM0FVAZM" role="ukAjM">
+                    <ref role="3cqZAo" node="2rFgM0FV$Rm" resolve="repository" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="2rFgM0FVwvu" role="3cqZAp" />
+        <node concept="3cpWs6" id="2rFgM0FVwvv" role="3cqZAp">
+          <node concept="2OqwBi" id="2rFgM0FVwvw" role="3cqZAk">
+            <node concept="37vLTw" id="2rFgM0FVwvx" role="2Oq$k0">
+              <ref role="3cqZAo" node="2rFgM0FVwue" resolve="res" />
+            </node>
+            <node concept="liA8E" id="2rFgM0FVwvy" role="2OqNvi">
+              <ref role="37wK5l" to="zn9m:~AsyncResult.getResultSync()" resolve="getResultSync" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="2rFgM0FVwvz" role="1B3o_S" />
+      <node concept="3uibUv" id="2rFgM0FVwv$" role="3clF45">
+        <ref role="3uigEE" to="mhbf:~SModel" resolve="SModel" />
+      </node>
+      <node concept="37vLTG" id="2rFgM0FVwv_" role="3clF46">
+        <property role="TrG5h" value="module" />
+        <node concept="3uibUv" id="2rFgM0FVwvA" role="1tU5fm">
+          <ref role="3uigEE" to="z1c3:~AbstractModule" resolve="AbstractModule" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="2rFgM0FVwvB" role="3clF46">
+        <property role="TrG5h" value="storageType" />
+        <node concept="17QB3L" id="2rFgM0FVwvC" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="2rFgM0FVwvD" role="3clF46">
+        <property role="TrG5h" value="name" />
+        <property role="3TUv4t" value="true" />
+        <node concept="17QB3L" id="2rFgM0FVwvE" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="2rFgM0FVwvF" role="3clF46">
+        <property role="TrG5h" value="devkits" />
+        <property role="3TUv4t" value="true" />
+        <node concept="_YKpA" id="2rFgM0FVwvG" role="1tU5fm">
+          <node concept="3uibUv" id="2rFgM0FVwvH" role="_ZDj9">
+            <ref role="3uigEE" to="z1c3:~DevKit" resolve="DevKit" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="2rFgM0FVwvI" role="3clF46">
+        <property role="TrG5h" value="languages" />
+        <property role="3TUv4t" value="true" />
+        <node concept="_YKpA" id="2rFgM0FVwvJ" role="1tU5fm">
+          <node concept="3uibUv" id="2rFgM0FVwvK" role="_ZDj9">
+            <ref role="3uigEE" to="c17a:~SLanguage" resolve="SLanguage" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="2rFgM0FVwvL" role="3clF46">
+        <property role="TrG5h" value="dependencies" />
+        <property role="3TUv4t" value="true" />
+        <node concept="_YKpA" id="2rFgM0FVwvM" role="1tU5fm">
+          <node concept="3uibUv" id="2rFgM0FVwvN" role="_ZDj9">
+            <ref role="3uigEE" to="mhbf:~SModel" resolve="SModel" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="2rFgM0FV$Rm" role="3clF46">
+        <property role="TrG5h" value="repository" />
+        <node concept="3uibUv" id="2rFgM0FV_IL" role="1tU5fm">
+          <ref role="3uigEE" to="lui2:~SRepository" resolve="SRepository" />
         </node>
       </node>
     </node>


### PR DESCRIPTION
Because now GlobalModelAccess has no way to execute a command, we have to provide a project repository to the add model operation.

For now I made the repository optional so that we just don't break the existing usages. When a repository is not provided we try to get it from the opened projects.