### PR TITLE
Bugfix for Graph.copy(), it doesn't create a proper independent copy.

### DIFF
--- a/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.common/models/com/mbeddr/mpsutil/common/graph.mps
+++ b/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.common/models/com/mbeddr/mpsutil/common/graph.mps
@@ -337,6 +337,8 @@
       <concept id="1165525191778" name="jetbrains.mps.baseLanguage.collections.structure.GetFirstOperation" flags="nn" index="1uHKPH" />
       <concept id="1165530316231" name="jetbrains.mps.baseLanguage.collections.structure.IsEmptyOperation" flags="nn" index="1v1jN8" />
       <concept id="1202120902084" name="jetbrains.mps.baseLanguage.collections.structure.WhereOperation" flags="nn" index="3zZkjj" />
+      <concept id="1240824834947" name="jetbrains.mps.baseLanguage.collections.structure.ValueAccessOperation" flags="nn" index="3AV6Ez" />
+      <concept id="1240825616499" name="jetbrains.mps.baseLanguage.collections.structure.KeyAccessOperation" flags="nn" index="3AY5_j" />
       <concept id="1197932370469" name="jetbrains.mps.baseLanguage.collections.structure.MapElement" flags="nn" index="3EllGN">
         <child id="1197932505799" name="map" index="3ElQJh" />
         <child id="1197932525128" name="key" index="3ElVtu" />
@@ -2369,41 +2371,85 @@
             </node>
           </node>
         </node>
-        <node concept="3clFbF" id="4D_91tBLMBe" role="3cqZAp">
-          <node concept="2OqwBi" id="4D_91tBLMLM" role="3clFbG">
-            <node concept="2OqwBi" id="4D_91tBLMCJ" role="2Oq$k0">
-              <node concept="37vLTw" id="4D_91tBLMBc" role="2Oq$k0">
-                <ref role="3cqZAo" node="4D_91tBLMwq" resolve="result" />
-              </node>
-              <node concept="2OwXpG" id="4D_91tBLMEI" role="2OqNvi">
-                <ref role="2Oxat5" node="9NO9Tq8VKi" resolve="forwardMap" />
-              </node>
+        <node concept="2Gpval" id="6h8gwE0xuPi" role="3cqZAp">
+          <node concept="2GrKxI" id="6h8gwE0xuPk" role="2Gsz3X">
+            <property role="TrG5h" value="m" />
+          </node>
+          <node concept="2OqwBi" id="6h8gwE0xzD8" role="2GsD0m">
+            <node concept="Xjq3P" id="6h8gwE0xzxy" role="2Oq$k0" />
+            <node concept="2OwXpG" id="6h8gwE0xzJj" role="2OqNvi">
+              <ref role="2Oxat5" node="9NO9Tq8VKi" resolve="forwardMap" />
             </node>
-            <node concept="3FNE7p" id="4D_91tBLMXe" role="2OqNvi">
-              <node concept="2OqwBi" id="4D_91tBLN2I" role="3FOfgg">
-                <node concept="Xjq3P" id="4D_91tBLMYE" role="2Oq$k0" />
-                <node concept="2OwXpG" id="4D_91tBLN8q" role="2OqNvi">
-                  <ref role="2Oxat5" node="9NO9Tq8VKi" resolve="forwardMap" />
+          </node>
+          <node concept="3clFbS" id="6h8gwE0xuPo" role="2LFqv$">
+            <node concept="3clFbF" id="6h8gwE0x$gT" role="3cqZAp">
+              <node concept="37vLTI" id="6h8gwE0xAvl" role="3clFbG">
+                <node concept="3EllGN" id="6h8gwE0x_4f" role="37vLTJ">
+                  <node concept="2OqwBi" id="6h8gwE0x_Nq" role="3ElVtu">
+                    <node concept="2GrUjf" id="6h8gwE0x__Y" role="2Oq$k0">
+                      <ref role="2Gs0qQ" node="6h8gwE0xuPk" resolve="m" />
+                    </node>
+                    <node concept="3AY5_j" id="6h8gwE0x_ZG" role="2OqNvi" />
+                  </node>
+                  <node concept="2OqwBi" id="6h8gwE0x$m6" role="3ElQJh">
+                    <node concept="37vLTw" id="6h8gwE0x$gS" role="2Oq$k0">
+                      <ref role="3cqZAo" node="4D_91tBLMwq" resolve="result" />
+                    </node>
+                    <node concept="2OwXpG" id="6h8gwE0x$st" role="2OqNvi">
+                      <ref role="2Oxat5" node="9NO9Tq8VKi" resolve="forwardMap" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="1rXfSq" id="6h8gwE0znp6" role="37vLTx">
+                  <ref role="37wK5l" node="6h8gwE0yTes" resolve="cloneSet" />
+                  <node concept="2OqwBi" id="6h8gwE0zo1E" role="37wK5m">
+                    <node concept="2GrUjf" id="6h8gwE0znJB" role="2Oq$k0">
+                      <ref role="2Gs0qQ" node="6h8gwE0xuPk" resolve="m" />
+                    </node>
+                    <node concept="3AV6Ez" id="6h8gwE0zofm" role="2OqNvi" />
+                  </node>
                 </node>
               </node>
             </node>
           </node>
         </node>
-        <node concept="3clFbF" id="4D_91tBLNih" role="3cqZAp">
-          <node concept="2OqwBi" id="4D_91tBLNy$" role="3clFbG">
-            <node concept="2OqwBi" id="4D_91tBLNnO" role="2Oq$k0">
-              <node concept="37vLTw" id="4D_91tBLNif" role="2Oq$k0">
-                <ref role="3cqZAo" node="4D_91tBLMwq" resolve="result" />
-              </node>
-              <node concept="2OwXpG" id="4D_91tBLNra" role="2OqNvi">
-                <ref role="2Oxat5" node="9NO9Tq8VKp" resolve="backwardMap" />
-              </node>
+        <node concept="2Gpval" id="6h8gwE0xE1C" role="3cqZAp">
+          <node concept="2GrKxI" id="6h8gwE0xE1D" role="2Gsz3X">
+            <property role="TrG5h" value="m" />
+          </node>
+          <node concept="2OqwBi" id="6h8gwE0xE1E" role="2GsD0m">
+            <node concept="Xjq3P" id="6h8gwE0xE1F" role="2Oq$k0" />
+            <node concept="2OwXpG" id="6h8gwE0xJbD" role="2OqNvi">
+              <ref role="2Oxat5" node="9NO9Tq8VKp" resolve="backwardMap" />
             </node>
-            <node concept="3FNE7p" id="4D_91tBLNHs" role="2OqNvi">
-              <node concept="2OqwBi" id="4D_91tBLNN1" role="3FOfgg">
-                <node concept="Xjq3P" id="4D_91tBLNIX" role="2Oq$k0" />
-                <node concept="2OwXpG" id="4D_91tBLNSH" role="2OqNvi">
-                  <ref role="2Oxat5" node="9NO9Tq8VKp" resolve="backwardMap" />
+          </node>
+          <node concept="3clFbS" id="6h8gwE0xE1H" role="2LFqv$">
+            <node concept="3clFbF" id="6h8gwE0xE1I" role="3cqZAp">
+              <node concept="37vLTI" id="6h8gwE0xE1J" role="3clFbG">
+                <node concept="1rXfSq" id="6h8gwE0zoH3" role="37vLTx">
+                  <ref role="37wK5l" node="6h8gwE0yTes" resolve="cloneSet" />
+                  <node concept="2OqwBi" id="6h8gwE0zpjW" role="37wK5m">
+                    <node concept="2GrUjf" id="6h8gwE0zp1T" role="2Oq$k0">
+                      <ref role="2Gs0qQ" node="6h8gwE0xE1D" resolve="m" />
+                    </node>
+                    <node concept="3AV6Ez" id="6h8gwE0zpyI" role="2OqNvi" />
+                  </node>
+                </node>
+                <node concept="3EllGN" id="6h8gwE0xE1O" role="37vLTJ">
+                  <node concept="2OqwBi" id="6h8gwE0xE1P" role="3ElVtu">
+                    <node concept="2GrUjf" id="6h8gwE0xE1Q" role="2Oq$k0">
+                      <ref role="2Gs0qQ" node="6h8gwE0xE1D" resolve="m" />
+                    </node>
+                    <node concept="3AY5_j" id="6h8gwE0xE1R" role="2OqNvi" />
+                  </node>
+                  <node concept="2OqwBi" id="6h8gwE0xE1S" role="3ElQJh">
+                    <node concept="37vLTw" id="6h8gwE0xE1T" role="2Oq$k0">
+                      <ref role="3cqZAo" node="4D_91tBLMwq" resolve="result" />
+                    </node>
+                    <node concept="2OwXpG" id="6h8gwE0xJX_" role="2OqNvi">
+                      <ref role="2Oxat5" node="9NO9Tq8VKp" resolve="backwardMap" />
+                    </node>
+                  </node>
                 </node>
               </node>
             </node>
@@ -2442,6 +2488,60 @@
           <ref role="16sUi3" node="9NO9Tq8VKh" resolve="T" />
         </node>
       </node>
+    </node>
+    <node concept="2tJIrI" id="6h8gwE0yklH" role="jymVt" />
+    <node concept="3clFb_" id="6h8gwE0yTes" role="jymVt">
+      <property role="TrG5h" value="cloneSet" />
+      <node concept="3clFbS" id="6h8gwE0y_OH" role="3clF47">
+        <node concept="3cpWs8" id="6h8gwE0z0Du" role="3cqZAp">
+          <node concept="3cpWsn" id="6h8gwE0z0Dv" role="3cpWs9">
+            <property role="TrG5h" value="cloned" />
+            <node concept="2hMVRd" id="6h8gwE0z07p" role="1tU5fm">
+              <node concept="16syzq" id="6h8gwE0z07s" role="2hN53Y">
+                <ref role="16sUi3" node="9NO9Tq8VKh" resolve="T" />
+              </node>
+            </node>
+            <node concept="2ShNRf" id="6h8gwE0z0Dw" role="33vP2m">
+              <node concept="2i4dXS" id="6h8gwE0z0Dx" role="2ShVmc">
+                <node concept="16syzq" id="6h8gwE0z0Dy" role="HW$YZ">
+                  <ref role="16sUi3" node="9NO9Tq8VKh" resolve="T" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="6h8gwE0yZPz" role="3cqZAp">
+          <node concept="2OqwBi" id="6h8gwE0z1$s" role="3clFbG">
+            <node concept="37vLTw" id="6h8gwE0z0Dz" role="2Oq$k0">
+              <ref role="3cqZAo" node="6h8gwE0z0Dv" resolve="cloned" />
+            </node>
+            <node concept="X8dFx" id="6h8gwE0z1Yi" role="2OqNvi">
+              <node concept="37vLTw" id="6h8gwE0z2LU" role="25WWJ7">
+                <ref role="3cqZAo" node="6h8gwE0yFtS" resolve="original" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="6h8gwE0z3YI" role="3cqZAp">
+          <node concept="37vLTw" id="6h8gwE0zaur" role="3cqZAk">
+            <ref role="3cqZAo" node="6h8gwE0z0Dv" resolve="cloned" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="6h8gwE0yFtS" role="3clF46">
+        <property role="TrG5h" value="original" />
+        <node concept="2hMVRd" id="6h8gwE0yFtQ" role="1tU5fm">
+          <node concept="16syzq" id="6h8gwE0yZae" role="2hN53Y">
+            <ref role="16sUi3" node="9NO9Tq8VKh" resolve="T" />
+          </node>
+        </node>
+      </node>
+      <node concept="2hMVRd" id="6h8gwE0y_f3" role="3clF45">
+        <node concept="16syzq" id="6h8gwE0y_lE" role="2hN53Y">
+          <ref role="16sUi3" node="9NO9Tq8VKh" resolve="T" />
+        </node>
+      </node>
+      <node concept="3Tm6S6" id="6h8gwE0yvbz" role="1B3o_S" />
     </node>
   </node>
   <node concept="312cEu" id="59VTJR_XXJb">

--- a/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.common/models/com/mbeddr/mpsutil/common/graphTest@tests.mps
+++ b/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.common/models/com/mbeddr/mpsutil/common/graphTest@tests.mps
@@ -156,6 +156,9 @@
         <child id="1144231399730" name="condition" index="1Dwp0S" />
         <child id="1144231408325" name="iteration" index="1Dwrff" />
       </concept>
+      <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="nn" index="3SKdUt">
+        <child id="8356039341262087992" name="line" index="1aUNEU" />
+      </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
       <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
     </language>
@@ -182,6 +185,14 @@
       </concept>
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+    <language id="c7fb639f-be78-4307-89b0-b5959c3fa8c8" name="jetbrains.mps.lang.text">
+      <concept id="155656958578482948" name="jetbrains.mps.lang.text.structure.Word" flags="ng" index="3oM_SD">
+        <property id="155656958578482949" name="value" index="3oM_SC" />
+      </concept>
+      <concept id="2535923850359271782" name="jetbrains.mps.lang.text.structure.Line" flags="ng" index="1PaTwC">
+        <child id="2535923850359271783" name="elements" index="1PaTwD" />
       </concept>
     </language>
     <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
@@ -5855,6 +5866,438 @@
               <ref role="37wK5l" to="gtp9:9NO9Tq8VOy" resolve="getTargets" />
               <node concept="3cmrfG" id="7P61H4bLC2y" role="37wK5m">
                 <property role="3cmrfH" value="5" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="6h8gwE0uWa0" role="1SL9yI">
+      <property role="TrG5h" value="copyGraphAndChangeCopy" />
+      <node concept="3cqZAl" id="6h8gwE0uWa1" role="3clF45" />
+      <node concept="3clFbS" id="6h8gwE0uWa5" role="3clF47">
+        <node concept="3cpWs8" id="6h8gwE0uWEE" role="3cqZAp">
+          <node concept="3cpWsn" id="6h8gwE0uWEF" role="3cpWs9">
+            <property role="TrG5h" value="nodes" />
+            <node concept="10Q1$e" id="6h8gwE0uWEG" role="1tU5fm">
+              <node concept="3uibUv" id="6h8gwE0uWEH" role="10Q1$1">
+                <ref role="3uigEE" to="wyt6:~Integer" resolve="Integer" />
+              </node>
+            </node>
+            <node concept="2BsdOp" id="6h8gwE0uWEI" role="33vP2m">
+              <node concept="3cmrfG" id="6h8gwE0uWEK" role="2BsfMF">
+                <property role="3cmrfH" value="1" />
+              </node>
+              <node concept="3cmrfG" id="6h8gwE0uWUh" role="2BsfMF">
+                <property role="3cmrfH" value="2" />
+              </node>
+              <node concept="3cmrfG" id="6h8gwE0uX1k" role="2BsfMF">
+                <property role="3cmrfH" value="3" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="6h8gwE0uWEM" role="3cqZAp">
+          <node concept="3cpWsn" id="6h8gwE0uWEN" role="3cpWs9">
+            <property role="TrG5h" value="edges" />
+            <node concept="10Q1$e" id="6h8gwE0uWEO" role="1tU5fm">
+              <node concept="10Q1$e" id="6h8gwE0uWEP" role="10Q1$1">
+                <node concept="3uibUv" id="6h8gwE0uWEQ" role="10Q1$1">
+                  <ref role="3uigEE" to="wyt6:~Integer" resolve="Integer" />
+                </node>
+              </node>
+            </node>
+            <node concept="2BsdOp" id="6h8gwE0uWER" role="33vP2m">
+              <node concept="2BsdOp" id="6h8gwE0uWES" role="2BsfMF">
+                <node concept="3cmrfG" id="6h8gwE0uXcj" role="2BsfMF">
+                  <property role="3cmrfH" value="1" />
+                </node>
+                <node concept="3cmrfG" id="6h8gwE0uXqx" role="2BsfMF">
+                  <property role="3cmrfH" value="2" />
+                </node>
+              </node>
+              <node concept="2BsdOp" id="6h8gwE0uWEV" role="2BsfMF">
+                <node concept="3cmrfG" id="6h8gwE0uWEW" role="2BsfMF">
+                  <property role="3cmrfH" value="2" />
+                </node>
+                <node concept="3cmrfG" id="6h8gwE0uWEX" role="2BsfMF">
+                  <property role="3cmrfH" value="3" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="6h8gwE0uWEY" role="3cqZAp">
+          <node concept="3cpWsn" id="6h8gwE0uWEZ" role="3cpWs9">
+            <property role="TrG5h" value="testGraph" />
+            <node concept="3uibUv" id="6h8gwE0uWF0" role="1tU5fm">
+              <ref role="3uigEE" to="gtp9:9NO9Tq8VKe" resolve="Graph" />
+              <node concept="3uibUv" id="6h8gwE0uWF1" role="11_B2D">
+                <ref role="3uigEE" to="wyt6:~Integer" resolve="Integer" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="6h8gwE0uWF2" role="33vP2m">
+              <node concept="2WthIp" id="6h8gwE0uWF3" role="2Oq$k0" />
+              <node concept="2XshWL" id="6h8gwE0uWF4" role="2OqNvi">
+                <ref role="2WH_rO" node="7P61H4bGMG7" resolve="createGraph" />
+                <node concept="37vLTw" id="6h8gwE0uWF5" role="2XxRq1">
+                  <ref role="3cqZAo" node="6h8gwE0uWEF" resolve="nodes" />
+                </node>
+                <node concept="37vLTw" id="6h8gwE0uWF6" role="2XxRq1">
+                  <ref role="3cqZAo" node="6h8gwE0uWEN" resolve="edges" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="6h8gwE0zIgi" role="3cqZAp" />
+        <node concept="3SKdUt" id="6h8gwE0zIz5" role="3cqZAp">
+          <node concept="1PaTwC" id="6h8gwE0zIz6" role="1aUNEU">
+            <node concept="3oM_SD" id="6h8gwE0zIDI" role="1PaTwD">
+              <property role="3oM_SC" value="the" />
+            </node>
+            <node concept="3oM_SD" id="6h8gwE0zIDS" role="1PaTwD">
+              <property role="3oM_SC" value="original" />
+            </node>
+            <node concept="3oM_SD" id="6h8gwE0zIE3" role="1PaTwD">
+              <property role="3oM_SC" value="graph" />
+            </node>
+            <node concept="3oM_SD" id="6h8gwE0zIEf" role="1PaTwD">
+              <property role="3oM_SC" value="should" />
+            </node>
+            <node concept="3oM_SD" id="6h8gwE0zIE$" role="1PaTwD">
+              <property role="3oM_SC" value="not" />
+            </node>
+            <node concept="3oM_SD" id="6h8gwE0zIEU" role="1PaTwD">
+              <property role="3oM_SC" value="be" />
+            </node>
+            <node concept="3oM_SD" id="6h8gwE0zIFM" role="1PaTwD">
+              <property role="3oM_SC" value="changed" />
+            </node>
+            <node concept="3oM_SD" id="6h8gwE0zIFU" role="1PaTwD">
+              <property role="3oM_SC" value="when" />
+            </node>
+            <node concept="3oM_SD" id="6h8gwE0zIGb" role="1PaTwD">
+              <property role="3oM_SC" value="changing" />
+            </node>
+            <node concept="3oM_SD" id="6h8gwE0zIG_" role="1PaTwD">
+              <property role="3oM_SC" value="the" />
+            </node>
+            <node concept="3oM_SD" id="6h8gwE0zIGS" role="1PaTwD">
+              <property role="3oM_SC" value="copy" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="6h8gwE0uXYG" role="3cqZAp">
+          <node concept="3cpWsn" id="6h8gwE0uXYH" role="3cpWs9">
+            <property role="TrG5h" value="copiedGraph" />
+            <node concept="3uibUv" id="6h8gwE0uXVn" role="1tU5fm">
+              <ref role="3uigEE" to="gtp9:9NO9Tq8VKe" resolve="Graph" />
+              <node concept="3uibUv" id="6h8gwE0uXVq" role="11_B2D">
+                <ref role="3uigEE" to="wyt6:~Integer" resolve="Integer" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="6h8gwE0uXYI" role="33vP2m">
+              <node concept="37vLTw" id="6h8gwE0uXYJ" role="2Oq$k0">
+                <ref role="3cqZAo" node="6h8gwE0uWEZ" resolve="testGraph" />
+              </node>
+              <node concept="liA8E" id="6h8gwE0uXYK" role="2OqNvi">
+                <ref role="37wK5l" to="gtp9:4D_91tBLK$j" resolve="copy" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="6h8gwE0x3Lw" role="3cqZAp">
+          <node concept="2OqwBi" id="6h8gwE0x3Lx" role="3clFbG">
+            <node concept="37vLTw" id="6h8gwE0x3Ly" role="2Oq$k0">
+              <ref role="3cqZAo" node="6h8gwE0uXYH" resolve="copiedGraph" />
+            </node>
+            <node concept="liA8E" id="6h8gwE0x3Lz" role="2OqNvi">
+              <ref role="37wK5l" to="gtp9:9NO9Tq8VN$" resolve="removeEdge" />
+              <node concept="3cmrfG" id="6h8gwE0x40k" role="37wK5m">
+                <property role="3cmrfH" value="1" />
+              </node>
+              <node concept="3cmrfG" id="6h8gwE0x41_" role="37wK5m">
+                <property role="3cmrfH" value="2" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="6h8gwE0wZKZ" role="3cqZAp">
+          <node concept="2OqwBi" id="6h8gwE0wZUz" role="3clFbG">
+            <node concept="37vLTw" id="6h8gwE0wZKX" role="2Oq$k0">
+              <ref role="3cqZAo" node="6h8gwE0uXYH" resolve="copiedGraph" />
+            </node>
+            <node concept="liA8E" id="6h8gwE0x02$" role="2OqNvi">
+              <ref role="37wK5l" to="gtp9:9NO9Tq8VN$" resolve="removeEdge" />
+              <node concept="3cmrfG" id="6h8gwE0x04k" role="37wK5m">
+                <property role="3cmrfH" value="2" />
+              </node>
+              <node concept="3cmrfG" id="6h8gwE0x0am" role="37wK5m">
+                <property role="3cmrfH" value="3" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="6h8gwE0zImC" role="3cqZAp" />
+        <node concept="3vlDli" id="6h8gwE0x3on" role="3cqZAp">
+          <node concept="2OqwBi" id="6h8gwE0x3oo" role="3tpDZA">
+            <node concept="37vLTw" id="6h8gwE0x3op" role="2Oq$k0">
+              <ref role="3cqZAo" node="6h8gwE0uWEZ" resolve="testGraph" />
+            </node>
+            <node concept="liA8E" id="6h8gwE0x3oq" role="2OqNvi">
+              <ref role="37wK5l" to="gtp9:9NO9Tq8VOV" resolve="getSources" />
+              <node concept="3cmrfG" id="6h8gwE0x3or" role="37wK5m">
+                <property role="3cmrfH" value="2" />
+              </node>
+            </node>
+          </node>
+          <node concept="2ShNRf" id="6h8gwE0x3os" role="3tpDZB">
+            <node concept="2i4dXS" id="6h8gwE0x3ot" role="2ShVmc">
+              <node concept="3uibUv" id="6h8gwE0x3ou" role="HW$YZ">
+                <ref role="3uigEE" to="wyt6:~Integer" resolve="Integer" />
+              </node>
+              <node concept="3cmrfG" id="6h8gwE0x3CA" role="HW$Y0">
+                <property role="3cmrfH" value="1" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3vlDli" id="6h8gwE0uYib" role="3cqZAp">
+          <node concept="2OqwBi" id="6h8gwE0v0wW" role="3tpDZA">
+            <node concept="37vLTw" id="6h8gwE0uYkz" role="2Oq$k0">
+              <ref role="3cqZAo" node="6h8gwE0uWEZ" resolve="testGraph" />
+            </node>
+            <node concept="liA8E" id="6h8gwE0vf9v" role="2OqNvi">
+              <ref role="37wK5l" to="gtp9:9NO9Tq8VOy" resolve="getTargets" />
+              <node concept="3cmrfG" id="6h8gwE0vfeL" role="37wK5m">
+                <property role="3cmrfH" value="2" />
+              </node>
+            </node>
+          </node>
+          <node concept="2ShNRf" id="6h8gwE0wWdh" role="3tpDZB">
+            <node concept="2i4dXS" id="6h8gwE0wWdi" role="2ShVmc">
+              <node concept="3uibUv" id="6h8gwE0wWdj" role="HW$YZ">
+                <ref role="3uigEE" to="wyt6:~Integer" resolve="Integer" />
+              </node>
+              <node concept="3cmrfG" id="6h8gwE0wW$b" role="HW$Y0">
+                <property role="3cmrfH" value="3" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="6h8gwE0zJnI" role="1SL9yI">
+      <property role="TrG5h" value="copyGraphAndChangeOriginal" />
+      <node concept="3cqZAl" id="6h8gwE0zJnJ" role="3clF45" />
+      <node concept="3clFbS" id="6h8gwE0zJnK" role="3clF47">
+        <node concept="3cpWs8" id="6h8gwE0zJnL" role="3cqZAp">
+          <node concept="3cpWsn" id="6h8gwE0zJnM" role="3cpWs9">
+            <property role="TrG5h" value="nodes" />
+            <node concept="10Q1$e" id="6h8gwE0zJnN" role="1tU5fm">
+              <node concept="3uibUv" id="6h8gwE0zJnO" role="10Q1$1">
+                <ref role="3uigEE" to="wyt6:~Integer" resolve="Integer" />
+              </node>
+            </node>
+            <node concept="2BsdOp" id="6h8gwE0zJnP" role="33vP2m">
+              <node concept="3cmrfG" id="6h8gwE0zJnQ" role="2BsfMF">
+                <property role="3cmrfH" value="1" />
+              </node>
+              <node concept="3cmrfG" id="6h8gwE0zJnR" role="2BsfMF">
+                <property role="3cmrfH" value="2" />
+              </node>
+              <node concept="3cmrfG" id="6h8gwE0zJnS" role="2BsfMF">
+                <property role="3cmrfH" value="3" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="6h8gwE0zJnT" role="3cqZAp">
+          <node concept="3cpWsn" id="6h8gwE0zJnU" role="3cpWs9">
+            <property role="TrG5h" value="edges" />
+            <node concept="10Q1$e" id="6h8gwE0zJnV" role="1tU5fm">
+              <node concept="10Q1$e" id="6h8gwE0zJnW" role="10Q1$1">
+                <node concept="3uibUv" id="6h8gwE0zJnX" role="10Q1$1">
+                  <ref role="3uigEE" to="wyt6:~Integer" resolve="Integer" />
+                </node>
+              </node>
+            </node>
+            <node concept="2BsdOp" id="6h8gwE0zJnY" role="33vP2m">
+              <node concept="2BsdOp" id="6h8gwE0zJnZ" role="2BsfMF">
+                <node concept="3cmrfG" id="6h8gwE0zJo0" role="2BsfMF">
+                  <property role="3cmrfH" value="1" />
+                </node>
+                <node concept="3cmrfG" id="6h8gwE0zJo1" role="2BsfMF">
+                  <property role="3cmrfH" value="2" />
+                </node>
+              </node>
+              <node concept="2BsdOp" id="6h8gwE0zJo2" role="2BsfMF">
+                <node concept="3cmrfG" id="6h8gwE0zJo3" role="2BsfMF">
+                  <property role="3cmrfH" value="2" />
+                </node>
+                <node concept="3cmrfG" id="6h8gwE0zJo4" role="2BsfMF">
+                  <property role="3cmrfH" value="3" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="6h8gwE0zJo5" role="3cqZAp">
+          <node concept="3cpWsn" id="6h8gwE0zJo6" role="3cpWs9">
+            <property role="TrG5h" value="testGraph" />
+            <node concept="3uibUv" id="6h8gwE0zJo7" role="1tU5fm">
+              <ref role="3uigEE" to="gtp9:9NO9Tq8VKe" resolve="Graph" />
+              <node concept="3uibUv" id="6h8gwE0zJo8" role="11_B2D">
+                <ref role="3uigEE" to="wyt6:~Integer" resolve="Integer" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="6h8gwE0zJo9" role="33vP2m">
+              <node concept="2WthIp" id="6h8gwE0zJoa" role="2Oq$k0" />
+              <node concept="2XshWL" id="6h8gwE0zJob" role="2OqNvi">
+                <ref role="2WH_rO" node="7P61H4bGMG7" resolve="createGraph" />
+                <node concept="37vLTw" id="6h8gwE0zJoc" role="2XxRq1">
+                  <ref role="3cqZAo" node="6h8gwE0zJnM" resolve="nodes" />
+                </node>
+                <node concept="37vLTw" id="6h8gwE0zJod" role="2XxRq1">
+                  <ref role="3cqZAo" node="6h8gwE0zJnU" resolve="edges" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="6h8gwE0zJoe" role="3cqZAp" />
+        <node concept="3SKdUt" id="6h8gwE0zJof" role="3cqZAp">
+          <node concept="1PaTwC" id="6h8gwE0zJog" role="1aUNEU">
+            <node concept="3oM_SD" id="6h8gwE0zJoh" role="1PaTwD">
+              <property role="3oM_SC" value="the" />
+            </node>
+            <node concept="3oM_SD" id="6h8gwE0zJoi" role="1PaTwD">
+              <property role="3oM_SC" value="copied" />
+            </node>
+            <node concept="3oM_SD" id="6h8gwE0zJoj" role="1PaTwD">
+              <property role="3oM_SC" value="graph" />
+            </node>
+            <node concept="3oM_SD" id="6h8gwE0zJok" role="1PaTwD">
+              <property role="3oM_SC" value="should" />
+            </node>
+            <node concept="3oM_SD" id="6h8gwE0zJol" role="1PaTwD">
+              <property role="3oM_SC" value="not" />
+            </node>
+            <node concept="3oM_SD" id="6h8gwE0zJom" role="1PaTwD">
+              <property role="3oM_SC" value="be" />
+            </node>
+            <node concept="3oM_SD" id="6h8gwE0zJon" role="1PaTwD">
+              <property role="3oM_SC" value="changed" />
+            </node>
+            <node concept="3oM_SD" id="6h8gwE0zJoo" role="1PaTwD">
+              <property role="3oM_SC" value="when" />
+            </node>
+            <node concept="3oM_SD" id="6h8gwE0zJop" role="1PaTwD">
+              <property role="3oM_SC" value="changing" />
+            </node>
+            <node concept="3oM_SD" id="6h8gwE0zJoq" role="1PaTwD">
+              <property role="3oM_SC" value="the" />
+            </node>
+            <node concept="3oM_SD" id="6h8gwE0zJor" role="1PaTwD">
+              <property role="3oM_SC" value="orinal" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="6h8gwE0zJos" role="3cqZAp">
+          <node concept="3cpWsn" id="6h8gwE0zJot" role="3cpWs9">
+            <property role="TrG5h" value="copiedGraph" />
+            <node concept="3uibUv" id="6h8gwE0zJou" role="1tU5fm">
+              <ref role="3uigEE" to="gtp9:9NO9Tq8VKe" resolve="Graph" />
+              <node concept="3uibUv" id="6h8gwE0zJov" role="11_B2D">
+                <ref role="3uigEE" to="wyt6:~Integer" resolve="Integer" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="6h8gwE0zJow" role="33vP2m">
+              <node concept="37vLTw" id="6h8gwE0zJox" role="2Oq$k0">
+                <ref role="3cqZAo" node="6h8gwE0zJo6" resolve="testGraph" />
+              </node>
+              <node concept="liA8E" id="6h8gwE0zJoy" role="2OqNvi">
+                <ref role="37wK5l" to="gtp9:4D_91tBLK$j" resolve="copy" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="6h8gwE0zJoz" role="3cqZAp">
+          <node concept="2OqwBi" id="6h8gwE0zJo$" role="3clFbG">
+            <node concept="37vLTw" id="6h8gwE0zL0k" role="2Oq$k0">
+              <ref role="3cqZAo" node="6h8gwE0zJo6" resolve="testGraph" />
+            </node>
+            <node concept="liA8E" id="6h8gwE0zJoA" role="2OqNvi">
+              <ref role="37wK5l" to="gtp9:9NO9Tq8VN$" resolve="removeEdge" />
+              <node concept="3cmrfG" id="6h8gwE0zJoB" role="37wK5m">
+                <property role="3cmrfH" value="1" />
+              </node>
+              <node concept="3cmrfG" id="6h8gwE0zJoC" role="37wK5m">
+                <property role="3cmrfH" value="2" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="6h8gwE0zJoD" role="3cqZAp">
+          <node concept="2OqwBi" id="6h8gwE0zJoE" role="3clFbG">
+            <node concept="37vLTw" id="6h8gwE0zL5Z" role="2Oq$k0">
+              <ref role="3cqZAo" node="6h8gwE0zJo6" resolve="testGraph" />
+            </node>
+            <node concept="liA8E" id="6h8gwE0zJoG" role="2OqNvi">
+              <ref role="37wK5l" to="gtp9:9NO9Tq8VN$" resolve="removeEdge" />
+              <node concept="3cmrfG" id="6h8gwE0zJoH" role="37wK5m">
+                <property role="3cmrfH" value="2" />
+              </node>
+              <node concept="3cmrfG" id="6h8gwE0zJoI" role="37wK5m">
+                <property role="3cmrfH" value="3" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="6h8gwE0zJoJ" role="3cqZAp" />
+        <node concept="3vlDli" id="6h8gwE0zJoK" role="3cqZAp">
+          <node concept="2OqwBi" id="6h8gwE0zJoL" role="3tpDZA">
+            <node concept="liA8E" id="6h8gwE0zJoN" role="2OqNvi">
+              <ref role="37wK5l" to="gtp9:9NO9Tq8VOV" resolve="getSources" />
+              <node concept="3cmrfG" id="6h8gwE0zJoO" role="37wK5m">
+                <property role="3cmrfH" value="2" />
+              </node>
+            </node>
+            <node concept="37vLTw" id="6h8gwE0zLbY" role="2Oq$k0">
+              <ref role="3cqZAo" node="6h8gwE0zJot" resolve="copiedGraph" />
+            </node>
+          </node>
+          <node concept="2ShNRf" id="6h8gwE0zJoP" role="3tpDZB">
+            <node concept="2i4dXS" id="6h8gwE0zJoQ" role="2ShVmc">
+              <node concept="3uibUv" id="6h8gwE0zJoR" role="HW$YZ">
+                <ref role="3uigEE" to="wyt6:~Integer" resolve="Integer" />
+              </node>
+              <node concept="3cmrfG" id="6h8gwE0zJoS" role="HW$Y0">
+                <property role="3cmrfH" value="1" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3vlDli" id="6h8gwE0zJoT" role="3cqZAp">
+          <node concept="2OqwBi" id="6h8gwE0zJoU" role="3tpDZA">
+            <node concept="37vLTw" id="6h8gwE0zLeg" role="2Oq$k0">
+              <ref role="3cqZAo" node="6h8gwE0zJot" resolve="copiedGraph" />
+            </node>
+            <node concept="liA8E" id="6h8gwE0zJoW" role="2OqNvi">
+              <ref role="37wK5l" to="gtp9:9NO9Tq8VOy" resolve="getTargets" />
+              <node concept="3cmrfG" id="6h8gwE0zJoX" role="37wK5m">
+                <property role="3cmrfH" value="2" />
+              </node>
+            </node>
+          </node>
+          <node concept="2ShNRf" id="6h8gwE0zJoY" role="3tpDZB">
+            <node concept="2i4dXS" id="6h8gwE0zJoZ" role="2ShVmc">
+              <node concept="3uibUv" id="6h8gwE0zJp0" role="HW$YZ">
+                <ref role="3uigEE" to="wyt6:~Integer" resolve="Integer" />
+              </node>
+              <node concept="3cmrfG" id="6h8gwE0zJp1" role="HW$Y0">
+                <property role="3cmrfH" value="3" />
               </node>
             </node>
           </node>


### PR DESCRIPTION
When copying a `Graph<T>` with its `copy()` method, the original and the copied graph were not independent. E.g., when removing an edge in one of the two graphs, the edge also vanished in the other one. Expected behavior: Each of the graphs (the original and the copy) can be changed independently.

This PR fixes this odd behavior and also contains two testcases.