### PR TITLE
Replaced instances of ModelReferenceExpression with ModelPointerExpre…

### DIFF
--- a/code/languages/com.mbeddr.analyses/languages/com.mbeddr.analyses.lantest/languageModels/behavior.mps
+++ b/code/languages/com.mbeddr.analyses/languages/com.mbeddr.analyses.lantest/languageModels/behavior.mps
@@ -91,7 +91,6 @@
       <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
         <reference id="1144433194310" name="classConcept" index="1Pybhc" />
       </concept>
-      <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
       <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
       <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
       <concept id="1068390468200" name="jetbrains.mps.baseLanguage.structure.FieldDeclaration" flags="ig" index="312cEg">
@@ -365,31 +364,15 @@
       <ref role="13i0hy" to="uu96:3Ts5Ln3NdMD" resolve="getModelWhereCheckingIsPerformed" />
       <node concept="3Tm1VV" id="x7DaR3OJQA" role="1B3o_S" />
       <node concept="3clFbS" id="x7DaR3OJQD" role="3clF47">
-        <node concept="3clFbF" id="3YjQI$iVwns" role="3cqZAp">
-          <node concept="2OqwBi" id="3YjQI$iK27E" role="3clFbG">
-            <node concept="2OqwBi" id="3YjQI$iK8NT" role="2Oq$k0">
-              <node concept="2YIFZM" id="3YjQI$iK8NU" role="2Oq$k0">
-                <ref role="37wK5l" to="dush:~PersistenceFacade.getInstance()" resolve="getInstance" />
-                <ref role="1Pybhc" to="dush:~PersistenceFacade" resolve="PersistenceFacade" />
+        <node concept="3clFbF" id="6M7zmThr7cJ" role="3cqZAp">
+          <node concept="2YIFZM" id="6M7zmThr7lx" role="3clFbG">
+            <ref role="37wK5l" to="9n5q:24J8fn3VMYI" resolve="getModel" />
+            <ref role="1Pybhc" to="9n5q:24J8fn3Vudv" resolve="MPSAccessFacade" />
+            <node concept="2OqwBi" id="6M7zmThr7yK" role="37wK5m">
+              <node concept="13iPFW" id="6M7zmThr7mG" role="2Oq$k0" />
+              <node concept="3TrEf2" id="6M7zmThr7Mk" role="2OqNvi">
+                <ref role="3Tt5mk" to="fowb:3Ts5Ln3NdYJ" resolve="tempModel" />
               </node>
-              <node concept="liA8E" id="3YjQI$iK8NV" role="2OqNvi">
-                <ref role="37wK5l" to="dush:~PersistenceFacade.createModelReference(java.lang.String)" resolve="createModelReference" />
-                <node concept="2OqwBi" id="3YjQI$iVzTG" role="37wK5m">
-                  <node concept="2OqwBi" id="3YjQI$iVzTH" role="2Oq$k0">
-                    <node concept="13iPFW" id="3YjQI$iVzTI" role="2Oq$k0" />
-                    <node concept="3TrEf2" id="3YjQI$iVzTJ" role="2OqNvi">
-                      <ref role="3Tt5mk" to="fowb:3Ts5Ln3NdYJ" resolve="tempModel" />
-                    </node>
-                  </node>
-                  <node concept="2qgKlT" id="3YjQI$iVzTK" role="2OqNvi">
-                    <ref role="37wK5l" to="tpeu:7K4mn_BeEzv" resolve="getFQName" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="liA8E" id="3YjQI$iK27G" role="2OqNvi">
-              <ref role="37wK5l" to="mhbf:~SModelReference.resolve(org.jetbrains.mps.openapi.module.SRepository)" resolve="resolve" />
-              <node concept="10Nm6u" id="3YjQI$iK27H" role="37wK5m" />
             </node>
           </node>
         </node>

--- a/code/languages/com.mbeddr.analyses/languages/com.mbeddr.analyses.lantest/languageModels/structure.mps
+++ b/code/languages/com.mbeddr.analyses/languages/com.mbeddr.analyses.lantest/languageModels/structure.mps
@@ -49,7 +49,7 @@
       <property role="20lmBu" value="fLJjDmT/aggregation" />
       <property role="20kJfa" value="tempModel" />
       <property role="20lbJX" value="fLJekj4/_1" />
-      <ref role="20lvS9" to="tp25:v3WHCwUiHy" resolve="ModelReferenceExpression" />
+      <ref role="20lvS9" to="tp25:1Bs_61$nfRn" resolve="ModelPointerExpression" />
     </node>
     <node concept="PrWs8" id="33cGTVo66E9" role="PzmwI">
       <ref role="PrY4T" to="gfdq:33cGTVo609o" resolve="ILanguageSpecificConfig" />

--- a/code/languages/com.mbeddr.analyses/solutions/com.mbeddr.lantest.testdata/models/com.mbeddr.lantest.testdata.res.mps
+++ b/code/languages/com.mbeddr.analyses/solutions/com.mbeddr.lantest.testdata/models/com.mbeddr.lantest.testdata.res.mps
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:354477a8-d237-4b8f-aa8c-949579d7305c(com.mbeddr.lantest.testdata.res)">
+  <persistence version="9" />
+  <languages />
+  <imports />
+  <registry />
+</model>
+

--- a/code/languages/com.mbeddr.analyses/solutions/com.mbeddr.lantest.testdata/models/com.mbeddr.lantest.testdata.temp.mps
+++ b/code/languages/com.mbeddr.analyses/solutions/com.mbeddr.lantest.testdata/models/com.mbeddr.lantest.testdata.temp.mps
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:43d5ba35-3aad-4961-b5e5-d15a20db12cd(com.mbeddr.lantest.testdata.temp)">
+  <persistence version="9" />
+  <languages />
+  <imports />
+  <registry />
+</model>
+

--- a/code/languages/com.mbeddr.analyses/solutions/com.mbeddr.lantest.testdata/models/com/mbeddr/lantest/testdata/harness.mps
+++ b/code/languages/com.mbeddr.analyses/solutions/com.mbeddr.lantest.testdata/models/com/mbeddr/lantest/testdata/harness.mps
@@ -65,6 +65,13 @@
         <property id="1863527487546097500" name="moduleId" index="1XweGW" />
         <property id="1863527487545993577" name="moduleName" index="1XxBO9" />
       </concept>
+      <concept id="361130699826193248" name="jetbrains.mps.lang.modelapi.structure.ModelPointer" flags="ng" index="1dCxOl">
+        <property id="1863527487546097494" name="modelId" index="1XweGQ" />
+        <child id="679099339649067980" name="name" index="1j$8Uc" />
+      </concept>
+      <concept id="679099339649053840" name="jetbrains.mps.lang.modelapi.structure.ModelName" flags="ng" index="1j_P7g">
+        <property id="679099339649053841" name="value" index="1j_P7h" />
+      </concept>
     </language>
     <language id="0316e52b-aaa9-47f4-9c0b-ca0d60cdc961" name="com.mbeddr.analyses.lantest">
       <concept id="5804819309059716628" name="com.mbeddr.analyses.lantest.structure.RandomImplementationModuleFromSolution" flags="ng" index="1lmYDW">
@@ -112,12 +119,11 @@
       <concept id="3262406899569270472" name="com.mbeddr.mpsutil.lantest.structure.RandomDescendantSeed" flags="ng" index="1$QBG2" />
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
-      <concept id="559557797393017698" name="jetbrains.mps.lang.smodel.structure.ModelReferenceExpression" flags="nn" index="BaHAS">
-        <property id="559557797393021807" name="stereotype" index="BaGAP" />
-        <property id="559557797393017702" name="name" index="BaHAW" />
-      </concept>
       <concept id="1678062499342629858" name="jetbrains.mps.lang.smodel.structure.ModuleRefExpression" flags="ng" index="37shsh">
         <child id="1678062499342629861" name="moduleId" index="37shsm" />
+      </concept>
+      <concept id="1863527487546129879" name="jetbrains.mps.lang.smodel.structure.ModelPointerExpression" flags="ng" index="1Xw6AR">
+        <child id="1863527487546132519" name="modelRef" index="1XwpL7" />
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
@@ -183,20 +189,16 @@
         <property role="dT9ia" value="com.mbeddr.core.statements" />
       </node>
     </node>
-    <node concept="BaHAS" id="6fGXG$6dmgV" role="1saM0L">
-      <property role="BaHAW" value="com.mbeddr.lantest.testdata.res" />
-      <property role="BaGAP" value="" />
-    </node>
     <node concept="1emTa" id="6fGXG$6dmjf" role="1emjp" />
     <node concept="3CPef5" id="x7DaR3P_QJ" role="3CPbyU">
-      <node concept="BaHAS" id="x7DaR3PAzD" role="3X$cyU">
-        <property role="BaHAW" value="com.mbeddr.lantest.testdata.res" />
-        <property role="BaGAP" value="" />
+      <node concept="1Xw6AR" id="6M7zmThrcIL" role="3X$cyU">
+        <node concept="1dCxOl" id="6M7zmThrcIT" role="1XwpL7">
+          <property role="1XweGQ" value="r:354477a8-d237-4b8f-aa8c-949579d7305c" />
+          <node concept="1j_P7g" id="6M7zmThrcIU" role="1j$8Uc">
+            <property role="1j_P7h" value="com.mbeddr.lantest.testdata.res" />
+          </node>
+        </node>
       </node>
-    </node>
-    <node concept="BaHAS" id="6fGXG$6dmgZ" role="1llUH_">
-      <property role="BaHAW" value="com.mbeddr.lantest.testdata.temp" />
-      <property role="BaGAP" value="" />
     </node>
     <node concept="1$QBG2" id="3cUcim$dilZ" role="1$QBHO" />
     <node concept="1lmYDW" id="33$Pd7DWKI8" role="fhwmk">
@@ -207,9 +209,29 @@
         </node>
       </node>
     </node>
-    <node concept="BaHAS" id="7VeUlv6SshD" role="1zXyiG">
-      <property role="BaHAW" value="com.mbeddr.lantest.testdata._language_testing_paper" />
-      <property role="BaGAP" value="" />
+    <node concept="1Xw6AR" id="6M7zmThr6VC" role="1zXyiG">
+      <node concept="1dCxOl" id="6M7zmThr6VK" role="1XwpL7">
+        <property role="1XweGQ" value="r:ab0e2d92-9ddf-43a1-b7c3-c84e6d55ea00" />
+        <node concept="1j_P7g" id="6M7zmThr6VL" role="1j$8Uc">
+          <property role="1j_P7h" value="com.mbeddr.lantest.testdata._language_testing_paper" />
+        </node>
+      </node>
+    </node>
+    <node concept="1Xw6AR" id="6M7zmThr6XB" role="1saM0L">
+      <node concept="1dCxOl" id="6M7zmThr6XG" role="1XwpL7">
+        <property role="1XweGQ" value="r:354477a8-d237-4b8f-aa8c-949579d7305c" />
+        <node concept="1j_P7g" id="6M7zmThr6XH" role="1j$8Uc">
+          <property role="1j_P7h" value="com.mbeddr.lantest.testdata.res" />
+        </node>
+      </node>
+    </node>
+    <node concept="1Xw6AR" id="6M7zmThr6XN" role="1llUH_">
+      <node concept="1dCxOl" id="6M7zmThr6XV" role="1XwpL7">
+        <property role="1XweGQ" value="r:43d5ba35-3aad-4961-b5e5-d15a20db12cd" />
+        <node concept="1j_P7g" id="6M7zmThr6XW" role="1j$8Uc">
+          <property role="1j_P7h" value="com.mbeddr.lantest.testdata.temp" />
+        </node>
+      </node>
     </node>
   </node>
 </model>

--- a/code/languages/com.mbeddr.analyses/tests/test.analyses.acsl/models/test/analyses/acsl/acsl_to_asserts@tests.mps
+++ b/code/languages/com.mbeddr.analyses/tests/test.analyses.acsl/models/test/analyses/acsl/acsl_to_asserts@tests.mps
@@ -82,6 +82,15 @@
     <language id="63e0e566-5131-447e-90e3-12ea330e1a00" name="com.mbeddr.mpsutil.blutil">
       <concept id="6451706574537082687" name="com.mbeddr.mpsutil.blutil.structure.ShortStaticMethodCall" flags="ng" index="NRdvd" />
     </language>
+    <language id="446c26eb-2b7b-4bf0-9b35-f83fa582753e" name="jetbrains.mps.lang.modelapi">
+      <concept id="361130699826193248" name="jetbrains.mps.lang.modelapi.structure.ModelPointer" flags="ng" index="1dCxOl">
+        <property id="1863527487546097494" name="modelId" index="1XweGQ" />
+        <child id="679099339649067980" name="name" index="1j$8Uc" />
+      </concept>
+      <concept id="679099339649053840" name="jetbrains.mps.lang.modelapi.structure.ModelName" flags="ng" index="1j_P7g">
+        <property id="679099339649053841" name="value" index="1j_P7h" />
+      </concept>
+    </language>
     <language id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest">
       <concept id="8427750732757990717" name="jetbrains.mps.baseLanguage.unitTest.structure.BinaryAssert" flags="nn" index="3tpDYu">
         <child id="8427750732757990725" name="actual" index="3tpDZA" />
@@ -93,11 +102,14 @@
       </concept>
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
-      <concept id="559557797393017698" name="jetbrains.mps.lang.smodel.structure.ModelReferenceExpression" flags="nn" index="BaHAS">
-        <property id="559557797393021807" name="stereotype" index="BaGAP" />
-        <property id="559557797393017702" name="name" index="BaHAW" />
+      <concept id="4065387505485742666" name="jetbrains.mps.lang.smodel.structure.ModelPointer_ResolveOperation" flags="ng" index="2yCiCJ" />
+      <concept id="4065387505485742749" name="jetbrains.mps.lang.smodel.structure.AbstractPointerResolveOperation" flags="ng" index="2yCiFS">
+        <child id="3648723375513868575" name="repositoryArg" index="Vysub" />
       </concept>
       <concept id="1143226024141" name="jetbrains.mps.lang.smodel.structure.SModelType" flags="in" index="H_c77" />
+      <concept id="1863527487546129879" name="jetbrains.mps.lang.smodel.structure.ModelPointerExpression" flags="ng" index="1Xw6AR">
+        <child id="1863527487546132519" name="modelRef" index="1XwpL7" />
+      </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
@@ -122,9 +134,23 @@
           <node concept="3cpWsn" id="5iBCJz7s$X9" role="3cpWs9">
             <property role="TrG5h" value="aModel" />
             <node concept="H_c77" id="5iBCJz7s$X7" role="1tU5fm" />
-            <node concept="BaHAS" id="5iBCJz7s$Xa" role="33vP2m">
-              <property role="BaHAW" value="acsl_to_asserts" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUhywgu" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUhyvTw" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUhyw2V" role="1XwpL7">
+                  <property role="1XweGQ" value="r:c84d8303-4671-43db-b027-bd3cf282fbcb" />
+                  <node concept="1j_P7g" id="xRVdUhyw2W" role="1j$8Uc">
+                    <property role="1j_P7h" value="acsl_to_asserts" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUhywxO" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUhyxxf" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUhywYk" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUhyyoh" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -280,9 +306,23 @@
           <node concept="3cpWsn" id="5iBCJz7sNCA" role="3cpWs9">
             <property role="TrG5h" value="aModel" />
             <node concept="H_c77" id="5iBCJz7sNC$" role="1tU5fm" />
-            <node concept="BaHAS" id="5iBCJz7sNCB" role="33vP2m">
-              <property role="BaHAW" value="acsl_to_asserts" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUhyzvH" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUhyz7l" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUhyzht" role="1XwpL7">
+                  <property role="1XweGQ" value="r:c84d8303-4671-43db-b027-bd3cf282fbcb" />
+                  <node concept="1j_P7g" id="xRVdUhyzhu" role="1j$8Uc">
+                    <property role="1j_P7h" value="acsl_to_asserts" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUhyzKq" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUhy$cI" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUhyzTl" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUhy$B2" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -481,9 +521,23 @@
           <node concept="3cpWsn" id="5iBCJz7sNZz" role="3cpWs9">
             <property role="TrG5h" value="aModel" />
             <node concept="H_c77" id="5iBCJz7sNZx" role="1tU5fm" />
-            <node concept="BaHAS" id="5iBCJz7sNZ$" role="33vP2m">
-              <property role="BaHAW" value="acsl_to_asserts" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUhy_XI" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUhy_pJ" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUhy_xz" role="1XwpL7">
+                  <property role="1XweGQ" value="r:c84d8303-4671-43db-b027-bd3cf282fbcb" />
+                  <node concept="1j_P7g" id="xRVdUhy_x$" role="1j$8Uc">
+                    <property role="1j_P7h" value="acsl_to_asserts" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUhyAc7" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUhyAxg" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUhyAiI" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUhyATg" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -606,9 +660,23 @@
           <node concept="3cpWsn" id="1fdMHEcc4wn" role="3cpWs9">
             <property role="TrG5h" value="aModel" />
             <node concept="H_c77" id="1fdMHEcc4wo" role="1tU5fm" />
-            <node concept="BaHAS" id="1fdMHEcc4wp" role="33vP2m">
-              <property role="BaHAW" value="acsl_to_asserts" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUhyBEz" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUhyBmN" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUhyBuB" role="1XwpL7">
+                  <property role="1XweGQ" value="r:c84d8303-4671-43db-b027-bd3cf282fbcb" />
+                  <node concept="1j_P7g" id="xRVdUhyBuC" role="1j$8Uc">
+                    <property role="1j_P7h" value="acsl_to_asserts" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUhyBSu" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUhyCga" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUhyBZ5" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUhyCSq" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>

--- a/code/languages/com.mbeddr.analyses/tests/test.analyses.acsl/models/test/analyses/acsl/function_contracts@tests.mps
+++ b/code/languages/com.mbeddr.analyses/tests/test.analyses.acsl/models/test/analyses/acsl/function_contracts@tests.mps
@@ -82,6 +82,15 @@
     <language id="63e0e566-5131-447e-90e3-12ea330e1a00" name="com.mbeddr.mpsutil.blutil">
       <concept id="6451706574537082687" name="com.mbeddr.mpsutil.blutil.structure.ShortStaticMethodCall" flags="ng" index="NRdvd" />
     </language>
+    <language id="446c26eb-2b7b-4bf0-9b35-f83fa582753e" name="jetbrains.mps.lang.modelapi">
+      <concept id="361130699826193248" name="jetbrains.mps.lang.modelapi.structure.ModelPointer" flags="ng" index="1dCxOl">
+        <property id="1863527487546097494" name="modelId" index="1XweGQ" />
+        <child id="679099339649067980" name="name" index="1j$8Uc" />
+      </concept>
+      <concept id="679099339649053840" name="jetbrains.mps.lang.modelapi.structure.ModelName" flags="ng" index="1j_P7g">
+        <property id="679099339649053841" name="value" index="1j_P7h" />
+      </concept>
+    </language>
     <language id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest">
       <concept id="8427750732757990717" name="jetbrains.mps.baseLanguage.unitTest.structure.BinaryAssert" flags="nn" index="3tpDYu">
         <child id="8427750732757990725" name="actual" index="3tpDZA" />
@@ -93,11 +102,14 @@
       </concept>
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
-      <concept id="559557797393017698" name="jetbrains.mps.lang.smodel.structure.ModelReferenceExpression" flags="nn" index="BaHAS">
-        <property id="559557797393021807" name="stereotype" index="BaGAP" />
-        <property id="559557797393017702" name="name" index="BaHAW" />
+      <concept id="4065387505485742666" name="jetbrains.mps.lang.smodel.structure.ModelPointer_ResolveOperation" flags="ng" index="2yCiCJ" />
+      <concept id="4065387505485742749" name="jetbrains.mps.lang.smodel.structure.AbstractPointerResolveOperation" flags="ng" index="2yCiFS">
+        <child id="3648723375513868575" name="repositoryArg" index="Vysub" />
       </concept>
       <concept id="1143226024141" name="jetbrains.mps.lang.smodel.structure.SModelType" flags="in" index="H_c77" />
+      <concept id="1863527487546129879" name="jetbrains.mps.lang.smodel.structure.ModelPointerExpression" flags="ng" index="1Xw6AR">
+        <child id="1863527487546132519" name="modelRef" index="1XwpL7" />
+      </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
@@ -139,9 +151,23 @@
                   <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
                 </node>
               </node>
-              <node concept="BaHAS" id="2$KQXNUNlQN" role="37wK5m">
-                <property role="BaHAW" value="acsl_to_cbmc" />
-                <property role="BaGAP" value="" />
+              <node concept="2OqwBi" id="xRVdUhyDUQ" role="37wK5m">
+                <node concept="1Xw6AR" id="xRVdUhyDjs" role="2Oq$k0">
+                  <node concept="1dCxOl" id="xRVdUhyDHp" role="1XwpL7">
+                    <property role="1XweGQ" value="r:6cfb001b-2a57-4844-ac51-090966d4235d" />
+                    <node concept="1j_P7g" id="xRVdUhyDHq" role="1j$8Uc">
+                      <property role="1j_P7h" value="acsl_to_cbmc" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2yCiCJ" id="xRVdUhyEb9" role="2OqNvi">
+                  <node concept="2OqwBi" id="xRVdUhyE_Y" role="Vysub">
+                    <node concept="1jxXqW" id="xRVdUhyEjl" role="2Oq$k0" />
+                    <node concept="liA8E" id="xRVdUhyEZy" role="2OqNvi">
+                      <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                    </node>
+                  </node>
+                </node>
               </node>
               <node concept="Xl_RD" id="2$KQXNUNlQO" role="37wK5m">
                 <property role="Xl_RC" value="behavior" />
@@ -289,9 +315,23 @@
                   <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
                 </node>
               </node>
-              <node concept="BaHAS" id="6WBmVK646SR" role="37wK5m">
-                <property role="BaHAW" value="acsl_to_cbmc" />
-                <property role="BaGAP" value="" />
+              <node concept="2OqwBi" id="xRVdUhyFGJ" role="37wK5m">
+                <node concept="1Xw6AR" id="xRVdUhyFs7" role="2Oq$k0">
+                  <node concept="1dCxOl" id="xRVdUhyFy$" role="1XwpL7">
+                    <property role="1XweGQ" value="r:6cfb001b-2a57-4844-ac51-090966d4235d" />
+                    <node concept="1j_P7g" id="xRVdUhyFy_" role="1j$8Uc">
+                      <property role="1j_P7h" value="acsl_to_cbmc" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2yCiCJ" id="xRVdUhyFTi" role="2OqNvi">
+                  <node concept="2OqwBi" id="xRVdUhyGlT" role="Vysub">
+                    <node concept="1jxXqW" id="xRVdUhyFYb" role="2Oq$k0" />
+                    <node concept="liA8E" id="xRVdUhyGGb" role="2OqNvi">
+                      <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                    </node>
+                  </node>
+                </node>
               </node>
               <node concept="Xl_RD" id="6WBmVK646SS" role="37wK5m">
                 <property role="Xl_RC" value="ensures" />
@@ -408,9 +448,23 @@
                   <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
                 </node>
               </node>
-              <node concept="BaHAS" id="29$2IGZgdJj" role="37wK5m">
-                <property role="BaHAW" value="acsl_to_cbmc" />
-                <property role="BaGAP" value="" />
+              <node concept="2OqwBi" id="xRVdUhyI6G" role="37wK5m">
+                <node concept="1Xw6AR" id="xRVdUhyHJ2" role="2Oq$k0">
+                  <node concept="1dCxOl" id="xRVdUhyHT0" role="1XwpL7">
+                    <property role="1XweGQ" value="r:6cfb001b-2a57-4844-ac51-090966d4235d" />
+                    <node concept="1j_P7g" id="xRVdUhyHT1" role="1j$8Uc">
+                      <property role="1j_P7h" value="acsl_to_cbmc" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2yCiCJ" id="xRVdUhyIne" role="2OqNvi">
+                  <node concept="2OqwBi" id="xRVdUhyIMx" role="Vysub">
+                    <node concept="1jxXqW" id="xRVdUhyIvD" role="2Oq$k0" />
+                    <node concept="liA8E" id="xRVdUhyJpm" role="2OqNvi">
+                      <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                    </node>
+                  </node>
+                </node>
               </node>
               <node concept="Xl_RD" id="29$2IGZgdJk" role="37wK5m">
                 <property role="Xl_RC" value="requires" />
@@ -554,9 +608,23 @@
           <node concept="3cpWsn" id="2UT$$fNlsgh" role="3cpWs9">
             <property role="TrG5h" value="aModel" />
             <node concept="H_c77" id="2UT$$fNlsgi" role="1tU5fm" />
-            <node concept="BaHAS" id="2UT$$fNlsgj" role="33vP2m">
-              <property role="BaHAW" value="acsl_to_cbmc" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUhyK7B" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUhyJR5" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUhyJXi" role="1XwpL7">
+                  <property role="1XweGQ" value="r:6cfb001b-2a57-4844-ac51-090966d4235d" />
+                  <node concept="1j_P7g" id="xRVdUhyJXj" role="1j$8Uc">
+                    <property role="1j_P7h" value="acsl_to_cbmc" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUhyKFn" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUhyKZP" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUhyKKn" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUhyLme" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -650,9 +718,23 @@
           <node concept="3cpWsn" id="1fdMHEcc4wn" role="3cpWs9">
             <property role="TrG5h" value="aModel" />
             <node concept="H_c77" id="1fdMHEcc4wo" role="1tU5fm" />
-            <node concept="BaHAS" id="1fdMHEcc4wp" role="33vP2m">
-              <property role="BaHAW" value="acsl_to_cbmc" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUhyM5U" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUhyLE3" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUhyLTY" role="1XwpL7">
+                  <property role="1XweGQ" value="r:6cfb001b-2a57-4844-ac51-090966d4235d" />
+                  <node concept="1j_P7g" id="xRVdUhyLTZ" role="1j$8Uc">
+                    <property role="1j_P7h" value="acsl_to_cbmc" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUhyMgh" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUhyMBX" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUhyMmS" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUhyN0x" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>

--- a/code/languages/com.mbeddr.analyses/tests/test.analyses.base/models/nodes_tracing_new.core@tests.mps
+++ b/code/languages/com.mbeddr.analyses/tests/test.analyses.base/models/nodes_tracing_new.core@tests.mps
@@ -6,6 +6,7 @@
     <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="1" />
     <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="11" />
     <use id="85e94e86-9fcb-43a2-9083-64c40006219e" name="com.mbeddr.mpsutil.nodes_tracing.test" version="0" />
+    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="17" />
   </languages>
   <imports />
   <registry>
@@ -35,10 +36,18 @@
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS" />
       <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
     </language>
+    <language id="446c26eb-2b7b-4bf0-9b35-f83fa582753e" name="jetbrains.mps.lang.modelapi">
+      <concept id="361130699826193248" name="jetbrains.mps.lang.modelapi.structure.ModelPointer" flags="ng" index="1dCxOl">
+        <property id="1863527487546097494" name="modelId" index="1XweGQ" />
+        <child id="679099339649067980" name="name" index="1j$8Uc" />
+      </concept>
+      <concept id="679099339649053840" name="jetbrains.mps.lang.modelapi.structure.ModelName" flags="ng" index="1j_P7g">
+        <property id="679099339649053841" name="value" index="1j_P7h" />
+      </concept>
+    </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
-      <concept id="559557797393017698" name="jetbrains.mps.lang.smodel.structure.ModelReferenceExpression" flags="nn" index="BaHAS">
-        <property id="559557797393021807" name="stereotype" index="BaGAP" />
-        <property id="559557797393017702" name="name" index="BaHAW" />
+      <concept id="1863527487546129879" name="jetbrains.mps.lang.smodel.structure.ModelPointerExpression" flags="ng" index="1Xw6AR">
+        <child id="1863527487546132519" name="modelRef" index="1XwpL7" />
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
@@ -63,16 +72,20 @@
       <property role="TrG5h" value="testPlainC" />
       <node concept="3cqZAl" id="7HmzdkqTFm5" role="3clF45" />
       <node concept="3clFbS" id="7HmzdkqTFm9" role="3clF47">
-        <node concept="1X3_iC" id="7Hmzdkr0BFa" role="lGtFl">
+        <node concept="1X3_iC" id="xRVdUh_vF$" role="lGtFl">
           <property role="3V$3am" value="statement" />
           <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
           <node concept="1xIcmD" id="7HmzdkqWBhx" role="8Wnug">
             <node concept="Xl_RD" id="7HmzdkqWBh_" role="1xDQ1B">
               <property role="Xl_RC" value="plainC" />
             </node>
-            <node concept="BaHAS" id="7HmzdkqWsMN" role="1xIeA0">
-              <property role="BaHAW" value="test.analyses.base.testcode.nodes_tracing_new.core" />
-              <property role="BaGAP" value="" />
+            <node concept="1Xw6AR" id="xRVdUh_vne" role="1xIeA0">
+              <node concept="1dCxOl" id="xRVdUh_vFj" role="1XwpL7">
+                <property role="1XweGQ" value="r:4fd66586-eb16-40a3-aeb5-ffbc7b0517a3" />
+                <node concept="1j_P7g" id="xRVdUh_vFk" role="1j$8Uc">
+                  <property role="1j_P7h" value="test.analyses.base.testcode.nodes_tracing_new.core" />
+                </node>
+              </node>
             </node>
           </node>
         </node>

--- a/code/languages/com.mbeddr.analyses/tests/test.analyses.base/models/test/analyses/base/nodes_tracing/basic@tests.mps
+++ b/code/languages/com.mbeddr.analyses/tests/test.analyses.base/models/test/analyses/base/nodes_tracing/basic@tests.mps
@@ -14,6 +14,7 @@
     <import index="d8ej" ref="r:fde4fd08-2694-4f15-a5e5-88fa2c92442c(com.mbeddr.analyses.utils.testing_utils)" />
     <import index="guwi" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.io(JDK/)" />
     <import index="btm1" ref="b0f8641f-bd77-4421-8425-30d9088a82f7/java:org.apache.commons.lang3(org.apache.commons/)" />
+    <import index="z1c3" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.project(MPS.Core/)" implicit="true" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
   </imports>
   <registry>
@@ -21,6 +22,7 @@
       <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
         <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
       </concept>
+      <concept id="1225467090849" name="jetbrains.mps.lang.test.structure.ProjectExpression" flags="nn" index="1jxXqW" />
       <concept id="1216913645126" name="jetbrains.mps.lang.test.structure.NodesTestCase" flags="lg" index="1lH9Xt">
         <child id="1217501895093" name="testMethods" index="1SL9yI" />
       </concept>
@@ -81,6 +83,15 @@
     <language id="63e0e566-5131-447e-90e3-12ea330e1a00" name="com.mbeddr.mpsutil.blutil">
       <concept id="6451706574537082687" name="com.mbeddr.mpsutil.blutil.structure.ShortStaticMethodCall" flags="ng" index="NRdvd" />
     </language>
+    <language id="446c26eb-2b7b-4bf0-9b35-f83fa582753e" name="jetbrains.mps.lang.modelapi">
+      <concept id="361130699826193248" name="jetbrains.mps.lang.modelapi.structure.ModelPointer" flags="ng" index="1dCxOl">
+        <property id="1863527487546097494" name="modelId" index="1XweGQ" />
+        <child id="679099339649067980" name="name" index="1j$8Uc" />
+      </concept>
+      <concept id="679099339649053840" name="jetbrains.mps.lang.modelapi.structure.ModelName" flags="ng" index="1j_P7g">
+        <property id="679099339649053841" name="value" index="1j_P7h" />
+      </concept>
+    </language>
     <language id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest">
       <concept id="8427750732757990717" name="jetbrains.mps.baseLanguage.unitTest.structure.BinaryAssert" flags="nn" index="3tpDYu">
         <child id="8427750732757990725" name="actual" index="3tpDZA" />
@@ -89,11 +100,14 @@
       <concept id="1171978097730" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertEquals" flags="nn" index="3vlDli" />
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
-      <concept id="559557797393017698" name="jetbrains.mps.lang.smodel.structure.ModelReferenceExpression" flags="nn" index="BaHAS">
-        <property id="559557797393021807" name="stereotype" index="BaGAP" />
-        <property id="559557797393017702" name="name" index="BaHAW" />
+      <concept id="4065387505485742666" name="jetbrains.mps.lang.smodel.structure.ModelPointer_ResolveOperation" flags="ng" index="2yCiCJ" />
+      <concept id="4065387505485742749" name="jetbrains.mps.lang.smodel.structure.AbstractPointerResolveOperation" flags="ng" index="2yCiFS">
+        <child id="3648723375513868575" name="repositoryArg" index="Vysub" />
       </concept>
       <concept id="1143226024141" name="jetbrains.mps.lang.smodel.structure.SModelType" flags="in" index="H_c77" />
+      <concept id="1863527487546129879" name="jetbrains.mps.lang.smodel.structure.ModelPointerExpression" flags="ng" index="1Xw6AR">
+        <child id="1863527487546132519" name="modelRef" index="1XwpL7" />
+      </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
@@ -135,9 +149,23 @@
           <node concept="3cpWsn" id="2ZKh15oiyox" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="2ZKh15oiyov" role="1tU5fm" />
-            <node concept="BaHAS" id="2ZKh15oiyoy" role="33vP2m">
-              <property role="BaHAW" value="test.analyses.cbmc.testcode.counterexample.mbeddr.core" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUhyTl1" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUhySJr" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUhyT2b" role="1XwpL7">
+                  <property role="1XweGQ" value="r:d20a8498-55ea-46f3-9220-542767b71661" />
+                  <node concept="1j_P7g" id="xRVdUhyT2c" role="1j$8Uc">
+                    <property role="1j_P7h" value="test.analyses.cbmc.testcode.counterexample.mbeddr.core" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUhyTEk" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUhyUpD" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUhyTVR" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUhyWfL" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -242,9 +270,23 @@
           <node concept="3cpWsn" id="2ZKh15oi_AC" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="2ZKh15oi_AD" role="1tU5fm" />
-            <node concept="BaHAS" id="2ZKh15oi_AE" role="33vP2m">
-              <property role="BaHAW" value="test.analyses.cbmc.testcode.counterexample.mbeddr.statemachines" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUhyYJ6" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUhyWMq" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUhyYnO" role="1XwpL7">
+                  <property role="1XweGQ" value="r:e2db5934-0aec-4dbd-8d13-2d3b7dc23298" />
+                  <node concept="1j_P7g" id="xRVdUhyYnP" role="1j$8Uc">
+                    <property role="1j_P7h" value="test.analyses.cbmc.testcode.counterexample.mbeddr.statemachines" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUhyZ3R" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUhyZKl" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUhyZkR" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUhz0iI" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -326,9 +368,23 @@
           <node concept="3cpWsn" id="2ZKh15oiAId" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="2ZKh15oiAIe" role="1tU5fm" />
-            <node concept="BaHAS" id="2ZKh15oiAIf" role="33vP2m">
-              <property role="BaHAW" value="test.analyses.cbmc.testcode.counterexample.mbeddr.components" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUhz2Lw" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUhz2d0" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUhz2vd" role="1XwpL7">
+                  <property role="1XweGQ" value="r:33c9d9c4-a88b-4fe7-95a6-63d05845ec6b" />
+                  <node concept="1j_P7g" id="xRVdUhz2ve" role="1j$8Uc">
+                    <property role="1j_P7h" value="test.analyses.cbmc.testcode.counterexample.mbeddr.components" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUhz4us" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUhz5aU" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUhz4Js" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUhz5Hj" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>

--- a/code/languages/com.mbeddr.analyses/tests/test.analyses.base/models/test/analyses/base/nodes_tracing/core@tests.mps
+++ b/code/languages/com.mbeddr.analyses/tests/test.analyses.base/models/test/analyses/base/nodes_tracing/core@tests.mps
@@ -10,15 +10,18 @@
   </languages>
   <imports>
     <import index="8fsg" ref="r:4c26acae-0f84-4664-bc8e-eb85ca6494bf(com.mbeddr.analyses.utils.nodes)" />
+    <import index="z1c3" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.project(MPS.Core/)" implicit="true" />
   </imports>
   <registry>
     <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
+      <concept id="1225467090849" name="jetbrains.mps.lang.test.structure.ProjectExpression" flags="nn" index="1jxXqW" />
       <concept id="1216913645126" name="jetbrains.mps.lang.test.structure.NodesTestCase" flags="lg" index="1lH9Xt">
         <child id="1217501895093" name="testMethods" index="1SL9yI" />
       </concept>
       <concept id="1225978065297" name="jetbrains.mps.lang.test.structure.SimpleNodeTest" flags="ng" index="1LZb2c" />
     </language>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
@@ -52,6 +55,15 @@
         <child id="8356039341262087992" name="line" index="1aUNEU" />
       </concept>
     </language>
+    <language id="446c26eb-2b7b-4bf0-9b35-f83fa582753e" name="jetbrains.mps.lang.modelapi">
+      <concept id="361130699826193248" name="jetbrains.mps.lang.modelapi.structure.ModelPointer" flags="ng" index="1dCxOl">
+        <property id="1863527487546097494" name="modelId" index="1XweGQ" />
+        <child id="679099339649067980" name="name" index="1j$8Uc" />
+      </concept>
+      <concept id="679099339649053840" name="jetbrains.mps.lang.modelapi.structure.ModelName" flags="ng" index="1j_P7g">
+        <property id="679099339649053841" name="value" index="1j_P7h" />
+      </concept>
+    </language>
     <language id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest">
       <concept id="8427750732757990717" name="jetbrains.mps.baseLanguage.unitTest.structure.BinaryAssert" flags="nn" index="3tpDYu">
         <child id="8427750732757990725" name="actual" index="3tpDZA" />
@@ -63,9 +75,12 @@
       </concept>
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
-      <concept id="559557797393017698" name="jetbrains.mps.lang.smodel.structure.ModelReferenceExpression" flags="nn" index="BaHAS">
-        <property id="559557797393021807" name="stereotype" index="BaGAP" />
-        <property id="559557797393017702" name="name" index="BaHAW" />
+      <concept id="4065387505485742666" name="jetbrains.mps.lang.smodel.structure.ModelPointer_ResolveOperation" flags="ng" index="2yCiCJ" />
+      <concept id="4065387505485742749" name="jetbrains.mps.lang.smodel.structure.AbstractPointerResolveOperation" flags="ng" index="2yCiFS">
+        <child id="3648723375513868575" name="repositoryArg" index="Vysub" />
+      </concept>
+      <concept id="1863527487546129879" name="jetbrains.mps.lang.smodel.structure.ModelPointerExpression" flags="ng" index="1Xw6AR">
+        <child id="1863527487546132519" name="modelRef" index="1XwpL7" />
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
@@ -108,9 +123,23 @@
           <node concept="2YIFZM" id="5Lx3sEEr0lr" role="3clFbG">
             <ref role="37wK5l" to="8fsg:2jwOBjYi0jK" resolve="setModelAndModule" />
             <ref role="1Pybhc" to="8fsg:2jwOBjYhZSX" resolve="NodesFindingUtilsForTests" />
-            <node concept="BaHAS" id="5Lx3sEEr0ls" role="37wK5m">
-              <property role="BaHAW" value="test.analyses.base.testcode.nodes_tracing.core" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUhz7Le" role="37wK5m">
+              <node concept="1Xw6AR" id="xRVdUhz7Hl" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUhz7Jh" role="1XwpL7">
+                  <property role="1XweGQ" value="r:47ab8e2b-57d7-419b-9d52-a12ca6d16eca" />
+                  <node concept="1j_P7g" id="xRVdUhz7Ji" role="1j$8Uc">
+                    <property role="1j_P7h" value="test.analyses.base.testcode.nodes_tracing.core" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUhz7Oi" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUhz84G" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUhz7Qm" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUhz8oi" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
             <node concept="Xl_RD" id="5Lx3sEEr0lt" role="37wK5m">
               <property role="Xl_RC" value="SimpleCode" />
@@ -210,9 +239,23 @@
           <node concept="2YIFZM" id="HxQJLPNlsN" role="3clFbG">
             <ref role="37wK5l" to="8fsg:2jwOBjYi0jK" resolve="setModelAndModule" />
             <ref role="1Pybhc" to="8fsg:2jwOBjYhZSX" resolve="NodesFindingUtilsForTests" />
-            <node concept="BaHAS" id="HxQJLPNlsO" role="37wK5m">
-              <property role="BaHAW" value="test.analyses.base.testcode.nodes_tracing.core" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUhz6dM" role="37wK5m">
+              <node concept="1Xw6AR" id="xRVdUhz68z" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUhz6av" role="1XwpL7">
+                  <property role="1XweGQ" value="r:47ab8e2b-57d7-419b-9d52-a12ca6d16eca" />
+                  <node concept="1j_P7g" id="xRVdUhz6aw" role="1j$8Uc">
+                    <property role="1j_P7h" value="test.analyses.base.testcode.nodes_tracing.core" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUhz6gQ" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUhz6xs" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUhz6iV" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUhz6P1" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
             <node concept="Xl_RD" id="HxQJLPNlsP" role="37wK5m">
               <property role="Xl_RC" value="DecTable" />
@@ -274,9 +317,23 @@
           <node concept="2YIFZM" id="2jwOBjYjHjv" role="3clFbG">
             <ref role="1Pybhc" to="8fsg:2jwOBjYhZSX" resolve="NodesFindingUtilsForTests" />
             <ref role="37wK5l" to="8fsg:2jwOBjYi0jK" resolve="setModelAndModule" />
-            <node concept="BaHAS" id="2jwOBjYjIIB" role="37wK5m">
-              <property role="BaHAW" value="test.analyses.base.testcode.nodes_tracing.core" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUhz6X9" role="37wK5m">
+              <node concept="1Xw6AR" id="xRVdUhz6Tg" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUhz6Vc" role="1XwpL7">
+                  <property role="1XweGQ" value="r:47ab8e2b-57d7-419b-9d52-a12ca6d16eca" />
+                  <node concept="1j_P7g" id="xRVdUhz6Vd" role="1j$8Uc">
+                    <property role="1j_P7h" value="test.analyses.base.testcode.nodes_tracing.core" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUhz71$" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUhz7ia" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUhz73D" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUhz7_J" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
             <node concept="Xl_RD" id="2jwOBjYjHBy" role="37wK5m">
               <property role="Xl_RC" value="DecTable" />

--- a/code/languages/com.mbeddr.analyses/tests/test.analyses.cbmc.testsgen/models/test/analyses/cbmc/testgen/smoke@tests.mps
+++ b/code/languages/com.mbeddr.analyses/tests/test.analyses.cbmc.testsgen/models/test/analyses/cbmc/testgen/smoke@tests.mps
@@ -86,6 +86,15 @@
     <language id="63e0e566-5131-447e-90e3-12ea330e1a00" name="com.mbeddr.mpsutil.blutil">
       <concept id="6451706574537082687" name="com.mbeddr.mpsutil.blutil.structure.ShortStaticMethodCall" flags="ng" index="NRdvd" />
     </language>
+    <language id="446c26eb-2b7b-4bf0-9b35-f83fa582753e" name="jetbrains.mps.lang.modelapi">
+      <concept id="361130699826193248" name="jetbrains.mps.lang.modelapi.structure.ModelPointer" flags="ng" index="1dCxOl">
+        <property id="1863527487546097494" name="modelId" index="1XweGQ" />
+        <child id="679099339649067980" name="name" index="1j$8Uc" />
+      </concept>
+      <concept id="679099339649053840" name="jetbrains.mps.lang.modelapi.structure.ModelName" flags="ng" index="1j_P7g">
+        <property id="679099339649053841" name="value" index="1j_P7h" />
+      </concept>
+    </language>
     <language id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest">
       <concept id="8427750732757990717" name="jetbrains.mps.baseLanguage.unitTest.structure.BinaryAssert" flags="nn" index="3tpDYu">
         <child id="8427750732757990725" name="actual" index="3tpDZA" />
@@ -97,11 +106,14 @@
       </concept>
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
-      <concept id="559557797393017698" name="jetbrains.mps.lang.smodel.structure.ModelReferenceExpression" flags="nn" index="BaHAS">
-        <property id="559557797393021807" name="stereotype" index="BaGAP" />
-        <property id="559557797393017702" name="name" index="BaHAW" />
+      <concept id="4065387505485742666" name="jetbrains.mps.lang.smodel.structure.ModelPointer_ResolveOperation" flags="ng" index="2yCiCJ" />
+      <concept id="4065387505485742749" name="jetbrains.mps.lang.smodel.structure.AbstractPointerResolveOperation" flags="ng" index="2yCiFS">
+        <child id="3648723375513868575" name="repositoryArg" index="Vysub" />
       </concept>
       <concept id="1143226024141" name="jetbrains.mps.lang.smodel.structure.SModelType" flags="in" index="H_c77" />
+      <concept id="1863527487546129879" name="jetbrains.mps.lang.smodel.structure.ModelPointerExpression" flags="ng" index="1Xw6AR">
+        <child id="1863527487546132519" name="modelRef" index="1XwpL7" />
+      </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
@@ -126,9 +138,23 @@
           <node concept="3cpWsn" id="73BQep1R8G6" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="73BQep1R8G4" role="1tU5fm" />
-            <node concept="BaHAS" id="73BQep1R8G7" role="33vP2m">
-              <property role="BaHAW" value="test.analyses.cbmc.testgen.testcode.smoke" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUhzca0" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUhzbQU" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUhzc0q" role="1XwpL7">
+                  <property role="1XweGQ" value="r:0f8e4b0e-6e74-4bcd-864c-2d81806092e2" />
+                  <node concept="1j_P7g" id="xRVdUhzc0r" role="1j$8Uc">
+                    <property role="1j_P7h" value="test.analyses.cbmc.testgen.testcode.smoke" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUhzcm5" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUhzcHN" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUhzcuo" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUhzdnJ" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -293,9 +319,23 @@
                   <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
                 </node>
               </node>
-              <node concept="BaHAS" id="2jb6dmWQqju" role="37wK5m">
-                <property role="BaHAW" value="test.analyses.cbmc.testgen.testcode.smoke" />
-                <property role="BaGAP" value="" />
+              <node concept="2OqwBi" id="xRVdUhzdID" role="37wK5m">
+                <node concept="1Xw6AR" id="xRVdUhzdIE" role="2Oq$k0">
+                  <node concept="1dCxOl" id="xRVdUhzdIF" role="1XwpL7">
+                    <property role="1XweGQ" value="r:0f8e4b0e-6e74-4bcd-864c-2d81806092e2" />
+                    <node concept="1j_P7g" id="xRVdUhzdIG" role="1j$8Uc">
+                      <property role="1j_P7h" value="test.analyses.cbmc.testgen.testcode.smoke" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2yCiCJ" id="xRVdUhzdIH" role="2OqNvi">
+                  <node concept="2OqwBi" id="xRVdUhzdII" role="Vysub">
+                    <node concept="1jxXqW" id="xRVdUhzdIJ" role="2Oq$k0" />
+                    <node concept="liA8E" id="xRVdUhzdIK" role="2OqNvi">
+                      <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                    </node>
+                  </node>
+                </node>
               </node>
               <node concept="Xl_RD" id="2jb6dmWQqjv" role="37wK5m">
                 <property role="Xl_RC" value="branch2" />
@@ -410,9 +450,23 @@
           <node concept="3cpWsn" id="341WyjDj2rL" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="341WyjDj2rM" role="1tU5fm" />
-            <node concept="BaHAS" id="341WyjDj2rN" role="33vP2m">
-              <property role="BaHAW" value="test.analyses.cbmc.testgen.testcode.smoke" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUhzehJ" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUhzehK" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUhzehL" role="1XwpL7">
+                  <property role="1XweGQ" value="r:0f8e4b0e-6e74-4bcd-864c-2d81806092e2" />
+                  <node concept="1j_P7g" id="xRVdUhzehM" role="1j$8Uc">
+                    <property role="1j_P7h" value="test.analyses.cbmc.testgen.testcode.smoke" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUhzehN" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUhzehO" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUhzehP" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUhzehQ" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>

--- a/code/languages/com.mbeddr.analyses/tests/test.analyses.cbmc.testsgen/models/test/analyses/cbmc/testgen/tests_saving@tests.mps
+++ b/code/languages/com.mbeddr.analyses/tests/test.analyses.cbmc.testsgen/models/test/analyses/cbmc/testgen/tests_saving@tests.mps
@@ -104,6 +104,15 @@
         <child id="8135709735327457495" name="oracleSteps" index="L1FwL" />
       </concept>
     </language>
+    <language id="446c26eb-2b7b-4bf0-9b35-f83fa582753e" name="jetbrains.mps.lang.modelapi">
+      <concept id="361130699826193248" name="jetbrains.mps.lang.modelapi.structure.ModelPointer" flags="ng" index="1dCxOl">
+        <property id="1863527487546097494" name="modelId" index="1XweGQ" />
+        <child id="679099339649067980" name="name" index="1j$8Uc" />
+      </concept>
+      <concept id="679099339649053840" name="jetbrains.mps.lang.modelapi.structure.ModelName" flags="ng" index="1j_P7g">
+        <property id="679099339649053841" name="value" index="1j_P7h" />
+      </concept>
+    </language>
     <language id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest">
       <concept id="8427750732757990717" name="jetbrains.mps.baseLanguage.unitTest.structure.BinaryAssert" flags="nn" index="3tpDYu">
         <child id="8427750732757990725" name="actual" index="3tpDZA" />
@@ -118,9 +127,9 @@
       <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
         <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
       </concept>
-      <concept id="559557797393017698" name="jetbrains.mps.lang.smodel.structure.ModelReferenceExpression" flags="nn" index="BaHAS">
-        <property id="559557797393021807" name="stereotype" index="BaGAP" />
-        <property id="559557797393017702" name="name" index="BaHAW" />
+      <concept id="4065387505485742666" name="jetbrains.mps.lang.smodel.structure.ModelPointer_ResolveOperation" flags="ng" index="2yCiCJ" />
+      <concept id="4065387505485742749" name="jetbrains.mps.lang.smodel.structure.AbstractPointerResolveOperation" flags="ng" index="2yCiFS">
+        <child id="3648723375513868575" name="repositoryArg" index="Vysub" />
       </concept>
       <concept id="1143226024141" name="jetbrains.mps.lang.smodel.structure.SModelType" flags="in" index="H_c77" />
       <concept id="1139621453865" name="jetbrains.mps.lang.smodel.structure.Node_IsInstanceOfOperation" flags="nn" index="1mIQ4w">
@@ -128,6 +137,9 @@
       </concept>
       <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
         <reference id="1138405853777" name="concept" index="ehGHo" />
+      </concept>
+      <concept id="1863527487546129879" name="jetbrains.mps.lang.smodel.structure.ModelPointerExpression" flags="ng" index="1Xw6AR">
+        <child id="1863527487546132519" name="modelRef" index="1XwpL7" />
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
@@ -157,9 +169,23 @@
           <node concept="3cpWsn" id="1ENIgcpefJ5" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="1ENIgcpefJ6" role="1tU5fm" />
-            <node concept="BaHAS" id="1ENIgcpefJ7" role="33vP2m">
-              <property role="BaHAW" value="test.analyses.cbmc.testgen.testcode.tests_saving" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUhzksE" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUhzi8D" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUhzil1" role="1XwpL7">
+                  <property role="1XweGQ" value="r:8dc49b0b-4201-469a-b470-2b924dfcaff1" />
+                  <node concept="1j_P7g" id="xRVdUhzil2" role="1j$8Uc">
+                    <property role="1j_P7h" value="test.analyses.cbmc.testgen.testcode.tests_saving" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUhzkF_" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUhzlfJ" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUhzkQK" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUhzlWN" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -386,9 +412,23 @@
           <node concept="3cpWsn" id="1ENIgcpgiXj" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="1ENIgcpgiXk" role="1tU5fm" />
-            <node concept="BaHAS" id="1ENIgcpgiXl" role="33vP2m">
-              <property role="BaHAW" value="test.analyses.cbmc.testgen.testcode.tests_saving" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUhzm9L" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUhzm9M" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUhzm9N" role="1XwpL7">
+                  <property role="1XweGQ" value="r:8dc49b0b-4201-469a-b470-2b924dfcaff1" />
+                  <node concept="1j_P7g" id="xRVdUhzm9O" role="1j$8Uc">
+                    <property role="1j_P7h" value="test.analyses.cbmc.testgen.testcode.tests_saving" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUhzm9P" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUhzm9Q" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUhzm9R" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUhzm9S" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -544,9 +584,23 @@
           <node concept="3cpWsn" id="3rqorKKj4CE" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="3rqorKKj4CF" role="1tU5fm" />
-            <node concept="BaHAS" id="3rqorKKj4CG" role="33vP2m">
-              <property role="BaHAW" value="test.analyses.cbmc.testgen.testcode.tests_saving" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUhzmyM" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUhzmyN" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUhzmyO" role="1XwpL7">
+                  <property role="1XweGQ" value="r:8dc49b0b-4201-469a-b470-2b924dfcaff1" />
+                  <node concept="1j_P7g" id="xRVdUhzmyP" role="1j$8Uc">
+                    <property role="1j_P7h" value="test.analyses.cbmc.testgen.testcode.tests_saving" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUhzmyQ" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUhzmyR" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUhzmyS" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUhzmyT" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -699,9 +753,23 @@
           <node concept="3cpWsn" id="1ENIgcphmDm" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="1ENIgcphmDn" role="1tU5fm" />
-            <node concept="BaHAS" id="1ENIgcphmDo" role="33vP2m">
-              <property role="BaHAW" value="test.analyses.cbmc.testgen.testcode.tests_saving" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUhzmFy" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUhzmFz" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUhzmF$" role="1XwpL7">
+                  <property role="1XweGQ" value="r:8dc49b0b-4201-469a-b470-2b924dfcaff1" />
+                  <node concept="1j_P7g" id="xRVdUhzmF_" role="1j$8Uc">
+                    <property role="1j_P7h" value="test.analyses.cbmc.testgen.testcode.tests_saving" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUhzmFA" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUhzmFB" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUhzmFC" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUhzmFD" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -863,9 +931,23 @@
           <node concept="3cpWsn" id="1ENIgcphxQk" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="1ENIgcphxQl" role="1tU5fm" />
-            <node concept="BaHAS" id="1ENIgcphxQm" role="33vP2m">
-              <property role="BaHAW" value="test.analyses.cbmc.testgen.testcode.tests_saving" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUhzmOi" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUhzmOj" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUhzmOk" role="1XwpL7">
+                  <property role="1XweGQ" value="r:8dc49b0b-4201-469a-b470-2b924dfcaff1" />
+                  <node concept="1j_P7g" id="xRVdUhzmOl" role="1j$8Uc">
+                    <property role="1j_P7h" value="test.analyses.cbmc.testgen.testcode.tests_saving" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUhzmOm" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUhzmOn" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUhzmOo" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUhzmOp" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -1015,9 +1097,23 @@
           <node concept="3cpWsn" id="1ENIgcplphn" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="1ENIgcplpho" role="1tU5fm" />
-            <node concept="BaHAS" id="1ENIgcplphp" role="33vP2m">
-              <property role="BaHAW" value="test.analyses.cbmc.testgen.testcode.tests_saving" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUhzmX5" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUhzmX6" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUhzmX7" role="1XwpL7">
+                  <property role="1XweGQ" value="r:8dc49b0b-4201-469a-b470-2b924dfcaff1" />
+                  <node concept="1j_P7g" id="xRVdUhzmX8" role="1j$8Uc">
+                    <property role="1j_P7h" value="test.analyses.cbmc.testgen.testcode.tests_saving" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUhzmX9" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUhzmXa" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUhzmXb" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUhzmXc" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -1173,9 +1269,23 @@
           <node concept="3cpWsn" id="1ENIgcpnvVQ" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="1ENIgcpnvVR" role="1tU5fm" />
-            <node concept="BaHAS" id="1ENIgcpnvVS" role="33vP2m">
-              <property role="BaHAW" value="test.analyses.cbmc.testgen.testcode.tests_saving" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUhzn5P" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUhzn5Q" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUhzn5R" role="1XwpL7">
+                  <property role="1XweGQ" value="r:8dc49b0b-4201-469a-b470-2b924dfcaff1" />
+                  <node concept="1j_P7g" id="xRVdUhzn5S" role="1j$8Uc">
+                    <property role="1j_P7h" value="test.analyses.cbmc.testgen.testcode.tests_saving" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUhzn5T" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUhzn5U" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUhzn5V" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUhzn5W" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -1337,9 +1447,23 @@
           <node concept="3cpWsn" id="1ENIgcppHPV" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="1ENIgcppHPW" role="1tU5fm" />
-            <node concept="BaHAS" id="1ENIgcppHPX" role="33vP2m">
-              <property role="BaHAW" value="test.analyses.cbmc.testgen.testcode.tests_saving" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUhzne_" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUhzneA" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUhzneB" role="1XwpL7">
+                  <property role="1XweGQ" value="r:8dc49b0b-4201-469a-b470-2b924dfcaff1" />
+                  <node concept="1j_P7g" id="xRVdUhzneC" role="1j$8Uc">
+                    <property role="1j_P7h" value="test.analyses.cbmc.testgen.testcode.tests_saving" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUhzneD" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUhzneE" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUhzneF" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUhzneG" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -1522,9 +1646,23 @@
           <node concept="3cpWsn" id="71I9cJUfXP3" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="71I9cJUfXP4" role="1tU5fm" />
-            <node concept="BaHAS" id="71I9cJUfXP5" role="33vP2m">
-              <property role="BaHAW" value="test.analyses.cbmc.testgen.testcode.tests_saving" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUhznsY" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUhznsZ" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUhznt0" role="1XwpL7">
+                  <property role="1XweGQ" value="r:8dc49b0b-4201-469a-b470-2b924dfcaff1" />
+                  <node concept="1j_P7g" id="xRVdUhznt1" role="1j$8Uc">
+                    <property role="1j_P7h" value="test.analyses.cbmc.testgen.testcode.tests_saving" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUhznt2" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUhznt3" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUhznt4" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUhznt5" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -1678,9 +1816,23 @@
           <node concept="3cpWsn" id="2g2rJI86f0o" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="2g2rJI86f0p" role="1tU5fm" />
-            <node concept="BaHAS" id="2g2rJI86f0q" role="33vP2m">
-              <property role="BaHAW" value="test.analyses.cbmc.testgen.testcode.tests_saving" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUhzn_L" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUhzn_M" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUhzn_N" role="1XwpL7">
+                  <property role="1XweGQ" value="r:8dc49b0b-4201-469a-b470-2b924dfcaff1" />
+                  <node concept="1j_P7g" id="xRVdUhzn_O" role="1j$8Uc">
+                    <property role="1j_P7h" value="test.analyses.cbmc.testgen.testcode.tests_saving" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUhzn_P" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUhzn_Q" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUhzn_R" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUhzn_S" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -1833,9 +1985,23 @@
           <node concept="3cpWsn" id="79ucxors37L" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="79ucxors37M" role="1tU5fm" />
-            <node concept="BaHAS" id="79ucxors37N" role="33vP2m">
-              <property role="BaHAW" value="test.analyses.cbmc.testgen.testcode.tests_saving" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUhznIx" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUhznIy" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUhznIz" role="1XwpL7">
+                  <property role="1XweGQ" value="r:8dc49b0b-4201-469a-b470-2b924dfcaff1" />
+                  <node concept="1j_P7g" id="xRVdUhznI$" role="1j$8Uc">
+                    <property role="1j_P7h" value="test.analyses.cbmc.testgen.testcode.tests_saving" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUhznI_" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUhznIA" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUhznIB" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUhznIC" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -1988,9 +2154,23 @@
           <node concept="3cpWsn" id="J0Nj4zYVaJ" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="J0Nj4zYVaK" role="1tU5fm" />
-            <node concept="BaHAS" id="J0Nj4zYVaL" role="33vP2m">
-              <property role="BaHAW" value="test.analyses.cbmc.testgen.testcode.tests_saving" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUhznRh" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUhznRi" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUhznRj" role="1XwpL7">
+                  <property role="1XweGQ" value="r:8dc49b0b-4201-469a-b470-2b924dfcaff1" />
+                  <node concept="1j_P7g" id="xRVdUhznRk" role="1j$8Uc">
+                    <property role="1j_P7h" value="test.analyses.cbmc.testgen.testcode.tests_saving" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUhznRl" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUhznRm" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUhznRn" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUhznRo" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -2206,9 +2386,23 @@
           <node concept="3cpWsn" id="J0Nj4$02rU" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="J0Nj4$02rV" role="1tU5fm" />
-            <node concept="BaHAS" id="J0Nj4$02rW" role="33vP2m">
-              <property role="BaHAW" value="test.analyses.cbmc.testgen.testcode.tests_saving" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUhzo2V" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUhzo2W" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUhzo2X" role="1XwpL7">
+                  <property role="1XweGQ" value="r:8dc49b0b-4201-469a-b470-2b924dfcaff1" />
+                  <node concept="1j_P7g" id="xRVdUhzo2Y" role="1j$8Uc">
+                    <property role="1j_P7h" value="test.analyses.cbmc.testgen.testcode.tests_saving" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUhzo2Z" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUhzo30" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUhzo31" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUhzo32" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>

--- a/code/languages/com.mbeddr.analyses/tests/test.analyses.cbmc.xmodel/models/suv_analyses@tests.mps
+++ b/code/languages/com.mbeddr.analyses/tests/test.analyses.cbmc.xmodel/models/suv_analyses@tests.mps
@@ -74,17 +74,29 @@
     <language id="63e0e566-5131-447e-90e3-12ea330e1a00" name="com.mbeddr.mpsutil.blutil">
       <concept id="6451706574537082687" name="com.mbeddr.mpsutil.blutil.structure.ShortStaticMethodCall" flags="ng" index="NRdvd" />
     </language>
+    <language id="446c26eb-2b7b-4bf0-9b35-f83fa582753e" name="jetbrains.mps.lang.modelapi">
+      <concept id="361130699826193248" name="jetbrains.mps.lang.modelapi.structure.ModelPointer" flags="ng" index="1dCxOl">
+        <property id="1863527487546097494" name="modelId" index="1XweGQ" />
+        <child id="679099339649067980" name="name" index="1j$8Uc" />
+      </concept>
+      <concept id="679099339649053840" name="jetbrains.mps.lang.modelapi.structure.ModelName" flags="ng" index="1j_P7g">
+        <property id="679099339649053841" name="value" index="1j_P7h" />
+      </concept>
+    </language>
     <language id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest">
       <concept id="1171981022339" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertTrue" flags="nn" index="3vwNmj">
         <child id="1171981057159" name="condition" index="3vwVQn" />
       </concept>
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
-      <concept id="559557797393017698" name="jetbrains.mps.lang.smodel.structure.ModelReferenceExpression" flags="nn" index="BaHAS">
-        <property id="559557797393021807" name="stereotype" index="BaGAP" />
-        <property id="559557797393017702" name="name" index="BaHAW" />
+      <concept id="4065387505485742666" name="jetbrains.mps.lang.smodel.structure.ModelPointer_ResolveOperation" flags="ng" index="2yCiCJ" />
+      <concept id="4065387505485742749" name="jetbrains.mps.lang.smodel.structure.AbstractPointerResolveOperation" flags="ng" index="2yCiFS">
+        <child id="3648723375513868575" name="repositoryArg" index="Vysub" />
       </concept>
       <concept id="1143226024141" name="jetbrains.mps.lang.smodel.structure.SModelType" flags="in" index="H_c77" />
+      <concept id="1863527487546129879" name="jetbrains.mps.lang.smodel.structure.ModelPointerExpression" flags="ng" index="1Xw6AR">
+        <child id="1863527487546132519" name="modelRef" index="1XwpL7" />
+      </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
@@ -108,9 +120,23 @@
           <node concept="3cpWsn" id="7bmaDMybMt1" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="7bmaDMybMsZ" role="1tU5fm" />
-            <node concept="BaHAS" id="7bmaDMybMt2" role="33vP2m">
-              <property role="BaHAW" value="test.analyses.cbmc.xmodel.testcode.suv_analyses" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUhzBCj" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUhzBln" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUhzBsL" role="1XwpL7">
+                  <property role="1XweGQ" value="r:ac0e1820-bb13-435e-ae81-034f97b96867" />
+                  <node concept="1j_P7g" id="xRVdUhzBsM" role="1j$8Uc">
+                    <property role="1j_P7h" value="test.analyses.cbmc.xmodel.testcode.suv_analyses" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUhzBRa" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUhzCbm" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUhzBXn" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUhzCJY" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -225,9 +251,23 @@
           <node concept="3cpWsn" id="7bmaDMybTOS" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="7bmaDMybTOT" role="1tU5fm" />
-            <node concept="BaHAS" id="7bmaDMybTOU" role="33vP2m">
-              <property role="BaHAW" value="test.analyses.cbmc.xmodel.testcode.suv_analyses" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUhzDpK" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUhzDpL" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUhzDpM" role="1XwpL7">
+                  <property role="1XweGQ" value="r:ac0e1820-bb13-435e-ae81-034f97b96867" />
+                  <node concept="1j_P7g" id="xRVdUhzDpN" role="1j$8Uc">
+                    <property role="1j_P7h" value="test.analyses.cbmc.xmodel.testcode.suv_analyses" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUhzDpO" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUhzDpP" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUhzDpQ" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUhzDpR" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -310,9 +350,23 @@
           <node concept="3cpWsn" id="7bmaDMybUZr" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="7bmaDMybUZs" role="1tU5fm" />
-            <node concept="BaHAS" id="7bmaDMybUZt" role="33vP2m">
-              <property role="BaHAW" value="test.analyses.cbmc.xmodel.testcode.suv_analyses" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUhzDyV" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUhzDyW" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUhzDyX" role="1XwpL7">
+                  <property role="1XweGQ" value="r:ac0e1820-bb13-435e-ae81-034f97b96867" />
+                  <node concept="1j_P7g" id="xRVdUhzDyY" role="1j$8Uc">
+                    <property role="1j_P7h" value="test.analyses.cbmc.xmodel.testcode.suv_analyses" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUhzDyZ" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUhzDz0" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUhzDz1" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUhzDz2" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>

--- a/code/languages/com.mbeddr.analyses/tests/test.analyses.cbmc/models/test/analyses/cbmc/advanced_verification_conditions@tests.mps
+++ b/code/languages/com.mbeddr.analyses/tests/test.analyses.cbmc/models/test/analyses/cbmc/advanced_verification_conditions@tests.mps
@@ -87,6 +87,15 @@
     <language id="63e0e566-5131-447e-90e3-12ea330e1a00" name="com.mbeddr.mpsutil.blutil">
       <concept id="6451706574537082687" name="com.mbeddr.mpsutil.blutil.structure.ShortStaticMethodCall" flags="ng" index="NRdvd" />
     </language>
+    <language id="446c26eb-2b7b-4bf0-9b35-f83fa582753e" name="jetbrains.mps.lang.modelapi">
+      <concept id="361130699826193248" name="jetbrains.mps.lang.modelapi.structure.ModelPointer" flags="ng" index="1dCxOl">
+        <property id="1863527487546097494" name="modelId" index="1XweGQ" />
+        <child id="679099339649067980" name="name" index="1j$8Uc" />
+      </concept>
+      <concept id="679099339649053840" name="jetbrains.mps.lang.modelapi.structure.ModelName" flags="ng" index="1j_P7g">
+        <property id="679099339649053841" name="value" index="1j_P7h" />
+      </concept>
+    </language>
     <language id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest">
       <concept id="8427750732757990717" name="jetbrains.mps.baseLanguage.unitTest.structure.BinaryAssert" flags="nn" index="3tpDYu">
         <child id="8427750732757990725" name="actual" index="3tpDZA" />
@@ -98,11 +107,14 @@
       </concept>
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
-      <concept id="559557797393017698" name="jetbrains.mps.lang.smodel.structure.ModelReferenceExpression" flags="nn" index="BaHAS">
-        <property id="559557797393021807" name="stereotype" index="BaGAP" />
-        <property id="559557797393017702" name="name" index="BaHAW" />
+      <concept id="4065387505485742666" name="jetbrains.mps.lang.smodel.structure.ModelPointer_ResolveOperation" flags="ng" index="2yCiCJ" />
+      <concept id="4065387505485742749" name="jetbrains.mps.lang.smodel.structure.AbstractPointerResolveOperation" flags="ng" index="2yCiFS">
+        <child id="3648723375513868575" name="repositoryArg" index="Vysub" />
       </concept>
       <concept id="1143226024141" name="jetbrains.mps.lang.smodel.structure.SModelType" flags="in" index="H_c77" />
+      <concept id="1863527487546129879" name="jetbrains.mps.lang.smodel.structure.ModelPointerExpression" flags="ng" index="1Xw6AR">
+        <child id="1863527487546132519" name="modelRef" index="1XwpL7" />
+      </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
@@ -135,9 +147,23 @@
           <node concept="3cpWsn" id="5EwdfGVgL4P" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="5EwdfGVgL4N" role="1tU5fm" />
-            <node concept="BaHAS" id="5EwdfGVgL4Q" role="33vP2m">
-              <property role="BaHAW" value="advanced_verification_condition" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUhz8FI" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUhz8$u" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUhz8C3" role="1XwpL7">
+                  <property role="1XweGQ" value="r:fade7891-e1f2-4378-9920-97528ff8c25a" />
+                  <node concept="1j_P7g" id="xRVdUhz8C4" role="1j$8Uc">
+                    <property role="1j_P7h" value="advanced_verification_condition" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUhz8LQ" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUhz94q" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUhz8Oe" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUhz9__" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -230,9 +256,23 @@
           <node concept="3cpWsn" id="5EwdfGVgLaD" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="5EwdfGVgLaB" role="1tU5fm" />
-            <node concept="BaHAS" id="5EwdfGVgLaE" role="33vP2m">
-              <property role="BaHAW" value="advanced_verification_condition" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUhz9CC" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUhz9CD" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUhz9CE" role="1XwpL7">
+                  <property role="1XweGQ" value="r:fade7891-e1f2-4378-9920-97528ff8c25a" />
+                  <node concept="1j_P7g" id="xRVdUhz9CF" role="1j$8Uc">
+                    <property role="1j_P7h" value="advanced_verification_condition" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUhz9CG" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUhz9CH" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUhz9CI" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUhz9CJ" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -307,9 +347,23 @@
           <node concept="3cpWsn" id="46evrC8ir2d" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="46evrC8ir2b" role="1tU5fm" />
-            <node concept="BaHAS" id="46evrC8ir2e" role="33vP2m">
-              <property role="BaHAW" value="advanced_verification_condition" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUhzayH" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUhzayI" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUhzayJ" role="1XwpL7">
+                  <property role="1XweGQ" value="r:fade7891-e1f2-4378-9920-97528ff8c25a" />
+                  <node concept="1j_P7g" id="xRVdUhzayK" role="1j$8Uc">
+                    <property role="1j_P7h" value="advanced_verification_condition" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUhzayL" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUhzayM" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUhzayN" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUhzayO" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -395,9 +449,23 @@
           <node concept="3cpWsn" id="46evrC8iqTT" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="46evrC8iqTR" role="1tU5fm" />
-            <node concept="BaHAS" id="46evrC8iqTU" role="33vP2m">
-              <property role="BaHAW" value="advanced_verification_condition" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUhzaAp" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUhzaAq" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUhzaAr" role="1XwpL7">
+                  <property role="1XweGQ" value="r:fade7891-e1f2-4378-9920-97528ff8c25a" />
+                  <node concept="1j_P7g" id="xRVdUhzaAs" role="1j$8Uc">
+                    <property role="1j_P7h" value="advanced_verification_condition" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUhzaAt" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUhzaAu" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUhzaAv" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUhzaAw" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -473,9 +541,23 @@
           <node concept="3cpWsn" id="5O4lpk$25" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="5O4lpk$23" role="1tU5fm" />
-            <node concept="BaHAS" id="5O4lpk$26" role="33vP2m">
-              <property role="BaHAW" value="advanced_verification_condition" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUhzaah" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUhzaai" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUhzaaj" role="1XwpL7">
+                  <property role="1XweGQ" value="r:fade7891-e1f2-4378-9920-97528ff8c25a" />
+                  <node concept="1j_P7g" id="xRVdUhzaak" role="1j$8Uc">
+                    <property role="1j_P7h" value="advanced_verification_condition" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUhzaal" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUhzaam" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUhzaan" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUhzaao" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -561,9 +643,23 @@
           <node concept="3cpWsn" id="5O4lpk$jY" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="5O4lpk$jW" role="1tU5fm" />
-            <node concept="BaHAS" id="5O4lpk$jZ" role="33vP2m">
-              <property role="BaHAW" value="advanced_verification_condition" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUhzadY" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUhzadZ" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUhzae0" role="1XwpL7">
+                  <property role="1XweGQ" value="r:fade7891-e1f2-4378-9920-97528ff8c25a" />
+                  <node concept="1j_P7g" id="xRVdUhzae1" role="1j$8Uc">
+                    <property role="1j_P7h" value="advanced_verification_condition" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUhzae2" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUhzae3" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUhzae4" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUhzae5" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -639,9 +735,23 @@
           <node concept="3cpWsn" id="5O4lpk$Kp" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="5O4lpk$Kn" role="1tU5fm" />
-            <node concept="BaHAS" id="5O4lpk$Kq" role="33vP2m">
-              <property role="BaHAW" value="advanced_verification_condition" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUhz9N$" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUhz9N_" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUhz9NA" role="1XwpL7">
+                  <property role="1XweGQ" value="r:fade7891-e1f2-4378-9920-97528ff8c25a" />
+                  <node concept="1j_P7g" id="xRVdUhz9NB" role="1j$8Uc">
+                    <property role="1j_P7h" value="advanced_verification_condition" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUhz9NC" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUhz9ND" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUhz9NE" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUhz9NF" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -726,9 +836,23 @@
           <node concept="3cpWsn" id="5O4lpk_2h" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="5O4lpk_2f" role="1tU5fm" />
-            <node concept="BaHAS" id="5O4lpk_2i" role="33vP2m">
-              <property role="BaHAW" value="advanced_verification_condition" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUhz9Rh" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUhz9Ri" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUhz9Rj" role="1XwpL7">
+                  <property role="1XweGQ" value="r:fade7891-e1f2-4378-9920-97528ff8c25a" />
+                  <node concept="1j_P7g" id="xRVdUhz9Rk" role="1j$8Uc">
+                    <property role="1j_P7h" value="advanced_verification_condition" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUhz9Rl" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUhz9Rm" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUhz9Rn" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUhz9Ro" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -803,9 +927,23 @@
           <node concept="3cpWsn" id="5O4lpk_oP" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="5O4lpk_oN" role="1tU5fm" />
-            <node concept="BaHAS" id="5O4lpk_oQ" role="33vP2m">
-              <property role="BaHAW" value="advanced_verification_condition" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUhzajE" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUhzajF" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUhzajG" role="1XwpL7">
+                  <property role="1XweGQ" value="r:fade7891-e1f2-4378-9920-97528ff8c25a" />
+                  <node concept="1j_P7g" id="xRVdUhzajH" role="1j$8Uc">
+                    <property role="1j_P7h" value="advanced_verification_condition" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUhzajI" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUhzajJ" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUhzajK" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUhzajL" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -890,9 +1028,23 @@
           <node concept="3cpWsn" id="5O4lpk_yl" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="5O4lpk_yj" role="1tU5fm" />
-            <node concept="BaHAS" id="5O4lpk_ym" role="33vP2m">
-              <property role="BaHAW" value="advanced_verification_condition" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUhzanm" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUhzann" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUhzano" role="1XwpL7">
+                  <property role="1XweGQ" value="r:fade7891-e1f2-4378-9920-97528ff8c25a" />
+                  <node concept="1j_P7g" id="xRVdUhzanp" role="1j$8Uc">
+                    <property role="1j_P7h" value="advanced_verification_condition" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUhzanq" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUhzanr" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUhzans" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUhzant" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -967,9 +1119,23 @@
           <node concept="3cpWsn" id="5O4lpksuX" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="5O4lpksuV" role="1tU5fm" />
-            <node concept="BaHAS" id="5O4lpksuY" role="33vP2m">
-              <property role="BaHAW" value="advanced_verification_condition" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUhzaLw" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUhzaLx" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUhzaLy" role="1XwpL7">
+                  <property role="1XweGQ" value="r:fade7891-e1f2-4378-9920-97528ff8c25a" />
+                  <node concept="1j_P7g" id="xRVdUhzaLz" role="1j$8Uc">
+                    <property role="1j_P7h" value="advanced_verification_condition" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUhzaL$" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUhzaL_" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUhzaLA" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUhzaLB" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -1054,9 +1220,23 @@
           <node concept="3cpWsn" id="5O4lpktu_" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="5O4lpktuz" role="1tU5fm" />
-            <node concept="BaHAS" id="5O4lpktuA" role="33vP2m">
-              <property role="BaHAW" value="advanced_verification_condition" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUhzaPc" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUhzaPd" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUhzaPe" role="1XwpL7">
+                  <property role="1XweGQ" value="r:fade7891-e1f2-4378-9920-97528ff8c25a" />
+                  <node concept="1j_P7g" id="xRVdUhzaPf" role="1j$8Uc">
+                    <property role="1j_P7h" value="advanced_verification_condition" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUhzaPg" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUhzaPh" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUhzaPi" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUhzaPj" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>

--- a/code/languages/com.mbeddr.analyses/tests/test.analyses.cbmc/models/test/analyses/cbmc/analysis_config@tests.mps
+++ b/code/languages/com.mbeddr.analyses/tests/test.analyses.cbmc/models/test/analyses/cbmc/analysis_config@tests.mps
@@ -102,6 +102,15 @@
     <language id="63e0e566-5131-447e-90e3-12ea330e1a00" name="com.mbeddr.mpsutil.blutil">
       <concept id="6451706574537082687" name="com.mbeddr.mpsutil.blutil.structure.ShortStaticMethodCall" flags="ng" index="NRdvd" />
     </language>
+    <language id="446c26eb-2b7b-4bf0-9b35-f83fa582753e" name="jetbrains.mps.lang.modelapi">
+      <concept id="361130699826193248" name="jetbrains.mps.lang.modelapi.structure.ModelPointer" flags="ng" index="1dCxOl">
+        <property id="1863527487546097494" name="modelId" index="1XweGQ" />
+        <child id="679099339649067980" name="name" index="1j$8Uc" />
+      </concept>
+      <concept id="679099339649053840" name="jetbrains.mps.lang.modelapi.structure.ModelName" flags="ng" index="1j_P7g">
+        <property id="679099339649053841" name="value" index="1j_P7h" />
+      </concept>
+    </language>
     <language id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest">
       <concept id="8427750732757990717" name="jetbrains.mps.baseLanguage.unitTest.structure.BinaryAssert" flags="nn" index="3tpDYu">
         <child id="8427750732757990725" name="actual" index="3tpDZA" />
@@ -113,9 +122,12 @@
       </concept>
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
-      <concept id="559557797393017698" name="jetbrains.mps.lang.smodel.structure.ModelReferenceExpression" flags="nn" index="BaHAS">
-        <property id="559557797393021807" name="stereotype" index="BaGAP" />
-        <property id="559557797393017702" name="name" index="BaHAW" />
+      <concept id="4065387505485742666" name="jetbrains.mps.lang.smodel.structure.ModelPointer_ResolveOperation" flags="ng" index="2yCiCJ" />
+      <concept id="4065387505485742749" name="jetbrains.mps.lang.smodel.structure.AbstractPointerResolveOperation" flags="ng" index="2yCiFS">
+        <child id="3648723375513868575" name="repositoryArg" index="Vysub" />
+      </concept>
+      <concept id="1863527487546129879" name="jetbrains.mps.lang.smodel.structure.ModelPointerExpression" flags="ng" index="1Xw6AR">
+        <child id="1863527487546132519" name="modelRef" index="1XwpL7" />
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
@@ -187,9 +199,23 @@
                   <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
                 </node>
               </node>
-              <node concept="BaHAS" id="3hNQKr2uv1U" role="37wK5m">
-                <property role="BaHAW" value="smoke_analysis" />
-                <property role="BaGAP" value="" />
+              <node concept="2OqwBi" id="xRVdUhzWS$" role="37wK5m">
+                <node concept="1Xw6AR" id="xRVdUhzWJA" role="2Oq$k0">
+                  <node concept="1dCxOl" id="xRVdUhzWNE" role="1XwpL7">
+                    <property role="1XweGQ" value="r:aa695920-eb93-44ad-af50-5a901429fc8c" />
+                    <node concept="1j_P7g" id="xRVdUhzWNF" role="1j$8Uc">
+                      <property role="1j_P7h" value="smoke_analysis" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2yCiCJ" id="xRVdUhzWZb" role="2OqNvi">
+                  <node concept="2OqwBi" id="xRVdUhzXhB" role="Vysub">
+                    <node concept="1jxXqW" id="xRVdUhzX1v" role="2Oq$k0" />
+                    <node concept="liA8E" id="xRVdUhzX_w" role="2OqNvi">
+                      <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                    </node>
+                  </node>
+                </node>
               </node>
             </node>
             <node concept="_YKpA" id="126LgZ0MXk1" role="1tU5fm">
@@ -249,9 +275,23 @@
                   <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
                 </node>
               </node>
-              <node concept="BaHAS" id="2Nt0AcmuS3B" role="37wK5m">
-                <property role="BaHAW" value="smoke_analysis" />
-                <property role="BaGAP" value="" />
+              <node concept="2OqwBi" id="xRVdUhzXC7" role="37wK5m">
+                <node concept="1Xw6AR" id="xRVdUhzXC8" role="2Oq$k0">
+                  <node concept="1dCxOl" id="xRVdUhzXC9" role="1XwpL7">
+                    <property role="1XweGQ" value="r:aa695920-eb93-44ad-af50-5a901429fc8c" />
+                    <node concept="1j_P7g" id="xRVdUhzXCa" role="1j$8Uc">
+                      <property role="1j_P7h" value="smoke_analysis" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2yCiCJ" id="xRVdUhzXCb" role="2OqNvi">
+                  <node concept="2OqwBi" id="xRVdUhzXCc" role="Vysub">
+                    <node concept="1jxXqW" id="xRVdUhzXCd" role="2Oq$k0" />
+                    <node concept="liA8E" id="xRVdUhzXCe" role="2OqNvi">
+                      <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                    </node>
+                  </node>
+                </node>
               </node>
             </node>
             <node concept="_YKpA" id="2Nt0AcmuS3C" role="1tU5fm">

--- a/code/languages/com.mbeddr.analyses/tests/test.analyses.cbmc/models/test/analyses/cbmc/architecture@tests.mps
+++ b/code/languages/com.mbeddr.analyses/tests/test.analyses.cbmc/models/test/analyses/cbmc/architecture@tests.mps
@@ -95,17 +95,29 @@
     <language id="63e0e566-5131-447e-90e3-12ea330e1a00" name="com.mbeddr.mpsutil.blutil">
       <concept id="6451706574537082687" name="com.mbeddr.mpsutil.blutil.structure.ShortStaticMethodCall" flags="ng" index="NRdvd" />
     </language>
+    <language id="446c26eb-2b7b-4bf0-9b35-f83fa582753e" name="jetbrains.mps.lang.modelapi">
+      <concept id="361130699826193248" name="jetbrains.mps.lang.modelapi.structure.ModelPointer" flags="ng" index="1dCxOl">
+        <property id="1863527487546097494" name="modelId" index="1XweGQ" />
+        <child id="679099339649067980" name="name" index="1j$8Uc" />
+      </concept>
+      <concept id="679099339649053840" name="jetbrains.mps.lang.modelapi.structure.ModelName" flags="ng" index="1j_P7g">
+        <property id="679099339649053841" name="value" index="1j_P7h" />
+      </concept>
+    </language>
     <language id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest">
       <concept id="1171981022339" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertTrue" flags="nn" index="3vwNmj">
         <child id="1171981057159" name="condition" index="3vwVQn" />
       </concept>
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
-      <concept id="559557797393017698" name="jetbrains.mps.lang.smodel.structure.ModelReferenceExpression" flags="nn" index="BaHAS">
-        <property id="559557797393021807" name="stereotype" index="BaGAP" />
-        <property id="559557797393017702" name="name" index="BaHAW" />
+      <concept id="4065387505485742666" name="jetbrains.mps.lang.smodel.structure.ModelPointer_ResolveOperation" flags="ng" index="2yCiCJ" />
+      <concept id="4065387505485742749" name="jetbrains.mps.lang.smodel.structure.AbstractPointerResolveOperation" flags="ng" index="2yCiFS">
+        <child id="3648723375513868575" name="repositoryArg" index="Vysub" />
       </concept>
       <concept id="1143226024141" name="jetbrains.mps.lang.smodel.structure.SModelType" flags="in" index="H_c77" />
+      <concept id="1863527487546129879" name="jetbrains.mps.lang.smodel.structure.ModelPointerExpression" flags="ng" index="1Xw6AR">
+        <child id="1863527487546132519" name="modelRef" index="1XwpL7" />
+      </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
@@ -165,9 +177,23 @@
           <node concept="3cpWsn" id="5EwdfGVgP3L" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="5EwdfGVgP3J" role="1tU5fm" />
-            <node concept="BaHAS" id="5EwdfGVgP3M" role="33vP2m">
-              <property role="BaHAW" value="architecture" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUhzWS$" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUhzWJA" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUhzY2z" role="1XwpL7">
+                  <property role="1XweGQ" value="r:6a981579-b1f2-4140-bb9d-c276343daf4a" />
+                  <node concept="1j_P7g" id="xRVdUhzY2$" role="1j$8Uc">
+                    <property role="1j_P7h" value="architecture" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUhzWZb" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUhzXhB" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUhzX1v" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUhzX_w" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -280,9 +306,23 @@
           <node concept="3cpWsn" id="5EwdfGVgPtg" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="5EwdfGVgPte" role="1tU5fm" />
-            <node concept="BaHAS" id="5EwdfGVgPth" role="33vP2m">
-              <property role="BaHAW" value="architecture" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUhzY6Q" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUhzY6R" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUhzY6S" role="1XwpL7">
+                  <property role="1XweGQ" value="r:6a981579-b1f2-4140-bb9d-c276343daf4a" />
+                  <node concept="1j_P7g" id="xRVdUhzY6T" role="1j$8Uc">
+                    <property role="1j_P7h" value="architecture" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUhzY6U" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUhzY6V" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUhzY6W" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUhzY6X" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -395,9 +435,23 @@
           <node concept="3cpWsn" id="5EwdfGVgQ1R" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="5EwdfGVgQ1P" role="1tU5fm" />
-            <node concept="BaHAS" id="5EwdfGVgQ1S" role="33vP2m">
-              <property role="BaHAW" value="architecture" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUhzYc1" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUhzYc2" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUhzYc3" role="1XwpL7">
+                  <property role="1XweGQ" value="r:6a981579-b1f2-4140-bb9d-c276343daf4a" />
+                  <node concept="1j_P7g" id="xRVdUhzYc4" role="1j$8Uc">
+                    <property role="1j_P7h" value="architecture" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUhzYc5" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUhzYc6" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUhzYc7" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUhzYc8" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>

--- a/code/languages/com.mbeddr.analyses/tests/test.analyses.cbmc/models/test/analyses/cbmc/assertions@tests.mps
+++ b/code/languages/com.mbeddr.analyses/tests/test.analyses.cbmc/models/test/analyses/cbmc/assertions@tests.mps
@@ -80,6 +80,15 @@
     <language id="63e0e566-5131-447e-90e3-12ea330e1a00" name="com.mbeddr.mpsutil.blutil">
       <concept id="6451706574537082687" name="com.mbeddr.mpsutil.blutil.structure.ShortStaticMethodCall" flags="ng" index="NRdvd" />
     </language>
+    <language id="446c26eb-2b7b-4bf0-9b35-f83fa582753e" name="jetbrains.mps.lang.modelapi">
+      <concept id="361130699826193248" name="jetbrains.mps.lang.modelapi.structure.ModelPointer" flags="ng" index="1dCxOl">
+        <property id="1863527487546097494" name="modelId" index="1XweGQ" />
+        <child id="679099339649067980" name="name" index="1j$8Uc" />
+      </concept>
+      <concept id="679099339649053840" name="jetbrains.mps.lang.modelapi.structure.ModelName" flags="ng" index="1j_P7g">
+        <property id="679099339649053841" name="value" index="1j_P7h" />
+      </concept>
+    </language>
     <language id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest">
       <concept id="8427750732757990717" name="jetbrains.mps.baseLanguage.unitTest.structure.BinaryAssert" flags="nn" index="3tpDYu">
         <child id="8427750732757990725" name="actual" index="3tpDZA" />
@@ -91,9 +100,12 @@
       </concept>
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
-      <concept id="559557797393017698" name="jetbrains.mps.lang.smodel.structure.ModelReferenceExpression" flags="nn" index="BaHAS">
-        <property id="559557797393021807" name="stereotype" index="BaGAP" />
-        <property id="559557797393017702" name="name" index="BaHAW" />
+      <concept id="4065387505485742666" name="jetbrains.mps.lang.smodel.structure.ModelPointer_ResolveOperation" flags="ng" index="2yCiCJ" />
+      <concept id="4065387505485742749" name="jetbrains.mps.lang.smodel.structure.AbstractPointerResolveOperation" flags="ng" index="2yCiFS">
+        <child id="3648723375513868575" name="repositoryArg" index="Vysub" />
+      </concept>
+      <concept id="1863527487546129879" name="jetbrains.mps.lang.smodel.structure.ModelPointerExpression" flags="ng" index="1Xw6AR">
+        <child id="1863527487546132519" name="modelRef" index="1XwpL7" />
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
@@ -136,9 +148,23 @@
                   <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
                 </node>
               </node>
-              <node concept="BaHAS" id="5EwdfGVgITC" role="37wK5m">
-                <property role="BaHAW" value="assertion" />
-                <property role="BaGAP" value="" />
+              <node concept="2OqwBi" id="xRVdUhzWS$" role="37wK5m">
+                <node concept="1Xw6AR" id="xRVdUhzWJA" role="2Oq$k0">
+                  <node concept="1dCxOl" id="xRVdUhzYGr" role="1XwpL7">
+                    <property role="1XweGQ" value="r:97f52bf3-b8b9-4cb2-83a4-5a8caf3dca9a" />
+                    <node concept="1j_P7g" id="xRVdUhzYGs" role="1j$8Uc">
+                      <property role="1j_P7h" value="assertion" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2yCiCJ" id="xRVdUhzWZb" role="2OqNvi">
+                  <node concept="2OqwBi" id="xRVdUhzXhB" role="Vysub">
+                    <node concept="1jxXqW" id="xRVdUhzX1v" role="2Oq$k0" />
+                    <node concept="liA8E" id="xRVdUhzX_w" role="2OqNvi">
+                      <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                    </node>
+                  </node>
+                </node>
               </node>
               <node concept="Xl_RD" id="5EwdfGVgITD" role="37wK5m">
                 <property role="Xl_RC" value="main" />
@@ -238,9 +264,23 @@
                     <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
                   </node>
                 </node>
-                <node concept="BaHAS" id="5EwdfGVgJbp" role="37wK5m">
-                  <property role="BaHAW" value="assertion" />
-                  <property role="BaGAP" value="" />
+                <node concept="2OqwBi" id="xRVdUhzYKk" role="37wK5m">
+                  <node concept="1Xw6AR" id="xRVdUhzYKl" role="2Oq$k0">
+                    <node concept="1dCxOl" id="xRVdUhzYKm" role="1XwpL7">
+                      <property role="1XweGQ" value="r:97f52bf3-b8b9-4cb2-83a4-5a8caf3dca9a" />
+                      <node concept="1j_P7g" id="xRVdUhzYKn" role="1j$8Uc">
+                        <property role="1j_P7h" value="assertion" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2yCiCJ" id="xRVdUhzYKo" role="2OqNvi">
+                    <node concept="2OqwBi" id="xRVdUhzYKp" role="Vysub">
+                      <node concept="1jxXqW" id="xRVdUhzYKq" role="2Oq$k0" />
+                      <node concept="liA8E" id="xRVdUhzYKr" role="2OqNvi">
+                        <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                      </node>
+                    </node>
+                  </node>
                 </node>
                 <node concept="Xl_RD" id="5EwdfGVgJbq" role="37wK5m">
                   <property role="Xl_RC" value="main" />
@@ -289,9 +329,23 @@
                     <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
                   </node>
                 </node>
-                <node concept="BaHAS" id="5EwdfGVgJrT" role="37wK5m">
-                  <property role="BaHAW" value="assertion" />
-                  <property role="BaGAP" value="" />
+                <node concept="2OqwBi" id="xRVdUhzYOo" role="37wK5m">
+                  <node concept="1Xw6AR" id="xRVdUhzYOp" role="2Oq$k0">
+                    <node concept="1dCxOl" id="xRVdUhzYOq" role="1XwpL7">
+                      <property role="1XweGQ" value="r:97f52bf3-b8b9-4cb2-83a4-5a8caf3dca9a" />
+                      <node concept="1j_P7g" id="xRVdUhzYOr" role="1j$8Uc">
+                        <property role="1j_P7h" value="assertion" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2yCiCJ" id="xRVdUhzYOs" role="2OqNvi">
+                    <node concept="2OqwBi" id="xRVdUhzYOt" role="Vysub">
+                      <node concept="1jxXqW" id="xRVdUhzYOu" role="2Oq$k0" />
+                      <node concept="liA8E" id="xRVdUhzYOv" role="2OqNvi">
+                        <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                      </node>
+                    </node>
+                  </node>
                 </node>
                 <node concept="Xl_RD" id="5EwdfGVgJrU" role="37wK5m">
                   <property role="Xl_RC" value="main" />
@@ -340,9 +394,23 @@
                     <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
                   </node>
                 </node>
-                <node concept="BaHAS" id="5EwdfGVgJGp" role="37wK5m">
-                  <property role="BaHAW" value="assertion" />
-                  <property role="BaGAP" value="" />
+                <node concept="2OqwBi" id="xRVdUhzYSF" role="37wK5m">
+                  <node concept="1Xw6AR" id="xRVdUhzYSG" role="2Oq$k0">
+                    <node concept="1dCxOl" id="xRVdUhzYSH" role="1XwpL7">
+                      <property role="1XweGQ" value="r:97f52bf3-b8b9-4cb2-83a4-5a8caf3dca9a" />
+                      <node concept="1j_P7g" id="xRVdUhzYSI" role="1j$8Uc">
+                        <property role="1j_P7h" value="assertion" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2yCiCJ" id="xRVdUhzYSJ" role="2OqNvi">
+                    <node concept="2OqwBi" id="xRVdUhzYSK" role="Vysub">
+                      <node concept="1jxXqW" id="xRVdUhzYSL" role="2Oq$k0" />
+                      <node concept="liA8E" id="xRVdUhzYSM" role="2OqNvi">
+                        <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                      </node>
+                    </node>
+                  </node>
                 </node>
                 <node concept="Xl_RD" id="5EwdfGVgJGq" role="37wK5m">
                   <property role="Xl_RC" value="main" />
@@ -391,9 +459,23 @@
                     <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
                   </node>
                 </node>
-                <node concept="BaHAS" id="5EwdfGVgJWT" role="37wK5m">
-                  <property role="BaHAW" value="assertion" />
-                  <property role="BaGAP" value="" />
+                <node concept="2OqwBi" id="xRVdUhzYWJ" role="37wK5m">
+                  <node concept="1Xw6AR" id="xRVdUhzYWK" role="2Oq$k0">
+                    <node concept="1dCxOl" id="xRVdUhzYWL" role="1XwpL7">
+                      <property role="1XweGQ" value="r:97f52bf3-b8b9-4cb2-83a4-5a8caf3dca9a" />
+                      <node concept="1j_P7g" id="xRVdUhzYWM" role="1j$8Uc">
+                        <property role="1j_P7h" value="assertion" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2yCiCJ" id="xRVdUhzYWN" role="2OqNvi">
+                    <node concept="2OqwBi" id="xRVdUhzYWO" role="Vysub">
+                      <node concept="1jxXqW" id="xRVdUhzYWP" role="2Oq$k0" />
+                      <node concept="liA8E" id="xRVdUhzYWQ" role="2OqNvi">
+                        <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                      </node>
+                    </node>
+                  </node>
                 </node>
                 <node concept="Xl_RD" id="5EwdfGVgJWU" role="37wK5m">
                   <property role="Xl_RC" value="main" />
@@ -456,9 +538,23 @@
                   <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
                 </node>
               </node>
-              <node concept="BaHAS" id="5EwdfGVgKdB" role="37wK5m">
-                <property role="BaHAW" value="assertion" />
-                <property role="BaGAP" value="" />
+              <node concept="2OqwBi" id="xRVdUhzZ12" role="37wK5m">
+                <node concept="1Xw6AR" id="xRVdUhzZ13" role="2Oq$k0">
+                  <node concept="1dCxOl" id="xRVdUhzZ14" role="1XwpL7">
+                    <property role="1XweGQ" value="r:97f52bf3-b8b9-4cb2-83a4-5a8caf3dca9a" />
+                    <node concept="1j_P7g" id="xRVdUhzZ15" role="1j$8Uc">
+                      <property role="1j_P7h" value="assertion" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2yCiCJ" id="xRVdUhzZ16" role="2OqNvi">
+                  <node concept="2OqwBi" id="xRVdUhzZ17" role="Vysub">
+                    <node concept="1jxXqW" id="xRVdUhzZ18" role="2Oq$k0" />
+                    <node concept="liA8E" id="xRVdUhzZ19" role="2OqNvi">
+                      <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                    </node>
+                  </node>
+                </node>
               </node>
               <node concept="Xl_RD" id="5EwdfGVgKdC" role="37wK5m">
                 <property role="Xl_RC" value="main" />

--- a/code/languages/com.mbeddr.analyses/tests/test.analyses.cbmc/models/test/analyses/cbmc/cbmc_arguments@tests.mps
+++ b/code/languages/com.mbeddr.analyses/tests/test.analyses.cbmc/models/test/analyses/cbmc/cbmc_arguments@tests.mps
@@ -167,6 +167,15 @@
         <child id="1205770614681" name="actualArgument" index="2XxRq1" />
       </concept>
     </language>
+    <language id="446c26eb-2b7b-4bf0-9b35-f83fa582753e" name="jetbrains.mps.lang.modelapi">
+      <concept id="361130699826193248" name="jetbrains.mps.lang.modelapi.structure.ModelPointer" flags="ng" index="1dCxOl">
+        <property id="1863527487546097494" name="modelId" index="1XweGQ" />
+        <child id="679099339649067980" name="name" index="1j$8Uc" />
+      </concept>
+      <concept id="679099339649053840" name="jetbrains.mps.lang.modelapi.structure.ModelName" flags="ng" index="1j_P7g">
+        <property id="679099339649053841" name="value" index="1j_P7h" />
+      </concept>
+    </language>
     <language id="7e09729e-68e4-4442-9bc8-024c5cdac3a2" name="com.mbeddr.analyses.cbmc.testing">
       <concept id="4791280061046124023" name="com.mbeddr.analyses.cbmc.testing.structure.CBMCCounterexampleStateTest" flags="ng" index="38rIoz">
         <property id="4791280061046124024" name="nodeKind" index="38rIoG" />
@@ -200,13 +209,16 @@
       </concept>
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
-      <concept id="559557797393017698" name="jetbrains.mps.lang.smodel.structure.ModelReferenceExpression" flags="nn" index="BaHAS">
-        <property id="559557797393021807" name="stereotype" index="BaGAP" />
-        <property id="559557797393017702" name="name" index="BaHAW" />
+      <concept id="4065387505485742666" name="jetbrains.mps.lang.smodel.structure.ModelPointer_ResolveOperation" flags="ng" index="2yCiCJ" />
+      <concept id="4065387505485742749" name="jetbrains.mps.lang.smodel.structure.AbstractPointerResolveOperation" flags="ng" index="2yCiFS">
+        <child id="3648723375513868575" name="repositoryArg" index="Vysub" />
       </concept>
       <concept id="1143226024141" name="jetbrains.mps.lang.smodel.structure.SModelType" flags="in" index="H_c77" />
       <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
         <reference id="1138405853777" name="concept" index="ehGHo" />
+      </concept>
+      <concept id="1863527487546129879" name="jetbrains.mps.lang.smodel.structure.ModelPointerExpression" flags="ng" index="1Xw6AR">
+        <child id="1863527487546132519" name="modelRef" index="1XwpL7" />
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
@@ -290,9 +302,23 @@
           <node concept="3cpWsn" id="5EwdfGVgS6M" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="5EwdfGVgS6K" role="1tU5fm" />
-            <node concept="BaHAS" id="5EwdfGVgS6N" role="33vP2m">
-              <property role="BaHAW" value="cbmc_arguments" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUhzZqB" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUhzZg3" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUhzZli" role="1XwpL7">
+                  <property role="1XweGQ" value="r:4f1c8a59-d217-4da1-a46c-f37182e9100a" />
+                  <node concept="1j_P7g" id="xRVdUhzZlj" role="1j$8Uc">
+                    <property role="1j_P7h" value="cbmc_arguments" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUhzZya" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUhzZS2" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUhzZAc" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh$0cZ" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -471,9 +497,23 @@
                   <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
                 </node>
               </node>
-              <node concept="BaHAS" id="5EwdfGVgWht" role="37wK5m">
-                <property role="BaHAW" value="cbmc_arguments" />
-                <property role="BaGAP" value="" />
+              <node concept="2OqwBi" id="xRVdUh$1H4" role="37wK5m">
+                <node concept="1Xw6AR" id="xRVdUh$1H5" role="2Oq$k0">
+                  <node concept="1dCxOl" id="xRVdUh$1H6" role="1XwpL7">
+                    <property role="1XweGQ" value="r:4f1c8a59-d217-4da1-a46c-f37182e9100a" />
+                    <node concept="1j_P7g" id="xRVdUh$1H7" role="1j$8Uc">
+                      <property role="1j_P7h" value="cbmc_arguments" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2yCiCJ" id="xRVdUh$1H8" role="2OqNvi">
+                  <node concept="2OqwBi" id="xRVdUh$1H9" role="Vysub">
+                    <node concept="1jxXqW" id="xRVdUh$1Ha" role="2Oq$k0" />
+                    <node concept="liA8E" id="xRVdUh$1Hb" role="2OqNvi">
+                      <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                    </node>
+                  </node>
+                </node>
               </node>
               <node concept="Xl_RD" id="5EwdfGVgWhu" role="37wK5m">
                 <property role="Xl_RC" value="main" />
@@ -856,9 +896,23 @@
           <node concept="3cpWsn" id="5KHBa6kVNmB" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="5KHBa6kVNm_" role="1tU5fm" />
-            <node concept="BaHAS" id="5KHBa6kVNmC" role="33vP2m">
-              <property role="BaHAW" value="cbmc_arguments" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh$0NC" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh$0ND" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh$0NE" role="1XwpL7">
+                  <property role="1XweGQ" value="r:4f1c8a59-d217-4da1-a46c-f37182e9100a" />
+                  <node concept="1j_P7g" id="xRVdUh$0NF" role="1j$8Uc">
+                    <property role="1j_P7h" value="cbmc_arguments" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh$0NG" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh$0NH" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh$0NI" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh$0NJ" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -959,9 +1013,23 @@
           <node concept="3cpWsn" id="5KHBa6kWOhu" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="5KHBa6kWOhv" role="1tU5fm" />
-            <node concept="BaHAS" id="5KHBa6kWOhw" role="33vP2m">
-              <property role="BaHAW" value="cbmc_arguments" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh$0TT" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh$0TU" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh$0TV" role="1XwpL7">
+                  <property role="1XweGQ" value="r:4f1c8a59-d217-4da1-a46c-f37182e9100a" />
+                  <node concept="1j_P7g" id="xRVdUh$0TW" role="1j$8Uc">
+                    <property role="1j_P7h" value="cbmc_arguments" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh$0TX" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh$0TY" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh$0TZ" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh$0U0" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -1033,9 +1101,23 @@
           <node concept="3cpWsn" id="5KHBa6kWPfe" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="5KHBa6kWPff" role="1tU5fm" />
-            <node concept="BaHAS" id="5KHBa6kWPfg" role="33vP2m">
-              <property role="BaHAW" value="cbmc_arguments" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh$0Yz" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh$0Y$" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh$0Y_" role="1XwpL7">
+                  <property role="1XweGQ" value="r:4f1c8a59-d217-4da1-a46c-f37182e9100a" />
+                  <node concept="1j_P7g" id="xRVdUh$0YA" role="1j$8Uc">
+                    <property role="1j_P7h" value="cbmc_arguments" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh$0YB" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh$0YC" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh$0YD" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh$0YE" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -1107,9 +1189,23 @@
           <node concept="3cpWsn" id="3aDyPAXW6DQ" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="3aDyPAXW6DR" role="1tU5fm" />
-            <node concept="BaHAS" id="3aDyPAXW6DS" role="33vP2m">
-              <property role="BaHAW" value="cbmc_arguments" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh$13d" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh$13e" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh$13f" role="1XwpL7">
+                  <property role="1XweGQ" value="r:4f1c8a59-d217-4da1-a46c-f37182e9100a" />
+                  <node concept="1j_P7g" id="xRVdUh$13g" role="1j$8Uc">
+                    <property role="1j_P7h" value="cbmc_arguments" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh$13h" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh$13i" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh$13j" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh$13k" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -1181,9 +1277,23 @@
           <node concept="3cpWsn" id="51BKItOC7a7" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="51BKItOC7a8" role="1tU5fm" />
-            <node concept="BaHAS" id="51BKItOC7a9" role="33vP2m">
-              <property role="BaHAW" value="cbmc_arguments" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh$17R" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh$17S" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh$17T" role="1XwpL7">
+                  <property role="1XweGQ" value="r:4f1c8a59-d217-4da1-a46c-f37182e9100a" />
+                  <node concept="1j_P7g" id="xRVdUh$17U" role="1j$8Uc">
+                    <property role="1j_P7h" value="cbmc_arguments" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh$17V" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh$17W" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh$17X" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh$17Y" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -1255,9 +1365,23 @@
           <node concept="3cpWsn" id="51BKItODN8g" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="51BKItODN8h" role="1tU5fm" />
-            <node concept="BaHAS" id="51BKItODN8i" role="33vP2m">
-              <property role="BaHAW" value="cbmc_arguments" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh$1cx" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh$1cy" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh$1cz" role="1XwpL7">
+                  <property role="1XweGQ" value="r:4f1c8a59-d217-4da1-a46c-f37182e9100a" />
+                  <node concept="1j_P7g" id="xRVdUh$1c$" role="1j$8Uc">
+                    <property role="1j_P7h" value="cbmc_arguments" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh$1c_" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh$1cA" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh$1cB" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh$1cC" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -1329,9 +1453,23 @@
           <node concept="3cpWsn" id="51BKItOEwWb" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="51BKItOEwWc" role="1tU5fm" />
-            <node concept="BaHAS" id="51BKItOEwWd" role="33vP2m">
-              <property role="BaHAW" value="cbmc_arguments" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh$1hb" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh$1hc" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh$1hd" role="1XwpL7">
+                  <property role="1XweGQ" value="r:4f1c8a59-d217-4da1-a46c-f37182e9100a" />
+                  <node concept="1j_P7g" id="xRVdUh$1he" role="1j$8Uc">
+                    <property role="1j_P7h" value="cbmc_arguments" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh$1hf" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh$1hg" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh$1hh" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh$1hi" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -1477,9 +1615,23 @@
           <node concept="3cpWsn" id="7yZlKoqjuyc" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="7yZlKoqjuyd" role="1tU5fm" />
-            <node concept="BaHAS" id="7yZlKoqjuye" role="33vP2m">
-              <property role="BaHAW" value="cbmc_arguments" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh$2f9" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh$2fa" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh$2fb" role="1XwpL7">
+                  <property role="1XweGQ" value="r:4f1c8a59-d217-4da1-a46c-f37182e9100a" />
+                  <node concept="1j_P7g" id="xRVdUh$2fc" role="1j$8Uc">
+                    <property role="1j_P7h" value="cbmc_arguments" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh$2fd" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh$2fe" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh$2ff" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh$2fg" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -1618,9 +1770,23 @@
           <node concept="3cpWsn" id="7yZlKoqjCiv" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="7yZlKoqjCiw" role="1tU5fm" />
-            <node concept="BaHAS" id="7yZlKoqjCix" role="33vP2m">
-              <property role="BaHAW" value="cbmc_arguments" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh$2jj" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh$2jk" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh$2jl" role="1XwpL7">
+                  <property role="1XweGQ" value="r:4f1c8a59-d217-4da1-a46c-f37182e9100a" />
+                  <node concept="1j_P7g" id="xRVdUh$2jm" role="1j$8Uc">
+                    <property role="1j_P7h" value="cbmc_arguments" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh$2jn" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh$2jo" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh$2jp" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh$2jq" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -1828,9 +1994,23 @@
           <node concept="3cpWsn" id="7yZlKoqkLQK" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="7yZlKoqkLQL" role="1tU5fm" />
-            <node concept="BaHAS" id="7yZlKoqkLQM" role="33vP2m">
-              <property role="BaHAW" value="cbmc_arguments" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh$1Wv" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh$1Ww" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh$1Wx" role="1XwpL7">
+                  <property role="1XweGQ" value="r:4f1c8a59-d217-4da1-a46c-f37182e9100a" />
+                  <node concept="1j_P7g" id="xRVdUh$1Wy" role="1j$8Uc">
+                    <property role="1j_P7h" value="cbmc_arguments" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh$1Wz" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh$1W$" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh$1W_" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh$1WA" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -1969,9 +2149,23 @@
           <node concept="3cpWsn" id="7yZlKoqkLRh" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="7yZlKoqkLRi" role="1tU5fm" />
-            <node concept="BaHAS" id="7yZlKoqkLRj" role="33vP2m">
-              <property role="BaHAW" value="cbmc_arguments" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh$20D" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh$20E" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh$20F" role="1XwpL7">
+                  <property role="1XweGQ" value="r:4f1c8a59-d217-4da1-a46c-f37182e9100a" />
+                  <node concept="1j_P7g" id="xRVdUh$20G" role="1j$8Uc">
+                    <property role="1j_P7h" value="cbmc_arguments" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh$20H" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh$20I" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh$20J" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh$20K" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -2044,9 +2238,23 @@
           <node concept="3cpWsn" id="6b3VADyzkXl" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="6b3VADyzkXm" role="1tU5fm" />
-            <node concept="BaHAS" id="6b3VADyzkXn" role="33vP2m">
-              <property role="BaHAW" value="cbmc_arguments" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh$1vz" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh$1v$" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh$1v_" role="1XwpL7">
+                  <property role="1XweGQ" value="r:4f1c8a59-d217-4da1-a46c-f37182e9100a" />
+                  <node concept="1j_P7g" id="xRVdUh$1vA" role="1j$8Uc">
+                    <property role="1j_P7h" value="cbmc_arguments" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh$1vB" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh$1vC" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh$1vD" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh$1vE" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>

--- a/code/languages/com.mbeddr.analyses/tests/test.analyses.cbmc/models/test/analyses/cbmc/cbmc_runtime_error@tests.mps
+++ b/code/languages/com.mbeddr.analyses/tests/test.analyses.cbmc/models/test/analyses/cbmc/cbmc_runtime_error@tests.mps
@@ -80,15 +80,27 @@
     <language id="63e0e566-5131-447e-90e3-12ea330e1a00" name="com.mbeddr.mpsutil.blutil">
       <concept id="6451706574537082687" name="com.mbeddr.mpsutil.blutil.structure.ShortStaticMethodCall" flags="ng" index="NRdvd" />
     </language>
+    <language id="446c26eb-2b7b-4bf0-9b35-f83fa582753e" name="jetbrains.mps.lang.modelapi">
+      <concept id="361130699826193248" name="jetbrains.mps.lang.modelapi.structure.ModelPointer" flags="ng" index="1dCxOl">
+        <property id="1863527487546097494" name="modelId" index="1XweGQ" />
+        <child id="679099339649067980" name="name" index="1j$8Uc" />
+      </concept>
+      <concept id="679099339649053840" name="jetbrains.mps.lang.modelapi.structure.ModelName" flags="ng" index="1j_P7g">
+        <property id="679099339649053841" name="value" index="1j_P7h" />
+      </concept>
+    </language>
     <language id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest">
       <concept id="1171981022339" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertTrue" flags="nn" index="3vwNmj">
         <child id="1171981057159" name="condition" index="3vwVQn" />
       </concept>
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
-      <concept id="559557797393017698" name="jetbrains.mps.lang.smodel.structure.ModelReferenceExpression" flags="nn" index="BaHAS">
-        <property id="559557797393021807" name="stereotype" index="BaGAP" />
-        <property id="559557797393017702" name="name" index="BaHAW" />
+      <concept id="4065387505485742666" name="jetbrains.mps.lang.smodel.structure.ModelPointer_ResolveOperation" flags="ng" index="2yCiCJ" />
+      <concept id="4065387505485742749" name="jetbrains.mps.lang.smodel.structure.AbstractPointerResolveOperation" flags="ng" index="2yCiFS">
+        <child id="3648723375513868575" name="repositoryArg" index="Vysub" />
+      </concept>
+      <concept id="1863527487546129879" name="jetbrains.mps.lang.smodel.structure.ModelPointerExpression" flags="ng" index="1Xw6AR">
+        <child id="1863527487546132519" name="modelRef" index="1XwpL7" />
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
@@ -126,9 +138,23 @@
                     <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
                   </node>
                 </node>
-                <node concept="BaHAS" id="5EwdfGVgWAx" role="37wK5m">
-                  <property role="BaHAW" value="cbmc_error" />
-                  <property role="BaGAP" value="" />
+                <node concept="2OqwBi" id="xRVdUh$2_s" role="37wK5m">
+                  <node concept="1Xw6AR" id="xRVdUh$2tA" role="2Oq$k0">
+                    <node concept="1dCxOl" id="xRVdUh$2xG" role="1XwpL7">
+                      <property role="1XweGQ" value="r:b9a28995-44f0-46ab-9146-3282d2b22957" />
+                      <node concept="1j_P7g" id="xRVdUh$2xH" role="1j$8Uc">
+                        <property role="1j_P7h" value="cbmc_error" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2yCiCJ" id="xRVdUh$2G4" role="2OqNvi">
+                    <node concept="2OqwBi" id="xRVdUh$2YS" role="Vysub">
+                      <node concept="1jxXqW" id="xRVdUh$2I$" role="2Oq$k0" />
+                      <node concept="liA8E" id="xRVdUh$3iX" role="2OqNvi">
+                        <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                      </node>
+                    </node>
+                  </node>
                 </node>
                 <node concept="Xl_RD" id="5EwdfGVgWAy" role="37wK5m">
                   <property role="Xl_RC" value="smoke" />

--- a/code/languages/com.mbeddr.analyses/tests/test.analyses.cbmc/models/test/analyses/cbmc/concurrency@tests.mps
+++ b/code/languages/com.mbeddr.analyses/tests/test.analyses.cbmc/models/test/analyses/cbmc/concurrency@tests.mps
@@ -101,6 +101,15 @@
     <language id="63e0e566-5131-447e-90e3-12ea330e1a00" name="com.mbeddr.mpsutil.blutil">
       <concept id="6451706574537082687" name="com.mbeddr.mpsutil.blutil.structure.ShortStaticMethodCall" flags="ng" index="NRdvd" />
     </language>
+    <language id="446c26eb-2b7b-4bf0-9b35-f83fa582753e" name="jetbrains.mps.lang.modelapi">
+      <concept id="361130699826193248" name="jetbrains.mps.lang.modelapi.structure.ModelPointer" flags="ng" index="1dCxOl">
+        <property id="1863527487546097494" name="modelId" index="1XweGQ" />
+        <child id="679099339649067980" name="name" index="1j$8Uc" />
+      </concept>
+      <concept id="679099339649053840" name="jetbrains.mps.lang.modelapi.structure.ModelName" flags="ng" index="1j_P7g">
+        <property id="679099339649053841" name="value" index="1j_P7h" />
+      </concept>
+    </language>
     <language id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest">
       <concept id="8427750732757990717" name="jetbrains.mps.baseLanguage.unitTest.structure.BinaryAssert" flags="nn" index="3tpDYu">
         <child id="8427750732757990725" name="actual" index="3tpDZA" />
@@ -112,11 +121,14 @@
       </concept>
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
-      <concept id="559557797393017698" name="jetbrains.mps.lang.smodel.structure.ModelReferenceExpression" flags="nn" index="BaHAS">
-        <property id="559557797393021807" name="stereotype" index="BaGAP" />
-        <property id="559557797393017702" name="name" index="BaHAW" />
+      <concept id="4065387505485742666" name="jetbrains.mps.lang.smodel.structure.ModelPointer_ResolveOperation" flags="ng" index="2yCiCJ" />
+      <concept id="4065387505485742749" name="jetbrains.mps.lang.smodel.structure.AbstractPointerResolveOperation" flags="ng" index="2yCiFS">
+        <child id="3648723375513868575" name="repositoryArg" index="Vysub" />
       </concept>
       <concept id="1143226024141" name="jetbrains.mps.lang.smodel.structure.SModelType" flags="in" index="H_c77" />
+      <concept id="1863527487546129879" name="jetbrains.mps.lang.smodel.structure.ModelPointerExpression" flags="ng" index="1Xw6AR">
+        <child id="1863527487546132519" name="modelRef" index="1XwpL7" />
+      </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
@@ -149,9 +161,23 @@
           <node concept="3cpWsn" id="5EwdfGVgYHA" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="5EwdfGVgYH$" role="1tU5fm" />
-            <node concept="BaHAS" id="5EwdfGVgYHB" role="33vP2m">
-              <property role="BaHAW" value="concurrency" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh$4ks" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh$4kt" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh$4ku" role="1XwpL7">
+                  <property role="1XweGQ" value="r:0a438a16-5c60-4a0f-bf9f-41ddfa32c0f4" />
+                  <node concept="1j_P7g" id="xRVdUh$4kv" role="1j$8Uc">
+                    <property role="1j_P7h" value="concurrency" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh$4kw" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh$4kx" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh$4ky" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh$4kz" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -301,9 +327,23 @@
                   <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
                 </node>
               </node>
-              <node concept="BaHAS" id="77fajPdkUco" role="37wK5m">
-                <property role="BaHAW" value="concurrency" />
-                <property role="BaGAP" value="" />
+              <node concept="2OqwBi" id="xRVdUh$2_s" role="37wK5m">
+                <node concept="1Xw6AR" id="xRVdUh$2tA" role="2Oq$k0">
+                  <node concept="1dCxOl" id="xRVdUh$3yO" role="1XwpL7">
+                    <property role="1XweGQ" value="r:0a438a16-5c60-4a0f-bf9f-41ddfa32c0f4" />
+                    <node concept="1j_P7g" id="xRVdUh$3yP" role="1j$8Uc">
+                      <property role="1j_P7h" value="concurrency" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2yCiCJ" id="xRVdUh$2G4" role="2OqNvi">
+                  <node concept="2OqwBi" id="xRVdUh$2YS" role="Vysub">
+                    <node concept="1jxXqW" id="xRVdUh$2I$" role="2Oq$k0" />
+                    <node concept="liA8E" id="xRVdUh$3iX" role="2OqNvi">
+                      <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                    </node>
+                  </node>
+                </node>
               </node>
               <node concept="Xl_RD" id="77fajPdkUcp" role="37wK5m">
                 <property role="Xl_RC" value="assert_seq1" />
@@ -391,9 +431,23 @@
                   <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
                 </node>
               </node>
-              <node concept="BaHAS" id="77fajPdjAOG" role="37wK5m">
-                <property role="BaHAW" value="concurrency" />
-                <property role="BaGAP" value="" />
+              <node concept="2OqwBi" id="xRVdUh$3IY" role="37wK5m">
+                <node concept="1Xw6AR" id="xRVdUh$3IZ" role="2Oq$k0">
+                  <node concept="1dCxOl" id="xRVdUh$3J0" role="1XwpL7">
+                    <property role="1XweGQ" value="r:0a438a16-5c60-4a0f-bf9f-41ddfa32c0f4" />
+                    <node concept="1j_P7g" id="xRVdUh$3J1" role="1j$8Uc">
+                      <property role="1j_P7h" value="concurrency" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2yCiCJ" id="xRVdUh$3J2" role="2OqNvi">
+                  <node concept="2OqwBi" id="xRVdUh$3J3" role="Vysub">
+                    <node concept="1jxXqW" id="xRVdUh$3J4" role="2Oq$k0" />
+                    <node concept="liA8E" id="xRVdUh$3J5" role="2OqNvi">
+                      <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                    </node>
+                  </node>
+                </node>
               </node>
               <node concept="Xl_RD" id="77fajPdjAOH" role="37wK5m">
                 <property role="Xl_RC" value="assert_seq2" />
@@ -481,9 +535,23 @@
                   <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
                 </node>
               </node>
-              <node concept="BaHAS" id="77fajPdkV$5" role="37wK5m">
-                <property role="BaHAW" value="concurrency" />
-                <property role="BaGAP" value="" />
+              <node concept="2OqwBi" id="xRVdUh$3TZ" role="37wK5m">
+                <node concept="1Xw6AR" id="xRVdUh$3U0" role="2Oq$k0">
+                  <node concept="1dCxOl" id="xRVdUh$3U1" role="1XwpL7">
+                    <property role="1XweGQ" value="r:0a438a16-5c60-4a0f-bf9f-41ddfa32c0f4" />
+                    <node concept="1j_P7g" id="xRVdUh$3U2" role="1j$8Uc">
+                      <property role="1j_P7h" value="concurrency" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2yCiCJ" id="xRVdUh$3U3" role="2OqNvi">
+                  <node concept="2OqwBi" id="xRVdUh$3U4" role="Vysub">
+                    <node concept="1jxXqW" id="xRVdUh$3U5" role="2Oq$k0" />
+                    <node concept="liA8E" id="xRVdUh$3U6" role="2OqNvi">
+                      <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                    </node>
+                  </node>
+                </node>
               </node>
               <node concept="Xl_RD" id="77fajPdkV$6" role="37wK5m">
                 <property role="Xl_RC" value="assert_seq3" />
@@ -561,9 +629,23 @@
                   <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
                 </node>
               </node>
-              <node concept="BaHAS" id="77fajPdlkoc" role="37wK5m">
-                <property role="BaHAW" value="concurrency" />
-                <property role="BaGAP" value="" />
+              <node concept="2OqwBi" id="xRVdUh$43L" role="37wK5m">
+                <node concept="1Xw6AR" id="xRVdUh$43M" role="2Oq$k0">
+                  <node concept="1dCxOl" id="xRVdUh$43N" role="1XwpL7">
+                    <property role="1XweGQ" value="r:0a438a16-5c60-4a0f-bf9f-41ddfa32c0f4" />
+                    <node concept="1j_P7g" id="xRVdUh$43O" role="1j$8Uc">
+                      <property role="1j_P7h" value="concurrency" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2yCiCJ" id="xRVdUh$43P" role="2OqNvi">
+                  <node concept="2OqwBi" id="xRVdUh$43Q" role="Vysub">
+                    <node concept="1jxXqW" id="xRVdUh$43R" role="2Oq$k0" />
+                    <node concept="liA8E" id="xRVdUh$43S" role="2OqNvi">
+                      <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                    </node>
+                  </node>
+                </node>
               </node>
               <node concept="Xl_RD" id="77fajPdlkod" role="37wK5m">
                 <property role="Xl_RC" value="happens_after" />

--- a/code/languages/com.mbeddr.analyses/tests/test.analyses.cbmc/models/test/analyses/cbmc/counterexample/mbeddr/components@tests.mps
+++ b/code/languages/com.mbeddr.analyses/tests/test.analyses.cbmc/models/test/analyses/cbmc/counterexample/mbeddr/components@tests.mps
@@ -22,6 +22,7 @@
     <import index="pyey" ref="r:b89a3cc8-64dd-45da-a374-472dedea6945(com.mbeddr.analyses.base.verification_conditions.structure)" />
     <import index="z1c3" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.project(MPS.Core/)" />
     <import index="fxhk" ref="r:fd182312-cbd2-4a09-87ee-383f798adf6c(com.mbeddr.analyses.cbmc.rt.testing_utils)" />
+    <import index="w1kc" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel(MPS.Core/)" />
   </imports>
   <registry>
     <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
@@ -94,6 +95,15 @@
     <language id="63e0e566-5131-447e-90e3-12ea330e1a00" name="com.mbeddr.mpsutil.blutil">
       <concept id="6451706574537082687" name="com.mbeddr.mpsutil.blutil.structure.ShortStaticMethodCall" flags="ng" index="NRdvd" />
     </language>
+    <language id="446c26eb-2b7b-4bf0-9b35-f83fa582753e" name="jetbrains.mps.lang.modelapi">
+      <concept id="361130699826193248" name="jetbrains.mps.lang.modelapi.structure.ModelPointer" flags="ng" index="1dCxOl">
+        <property id="1863527487546097494" name="modelId" index="1XweGQ" />
+        <child id="679099339649067980" name="name" index="1j$8Uc" />
+      </concept>
+      <concept id="679099339649053840" name="jetbrains.mps.lang.modelapi.structure.ModelName" flags="ng" index="1j_P7g">
+        <property id="679099339649053841" name="value" index="1j_P7h" />
+      </concept>
+    </language>
     <language id="7e09729e-68e4-4442-9bc8-024c5cdac3a2" name="com.mbeddr.analyses.cbmc.testing">
       <concept id="4791280061046124023" name="com.mbeddr.analyses.cbmc.testing.structure.CBMCCounterexampleStateTest" flags="ng" index="38rIoz">
         <property id="4791280061046124024" name="nodeKind" index="38rIoG" />
@@ -111,13 +121,16 @@
       </concept>
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
-      <concept id="559557797393017698" name="jetbrains.mps.lang.smodel.structure.ModelReferenceExpression" flags="nn" index="BaHAS">
-        <property id="559557797393021807" name="stereotype" index="BaGAP" />
-        <property id="559557797393017702" name="name" index="BaHAW" />
+      <concept id="4065387505485742666" name="jetbrains.mps.lang.smodel.structure.ModelPointer_ResolveOperation" flags="ng" index="2yCiCJ" />
+      <concept id="4065387505485742749" name="jetbrains.mps.lang.smodel.structure.AbstractPointerResolveOperation" flags="ng" index="2yCiFS">
+        <child id="3648723375513868575" name="repositoryArg" index="Vysub" />
       </concept>
       <concept id="1143226024141" name="jetbrains.mps.lang.smodel.structure.SModelType" flags="in" index="H_c77" />
       <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
         <reference id="1138405853777" name="concept" index="ehGHo" />
+      </concept>
+      <concept id="1863527487546129879" name="jetbrains.mps.lang.smodel.structure.ModelPointerExpression" flags="ng" index="1Xw6AR">
+        <child id="1863527487546132519" name="modelRef" index="1XwpL7" />
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
@@ -442,9 +455,21 @@
       <property role="od$2w" value="false" />
       <node concept="3clFbS" id="5djBfpcTb1u" role="3clF47">
         <node concept="3clFbF" id="5djBfpcTb1v" role="3cqZAp">
-          <node concept="BaHAS" id="5djBfpcTb1w" role="3clFbG">
-            <property role="BaHAW" value="test.analyses.cbmc.testcode.counterexample.mbeddr.components" />
-            <property role="BaGAP" value="" />
+          <node concept="2OqwBi" id="xRVdUh$4um" role="3clFbG">
+            <node concept="1Xw6AR" id="xRVdUh$4r0" role="2Oq$k0">
+              <node concept="1dCxOl" id="xRVdUh$5YP" role="1XwpL7">
+                <property role="1XweGQ" value="r:33c9d9c4-a88b-4fe7-95a6-63d05845ec6b" />
+                <node concept="1j_P7g" id="xRVdUh$5YQ" role="1j$8Uc">
+                  <property role="1j_P7h" value="test.analyses.cbmc.testcode.counterexample.mbeddr.components" />
+                </node>
+              </node>
+            </node>
+            <node concept="2yCiCJ" id="xRVdUh$4yx" role="2OqNvi">
+              <node concept="2YIFZM" id="xRVdUh$4$z" role="Vysub">
+                <ref role="37wK5l" to="w1kc:~MPSModuleRepository.getInstance()" resolve="getInstance" />
+                <ref role="1Pybhc" to="w1kc:~MPSModuleRepository" resolve="MPSModuleRepository" />
+              </node>
+            </node>
           </node>
         </node>
       </node>

--- a/code/languages/com.mbeddr.analyses/tests/test.analyses.cbmc/models/test/analyses/cbmc/counterexample/mbeddr/core@tests.mps
+++ b/code/languages/com.mbeddr.analyses/tests/test.analyses.cbmc/models/test/analyses/cbmc/counterexample/mbeddr/core@tests.mps
@@ -27,6 +27,7 @@
     <import index="z1c3" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.project(MPS.Core/)" />
     <import index="lui2" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.module(MPS.OpenAPI/)" />
     <import index="fwk" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.textgen.trace(MPS.Core/)" />
+    <import index="w1kc" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel(MPS.Core/)" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
   </imports>
   <registry>
@@ -170,9 +171,9 @@
       </concept>
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
-      <concept id="559557797393017698" name="jetbrains.mps.lang.smodel.structure.ModelReferenceExpression" flags="nn" index="BaHAS">
-        <property id="559557797393021807" name="stereotype" index="BaGAP" />
-        <property id="559557797393017702" name="name" index="BaHAW" />
+      <concept id="4065387505485742666" name="jetbrains.mps.lang.smodel.structure.ModelPointer_ResolveOperation" flags="ng" index="2yCiCJ" />
+      <concept id="4065387505485742749" name="jetbrains.mps.lang.smodel.structure.AbstractPointerResolveOperation" flags="ng" index="2yCiFS">
+        <child id="3648723375513868575" name="repositoryArg" index="Vysub" />
       </concept>
       <concept id="1143226024141" name="jetbrains.mps.lang.smodel.structure.SModelType" flags="in" index="H_c77" />
       <concept id="1145404486709" name="jetbrains.mps.lang.smodel.structure.SemanticDowncastExpression" flags="nn" index="2JrnkZ">
@@ -1362,10 +1363,22 @@
       <property role="DiZV1" value="false" />
       <property role="od$2w" value="false" />
       <node concept="3clFbS" id="5djBfpcTb1u" role="3clF47">
-        <node concept="3clFbF" id="5djBfpcTb1v" role="3cqZAp">
-          <node concept="BaHAS" id="5djBfpcTb1w" role="3clFbG">
-            <property role="BaHAW" value="test.analyses.cbmc.testcode.counterexample.mbeddr.core" />
-            <property role="BaGAP" value="" />
+        <node concept="3clFbF" id="xRVdUh$69f" role="3cqZAp">
+          <node concept="2OqwBi" id="xRVdUh$6bB" role="3clFbG">
+            <node concept="1Xw6AR" id="xRVdUh$69c" role="2Oq$k0">
+              <node concept="1dCxOl" id="xRVdUh$69T" role="1XwpL7">
+                <property role="1XweGQ" value="r:d20a8498-55ea-46f3-9220-542767b71661" />
+                <node concept="1j_P7g" id="xRVdUh$69U" role="1j$8Uc">
+                  <property role="1j_P7h" value="test.analyses.cbmc.testcode.counterexample.mbeddr.core" />
+                </node>
+              </node>
+            </node>
+            <node concept="2yCiCJ" id="xRVdUh$6mO" role="2OqNvi">
+              <node concept="2YIFZM" id="xRVdUh$6nf" role="Vysub">
+                <ref role="1Pybhc" to="w1kc:~MPSModuleRepository" resolve="MPSModuleRepository" />
+                <ref role="37wK5l" to="w1kc:~MPSModuleRepository.getInstance()" resolve="getInstance" />
+              </node>
+            </node>
           </node>
         </node>
       </node>

--- a/code/languages/com.mbeddr.analyses/tests/test.analyses.cbmc/models/test/analyses/cbmc/counterexample/mbeddr/statemachines@tests.mps
+++ b/code/languages/com.mbeddr.analyses/tests/test.analyses.cbmc/models/test/analyses/cbmc/counterexample/mbeddr/statemachines@tests.mps
@@ -104,6 +104,15 @@
     <language id="443f4c36-fcf5-4eb6-9500-8d06ed259e3e" name="jetbrains.mps.baseLanguage.classifiers">
       <concept id="1205769003971" name="jetbrains.mps.baseLanguage.classifiers.structure.DefaultClassifierMethodDeclaration" flags="ng" index="2XrIbr" />
     </language>
+    <language id="446c26eb-2b7b-4bf0-9b35-f83fa582753e" name="jetbrains.mps.lang.modelapi">
+      <concept id="361130699826193248" name="jetbrains.mps.lang.modelapi.structure.ModelPointer" flags="ng" index="1dCxOl">
+        <property id="1863527487546097494" name="modelId" index="1XweGQ" />
+        <child id="679099339649067980" name="name" index="1j$8Uc" />
+      </concept>
+      <concept id="679099339649053840" name="jetbrains.mps.lang.modelapi.structure.ModelName" flags="ng" index="1j_P7g">
+        <property id="679099339649053841" name="value" index="1j_P7h" />
+      </concept>
+    </language>
     <language id="7e09729e-68e4-4442-9bc8-024c5cdac3a2" name="com.mbeddr.analyses.cbmc.testing">
       <concept id="4791280061046124023" name="com.mbeddr.analyses.cbmc.testing.structure.CBMCCounterexampleStateTest" flags="ng" index="38rIoz">
         <property id="5665549241468834974" name="alternativeSteps" index="35AWuq" />
@@ -128,13 +137,16 @@
       </concept>
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
-      <concept id="559557797393017698" name="jetbrains.mps.lang.smodel.structure.ModelReferenceExpression" flags="nn" index="BaHAS">
-        <property id="559557797393021807" name="stereotype" index="BaGAP" />
-        <property id="559557797393017702" name="name" index="BaHAW" />
+      <concept id="4065387505485742666" name="jetbrains.mps.lang.smodel.structure.ModelPointer_ResolveOperation" flags="ng" index="2yCiCJ" />
+      <concept id="4065387505485742749" name="jetbrains.mps.lang.smodel.structure.AbstractPointerResolveOperation" flags="ng" index="2yCiFS">
+        <child id="3648723375513868575" name="repositoryArg" index="Vysub" />
       </concept>
       <concept id="1143226024141" name="jetbrains.mps.lang.smodel.structure.SModelType" flags="in" index="H_c77" />
       <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
         <reference id="1138405853777" name="concept" index="ehGHo" />
+      </concept>
+      <concept id="1863527487546129879" name="jetbrains.mps.lang.smodel.structure.ModelPointerExpression" flags="ng" index="1Xw6AR">
+        <child id="1863527487546132519" name="modelRef" index="1XwpL7" />
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
@@ -168,9 +180,23 @@
       <node concept="H_c77" id="4Y$LvVOinTr" role="3clF45" />
       <node concept="3clFbS" id="4Y$LvVOimF_" role="3clF47">
         <node concept="3clFbF" id="4Y$LvVOinV5" role="3cqZAp">
-          <node concept="BaHAS" id="4Y$LvVOinV7" role="3clFbG">
-            <property role="BaHAW" value="test.analyses.cbmc.testcode.counterexample.mbeddr.statemachines" />
-            <property role="BaGAP" value="" />
+          <node concept="2OqwBi" id="xRVdUh$7Eg" role="3clFbG">
+            <node concept="1Xw6AR" id="xRVdUh$7Eh" role="2Oq$k0">
+              <node concept="1dCxOl" id="xRVdUh$7Ei" role="1XwpL7">
+                <property role="1XweGQ" value="r:e2db5934-0aec-4dbd-8d13-2d3b7dc23298" />
+                <node concept="1j_P7g" id="xRVdUh$7Ej" role="1j$8Uc">
+                  <property role="1j_P7h" value="test.analyses.cbmc.testcode.counterexample.mbeddr.statemachines" />
+                </node>
+              </node>
+            </node>
+            <node concept="2yCiCJ" id="xRVdUh$7Ek" role="2OqNvi">
+              <node concept="2OqwBi" id="xRVdUh$7El" role="Vysub">
+                <node concept="1jxXqW" id="xRVdUh$7Em" role="2Oq$k0" />
+                <node concept="liA8E" id="xRVdUh$7En" role="2OqNvi">
+                  <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                </node>
+              </node>
+            </node>
           </node>
         </node>
       </node>
@@ -183,9 +209,23 @@
           <node concept="3cpWsn" id="2WJ8cS_xNJ6" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="2WJ8cS_xNJ1" role="1tU5fm" />
-            <node concept="BaHAS" id="2WJ8cS_xNO6" role="33vP2m">
-              <property role="BaHAW" value="test.analyses.cbmc.testcode.counterexample.mbeddr.statemachines" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh$7Fm" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh$7Fn" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh$7Fo" role="1XwpL7">
+                  <property role="1XweGQ" value="r:e2db5934-0aec-4dbd-8d13-2d3b7dc23298" />
+                  <node concept="1j_P7g" id="xRVdUh$7Fp" role="1j$8Uc">
+                    <property role="1j_P7h" value="test.analyses.cbmc.testcode.counterexample.mbeddr.statemachines" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh$7Fq" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh$7Fr" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh$7Fs" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh$7Ft" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -365,9 +405,23 @@
           <node concept="3cpWsn" id="2WJ8cS_xNsi" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="2WJ8cS_xNsd" role="1tU5fm" />
-            <node concept="BaHAS" id="2WJ8cS_xIzC" role="33vP2m">
-              <property role="BaHAW" value="test.analyses.cbmc.testcode.counterexample.mbeddr.statemachines" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh$80i" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh$80j" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh$80k" role="1XwpL7">
+                  <property role="1XweGQ" value="r:e2db5934-0aec-4dbd-8d13-2d3b7dc23298" />
+                  <node concept="1j_P7g" id="xRVdUh$80l" role="1j$8Uc">
+                    <property role="1j_P7h" value="test.analyses.cbmc.testcode.counterexample.mbeddr.statemachines" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh$80m" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh$80n" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh$80o" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh$80p" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -670,9 +724,23 @@
           <node concept="3cpWsn" id="1hCIBtjelpi" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="1hCIBtjelpj" role="1tU5fm" />
-            <node concept="BaHAS" id="1hCIBtjelpk" role="33vP2m">
-              <property role="BaHAW" value="test.analyses.cbmc.testcode.counterexample.mbeddr.statemachines" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh$8qS" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh$8qT" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh$8qU" role="1XwpL7">
+                  <property role="1XweGQ" value="r:e2db5934-0aec-4dbd-8d13-2d3b7dc23298" />
+                  <node concept="1j_P7g" id="xRVdUh$8qV" role="1j$8Uc">
+                    <property role="1j_P7h" value="test.analyses.cbmc.testcode.counterexample.mbeddr.statemachines" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh$8qW" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh$8qX" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh$8qY" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh$8qZ" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -944,9 +1012,23 @@
           <node concept="3cpWsn" id="1hCIBtje_fu" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="1hCIBtje_fv" role="1tU5fm" />
-            <node concept="BaHAS" id="1hCIBtje_fw" role="33vP2m">
-              <property role="BaHAW" value="test.analyses.cbmc.testcode.counterexample.mbeddr.statemachines" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh$8F8" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh$8F9" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh$8Fa" role="1XwpL7">
+                  <property role="1XweGQ" value="r:e2db5934-0aec-4dbd-8d13-2d3b7dc23298" />
+                  <node concept="1j_P7g" id="xRVdUh$8Fb" role="1j$8Uc">
+                    <property role="1j_P7h" value="test.analyses.cbmc.testcode.counterexample.mbeddr.statemachines" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh$8Fc" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh$8Fd" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh$8Fe" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh$8Ff" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -1156,9 +1238,23 @@
           <node concept="3cpWsn" id="1hCIBtjePNI" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="1hCIBtjePNJ" role="1tU5fm" />
-            <node concept="BaHAS" id="1hCIBtjePNK" role="33vP2m">
-              <property role="BaHAW" value="test.analyses.cbmc.testcode.counterexample.mbeddr.statemachines" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh$8MA" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh$8MB" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh$8MC" role="1XwpL7">
+                  <property role="1XweGQ" value="r:e2db5934-0aec-4dbd-8d13-2d3b7dc23298" />
+                  <node concept="1j_P7g" id="xRVdUh$8MD" role="1j$8Uc">
+                    <property role="1j_P7h" value="test.analyses.cbmc.testcode.counterexample.mbeddr.statemachines" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh$8ME" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh$8MF" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh$8MG" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh$8MH" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -1278,9 +1374,23 @@
           <node concept="3cpWsn" id="1fLSIrNnaVD" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="1fLSIrNnaVE" role="1tU5fm" />
-            <node concept="BaHAS" id="1fLSIrNnaVF" role="33vP2m">
-              <property role="BaHAW" value="test.analyses.cbmc.testcode.counterexample.mbeddr.statemachines" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh$8Uj" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh$8Uk" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh$8Ul" role="1XwpL7">
+                  <property role="1XweGQ" value="r:e2db5934-0aec-4dbd-8d13-2d3b7dc23298" />
+                  <node concept="1j_P7g" id="xRVdUh$8Um" role="1j$8Uc">
+                    <property role="1j_P7h" value="test.analyses.cbmc.testcode.counterexample.mbeddr.statemachines" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh$8Un" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh$8Uo" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh$8Up" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh$8Uq" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -1432,9 +1542,23 @@
           <node concept="3cpWsn" id="38xi_3mwZTY" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="38xi_3mwZTZ" role="1tU5fm" />
-            <node concept="BaHAS" id="38xi_3mwZU0" role="33vP2m">
-              <property role="BaHAW" value="test.analyses.cbmc.testcode.counterexample.mbeddr.statemachines" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh$6NY" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh$6EP" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh$6Jf" role="1XwpL7">
+                  <property role="1XweGQ" value="r:e2db5934-0aec-4dbd-8d13-2d3b7dc23298" />
+                  <node concept="1j_P7g" id="xRVdUh$6Jg" role="1j$8Uc">
+                    <property role="1j_P7h" value="test.analyses.cbmc.testcode.counterexample.mbeddr.statemachines" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh$6UV" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh$7f9" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh$6Y8" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh$7ze" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>

--- a/code/languages/com.mbeddr.analyses/tests/test.analyses.cbmc/models/test/analyses/cbmc/dead_code@tests.mps
+++ b/code/languages/com.mbeddr.analyses/tests/test.analyses.cbmc/models/test/analyses/cbmc/dead_code@tests.mps
@@ -101,6 +101,15 @@
     <language id="63e0e566-5131-447e-90e3-12ea330e1a00" name="com.mbeddr.mpsutil.blutil">
       <concept id="6451706574537082687" name="com.mbeddr.mpsutil.blutil.structure.ShortStaticMethodCall" flags="ng" index="NRdvd" />
     </language>
+    <language id="446c26eb-2b7b-4bf0-9b35-f83fa582753e" name="jetbrains.mps.lang.modelapi">
+      <concept id="361130699826193248" name="jetbrains.mps.lang.modelapi.structure.ModelPointer" flags="ng" index="1dCxOl">
+        <property id="1863527487546097494" name="modelId" index="1XweGQ" />
+        <child id="679099339649067980" name="name" index="1j$8Uc" />
+      </concept>
+      <concept id="679099339649053840" name="jetbrains.mps.lang.modelapi.structure.ModelName" flags="ng" index="1j_P7g">
+        <property id="679099339649053841" name="value" index="1j_P7h" />
+      </concept>
+    </language>
     <language id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest">
       <concept id="8427750732757990717" name="jetbrains.mps.baseLanguage.unitTest.structure.BinaryAssert" flags="nn" index="3tpDYu">
         <child id="8427750732757990725" name="actual" index="3tpDZA" />
@@ -112,11 +121,14 @@
       </concept>
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
-      <concept id="559557797393017698" name="jetbrains.mps.lang.smodel.structure.ModelReferenceExpression" flags="nn" index="BaHAS">
-        <property id="559557797393021807" name="stereotype" index="BaGAP" />
-        <property id="559557797393017702" name="name" index="BaHAW" />
+      <concept id="4065387505485742666" name="jetbrains.mps.lang.smodel.structure.ModelPointer_ResolveOperation" flags="ng" index="2yCiCJ" />
+      <concept id="4065387505485742749" name="jetbrains.mps.lang.smodel.structure.AbstractPointerResolveOperation" flags="ng" index="2yCiFS">
+        <child id="3648723375513868575" name="repositoryArg" index="Vysub" />
       </concept>
       <concept id="1143226024141" name="jetbrains.mps.lang.smodel.structure.SModelType" flags="in" index="H_c77" />
+      <concept id="1863527487546129879" name="jetbrains.mps.lang.smodel.structure.ModelPointerExpression" flags="ng" index="1Xw6AR">
+        <child id="1863527487546132519" name="modelRef" index="1XwpL7" />
+      </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
@@ -162,9 +174,23 @@
                   <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
                 </node>
               </node>
-              <node concept="BaHAS" id="4pAFZeasiYZ" role="37wK5m">
-                <property role="BaHAW" value="dead_code" />
-                <property role="BaGAP" value="" />
+              <node concept="2OqwBi" id="xRVdUh$bG7" role="37wK5m">
+                <node concept="1Xw6AR" id="xRVdUh$bG8" role="2Oq$k0">
+                  <node concept="1dCxOl" id="xRVdUh$bG9" role="1XwpL7">
+                    <property role="1XweGQ" value="r:1fd1b475-bb55-4fab-9e23-9a716bb5ac73" />
+                    <node concept="1j_P7g" id="xRVdUh$bGa" role="1j$8Uc">
+                      <property role="1j_P7h" value="dead_code" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2yCiCJ" id="xRVdUh$bGb" role="2OqNvi">
+                  <node concept="2OqwBi" id="xRVdUh$bGc" role="Vysub">
+                    <node concept="1jxXqW" id="xRVdUh$bGd" role="2Oq$k0" />
+                    <node concept="liA8E" id="xRVdUh$bGe" role="2OqNvi">
+                      <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                    </node>
+                  </node>
+                </node>
               </node>
               <node concept="Xl_RD" id="4pAFZeasiZ0" role="37wK5m">
                 <property role="Xl_RC" value="statemachine" />
@@ -313,9 +339,23 @@
                   <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
                 </node>
               </node>
-              <node concept="BaHAS" id="153zJclN7Ol" role="37wK5m">
-                <property role="BaHAW" value="dead_code" />
-                <property role="BaGAP" value="" />
+              <node concept="2OqwBi" id="xRVdUh$bcH" role="37wK5m">
+                <node concept="1Xw6AR" id="xRVdUh$bcI" role="2Oq$k0">
+                  <node concept="1dCxOl" id="xRVdUh$bcJ" role="1XwpL7">
+                    <property role="1XweGQ" value="r:1fd1b475-bb55-4fab-9e23-9a716bb5ac73" />
+                    <node concept="1j_P7g" id="xRVdUh$bcK" role="1j$8Uc">
+                      <property role="1j_P7h" value="dead_code" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2yCiCJ" id="xRVdUh$bcL" role="2OqNvi">
+                  <node concept="2OqwBi" id="xRVdUh$bcM" role="Vysub">
+                    <node concept="1jxXqW" id="xRVdUh$bcN" role="2Oq$k0" />
+                    <node concept="liA8E" id="xRVdUh$bcO" role="2OqNvi">
+                      <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                    </node>
+                  </node>
+                </node>
               </node>
               <node concept="Xl_RD" id="153zJclN7Om" role="37wK5m">
                 <property role="Xl_RC" value="smoke" />
@@ -391,9 +431,23 @@
                   <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
                 </node>
               </node>
-              <node concept="BaHAS" id="153zJclN7OM" role="37wK5m">
-                <property role="BaHAW" value="dead_code" />
-                <property role="BaGAP" value="" />
+              <node concept="2OqwBi" id="xRVdUh$bic" role="37wK5m">
+                <node concept="1Xw6AR" id="xRVdUh$bid" role="2Oq$k0">
+                  <node concept="1dCxOl" id="xRVdUh$bie" role="1XwpL7">
+                    <property role="1XweGQ" value="r:1fd1b475-bb55-4fab-9e23-9a716bb5ac73" />
+                    <node concept="1j_P7g" id="xRVdUh$bif" role="1j$8Uc">
+                      <property role="1j_P7h" value="dead_code" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2yCiCJ" id="xRVdUh$big" role="2OqNvi">
+                  <node concept="2OqwBi" id="xRVdUh$bih" role="Vysub">
+                    <node concept="1jxXqW" id="xRVdUh$bii" role="2Oq$k0" />
+                    <node concept="liA8E" id="xRVdUh$bij" role="2OqNvi">
+                      <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                    </node>
+                  </node>
+                </node>
               </node>
               <node concept="Xl_RD" id="153zJclN7ON" role="37wK5m">
                 <property role="Xl_RC" value="smoke" />
@@ -477,9 +531,23 @@
                   <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
                 </node>
               </node>
-              <node concept="BaHAS" id="153zJclN7Ph" role="37wK5m">
-                <property role="BaHAW" value="dead_code" />
-                <property role="BaGAP" value="" />
+              <node concept="2OqwBi" id="xRVdUh$bor" role="37wK5m">
+                <node concept="1Xw6AR" id="xRVdUh$bos" role="2Oq$k0">
+                  <node concept="1dCxOl" id="xRVdUh$bot" role="1XwpL7">
+                    <property role="1XweGQ" value="r:1fd1b475-bb55-4fab-9e23-9a716bb5ac73" />
+                    <node concept="1j_P7g" id="xRVdUh$bou" role="1j$8Uc">
+                      <property role="1j_P7h" value="dead_code" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2yCiCJ" id="xRVdUh$bov" role="2OqNvi">
+                  <node concept="2OqwBi" id="xRVdUh$bow" role="Vysub">
+                    <node concept="1jxXqW" id="xRVdUh$box" role="2Oq$k0" />
+                    <node concept="liA8E" id="xRVdUh$boy" role="2OqNvi">
+                      <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                    </node>
+                  </node>
+                </node>
               </node>
               <node concept="Xl_RD" id="153zJclN7Pi" role="37wK5m">
                 <property role="Xl_RC" value="smoke" />
@@ -597,9 +665,23 @@
           <node concept="3cpWsn" id="5EwdfGVgZy4" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="5EwdfGVgZy2" role="1tU5fm" />
-            <node concept="BaHAS" id="5EwdfGVgZy5" role="33vP2m">
-              <property role="BaHAW" value="dead_code" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh$9_j" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh$9i7" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh$9rE" role="1XwpL7">
+                  <property role="1XweGQ" value="r:1fd1b475-bb55-4fab-9e23-9a716bb5ac73" />
+                  <node concept="1j_P7g" id="xRVdUh$9rF" role="1j$8Uc">
+                    <property role="1j_P7h" value="dead_code" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh$9KV" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh$afr" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh$9Th" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh$aDn" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>

--- a/code/languages/com.mbeddr.analyses/tests/test.analyses.cbmc/models/test/analyses/cbmc/dectab@tests.mps
+++ b/code/languages/com.mbeddr.analyses/tests/test.analyses.cbmc/models/test/analyses/cbmc/dectab@tests.mps
@@ -86,6 +86,15 @@
     <language id="63e0e566-5131-447e-90e3-12ea330e1a00" name="com.mbeddr.mpsutil.blutil">
       <concept id="6451706574537082687" name="com.mbeddr.mpsutil.blutil.structure.ShortStaticMethodCall" flags="ng" index="NRdvd" />
     </language>
+    <language id="446c26eb-2b7b-4bf0-9b35-f83fa582753e" name="jetbrains.mps.lang.modelapi">
+      <concept id="361130699826193248" name="jetbrains.mps.lang.modelapi.structure.ModelPointer" flags="ng" index="1dCxOl">
+        <property id="1863527487546097494" name="modelId" index="1XweGQ" />
+        <child id="679099339649067980" name="name" index="1j$8Uc" />
+      </concept>
+      <concept id="679099339649053840" name="jetbrains.mps.lang.modelapi.structure.ModelName" flags="ng" index="1j_P7g">
+        <property id="679099339649053841" name="value" index="1j_P7h" />
+      </concept>
+    </language>
     <language id="7e09729e-68e4-4442-9bc8-024c5cdac3a2" name="com.mbeddr.analyses.cbmc.testing">
       <concept id="4791280061046124023" name="com.mbeddr.analyses.cbmc.testing.structure.CBMCCounterexampleStateTest" flags="ng" index="38rIoz">
         <property id="5665549241468834974" name="alternativeSteps" index="35AWuq" />
@@ -110,13 +119,16 @@
       </concept>
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
-      <concept id="559557797393017698" name="jetbrains.mps.lang.smodel.structure.ModelReferenceExpression" flags="nn" index="BaHAS">
-        <property id="559557797393021807" name="stereotype" index="BaGAP" />
-        <property id="559557797393017702" name="name" index="BaHAW" />
+      <concept id="4065387505485742666" name="jetbrains.mps.lang.smodel.structure.ModelPointer_ResolveOperation" flags="ng" index="2yCiCJ" />
+      <concept id="4065387505485742749" name="jetbrains.mps.lang.smodel.structure.AbstractPointerResolveOperation" flags="ng" index="2yCiFS">
+        <child id="3648723375513868575" name="repositoryArg" index="Vysub" />
       </concept>
       <concept id="1143226024141" name="jetbrains.mps.lang.smodel.structure.SModelType" flags="in" index="H_c77" />
       <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
         <reference id="1138405853777" name="concept" index="ehGHo" />
+      </concept>
+      <concept id="1863527487546129879" name="jetbrains.mps.lang.smodel.structure.ModelPointerExpression" flags="ng" index="1Xw6AR">
+        <child id="1863527487546132519" name="modelRef" index="1XwpL7" />
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
@@ -142,9 +154,23 @@
           <node concept="3cpWsn" id="71B0VAs0eEm" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="71B0VAs0eEk" role="1tU5fm" />
-            <node concept="BaHAS" id="71B0VAs0eEn" role="33vP2m">
-              <property role="BaHAW" value="dectab" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh$9_j" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh$cJ6" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh$cR9" role="1XwpL7">
+                  <property role="1XweGQ" value="r:b864701b-2294-45a3-a7d9-6fbb1dba233f" />
+                  <node concept="1j_P7g" id="xRVdUh$cRa" role="1j$8Uc">
+                    <property role="1j_P7h" value="dectab" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh$9KV" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh$afr" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh$9Th" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh$aDn" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -337,9 +363,23 @@
           <node concept="3cpWsn" id="71B0VAs0h0Z" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="71B0VAs0h0X" role="1tU5fm" />
-            <node concept="BaHAS" id="71B0VAs0h10" role="33vP2m">
-              <property role="BaHAW" value="dectab" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh$cZ9" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh$cZa" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh$cZb" role="1XwpL7">
+                  <property role="1XweGQ" value="r:b864701b-2294-45a3-a7d9-6fbb1dba233f" />
+                  <node concept="1j_P7g" id="xRVdUh$cZc" role="1j$8Uc">
+                    <property role="1j_P7h" value="dectab" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh$cZd" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh$cZe" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh$cZf" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh$cZg" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -614,9 +654,23 @@
           <node concept="3cpWsn" id="1_cCL2G2g7s" role="3cpWs9">
             <property role="TrG5h" value="model" />
             <node concept="H_c77" id="1_cCL2G2g7q" role="1tU5fm" />
-            <node concept="BaHAS" id="1_cCL2G2g7t" role="33vP2m">
-              <property role="BaHAW" value="dectab" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh$drZ" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh$ds0" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh$ds1" role="1XwpL7">
+                  <property role="1XweGQ" value="r:b864701b-2294-45a3-a7d9-6fbb1dba233f" />
+                  <node concept="1j_P7g" id="xRVdUh$ds2" role="1j$8Uc">
+                    <property role="1j_P7h" value="dectab" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh$ds3" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh$ds4" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh$ds5" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh$ds6" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>

--- a/code/languages/com.mbeddr.analyses/tests/test.analyses.cbmc/models/test/analyses/cbmc/expressions@tests.mps
+++ b/code/languages/com.mbeddr.analyses/tests/test.analyses.cbmc/models/test/analyses/cbmc/expressions@tests.mps
@@ -75,17 +75,29 @@
     <language id="63e0e566-5131-447e-90e3-12ea330e1a00" name="com.mbeddr.mpsutil.blutil">
       <concept id="6451706574537082687" name="com.mbeddr.mpsutil.blutil.structure.ShortStaticMethodCall" flags="ng" index="NRdvd" />
     </language>
+    <language id="446c26eb-2b7b-4bf0-9b35-f83fa582753e" name="jetbrains.mps.lang.modelapi">
+      <concept id="361130699826193248" name="jetbrains.mps.lang.modelapi.structure.ModelPointer" flags="ng" index="1dCxOl">
+        <property id="1863527487546097494" name="modelId" index="1XweGQ" />
+        <child id="679099339649067980" name="name" index="1j$8Uc" />
+      </concept>
+      <concept id="679099339649053840" name="jetbrains.mps.lang.modelapi.structure.ModelName" flags="ng" index="1j_P7g">
+        <property id="679099339649053841" name="value" index="1j_P7h" />
+      </concept>
+    </language>
     <language id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest">
       <concept id="1171981022339" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertTrue" flags="nn" index="3vwNmj">
         <child id="1171981057159" name="condition" index="3vwVQn" />
       </concept>
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
-      <concept id="559557797393017698" name="jetbrains.mps.lang.smodel.structure.ModelReferenceExpression" flags="nn" index="BaHAS">
-        <property id="559557797393021807" name="stereotype" index="BaGAP" />
-        <property id="559557797393017702" name="name" index="BaHAW" />
+      <concept id="4065387505485742666" name="jetbrains.mps.lang.smodel.structure.ModelPointer_ResolveOperation" flags="ng" index="2yCiCJ" />
+      <concept id="4065387505485742749" name="jetbrains.mps.lang.smodel.structure.AbstractPointerResolveOperation" flags="ng" index="2yCiFS">
+        <child id="3648723375513868575" name="repositoryArg" index="Vysub" />
       </concept>
       <concept id="1143226024141" name="jetbrains.mps.lang.smodel.structure.SModelType" flags="in" index="H_c77" />
+      <concept id="1863527487546129879" name="jetbrains.mps.lang.smodel.structure.ModelPointerExpression" flags="ng" index="1Xw6AR">
+        <child id="1863527487546132519" name="modelRef" index="1XwpL7" />
+      </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
@@ -112,9 +124,23 @@
           <node concept="3cpWsn" id="5EwdfGVh3W9" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="5EwdfGVh3W7" role="1tU5fm" />
-            <node concept="BaHAS" id="5EwdfGVh3Wa" role="33vP2m">
-              <property role="BaHAW" value="expressions" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh$f0T" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh$f0U" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh$f0V" role="1XwpL7">
+                  <property role="1XweGQ" value="r:cbfadaef-22b1-45d8-a57c-91ff3dfebacc" />
+                  <node concept="1j_P7g" id="xRVdUh$f0W" role="1j$8Uc">
+                    <property role="1j_P7h" value="expressions" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh$f0X" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh$f0Y" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh$f0Z" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh$f10" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -213,9 +239,23 @@
                   <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
                 </node>
               </node>
-              <node concept="BaHAS" id="72mSD5S00Vo" role="37wK5m">
-                <property role="BaHAW" value="expressions" />
-                <property role="BaGAP" value="" />
+              <node concept="2OqwBi" id="xRVdUh$dY1" role="37wK5m">
+                <node concept="1Xw6AR" id="xRVdUh$dLn" role="2Oq$k0">
+                  <node concept="1dCxOl" id="xRVdUh$dRQ" role="1XwpL7">
+                    <property role="1XweGQ" value="r:cbfadaef-22b1-45d8-a57c-91ff3dfebacc" />
+                    <node concept="1j_P7g" id="xRVdUh$dRR" role="1j$8Uc">
+                      <property role="1j_P7h" value="expressions" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2yCiCJ" id="xRVdUh$e72" role="2OqNvi">
+                  <node concept="2OqwBi" id="xRVdUh$euG" role="Vysub">
+                    <node concept="1jxXqW" id="xRVdUh$ebX" role="2Oq$k0" />
+                    <node concept="liA8E" id="xRVdUh$ePc" role="2OqNvi">
+                      <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                    </node>
+                  </node>
+                </node>
               </node>
               <node concept="Xl_RD" id="72mSD5S00Vp" role="37wK5m">
                 <property role="Xl_RC" value="implies" />

--- a/code/languages/com.mbeddr.analyses/tests/test.analyses.cbmc/models/test/analyses/cbmc/external_files@tests.mps
+++ b/code/languages/com.mbeddr.analyses/tests/test.analyses.cbmc/models/test/analyses/cbmc/external_files@tests.mps
@@ -92,6 +92,15 @@
     <language id="63e0e566-5131-447e-90e3-12ea330e1a00" name="com.mbeddr.mpsutil.blutil">
       <concept id="6451706574537082687" name="com.mbeddr.mpsutil.blutil.structure.ShortStaticMethodCall" flags="ng" index="NRdvd" />
     </language>
+    <language id="446c26eb-2b7b-4bf0-9b35-f83fa582753e" name="jetbrains.mps.lang.modelapi">
+      <concept id="361130699826193248" name="jetbrains.mps.lang.modelapi.structure.ModelPointer" flags="ng" index="1dCxOl">
+        <property id="1863527487546097494" name="modelId" index="1XweGQ" />
+        <child id="679099339649067980" name="name" index="1j$8Uc" />
+      </concept>
+      <concept id="679099339649053840" name="jetbrains.mps.lang.modelapi.structure.ModelName" flags="ng" index="1j_P7g">
+        <property id="679099339649053841" name="value" index="1j_P7h" />
+      </concept>
+    </language>
     <language id="7e09729e-68e4-4442-9bc8-024c5cdac3a2" name="com.mbeddr.analyses.cbmc.testing">
       <concept id="4791280061046124023" name="com.mbeddr.analyses.cbmc.testing.structure.CBMCCounterexampleStateTest" flags="ng" index="38rIoz">
         <property id="5665549241468834974" name="alternativeSteps" index="35AWuq" />
@@ -116,9 +125,9 @@
       </concept>
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
-      <concept id="559557797393017698" name="jetbrains.mps.lang.smodel.structure.ModelReferenceExpression" flags="nn" index="BaHAS">
-        <property id="559557797393021807" name="stereotype" index="BaGAP" />
-        <property id="559557797393017702" name="name" index="BaHAW" />
+      <concept id="4065387505485742666" name="jetbrains.mps.lang.smodel.structure.ModelPointer_ResolveOperation" flags="ng" index="2yCiCJ" />
+      <concept id="4065387505485742749" name="jetbrains.mps.lang.smodel.structure.AbstractPointerResolveOperation" flags="ng" index="2yCiFS">
+        <child id="3648723375513868575" name="repositoryArg" index="Vysub" />
       </concept>
       <concept id="1143226024141" name="jetbrains.mps.lang.smodel.structure.SModelType" flags="in" index="H_c77" />
       <concept id="1145404486709" name="jetbrains.mps.lang.smodel.structure.SemanticDowncastExpression" flags="nn" index="2JrnkZ">
@@ -126,6 +135,9 @@
       </concept>
       <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
         <reference id="1138405853777" name="concept" index="ehGHo" />
+      </concept>
+      <concept id="1863527487546129879" name="jetbrains.mps.lang.smodel.structure.ModelPointerExpression" flags="ng" index="1Xw6AR">
+        <child id="1863527487546132519" name="modelRef" index="1XwpL7" />
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
@@ -163,9 +175,23 @@
           <node concept="3cpWsn" id="1_cCL2G2g7s" role="3cpWs9">
             <property role="TrG5h" value="model" />
             <node concept="H_c77" id="1_cCL2G2g7q" role="1tU5fm" />
-            <node concept="BaHAS" id="28vOu_ursVf" role="33vP2m">
-              <property role="BaHAW" value="external_c_files" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh$gbc" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh$fSw" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh$g1N" role="1XwpL7">
+                  <property role="1XweGQ" value="r:83d6a018-c6c6-4282-9ac6-3f981c615adc" />
+                  <node concept="1j_P7g" id="xRVdUh$g1O" role="1j$8Uc">
+                    <property role="1j_P7h" value="external_c_files" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh$gn2" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh$gP2" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh$gv8" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh$heH" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -416,9 +442,23 @@
           <node concept="3cpWsn" id="ZdgXCCImh8" role="3cpWs9">
             <property role="TrG5h" value="model" />
             <node concept="H_c77" id="ZdgXCCImh9" role="1tU5fm" />
-            <node concept="BaHAS" id="ZdgXCCImha" role="33vP2m">
-              <property role="BaHAW" value="external_c_files" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh$hCK" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh$hCL" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh$hCM" role="1XwpL7">
+                  <property role="1XweGQ" value="r:83d6a018-c6c6-4282-9ac6-3f981c615adc" />
+                  <node concept="1j_P7g" id="xRVdUh$hCN" role="1j$8Uc">
+                    <property role="1j_P7h" value="external_c_files" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh$hCO" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh$hCP" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh$hCQ" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh$hCR" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -669,9 +709,23 @@
           <node concept="3cpWsn" id="28vOu_uryPK" role="3cpWs9">
             <property role="TrG5h" value="model" />
             <node concept="H_c77" id="28vOu_uryPL" role="1tU5fm" />
-            <node concept="BaHAS" id="28vOu_uryPM" role="33vP2m">
-              <property role="BaHAW" value="external_c_files" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh$hLL" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh$hLM" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh$hLN" role="1XwpL7">
+                  <property role="1XweGQ" value="r:83d6a018-c6c6-4282-9ac6-3f981c615adc" />
+                  <node concept="1j_P7g" id="xRVdUh$hLO" role="1j$8Uc">
+                    <property role="1j_P7h" value="external_c_files" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh$hLP" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh$hLQ" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh$hLR" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh$hLS" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -830,9 +884,23 @@
           <node concept="3cpWsn" id="28vOu_ur$ug" role="3cpWs9">
             <property role="TrG5h" value="model" />
             <node concept="H_c77" id="28vOu_ur$uh" role="1tU5fm" />
-            <node concept="BaHAS" id="28vOu_ur$ui" role="33vP2m">
-              <property role="BaHAW" value="external_c_files" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh$hSi" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh$hSj" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh$hSk" role="1XwpL7">
+                  <property role="1XweGQ" value="r:83d6a018-c6c6-4282-9ac6-3f981c615adc" />
+                  <node concept="1j_P7g" id="xRVdUh$hSl" role="1j$8Uc">
+                    <property role="1j_P7h" value="external_c_files" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh$hSm" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh$hSn" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh$hSo" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh$hSp" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -1027,9 +1095,23 @@
           <node concept="3cpWsn" id="7kPcpiFiVh5" role="3cpWs9">
             <property role="TrG5h" value="model" />
             <node concept="H_c77" id="7kPcpiFiVh6" role="1tU5fm" />
-            <node concept="BaHAS" id="7kPcpiFiVh7" role="33vP2m">
-              <property role="BaHAW" value="external_c_files" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh$imm" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh$imn" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh$imo" role="1XwpL7">
+                  <property role="1XweGQ" value="r:83d6a018-c6c6-4282-9ac6-3f981c615adc" />
+                  <node concept="1j_P7g" id="xRVdUh$imp" role="1j$8Uc">
+                    <property role="1j_P7h" value="external_c_files" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh$imq" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh$imr" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh$ims" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh$imt" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -1175,9 +1257,23 @@
           <node concept="3cpWsn" id="7kPcpiFiXhI" role="3cpWs9">
             <property role="TrG5h" value="model" />
             <node concept="H_c77" id="7kPcpiFiXhJ" role="1tU5fm" />
-            <node concept="BaHAS" id="7kPcpiFiXhK" role="33vP2m">
-              <property role="BaHAW" value="external_c_files" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh$isd" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh$ise" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh$isf" role="1XwpL7">
+                  <property role="1XweGQ" value="r:83d6a018-c6c6-4282-9ac6-3f981c615adc" />
+                  <node concept="1j_P7g" id="xRVdUh$isg" role="1j$8Uc">
+                    <property role="1j_P7h" value="external_c_files" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh$ish" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh$isi" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh$isj" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh$isk" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -1323,9 +1419,23 @@
           <node concept="3cpWsn" id="7kPcpiFiXK7" role="3cpWs9">
             <property role="TrG5h" value="model" />
             <node concept="H_c77" id="7kPcpiFiXK8" role="1tU5fm" />
-            <node concept="BaHAS" id="7kPcpiFiXK9" role="33vP2m">
-              <property role="BaHAW" value="external_c_files" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh$iy4" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh$iy5" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh$iy6" role="1XwpL7">
+                  <property role="1XweGQ" value="r:83d6a018-c6c6-4282-9ac6-3f981c615adc" />
+                  <node concept="1j_P7g" id="xRVdUh$iy7" role="1j$8Uc">
+                    <property role="1j_P7h" value="external_c_files" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh$iy8" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh$iy9" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh$iya" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh$iyb" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>

--- a/code/languages/com.mbeddr.analyses/tests/test.analyses.cbmc/models/test/analyses/cbmc/external_h_files@tests.mps
+++ b/code/languages/com.mbeddr.analyses/tests/test.analyses.cbmc/models/test/analyses/cbmc/external_h_files@tests.mps
@@ -92,6 +92,15 @@
     <language id="63e0e566-5131-447e-90e3-12ea330e1a00" name="com.mbeddr.mpsutil.blutil">
       <concept id="6451706574537082687" name="com.mbeddr.mpsutil.blutil.structure.ShortStaticMethodCall" flags="ng" index="NRdvd" />
     </language>
+    <language id="446c26eb-2b7b-4bf0-9b35-f83fa582753e" name="jetbrains.mps.lang.modelapi">
+      <concept id="361130699826193248" name="jetbrains.mps.lang.modelapi.structure.ModelPointer" flags="ng" index="1dCxOl">
+        <property id="1863527487546097494" name="modelId" index="1XweGQ" />
+        <child id="679099339649067980" name="name" index="1j$8Uc" />
+      </concept>
+      <concept id="679099339649053840" name="jetbrains.mps.lang.modelapi.structure.ModelName" flags="ng" index="1j_P7g">
+        <property id="679099339649053841" name="value" index="1j_P7h" />
+      </concept>
+    </language>
     <language id="7e09729e-68e4-4442-9bc8-024c5cdac3a2" name="com.mbeddr.analyses.cbmc.testing">
       <concept id="4791280061046124023" name="com.mbeddr.analyses.cbmc.testing.structure.CBMCCounterexampleStateTest" flags="ng" index="38rIoz">
         <property id="4791280061046124024" name="nodeKind" index="38rIoG" />
@@ -114,9 +123,9 @@
       </concept>
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
-      <concept id="559557797393017698" name="jetbrains.mps.lang.smodel.structure.ModelReferenceExpression" flags="nn" index="BaHAS">
-        <property id="559557797393021807" name="stereotype" index="BaGAP" />
-        <property id="559557797393017702" name="name" index="BaHAW" />
+      <concept id="4065387505485742666" name="jetbrains.mps.lang.smodel.structure.ModelPointer_ResolveOperation" flags="ng" index="2yCiCJ" />
+      <concept id="4065387505485742749" name="jetbrains.mps.lang.smodel.structure.AbstractPointerResolveOperation" flags="ng" index="2yCiFS">
+        <child id="3648723375513868575" name="repositoryArg" index="Vysub" />
       </concept>
       <concept id="1143226024141" name="jetbrains.mps.lang.smodel.structure.SModelType" flags="in" index="H_c77" />
       <concept id="1145404486709" name="jetbrains.mps.lang.smodel.structure.SemanticDowncastExpression" flags="nn" index="2JrnkZ">
@@ -124,6 +133,9 @@
       </concept>
       <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
         <reference id="1138405853777" name="concept" index="ehGHo" />
+      </concept>
+      <concept id="1863527487546129879" name="jetbrains.mps.lang.smodel.structure.ModelPointerExpression" flags="ng" index="1Xw6AR">
+        <child id="1863527487546132519" name="modelRef" index="1XwpL7" />
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
@@ -157,9 +169,23 @@
           <node concept="3cpWsn" id="2kft9cs5mbs" role="3cpWs9">
             <property role="TrG5h" value="model" />
             <node concept="H_c77" id="2kft9cs5mbt" role="1tU5fm" />
-            <node concept="BaHAS" id="2kft9cs5mbu" role="33vP2m">
-              <property role="BaHAW" value="external_h_files" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh$j9N" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh$iSP" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh$j1h" role="1XwpL7">
+                  <property role="1XweGQ" value="r:9fe2b981-3dbc-4f0d-9419-d82d67e62943" />
+                  <node concept="1j_P7g" id="xRVdUh$j1i" role="1j$8Uc">
+                    <property role="1j_P7h" value="external_h_files" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh$jkM" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh$jI9" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh$js1" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh$k6g" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>

--- a/code/languages/com.mbeddr.analyses/tests/test.analyses.cbmc/models/test/analyses/cbmc/gswitch@tests.mps
+++ b/code/languages/com.mbeddr.analyses/tests/test.analyses.cbmc/models/test/analyses/cbmc/gswitch@tests.mps
@@ -86,6 +86,15 @@
     <language id="63e0e566-5131-447e-90e3-12ea330e1a00" name="com.mbeddr.mpsutil.blutil">
       <concept id="6451706574537082687" name="com.mbeddr.mpsutil.blutil.structure.ShortStaticMethodCall" flags="ng" index="NRdvd" />
     </language>
+    <language id="446c26eb-2b7b-4bf0-9b35-f83fa582753e" name="jetbrains.mps.lang.modelapi">
+      <concept id="361130699826193248" name="jetbrains.mps.lang.modelapi.structure.ModelPointer" flags="ng" index="1dCxOl">
+        <property id="1863527487546097494" name="modelId" index="1XweGQ" />
+        <child id="679099339649067980" name="name" index="1j$8Uc" />
+      </concept>
+      <concept id="679099339649053840" name="jetbrains.mps.lang.modelapi.structure.ModelName" flags="ng" index="1j_P7g">
+        <property id="679099339649053841" name="value" index="1j_P7h" />
+      </concept>
+    </language>
     <language id="7e09729e-68e4-4442-9bc8-024c5cdac3a2" name="com.mbeddr.analyses.cbmc.testing">
       <concept id="4791280061046124023" name="com.mbeddr.analyses.cbmc.testing.structure.CBMCCounterexampleStateTest" flags="ng" index="38rIoz">
         <property id="4791280061046124024" name="nodeKind" index="38rIoG" />
@@ -103,13 +112,16 @@
       </concept>
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
-      <concept id="559557797393017698" name="jetbrains.mps.lang.smodel.structure.ModelReferenceExpression" flags="nn" index="BaHAS">
-        <property id="559557797393021807" name="stereotype" index="BaGAP" />
-        <property id="559557797393017702" name="name" index="BaHAW" />
+      <concept id="4065387505485742666" name="jetbrains.mps.lang.smodel.structure.ModelPointer_ResolveOperation" flags="ng" index="2yCiCJ" />
+      <concept id="4065387505485742749" name="jetbrains.mps.lang.smodel.structure.AbstractPointerResolveOperation" flags="ng" index="2yCiFS">
+        <child id="3648723375513868575" name="repositoryArg" index="Vysub" />
       </concept>
       <concept id="1143226024141" name="jetbrains.mps.lang.smodel.structure.SModelType" flags="in" index="H_c77" />
       <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
         <reference id="1138405853777" name="concept" index="ehGHo" />
+      </concept>
+      <concept id="1863527487546129879" name="jetbrains.mps.lang.smodel.structure.ModelPointerExpression" flags="ng" index="1Xw6AR">
+        <child id="1863527487546132519" name="modelRef" index="1XwpL7" />
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
@@ -134,9 +146,23 @@
           <node concept="3cpWsn" id="71B0VAs0odN" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="71B0VAs0odL" role="1tU5fm" />
-            <node concept="BaHAS" id="71B0VAs0odO" role="33vP2m">
-              <property role="BaHAW" value="gswitch" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh$lmG" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh$kUQ" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh$l8I" role="1XwpL7">
+                  <property role="1XweGQ" value="r:8a83230a-1b22-4280-b956-b38ab74d81ab" />
+                  <node concept="1j_P7g" id="xRVdUh$l8J" role="1j$8Uc">
+                    <property role="1j_P7h" value="gswitch" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh$lB7" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh$maV" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh$lNM" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh$mCi" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -394,9 +420,23 @@
           <node concept="3cpWsn" id="71B0VAs0oJF" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="71B0VAs0oJD" role="1tU5fm" />
-            <node concept="BaHAS" id="71B0VAs0oJG" role="33vP2m">
-              <property role="BaHAW" value="gswitch" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh$mPw" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh$mPx" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh$mPy" role="1XwpL7">
+                  <property role="1XweGQ" value="r:8a83230a-1b22-4280-b956-b38ab74d81ab" />
+                  <node concept="1j_P7g" id="xRVdUh$mPz" role="1j$8Uc">
+                    <property role="1j_P7h" value="gswitch" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh$mP$" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh$mP_" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh$mPA" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh$mPB" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -475,9 +515,23 @@
           <node concept="3cpWsn" id="5EwdfGVh6TL" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="5EwdfGVh6TJ" role="1tU5fm" />
-            <node concept="BaHAS" id="5EwdfGVh6TM" role="33vP2m">
-              <property role="BaHAW" value="gswitch" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh$mV1" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh$mV2" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh$mV3" role="1XwpL7">
+                  <property role="1XweGQ" value="r:8a83230a-1b22-4280-b956-b38ab74d81ab" />
+                  <node concept="1j_P7g" id="xRVdUh$mV4" role="1j$8Uc">
+                    <property role="1j_P7h" value="gswitch" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh$mV5" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh$mV6" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh$mV7" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh$mV8" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>

--- a/code/languages/com.mbeddr.analyses/tests/test.analyses.cbmc/models/test/analyses/cbmc/harness@tests.mps
+++ b/code/languages/com.mbeddr.analyses/tests/test.analyses.cbmc/models/test/analyses/cbmc/harness@tests.mps
@@ -88,6 +88,15 @@
     <language id="63e0e566-5131-447e-90e3-12ea330e1a00" name="com.mbeddr.mpsutil.blutil">
       <concept id="6451706574537082687" name="com.mbeddr.mpsutil.blutil.structure.ShortStaticMethodCall" flags="ng" index="NRdvd" />
     </language>
+    <language id="446c26eb-2b7b-4bf0-9b35-f83fa582753e" name="jetbrains.mps.lang.modelapi">
+      <concept id="361130699826193248" name="jetbrains.mps.lang.modelapi.structure.ModelPointer" flags="ng" index="1dCxOl">
+        <property id="1863527487546097494" name="modelId" index="1XweGQ" />
+        <child id="679099339649067980" name="name" index="1j$8Uc" />
+      </concept>
+      <concept id="679099339649053840" name="jetbrains.mps.lang.modelapi.structure.ModelName" flags="ng" index="1j_P7g">
+        <property id="679099339649053841" name="value" index="1j_P7h" />
+      </concept>
+    </language>
     <language id="7e09729e-68e4-4442-9bc8-024c5cdac3a2" name="com.mbeddr.analyses.cbmc.testing">
       <concept id="4791280061046124023" name="com.mbeddr.analyses.cbmc.testing.structure.CBMCCounterexampleStateTest" flags="ng" index="38rIoz">
         <property id="4791280061046124024" name="nodeKind" index="38rIoG" />
@@ -111,13 +120,16 @@
       </concept>
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
-      <concept id="559557797393017698" name="jetbrains.mps.lang.smodel.structure.ModelReferenceExpression" flags="nn" index="BaHAS">
-        <property id="559557797393021807" name="stereotype" index="BaGAP" />
-        <property id="559557797393017702" name="name" index="BaHAW" />
+      <concept id="4065387505485742666" name="jetbrains.mps.lang.smodel.structure.ModelPointer_ResolveOperation" flags="ng" index="2yCiCJ" />
+      <concept id="4065387505485742749" name="jetbrains.mps.lang.smodel.structure.AbstractPointerResolveOperation" flags="ng" index="2yCiFS">
+        <child id="3648723375513868575" name="repositoryArg" index="Vysub" />
       </concept>
       <concept id="1143226024141" name="jetbrains.mps.lang.smodel.structure.SModelType" flags="in" index="H_c77" />
       <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
         <reference id="1138405853777" name="concept" index="ehGHo" />
+      </concept>
+      <concept id="1863527487546129879" name="jetbrains.mps.lang.smodel.structure.ModelPointerExpression" flags="ng" index="1Xw6AR">
+        <child id="1863527487546132519" name="modelRef" index="1XwpL7" />
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
@@ -158,9 +170,23 @@
                     <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
                   </node>
                 </node>
-                <node concept="BaHAS" id="5EwdfGVhbnY" role="37wK5m">
-                  <property role="BaHAW" value="harness" />
-                  <property role="BaGAP" value="" />
+                <node concept="2OqwBi" id="xRVdUh$qFl" role="37wK5m">
+                  <node concept="1Xw6AR" id="xRVdUh$qFm" role="2Oq$k0">
+                    <node concept="1dCxOl" id="xRVdUh$qFn" role="1XwpL7">
+                      <property role="1XweGQ" value="r:3545ae3d-c784-4b5b-acb4-6803eb602692" />
+                      <node concept="1j_P7g" id="xRVdUh$qFo" role="1j$8Uc">
+                        <property role="1j_P7h" value="harness" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2yCiCJ" id="xRVdUh$qFp" role="2OqNvi">
+                    <node concept="2OqwBi" id="xRVdUh$qFq" role="Vysub">
+                      <node concept="1jxXqW" id="xRVdUh$qFr" role="2Oq$k0" />
+                      <node concept="liA8E" id="xRVdUh$qFs" role="2OqNvi">
+                        <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                      </node>
+                    </node>
+                  </node>
                 </node>
                 <node concept="Xl_RD" id="5EwdfGVhbnZ" role="37wK5m">
                   <property role="Xl_RC" value="range" />
@@ -209,9 +235,23 @@
                     <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
                   </node>
                 </node>
-                <node concept="BaHAS" id="5EwdfGVhbDW" role="37wK5m">
-                  <property role="BaHAW" value="harness" />
-                  <property role="BaGAP" value="" />
+                <node concept="2OqwBi" id="xRVdUh$qIT" role="37wK5m">
+                  <node concept="1Xw6AR" id="xRVdUh$qIU" role="2Oq$k0">
+                    <node concept="1dCxOl" id="xRVdUh$qIV" role="1XwpL7">
+                      <property role="1XweGQ" value="r:3545ae3d-c784-4b5b-acb4-6803eb602692" />
+                      <node concept="1j_P7g" id="xRVdUh$qIW" role="1j$8Uc">
+                        <property role="1j_P7h" value="harness" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2yCiCJ" id="xRVdUh$qIX" role="2OqNvi">
+                    <node concept="2OqwBi" id="xRVdUh$qIY" role="Vysub">
+                      <node concept="1jxXqW" id="xRVdUh$qIZ" role="2Oq$k0" />
+                      <node concept="liA8E" id="xRVdUh$qJ0" role="2OqNvi">
+                        <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                      </node>
+                    </node>
+                  </node>
                 </node>
                 <node concept="Xl_RD" id="5EwdfGVhbDX" role="37wK5m">
                   <property role="Xl_RC" value="range" />
@@ -266,9 +306,23 @@
           <node concept="3cpWsn" id="5EwdfGVhcoj" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="5EwdfGVhcoh" role="1tU5fm" />
-            <node concept="BaHAS" id="5EwdfGVhcok" role="33vP2m">
-              <property role="BaHAW" value="harness" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh$qTF" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh$qTG" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh$qTH" role="1XwpL7">
+                  <property role="1XweGQ" value="r:3545ae3d-c784-4b5b-acb4-6803eb602692" />
+                  <node concept="1j_P7g" id="xRVdUh$qTI" role="1j$8Uc">
+                    <property role="1j_P7h" value="harness" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh$qTJ" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh$qTK" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh$qTL" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh$qTM" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -326,9 +380,23 @@
           <node concept="3cpWsn" id="5EwdfGVhct4" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="5EwdfGVhct2" role="1tU5fm" />
-            <node concept="BaHAS" id="5EwdfGVhct5" role="33vP2m">
-              <property role="BaHAW" value="harness" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh$qWT" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh$qWU" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh$qWV" role="1XwpL7">
+                  <property role="1XweGQ" value="r:3545ae3d-c784-4b5b-acb4-6803eb602692" />
+                  <node concept="1j_P7g" id="xRVdUh$qWW" role="1j$8Uc">
+                    <property role="1j_P7h" value="harness" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh$qWX" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh$qWY" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh$qWZ" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh$qX0" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -407,9 +475,23 @@
           <node concept="3cpWsn" id="5EwdfGVhcNn" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="5EwdfGVhcNl" role="1tU5fm" />
-            <node concept="BaHAS" id="5EwdfGVhcNo" role="33vP2m">
-              <property role="BaHAW" value="harness" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh$r3D" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh$r3E" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh$r3F" role="1XwpL7">
+                  <property role="1XweGQ" value="r:3545ae3d-c784-4b5b-acb4-6803eb602692" />
+                  <node concept="1j_P7g" id="xRVdUh$r3G" role="1j$8Uc">
+                    <property role="1j_P7h" value="harness" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh$r3H" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh$r3I" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh$r3J" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh$r3K" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -471,9 +553,23 @@
           <node concept="3cpWsn" id="5EwdfGVhdf8" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="5EwdfGVhdf6" role="1tU5fm" />
-            <node concept="BaHAS" id="5EwdfGVhdf9" role="33vP2m">
-              <property role="BaHAW" value="harness" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh$rsC" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh$rsD" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh$rsE" role="1XwpL7">
+                  <property role="1XweGQ" value="r:3545ae3d-c784-4b5b-acb4-6803eb602692" />
+                  <node concept="1j_P7g" id="xRVdUh$rsF" role="1j$8Uc">
+                    <property role="1j_P7h" value="harness" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh$rsG" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh$rsH" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh$rsI" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh$rsJ" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -531,9 +627,23 @@
           <node concept="3cpWsn" id="5EwdfGVhdzW" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="5EwdfGVhdzU" role="1tU5fm" />
-            <node concept="BaHAS" id="5EwdfGVhdzX" role="33vP2m">
-              <property role="BaHAW" value="harness" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh$rwm" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh$rwn" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh$rwo" role="1XwpL7">
+                  <property role="1XweGQ" value="r:3545ae3d-c784-4b5b-acb4-6803eb602692" />
+                  <node concept="1j_P7g" id="xRVdUh$rwp" role="1j$8Uc">
+                    <property role="1j_P7h" value="harness" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh$rwq" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh$rwr" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh$rws" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh$rwt" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -606,9 +716,23 @@
           <node concept="3cpWsn" id="5EwdfGVhdLP" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="5EwdfGVhdLN" role="1tU5fm" />
-            <node concept="BaHAS" id="5EwdfGVhdLQ" role="33vP2m">
-              <property role="BaHAW" value="harness" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh$r$j" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh$r$k" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh$r$l" role="1XwpL7">
+                  <property role="1XweGQ" value="r:3545ae3d-c784-4b5b-acb4-6803eb602692" />
+                  <node concept="1j_P7g" id="xRVdUh$r$m" role="1j$8Uc">
+                    <property role="1j_P7h" value="harness" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh$r$n" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh$r$o" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh$r$p" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh$r$q" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -666,9 +790,23 @@
           <node concept="3cpWsn" id="5EwdfGVhe67" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="5EwdfGVhe65" role="1tU5fm" />
-            <node concept="BaHAS" id="5EwdfGVhe68" role="33vP2m">
-              <property role="BaHAW" value="harness" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh$rCg" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh$rCh" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh$rCi" role="1XwpL7">
+                  <property role="1XweGQ" value="r:3545ae3d-c784-4b5b-acb4-6803eb602692" />
+                  <node concept="1j_P7g" id="xRVdUh$rCj" role="1j$8Uc">
+                    <property role="1j_P7h" value="harness" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh$rCk" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh$rCl" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh$rCm" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh$rCn" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -741,9 +879,23 @@
           <node concept="3cpWsn" id="5EwdfGVhejK" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="5EwdfGVhejI" role="1tU5fm" />
-            <node concept="BaHAS" id="5EwdfGVhejL" role="33vP2m">
-              <property role="BaHAW" value="harness" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh$rGd" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh$rGe" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh$rGf" role="1XwpL7">
+                  <property role="1XweGQ" value="r:3545ae3d-c784-4b5b-acb4-6803eb602692" />
+                  <node concept="1j_P7g" id="xRVdUh$rGg" role="1j$8Uc">
+                    <property role="1j_P7h" value="harness" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh$rGh" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh$rGi" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh$rGj" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh$rGk" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -801,9 +953,23 @@
           <node concept="3cpWsn" id="sn0OadKFrK" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="sn0OadKFrI" role="1tU5fm" />
-            <node concept="BaHAS" id="sn0OadKFrL" role="33vP2m">
-              <property role="BaHAW" value="harness" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh$rKa" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh$rKb" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh$rKc" role="1XwpL7">
+                  <property role="1XweGQ" value="r:3545ae3d-c784-4b5b-acb4-6803eb602692" />
+                  <node concept="1j_P7g" id="xRVdUh$rKd" role="1j$8Uc">
+                    <property role="1j_P7h" value="harness" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh$rKe" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh$rKf" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh$rKg" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh$rKh" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -1117,9 +1283,23 @@
                   <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
                 </node>
               </node>
-              <node concept="BaHAS" id="5KHBa6kSzYX" role="37wK5m">
-                <property role="BaHAW" value="harness" />
-                <property role="BaGAP" value="" />
+              <node concept="2OqwBi" id="xRVdUh$nsS" role="37wK5m">
+                <node concept="1Xw6AR" id="xRVdUh$nga" role="2Oq$k0">
+                  <node concept="1dCxOl" id="xRVdUh$nmF" role="1XwpL7">
+                    <property role="1XweGQ" value="r:3545ae3d-c784-4b5b-acb4-6803eb602692" />
+                    <node concept="1j_P7g" id="xRVdUh$nmG" role="1j$8Uc">
+                      <property role="1j_P7h" value="harness" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2yCiCJ" id="xRVdUh$n_V" role="2OqNvi">
+                  <node concept="2OqwBi" id="xRVdUh$nXD" role="Vysub">
+                    <node concept="1jxXqW" id="xRVdUh$nES" role="2Oq$k0" />
+                    <node concept="liA8E" id="xRVdUh$okb" role="2OqNvi">
+                      <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                    </node>
+                  </node>
+                </node>
               </node>
               <node concept="Xl_RD" id="5KHBa6kSzYY" role="37wK5m">
                 <property role="Xl_RC" value="arrays_and_matrixes" />
@@ -1248,9 +1428,23 @@
           <node concept="3cpWsn" id="prDxnvpqAT" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="prDxnvpqAR" role="1tU5fm" />
-            <node concept="BaHAS" id="prDxnvpqAU" role="33vP2m">
-              <property role="BaHAW" value="harness" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh$opz" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh$op$" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh$op_" role="1XwpL7">
+                  <property role="1XweGQ" value="r:3545ae3d-c784-4b5b-acb4-6803eb602692" />
+                  <node concept="1j_P7g" id="xRVdUh$opA" role="1j$8Uc">
+                    <property role="1j_P7h" value="harness" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh$opB" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh$opC" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh$opD" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh$opE" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -1406,9 +1600,23 @@
                   <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
                 </node>
               </node>
-              <node concept="BaHAS" id="6ODCss3871z" role="37wK5m">
-                <property role="BaHAW" value="harness" />
-                <property role="BaGAP" value="" />
+              <node concept="2OqwBi" id="xRVdUh$oRE" role="37wK5m">
+                <node concept="1Xw6AR" id="xRVdUh$oRF" role="2Oq$k0">
+                  <node concept="1dCxOl" id="xRVdUh$oRG" role="1XwpL7">
+                    <property role="1XweGQ" value="r:3545ae3d-c784-4b5b-acb4-6803eb602692" />
+                    <node concept="1j_P7g" id="xRVdUh$oRH" role="1j$8Uc">
+                      <property role="1j_P7h" value="harness" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2yCiCJ" id="xRVdUh$oRI" role="2OqNvi">
+                  <node concept="2OqwBi" id="xRVdUh$oRJ" role="Vysub">
+                    <node concept="1jxXqW" id="xRVdUh$oRK" role="2Oq$k0" />
+                    <node concept="liA8E" id="xRVdUh$oRL" role="2OqNvi">
+                      <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                    </node>
+                  </node>
+                </node>
               </node>
               <node concept="Xl_RD" id="6ODCss3871$" role="37wK5m">
                 <property role="Xl_RC" value="boolean" />
@@ -1559,9 +1767,23 @@
           <node concept="3cpWsn" id="5EwdfGVh9V0" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="5EwdfGVh9UY" role="1tU5fm" />
-            <node concept="BaHAS" id="5EwdfGVh9V1" role="33vP2m">
-              <property role="BaHAW" value="harness" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh$qat" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh$qau" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh$qav" role="1XwpL7">
+                  <property role="1XweGQ" value="r:3545ae3d-c784-4b5b-acb4-6803eb602692" />
+                  <node concept="1j_P7g" id="xRVdUh$qaw" role="1j$8Uc">
+                    <property role="1j_P7h" value="harness" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh$qax" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh$qay" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh$qaz" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh$qa$" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -1791,9 +2013,23 @@
                   <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
                 </node>
               </node>
-              <node concept="BaHAS" id="5EwdfGVhaUB" role="37wK5m">
-                <property role="BaHAW" value="harness" />
-                <property role="BaGAP" value="" />
+              <node concept="2OqwBi" id="xRVdUh$qmy" role="37wK5m">
+                <node concept="1Xw6AR" id="xRVdUh$qmz" role="2Oq$k0">
+                  <node concept="1dCxOl" id="xRVdUh$qm$" role="1XwpL7">
+                    <property role="1XweGQ" value="r:3545ae3d-c784-4b5b-acb4-6803eb602692" />
+                    <node concept="1j_P7g" id="xRVdUh$qm_" role="1j$8Uc">
+                      <property role="1j_P7h" value="harness" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2yCiCJ" id="xRVdUh$qmA" role="2OqNvi">
+                  <node concept="2OqwBi" id="xRVdUh$qmB" role="Vysub">
+                    <node concept="1jxXqW" id="xRVdUh$qmC" role="2Oq$k0" />
+                    <node concept="liA8E" id="xRVdUh$qmD" role="2OqNvi">
+                      <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                    </node>
+                  </node>
+                </node>
               </node>
               <node concept="Xl_RD" id="5EwdfGVhaUC" role="37wK5m">
                 <property role="Xl_RC" value="interval" />
@@ -2021,9 +2257,23 @@
           <node concept="3cpWsn" id="5EwdfGVheXW" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="5EwdfGVheXU" role="1tU5fm" />
-            <node concept="BaHAS" id="5EwdfGVheXX" role="33vP2m">
-              <property role="BaHAW" value="harness" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh$rVv" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh$rVw" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh$rVx" role="1XwpL7">
+                  <property role="1XweGQ" value="r:3545ae3d-c784-4b5b-acb4-6803eb602692" />
+                  <node concept="1j_P7g" id="xRVdUh$rVy" role="1j$8Uc">
+                    <property role="1j_P7h" value="harness" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh$rVz" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh$rV$" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh$rV_" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh$rVA" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -2122,9 +2372,23 @@
                   <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
                 </node>
               </node>
-              <node concept="BaHAS" id="awtkG0cIaD" role="37wK5m">
-                <property role="BaHAW" value="harness" />
-                <property role="BaGAP" value="" />
+              <node concept="2OqwBi" id="xRVdUh$pjK" role="37wK5m">
+                <node concept="1Xw6AR" id="xRVdUh$pjL" role="2Oq$k0">
+                  <node concept="1dCxOl" id="xRVdUh$pjM" role="1XwpL7">
+                    <property role="1XweGQ" value="r:3545ae3d-c784-4b5b-acb4-6803eb602692" />
+                    <node concept="1j_P7g" id="xRVdUh$pjN" role="1j$8Uc">
+                      <property role="1j_P7h" value="harness" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2yCiCJ" id="xRVdUh$pjO" role="2OqNvi">
+                  <node concept="2OqwBi" id="xRVdUh$pjP" role="Vysub">
+                    <node concept="1jxXqW" id="xRVdUh$pjQ" role="2Oq$k0" />
+                    <node concept="liA8E" id="xRVdUh$pjR" role="2OqNvi">
+                      <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                    </node>
+                  </node>
+                </node>
               </node>
               <node concept="Xl_RD" id="awtkG0cIaE" role="37wK5m">
                 <property role="Xl_RC" value="enumerations" />
@@ -2186,9 +2450,23 @@
                   <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
                 </node>
               </node>
-              <node concept="BaHAS" id="awtkG0cIC1" role="37wK5m">
-                <property role="BaHAW" value="harness" />
-                <property role="BaGAP" value="" />
+              <node concept="2OqwBi" id="xRVdUh$pom" role="37wK5m">
+                <node concept="1Xw6AR" id="xRVdUh$pon" role="2Oq$k0">
+                  <node concept="1dCxOl" id="xRVdUh$poo" role="1XwpL7">
+                    <property role="1XweGQ" value="r:3545ae3d-c784-4b5b-acb4-6803eb602692" />
+                    <node concept="1j_P7g" id="xRVdUh$pop" role="1j$8Uc">
+                      <property role="1j_P7h" value="harness" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2yCiCJ" id="xRVdUh$poq" role="2OqNvi">
+                  <node concept="2OqwBi" id="xRVdUh$por" role="Vysub">
+                    <node concept="1jxXqW" id="xRVdUh$pos" role="2Oq$k0" />
+                    <node concept="liA8E" id="xRVdUh$pot" role="2OqNvi">
+                      <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                    </node>
+                  </node>
+                </node>
               </node>
               <node concept="Xl_RD" id="awtkG0cIC2" role="37wK5m">
                 <property role="Xl_RC" value="enumerations" />
@@ -2250,9 +2528,23 @@
                   <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
                 </node>
               </node>
-              <node concept="BaHAS" id="3SvxfU18eFG" role="37wK5m">
-                <property role="BaHAW" value="harness" />
-                <property role="BaGAP" value="" />
+              <node concept="2OqwBi" id="xRVdUh$psW" role="37wK5m">
+                <node concept="1Xw6AR" id="xRVdUh$psX" role="2Oq$k0">
+                  <node concept="1dCxOl" id="xRVdUh$psY" role="1XwpL7">
+                    <property role="1XweGQ" value="r:3545ae3d-c784-4b5b-acb4-6803eb602692" />
+                    <node concept="1j_P7g" id="xRVdUh$psZ" role="1j$8Uc">
+                      <property role="1j_P7h" value="harness" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2yCiCJ" id="xRVdUh$pt0" role="2OqNvi">
+                  <node concept="2OqwBi" id="xRVdUh$pt1" role="Vysub">
+                    <node concept="1jxXqW" id="xRVdUh$pt2" role="2Oq$k0" />
+                    <node concept="liA8E" id="xRVdUh$pt3" role="2OqNvi">
+                      <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                    </node>
+                  </node>
+                </node>
               </node>
               <node concept="Xl_RD" id="3SvxfU18eFH" role="37wK5m">
                 <property role="Xl_RC" value="enumerations" />
@@ -2314,9 +2606,23 @@
                   <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
                 </node>
               </node>
-              <node concept="BaHAS" id="3SvxfU18eG1" role="37wK5m">
-                <property role="BaHAW" value="harness" />
-                <property role="BaGAP" value="" />
+              <node concept="2OqwBi" id="xRVdUh$pxy" role="37wK5m">
+                <node concept="1Xw6AR" id="xRVdUh$pxz" role="2Oq$k0">
+                  <node concept="1dCxOl" id="xRVdUh$px$" role="1XwpL7">
+                    <property role="1XweGQ" value="r:3545ae3d-c784-4b5b-acb4-6803eb602692" />
+                    <node concept="1j_P7g" id="xRVdUh$px_" role="1j$8Uc">
+                      <property role="1j_P7h" value="harness" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2yCiCJ" id="xRVdUh$pxA" role="2OqNvi">
+                  <node concept="2OqwBi" id="xRVdUh$pxB" role="Vysub">
+                    <node concept="1jxXqW" id="xRVdUh$pxC" role="2Oq$k0" />
+                    <node concept="liA8E" id="xRVdUh$pxD" role="2OqNvi">
+                      <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                    </node>
+                  </node>
+                </node>
               </node>
               <node concept="Xl_RD" id="3SvxfU18eG2" role="37wK5m">
                 <property role="Xl_RC" value="enumerations" />

--- a/code/languages/com.mbeddr.analyses/tests/test.analyses.cbmc/models/test/analyses/cbmc/html_saver@tests.mps
+++ b/code/languages/com.mbeddr.analyses/tests/test.analyses.cbmc/models/test/analyses/cbmc/html_saver@tests.mps
@@ -139,6 +139,15 @@
         <child id="1199569916463" name="body" index="1bW5cS" />
       </concept>
     </language>
+    <language id="446c26eb-2b7b-4bf0-9b35-f83fa582753e" name="jetbrains.mps.lang.modelapi">
+      <concept id="361130699826193248" name="jetbrains.mps.lang.modelapi.structure.ModelPointer" flags="ng" index="1dCxOl">
+        <property id="1863527487546097494" name="modelId" index="1XweGQ" />
+        <child id="679099339649067980" name="name" index="1j$8Uc" />
+      </concept>
+      <concept id="679099339649053840" name="jetbrains.mps.lang.modelapi.structure.ModelName" flags="ng" index="1j_P7g">
+        <property id="679099339649053841" name="value" index="1j_P7h" />
+      </concept>
+    </language>
     <language id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest">
       <concept id="8427750732757990717" name="jetbrains.mps.baseLanguage.unitTest.structure.BinaryAssert" flags="nn" index="3tpDYu">
         <child id="8427750732757990725" name="actual" index="3tpDZA" />
@@ -150,9 +159,12 @@
       </concept>
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
-      <concept id="559557797393017698" name="jetbrains.mps.lang.smodel.structure.ModelReferenceExpression" flags="nn" index="BaHAS">
-        <property id="559557797393021807" name="stereotype" index="BaGAP" />
-        <property id="559557797393017702" name="name" index="BaHAW" />
+      <concept id="4065387505485742666" name="jetbrains.mps.lang.smodel.structure.ModelPointer_ResolveOperation" flags="ng" index="2yCiCJ" />
+      <concept id="4065387505485742749" name="jetbrains.mps.lang.smodel.structure.AbstractPointerResolveOperation" flags="ng" index="2yCiFS">
+        <child id="3648723375513868575" name="repositoryArg" index="Vysub" />
+      </concept>
+      <concept id="1863527487546129879" name="jetbrains.mps.lang.smodel.structure.ModelPointerExpression" flags="ng" index="1Xw6AR">
+        <child id="1863527487546132519" name="modelRef" index="1XwpL7" />
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
@@ -208,9 +220,23 @@
                   <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
                 </node>
               </node>
-              <node concept="BaHAS" id="5EwdfGVhi3X" role="37wK5m">
-                <property role="BaHAW" value="assertion" />
-                <property role="BaGAP" value="" />
+              <node concept="2OqwBi" id="xRVdUh$tOH" role="37wK5m">
+                <node concept="1Xw6AR" id="xRVdUh$t_x" role="2Oq$k0">
+                  <node concept="1dCxOl" id="xRVdUh$tHh" role="1XwpL7">
+                    <property role="1XweGQ" value="r:97f52bf3-b8b9-4cb2-83a4-5a8caf3dca9a" />
+                    <node concept="1j_P7g" id="xRVdUh$tHi" role="1j$8Uc">
+                      <property role="1j_P7h" value="assertion" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2yCiCJ" id="xRVdUh$tZ0" role="2OqNvi">
+                  <node concept="2OqwBi" id="xRVdUh$ups" role="Vysub">
+                    <node concept="1jxXqW" id="xRVdUh$u5s" role="2Oq$k0" />
+                    <node concept="liA8E" id="xRVdUh$uLd" role="2OqNvi">
+                      <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                    </node>
+                  </node>
+                </node>
               </node>
               <node concept="Xl_RD" id="5EwdfGVhi3Y" role="37wK5m">
                 <property role="Xl_RC" value="main" />

--- a/code/languages/com.mbeddr.analyses/tests/test.analyses.cbmc/models/test/analyses/cbmc/loops_unwinding@tests.mps
+++ b/code/languages/com.mbeddr.analyses/tests/test.analyses.cbmc/models/test/analyses/cbmc/loops_unwinding@tests.mps
@@ -143,6 +143,15 @@
         <child id="1205770614681" name="actualArgument" index="2XxRq1" />
       </concept>
     </language>
+    <language id="446c26eb-2b7b-4bf0-9b35-f83fa582753e" name="jetbrains.mps.lang.modelapi">
+      <concept id="361130699826193248" name="jetbrains.mps.lang.modelapi.structure.ModelPointer" flags="ng" index="1dCxOl">
+        <property id="1863527487546097494" name="modelId" index="1XweGQ" />
+        <child id="679099339649067980" name="name" index="1j$8Uc" />
+      </concept>
+      <concept id="679099339649053840" name="jetbrains.mps.lang.modelapi.structure.ModelName" flags="ng" index="1j_P7g">
+        <property id="679099339649053841" name="value" index="1j_P7h" />
+      </concept>
+    </language>
     <language id="7e09729e-68e4-4442-9bc8-024c5cdac3a2" name="com.mbeddr.analyses.cbmc.testing">
       <concept id="4791280061046124023" name="com.mbeddr.analyses.cbmc.testing.structure.CBMCCounterexampleStateTest" flags="ng" index="38rIoz">
         <property id="4791280061046124024" name="nodeKind" index="38rIoG" />
@@ -168,9 +177,9 @@
       <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
         <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
       </concept>
-      <concept id="559557797393017698" name="jetbrains.mps.lang.smodel.structure.ModelReferenceExpression" flags="nn" index="BaHAS">
-        <property id="559557797393021807" name="stereotype" index="BaGAP" />
-        <property id="559557797393017702" name="name" index="BaHAW" />
+      <concept id="4065387505485742666" name="jetbrains.mps.lang.smodel.structure.ModelPointer_ResolveOperation" flags="ng" index="2yCiCJ" />
+      <concept id="4065387505485742749" name="jetbrains.mps.lang.smodel.structure.AbstractPointerResolveOperation" flags="ng" index="2yCiFS">
+        <child id="3648723375513868575" name="repositoryArg" index="Vysub" />
       </concept>
       <concept id="1143226024141" name="jetbrains.mps.lang.smodel.structure.SModelType" flags="in" index="H_c77" />
       <concept id="1139621453865" name="jetbrains.mps.lang.smodel.structure.Node_IsInstanceOfOperation" flags="nn" index="1mIQ4w">
@@ -178,6 +187,9 @@
       </concept>
       <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
         <reference id="1138405853777" name="concept" index="ehGHo" />
+      </concept>
+      <concept id="1863527487546129879" name="jetbrains.mps.lang.smodel.structure.ModelPointerExpression" flags="ng" index="1Xw6AR">
+        <child id="1863527487546132519" name="modelRef" index="1XwpL7" />
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
@@ -231,9 +243,23 @@
                   <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
                 </node>
               </node>
-              <node concept="BaHAS" id="7xDyb4PL83o" role="37wK5m">
-                <property role="BaHAW" value="loops_unwinding" />
-                <property role="BaGAP" value="" />
+              <node concept="2OqwBi" id="xRVdUh$wrz" role="37wK5m">
+                <node concept="1Xw6AR" id="xRVdUh$wr$" role="2Oq$k0">
+                  <node concept="1dCxOl" id="xRVdUh$wr_" role="1XwpL7">
+                    <property role="1XweGQ" value="r:67877e7f-c493-4b0c-bfd5-62042be0186a" />
+                    <node concept="1j_P7g" id="xRVdUh$wrA" role="1j$8Uc">
+                      <property role="1j_P7h" value="loops_unwinding" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2yCiCJ" id="xRVdUh$wrB" role="2OqNvi">
+                  <node concept="2OqwBi" id="xRVdUh$wrC" role="Vysub">
+                    <node concept="1jxXqW" id="xRVdUh$wrD" role="2Oq$k0" />
+                    <node concept="liA8E" id="xRVdUh$wrE" role="2OqNvi">
+                      <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                    </node>
+                  </node>
+                </node>
               </node>
             </node>
             <node concept="_YKpA" id="7xDyb4PL83p" role="1tU5fm">
@@ -524,9 +550,23 @@
           <node concept="3cpWsn" id="24GUsn9DOZ_" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="24GUsn9DOZz" role="1tU5fm" />
-            <node concept="BaHAS" id="24GUsn9DOZA" role="33vP2m">
-              <property role="BaHAW" value="loops_unwinding" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh$xgf" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh$xgg" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh$xgh" role="1XwpL7">
+                  <property role="1XweGQ" value="r:67877e7f-c493-4b0c-bfd5-62042be0186a" />
+                  <node concept="1j_P7g" id="xRVdUh$xgi" role="1j$8Uc">
+                    <property role="1j_P7h" value="loops_unwinding" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh$xgj" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh$xgk" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh$xgl" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh$xgm" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -677,9 +717,23 @@
           <node concept="3cpWsn" id="6hXQBIqSNb$" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="6hXQBIqSNb_" role="1tU5fm" />
-            <node concept="BaHAS" id="6hXQBIqSNbA" role="33vP2m">
-              <property role="BaHAW" value="loops_unwinding" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh$xoL" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh$xoM" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh$xoN" role="1XwpL7">
+                  <property role="1XweGQ" value="r:67877e7f-c493-4b0c-bfd5-62042be0186a" />
+                  <node concept="1j_P7g" id="xRVdUh$xoO" role="1j$8Uc">
+                    <property role="1j_P7h" value="loops_unwinding" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh$xoP" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh$xoQ" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh$xoR" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh$xoS" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -853,9 +907,23 @@
           <node concept="3cpWsn" id="5etR5IKmf7y" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="5etR5IKmf7w" role="1tU5fm" />
-            <node concept="BaHAS" id="5etR5IKmf7z" role="33vP2m">
-              <property role="BaHAW" value="loops_unwinding" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh$y00" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh$y01" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh$y02" role="1XwpL7">
+                  <property role="1XweGQ" value="r:67877e7f-c493-4b0c-bfd5-62042be0186a" />
+                  <node concept="1j_P7g" id="xRVdUh$y03" role="1j$8Uc">
+                    <property role="1j_P7h" value="loops_unwinding" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh$y04" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh$y05" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh$y06" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh$y07" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -952,9 +1020,23 @@
           <node concept="3cpWsn" id="5etR5IKmfQL" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="5etR5IKmfQM" role="1tU5fm" />
-            <node concept="BaHAS" id="5etR5IKmfQN" role="33vP2m">
-              <property role="BaHAW" value="loops_unwinding" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh$y5C" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh$y5D" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh$y5E" role="1XwpL7">
+                  <property role="1XweGQ" value="r:67877e7f-c493-4b0c-bfd5-62042be0186a" />
+                  <node concept="1j_P7g" id="xRVdUh$y5F" role="1j$8Uc">
+                    <property role="1j_P7h" value="loops_unwinding" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh$y5G" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh$y5H" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh$y5I" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh$y5J" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -1125,9 +1207,23 @@
           <node concept="3cpWsn" id="5cKTps7Ib_g" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="5cKTps7Ib_b" role="1tU5fm" />
-            <node concept="BaHAS" id="5cKTps7IbEU" role="33vP2m">
-              <property role="BaHAW" value="loops_unwinding" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh$vk7" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh$v8l" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh$veb" role="1XwpL7">
+                  <property role="1XweGQ" value="r:67877e7f-c493-4b0c-bfd5-62042be0186a" />
+                  <node concept="1j_P7g" id="xRVdUh$vec" role="1j$8Uc">
+                    <property role="1j_P7h" value="loops_unwinding" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh$vsw" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh$vNA" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh$vx9" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh$w9O" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>

--- a/code/languages/com.mbeddr.analyses/tests/test.analyses.cbmc/models/test/analyses/cbmc/partial_loops@tests.mps
+++ b/code/languages/com.mbeddr.analyses/tests/test.analyses.cbmc/models/test/analyses/cbmc/partial_loops@tests.mps
@@ -103,6 +103,15 @@
     <language id="63e0e566-5131-447e-90e3-12ea330e1a00" name="com.mbeddr.mpsutil.blutil">
       <concept id="6451706574537082687" name="com.mbeddr.mpsutil.blutil.structure.ShortStaticMethodCall" flags="ng" index="NRdvd" />
     </language>
+    <language id="446c26eb-2b7b-4bf0-9b35-f83fa582753e" name="jetbrains.mps.lang.modelapi">
+      <concept id="361130699826193248" name="jetbrains.mps.lang.modelapi.structure.ModelPointer" flags="ng" index="1dCxOl">
+        <property id="1863527487546097494" name="modelId" index="1XweGQ" />
+        <child id="679099339649067980" name="name" index="1j$8Uc" />
+      </concept>
+      <concept id="679099339649053840" name="jetbrains.mps.lang.modelapi.structure.ModelName" flags="ng" index="1j_P7g">
+        <property id="679099339649053841" name="value" index="1j_P7h" />
+      </concept>
+    </language>
     <language id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest">
       <concept id="8427750732757990717" name="jetbrains.mps.baseLanguage.unitTest.structure.BinaryAssert" flags="nn" index="3tpDYu">
         <child id="8427750732757990725" name="actual" index="3tpDZA" />
@@ -120,9 +129,12 @@
       </concept>
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
-      <concept id="559557797393017698" name="jetbrains.mps.lang.smodel.structure.ModelReferenceExpression" flags="nn" index="BaHAS">
-        <property id="559557797393021807" name="stereotype" index="BaGAP" />
-        <property id="559557797393017702" name="name" index="BaHAW" />
+      <concept id="4065387505485742666" name="jetbrains.mps.lang.smodel.structure.ModelPointer_ResolveOperation" flags="ng" index="2yCiCJ" />
+      <concept id="4065387505485742749" name="jetbrains.mps.lang.smodel.structure.AbstractPointerResolveOperation" flags="ng" index="2yCiFS">
+        <child id="3648723375513868575" name="repositoryArg" index="Vysub" />
+      </concept>
+      <concept id="1863527487546129879" name="jetbrains.mps.lang.smodel.structure.ModelPointerExpression" flags="ng" index="1Xw6AR">
+        <child id="1863527487546132519" name="modelRef" index="1XwpL7" />
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
@@ -168,9 +180,23 @@
                   <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
                 </node>
               </node>
-              <node concept="BaHAS" id="4xcwUoATNVQ" role="37wK5m">
-                <property role="BaHAW" value="partial_loops" />
-                <property role="BaGAP" value="" />
+              <node concept="2OqwBi" id="xRVdUh$zMp" role="37wK5m">
+                <node concept="1Xw6AR" id="xRVdUh$zjy" role="2Oq$k0">
+                  <node concept="1dCxOl" id="xRVdUh$zzl" role="1XwpL7">
+                    <property role="1XweGQ" value="r:eb1bb2df-a28d-4d20-8990-e2ce1acfa0c9" />
+                    <node concept="1j_P7g" id="xRVdUh$zzm" role="1j$8Uc">
+                      <property role="1j_P7h" value="partial_loops" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2yCiCJ" id="xRVdUh$$4w" role="2OqNvi">
+                  <node concept="2OqwBi" id="xRVdUh$$HW" role="Vysub">
+                    <node concept="1jxXqW" id="xRVdUh$$ik" role="2Oq$k0" />
+                    <node concept="liA8E" id="xRVdUh$_d$" role="2OqNvi">
+                      <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                    </node>
+                  </node>
+                </node>
               </node>
             </node>
             <node concept="_YKpA" id="4xcwUoATNVR" role="1tU5fm">

--- a/code/languages/com.mbeddr.analyses/tests/test.analyses.cbmc/models/test/analyses/cbmc/ppc@tests.mps
+++ b/code/languages/com.mbeddr.analyses/tests/test.analyses.cbmc/models/test/analyses/cbmc/ppc@tests.mps
@@ -99,6 +99,15 @@
     <language id="63e0e566-5131-447e-90e3-12ea330e1a00" name="com.mbeddr.mpsutil.blutil">
       <concept id="6451706574537082687" name="com.mbeddr.mpsutil.blutil.structure.ShortStaticMethodCall" flags="ng" index="NRdvd" />
     </language>
+    <language id="446c26eb-2b7b-4bf0-9b35-f83fa582753e" name="jetbrains.mps.lang.modelapi">
+      <concept id="361130699826193248" name="jetbrains.mps.lang.modelapi.structure.ModelPointer" flags="ng" index="1dCxOl">
+        <property id="1863527487546097494" name="modelId" index="1XweGQ" />
+        <child id="679099339649067980" name="name" index="1j$8Uc" />
+      </concept>
+      <concept id="679099339649053840" name="jetbrains.mps.lang.modelapi.structure.ModelName" flags="ng" index="1j_P7g">
+        <property id="679099339649053841" name="value" index="1j_P7h" />
+      </concept>
+    </language>
     <language id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest">
       <concept id="8427750732757990717" name="jetbrains.mps.baseLanguage.unitTest.structure.BinaryAssert" flags="nn" index="3tpDYu">
         <child id="8427750732757990725" name="actual" index="3tpDZA" />
@@ -111,11 +120,14 @@
       <concept id="1171985735491" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertSame" flags="nn" index="3vMLTj" />
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
-      <concept id="559557797393017698" name="jetbrains.mps.lang.smodel.structure.ModelReferenceExpression" flags="nn" index="BaHAS">
-        <property id="559557797393021807" name="stereotype" index="BaGAP" />
-        <property id="559557797393017702" name="name" index="BaHAW" />
+      <concept id="4065387505485742666" name="jetbrains.mps.lang.smodel.structure.ModelPointer_ResolveOperation" flags="ng" index="2yCiCJ" />
+      <concept id="4065387505485742749" name="jetbrains.mps.lang.smodel.structure.AbstractPointerResolveOperation" flags="ng" index="2yCiFS">
+        <child id="3648723375513868575" name="repositoryArg" index="Vysub" />
       </concept>
       <concept id="1143226024141" name="jetbrains.mps.lang.smodel.structure.SModelType" flags="in" index="H_c77" />
+      <concept id="1863527487546129879" name="jetbrains.mps.lang.smodel.structure.ModelPointerExpression" flags="ng" index="1Xw6AR">
+        <child id="1863527487546132519" name="modelRef" index="1XwpL7" />
+      </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
@@ -153,9 +165,23 @@
           <node concept="3cpWsn" id="5EwdfGVhols" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="5EwdfGVholq" role="1tU5fm" />
-            <node concept="BaHAS" id="5EwdfGVholt" role="33vP2m">
-              <property role="BaHAW" value="ppc" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh$BhO" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh$BbM" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh$BeK" role="1XwpL7">
+                  <property role="1XweGQ" value="r:90e04ebb-f4b7-4346-a3a9-9b3308ef4c60" />
+                  <node concept="1j_P7g" id="xRVdUh$BeL" role="1j$8Uc">
+                    <property role="1j_P7h" value="ppc" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh$BmR" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh$BCd" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh$BoC" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh$BVz" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -206,9 +232,23 @@
           <node concept="3cpWsn" id="5EwdfGVhpCc" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="5EwdfGVhpCa" role="1tU5fm" />
-            <node concept="BaHAS" id="5EwdfGVhpCd" role="33vP2m">
-              <property role="BaHAW" value="ppc" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh$BY7" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh$BY8" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh$BY9" role="1XwpL7">
+                  <property role="1XweGQ" value="r:90e04ebb-f4b7-4346-a3a9-9b3308ef4c60" />
+                  <node concept="1j_P7g" id="xRVdUh$BYa" role="1j$8Uc">
+                    <property role="1j_P7h" value="ppc" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh$BYb" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh$BYc" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh$BYd" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh$BYe" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -386,9 +426,23 @@
           <node concept="3cpWsn" id="5EwdfGVhqU2" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="5EwdfGVhqU0" role="1tU5fm" />
-            <node concept="BaHAS" id="5EwdfGVhqU3" role="33vP2m">
-              <property role="BaHAW" value="ppc" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh$Cei" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh$Cej" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh$Cek" role="1XwpL7">
+                  <property role="1XweGQ" value="r:90e04ebb-f4b7-4346-a3a9-9b3308ef4c60" />
+                  <node concept="1j_P7g" id="xRVdUh$Cel" role="1j$8Uc">
+                    <property role="1j_P7h" value="ppc" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh$Cem" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh$Cen" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh$Ceo" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh$Cep" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -652,9 +706,23 @@
           <node concept="3cpWsn" id="5EwdfGVhsbS" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="5EwdfGVhsbQ" role="1tU5fm" />
-            <node concept="BaHAS" id="5EwdfGVhsbT" role="33vP2m">
-              <property role="BaHAW" value="ppc" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh$CQD" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh$CQE" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh$CQF" role="1XwpL7">
+                  <property role="1XweGQ" value="r:90e04ebb-f4b7-4346-a3a9-9b3308ef4c60" />
+                  <node concept="1j_P7g" id="xRVdUh$CQG" role="1j$8Uc">
+                    <property role="1j_P7h" value="ppc" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh$CQH" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh$CQI" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh$CQJ" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh$CQK" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -913,9 +981,23 @@
           <node concept="3cpWsn" id="5EwdfGVhtoP" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="5EwdfGVhtoN" role="1tU5fm" />
-            <node concept="BaHAS" id="5EwdfGVhtoQ" role="33vP2m">
-              <property role="BaHAW" value="ppc" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh$D4z" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh$D4$" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh$D4_" role="1XwpL7">
+                  <property role="1XweGQ" value="r:90e04ebb-f4b7-4346-a3a9-9b3308ef4c60" />
+                  <node concept="1j_P7g" id="xRVdUh$D4A" role="1j$8Uc">
+                    <property role="1j_P7h" value="ppc" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh$D4B" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh$D4C" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh$D4D" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh$D4E" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>

--- a/code/languages/com.mbeddr.analyses/tests/test.analyses.cbmc/models/test/analyses/cbmc/protocol@tests.mps
+++ b/code/languages/com.mbeddr.analyses/tests/test.analyses.cbmc/models/test/analyses/cbmc/protocol@tests.mps
@@ -90,6 +90,15 @@
     <language id="63e0e566-5131-447e-90e3-12ea330e1a00" name="com.mbeddr.mpsutil.blutil">
       <concept id="6451706574537082687" name="com.mbeddr.mpsutil.blutil.structure.ShortStaticMethodCall" flags="ng" index="NRdvd" />
     </language>
+    <language id="446c26eb-2b7b-4bf0-9b35-f83fa582753e" name="jetbrains.mps.lang.modelapi">
+      <concept id="361130699826193248" name="jetbrains.mps.lang.modelapi.structure.ModelPointer" flags="ng" index="1dCxOl">
+        <property id="1863527487546097494" name="modelId" index="1XweGQ" />
+        <child id="679099339649067980" name="name" index="1j$8Uc" />
+      </concept>
+      <concept id="679099339649053840" name="jetbrains.mps.lang.modelapi.structure.ModelName" flags="ng" index="1j_P7g">
+        <property id="679099339649053841" name="value" index="1j_P7h" />
+      </concept>
+    </language>
     <language id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest">
       <concept id="8427750732757990717" name="jetbrains.mps.baseLanguage.unitTest.structure.BinaryAssert" flags="nn" index="3tpDYu">
         <child id="8427750732757990725" name="actual" index="3tpDZA" />
@@ -101,11 +110,14 @@
       <concept id="1171985735491" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertSame" flags="nn" index="3vMLTj" />
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
-      <concept id="559557797393017698" name="jetbrains.mps.lang.smodel.structure.ModelReferenceExpression" flags="nn" index="BaHAS">
-        <property id="559557797393021807" name="stereotype" index="BaGAP" />
-        <property id="559557797393017702" name="name" index="BaHAW" />
+      <concept id="4065387505485742666" name="jetbrains.mps.lang.smodel.structure.ModelPointer_ResolveOperation" flags="ng" index="2yCiCJ" />
+      <concept id="4065387505485742749" name="jetbrains.mps.lang.smodel.structure.AbstractPointerResolveOperation" flags="ng" index="2yCiFS">
+        <child id="3648723375513868575" name="repositoryArg" index="Vysub" />
       </concept>
       <concept id="1143226024141" name="jetbrains.mps.lang.smodel.structure.SModelType" flags="in" index="H_c77" />
+      <concept id="1863527487546129879" name="jetbrains.mps.lang.smodel.structure.ModelPointerExpression" flags="ng" index="1Xw6AR">
+        <child id="1863527487546132519" name="modelRef" index="1XwpL7" />
+      </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
@@ -142,9 +154,23 @@
           <node concept="3cpWsn" id="5EwdfGVhAWT" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="5EwdfGVhAWR" role="1tU5fm" />
-            <node concept="BaHAS" id="5EwdfGVhAWU" role="33vP2m">
-              <property role="BaHAW" value="protocol_unwinding_loops" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh$LlN" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh$L0V" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh$Lbk" role="1XwpL7">
+                  <property role="1XweGQ" value="r:4536fdaf-556a-40d0-a4b7-679879466b0f" />
+                  <node concept="1j_P7g" id="xRVdUh$Lbl" role="1j$8Uc">
+                    <property role="1j_P7h" value="protocol_unwinding_loops" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh$LF7" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh$Mbj" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh$LOj" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh$MA4" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -316,9 +342,23 @@
           <node concept="3cpWsn" id="5EwdfGVhu3T" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="5EwdfGVhu3R" role="1tU5fm" />
-            <node concept="BaHAS" id="5EwdfGVhu3U" role="33vP2m">
-              <property role="BaHAW" value="protocol_extended_component" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh$DUo" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh$DLO" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh$DQ3" role="1XwpL7">
+                  <property role="1XweGQ" value="r:64c82e8e-f1ff-4165-8a0e-07a8bb91a197" />
+                  <node concept="1j_P7g" id="xRVdUh$DQ4" role="1j$8Uc">
+                    <property role="1j_P7h" value="protocol_extended_component" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh$E1a" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh$Elj" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh$E4c" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh$EDU" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -394,9 +434,23 @@
           <node concept="3cpWsn" id="5EwdfGVhvBP" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="5EwdfGVhvBN" role="1tU5fm" />
-            <node concept="BaHAS" id="5EwdfGVhvBQ" role="33vP2m">
-              <property role="BaHAW" value="protocol_smoke" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh$H7j" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh$GE3" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh$GOs" role="1XwpL7">
+                  <property role="1XweGQ" value="r:1ec3107b-123d-4426-af3e-bc24b0567931" />
+                  <node concept="1j_P7g" id="xRVdUh$GOt" role="1j$8Uc">
+                    <property role="1j_P7h" value="protocol_smoke" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh$Hkf" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh$HOr" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh$Htr" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh$Iev" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -563,9 +617,23 @@
           <node concept="3cpWsn" id="5EwdfGVhwen" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="5EwdfGVhwel" role="1tU5fm" />
-            <node concept="BaHAS" id="5EwdfGVhweo" role="33vP2m">
-              <property role="BaHAW" value="protocol_smoke" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh$Ip6" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh$Ip7" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh$Ip8" role="1XwpL7">
+                  <property role="1XweGQ" value="r:1ec3107b-123d-4426-af3e-bc24b0567931" />
+                  <node concept="1j_P7g" id="xRVdUh$Ip9" role="1j$8Uc">
+                    <property role="1j_P7h" value="protocol_smoke" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh$Ipa" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh$Ipb" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh$Ipc" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh$Ipd" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -692,9 +760,23 @@
           <node concept="3cpWsn" id="71B0VAs00dz" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="71B0VAs00dx" role="1tU5fm" />
-            <node concept="BaHAS" id="71B0VAs00d$" role="33vP2m">
-              <property role="BaHAW" value="protocol_smoke" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh$IQg" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh$IQh" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh$IQi" role="1XwpL7">
+                  <property role="1XweGQ" value="r:1ec3107b-123d-4426-af3e-bc24b0567931" />
+                  <node concept="1j_P7g" id="xRVdUh$IQj" role="1j$8Uc">
+                    <property role="1j_P7h" value="protocol_smoke" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh$IQk" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh$IQl" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh$IQm" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh$IQn" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -843,9 +925,23 @@
           <node concept="3cpWsn" id="71B0VArZZUe" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="71B0VArZZUc" role="1tU5fm" />
-            <node concept="BaHAS" id="71B0VArZZUf" role="33vP2m">
-              <property role="BaHAW" value="protocol_smoke" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh$J0n" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh$J0o" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh$J0p" role="1XwpL7">
+                  <property role="1XweGQ" value="r:1ec3107b-123d-4426-af3e-bc24b0567931" />
+                  <node concept="1j_P7g" id="xRVdUh$J0q" role="1j$8Uc">
+                    <property role="1j_P7h" value="protocol_smoke" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh$J0r" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh$J0s" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh$J0t" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh$J0u" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -971,9 +1067,23 @@
           <node concept="3cpWsn" id="5EwdfGVhyfv" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="5EwdfGVhyft" role="1tU5fm" />
-            <node concept="BaHAS" id="5EwdfGVhyfw" role="33vP2m">
-              <property role="BaHAW" value="protocol_smoke" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh$J81" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh$J82" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh$J83" role="1XwpL7">
+                  <property role="1XweGQ" value="r:1ec3107b-123d-4426-af3e-bc24b0567931" />
+                  <node concept="1j_P7g" id="xRVdUh$J84" role="1j$8Uc">
+                    <property role="1j_P7h" value="protocol_smoke" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh$J85" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh$J86" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh$J87" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh$J88" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -1100,9 +1210,23 @@
           <node concept="3cpWsn" id="71B0VArZZE8" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="71B0VArZZE6" role="1tU5fm" />
-            <node concept="BaHAS" id="71B0VArZZE9" role="33vP2m">
-              <property role="BaHAW" value="protocol_smoke" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh$J_b" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh$J_c" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh$J_d" role="1XwpL7">
+                  <property role="1XweGQ" value="r:1ec3107b-123d-4426-af3e-bc24b0567931" />
+                  <node concept="1j_P7g" id="xRVdUh$J_e" role="1j$8Uc">
+                    <property role="1j_P7h" value="protocol_smoke" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh$J_f" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh$J_g" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh$J_h" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh$J_i" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -1208,9 +1332,23 @@
           <node concept="3cpWsn" id="5EwdfGVhyGO" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="5EwdfGVhyGM" role="1tU5fm" />
-            <node concept="BaHAS" id="5EwdfGVhyGP" role="33vP2m">
-              <property role="BaHAW" value="protocol_smoke" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh$JG5" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh$JG6" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh$JG7" role="1XwpL7">
+                  <property role="1XweGQ" value="r:1ec3107b-123d-4426-af3e-bc24b0567931" />
+                  <node concept="1j_P7g" id="xRVdUh$JG8" role="1j$8Uc">
+                    <property role="1j_P7h" value="protocol_smoke" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh$JG9" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh$JGa" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh$JGb" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh$JGc" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -1337,9 +1475,23 @@
           <node concept="3cpWsn" id="5EwdfGVhza1" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="5EwdfGVhz9Z" role="1tU5fm" />
-            <node concept="BaHAS" id="5EwdfGVhza2" role="33vP2m">
-              <property role="BaHAW" value="protocol_smoke" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh$JNJ" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh$JNK" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh$JNL" role="1XwpL7">
+                  <property role="1XweGQ" value="r:1ec3107b-123d-4426-af3e-bc24b0567931" />
+                  <node concept="1j_P7g" id="xRVdUh$JNM" role="1j$8Uc">
+                    <property role="1j_P7h" value="protocol_smoke" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh$JNN" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh$JNO" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh$JNP" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh$JNQ" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -1466,9 +1618,23 @@
           <node concept="3cpWsn" id="5EwdfGVhztG" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="5EwdfGVhztE" role="1tU5fm" />
-            <node concept="BaHAS" id="5EwdfGVhztH" role="33vP2m">
-              <property role="BaHAW" value="protocol_smoke" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh$KgT" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh$KgU" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh$KgV" role="1XwpL7">
+                  <property role="1XweGQ" value="r:1ec3107b-123d-4426-af3e-bc24b0567931" />
+                  <node concept="1j_P7g" id="xRVdUh$KgW" role="1j$8Uc">
+                    <property role="1j_P7h" value="protocol_smoke" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh$KgX" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh$KgY" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh$KgZ" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh$Kh0" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -1544,9 +1710,23 @@
           <node concept="3cpWsn" id="5EwdfGVh$6B" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="5EwdfGVh$6_" role="1tU5fm" />
-            <node concept="BaHAS" id="5EwdfGVh$6C" role="33vP2m">
-              <property role="BaHAW" value="protocol_smoke" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh$Klr" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh$Kls" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh$Klt" role="1XwpL7">
+                  <property role="1XweGQ" value="r:1ec3107b-123d-4426-af3e-bc24b0567931" />
+                  <node concept="1j_P7g" id="xRVdUh$Klu" role="1j$8Uc">
+                    <property role="1j_P7h" value="protocol_smoke" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh$Klv" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh$Klw" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh$Klx" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh$Kly" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>

--- a/code/languages/com.mbeddr.analyses/tests/test.analyses.cbmc/models/test/analyses/cbmc/robustness@tests.mps
+++ b/code/languages/com.mbeddr.analyses/tests/test.analyses.cbmc/models/test/analyses/cbmc/robustness@tests.mps
@@ -140,6 +140,15 @@
         <child id="1199569916463" name="body" index="1bW5cS" />
       </concept>
     </language>
+    <language id="446c26eb-2b7b-4bf0-9b35-f83fa582753e" name="jetbrains.mps.lang.modelapi">
+      <concept id="361130699826193248" name="jetbrains.mps.lang.modelapi.structure.ModelPointer" flags="ng" index="1dCxOl">
+        <property id="1863527487546097494" name="modelId" index="1XweGQ" />
+        <child id="679099339649067980" name="name" index="1j$8Uc" />
+      </concept>
+      <concept id="679099339649053840" name="jetbrains.mps.lang.modelapi.structure.ModelName" flags="ng" index="1j_P7g">
+        <property id="679099339649053841" name="value" index="1j_P7h" />
+      </concept>
+    </language>
     <language id="7e09729e-68e4-4442-9bc8-024c5cdac3a2" name="com.mbeddr.analyses.cbmc.testing">
       <concept id="4791280061046124023" name="com.mbeddr.analyses.cbmc.testing.structure.CBMCCounterexampleStateTest" flags="ng" index="38rIoz">
         <property id="5665549241468834974" name="alternativeSteps" index="35AWuq" />
@@ -170,13 +179,16 @@
       </concept>
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
-      <concept id="559557797393017698" name="jetbrains.mps.lang.smodel.structure.ModelReferenceExpression" flags="nn" index="BaHAS">
-        <property id="559557797393021807" name="stereotype" index="BaGAP" />
-        <property id="559557797393017702" name="name" index="BaHAW" />
+      <concept id="4065387505485742666" name="jetbrains.mps.lang.smodel.structure.ModelPointer_ResolveOperation" flags="ng" index="2yCiCJ" />
+      <concept id="4065387505485742749" name="jetbrains.mps.lang.smodel.structure.AbstractPointerResolveOperation" flags="ng" index="2yCiFS">
+        <child id="3648723375513868575" name="repositoryArg" index="Vysub" />
       </concept>
       <concept id="1143226024141" name="jetbrains.mps.lang.smodel.structure.SModelType" flags="in" index="H_c77" />
       <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
         <reference id="1138405853777" name="concept" index="ehGHo" />
+      </concept>
+      <concept id="1863527487546129879" name="jetbrains.mps.lang.smodel.structure.ModelPointerExpression" flags="ng" index="1Xw6AR">
+        <child id="1863527487546132519" name="modelRef" index="1XwpL7" />
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
@@ -257,9 +269,23 @@
           <node concept="3cpWsn" id="5EwdfGVhD4$" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="5EwdfGVhD4y" role="1tU5fm" />
-            <node concept="BaHAS" id="5EwdfGVhD4_" role="33vP2m">
-              <property role="BaHAW" value="robustness" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh$PpJ" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh$PpK" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh$PpL" role="1XwpL7">
+                  <property role="1XweGQ" value="r:4399c8bd-b0a1-454c-b0ff-74fed25055ef" />
+                  <node concept="1j_P7g" id="xRVdUh$PpM" role="1j$8Uc">
+                    <property role="1j_P7h" value="robustness" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh$PpN" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh$PpO" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh$PpP" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh$PpQ" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -553,9 +579,23 @@
           <node concept="3cpWsn" id="5EwdfGVhGet" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="5EwdfGVhGer" role="1tU5fm" />
-            <node concept="BaHAS" id="5EwdfGVhGeu" role="33vP2m">
-              <property role="BaHAW" value="robustness" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh$Q6Y" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh$Q6Z" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh$Q70" role="1XwpL7">
+                  <property role="1XweGQ" value="r:4399c8bd-b0a1-454c-b0ff-74fed25055ef" />
+                  <node concept="1j_P7g" id="xRVdUh$Q71" role="1j$8Uc">
+                    <property role="1j_P7h" value="robustness" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh$Q72" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh$Q73" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh$Q74" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh$Q75" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -704,9 +744,23 @@
           <node concept="3cpWsn" id="5EwdfGVhMOx" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="5EwdfGVhMOv" role="1tU5fm" />
-            <node concept="BaHAS" id="5EwdfGVhMOy" role="33vP2m">
-              <property role="BaHAW" value="robustness" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh$S45" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh$S46" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh$S47" role="1XwpL7">
+                  <property role="1XweGQ" value="r:4399c8bd-b0a1-454c-b0ff-74fed25055ef" />
+                  <node concept="1j_P7g" id="xRVdUh$S48" role="1j$8Uc">
+                    <property role="1j_P7h" value="robustness" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh$S49" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh$S4a" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh$S4b" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh$S4c" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -852,9 +906,23 @@
           <node concept="3cpWsn" id="5EwdfGVhHDi" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="5EwdfGVhHDg" role="1tU5fm" />
-            <node concept="BaHAS" id="5EwdfGVhHDj" role="33vP2m">
-              <property role="BaHAW" value="robustness" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh$Qz7" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh$Qz8" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh$Qz9" role="1XwpL7">
+                  <property role="1XweGQ" value="r:4399c8bd-b0a1-454c-b0ff-74fed25055ef" />
+                  <node concept="1j_P7g" id="xRVdUh$Qza" role="1j$8Uc">
+                    <property role="1j_P7h" value="robustness" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh$Qzb" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh$Qzc" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh$Qzd" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh$Qze" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -996,9 +1064,23 @@
           <node concept="3cpWsn" id="5EwdfGVhGN2" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="5EwdfGVhGN0" role="1tU5fm" />
-            <node concept="BaHAS" id="5EwdfGVhGN3" role="33vP2m">
-              <property role="BaHAW" value="robustness" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh$Ql7" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh$Ql8" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh$Ql9" role="1XwpL7">
+                  <property role="1XweGQ" value="r:4399c8bd-b0a1-454c-b0ff-74fed25055ef" />
+                  <node concept="1j_P7g" id="xRVdUh$Qla" role="1j$8Uc">
+                    <property role="1j_P7h" value="robustness" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh$Qlb" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh$Qlc" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh$Qld" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh$Qle" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -1149,9 +1231,23 @@
           <node concept="3cpWsn" id="5EwdfGVhHac" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="5EwdfGVhHaa" role="1tU5fm" />
-            <node concept="BaHAS" id="5EwdfGVhHad" role="33vP2m">
-              <property role="BaHAW" value="robustness" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh$QoV" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh$QoW" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh$QoX" role="1XwpL7">
+                  <property role="1XweGQ" value="r:4399c8bd-b0a1-454c-b0ff-74fed25055ef" />
+                  <node concept="1j_P7g" id="xRVdUh$QoY" role="1j$8Uc">
+                    <property role="1j_P7h" value="robustness" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh$QoZ" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh$Qp0" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh$Qp1" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh$Qp2" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -1365,9 +1461,23 @@
           <node concept="3cpWsn" id="5EwdfGVhOxv" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="5EwdfGVhOxt" role="1tU5fm" />
-            <node concept="BaHAS" id="5EwdfGVhOxw" role="33vP2m">
-              <property role="BaHAW" value="robustness" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh$Suq" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh$Sur" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh$Sus" role="1XwpL7">
+                  <property role="1XweGQ" value="r:4399c8bd-b0a1-454c-b0ff-74fed25055ef" />
+                  <node concept="1j_P7g" id="xRVdUh$Sut" role="1j$8Uc">
+                    <property role="1j_P7h" value="robustness" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh$Suu" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh$Suv" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh$Suw" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh$Sux" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -1651,9 +1761,23 @@
           <node concept="3cpWsn" id="5EwdfGVhEJJ" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="5EwdfGVhEJH" role="1tU5fm" />
-            <node concept="BaHAS" id="5EwdfGVhEJK" role="33vP2m">
-              <property role="BaHAW" value="robustness" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh$PPj" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh$PPk" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh$PPl" role="1XwpL7">
+                  <property role="1XweGQ" value="r:4399c8bd-b0a1-454c-b0ff-74fed25055ef" />
+                  <node concept="1j_P7g" id="xRVdUh$PPm" role="1j$8Uc">
+                    <property role="1j_P7h" value="robustness" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh$PPn" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh$PPo" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh$PPp" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh$PPq" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -1887,9 +2011,23 @@
           <node concept="3cpWsn" id="5EwdfGVhFj1" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="5EwdfGVhFiZ" role="1tU5fm" />
-            <node concept="BaHAS" id="5EwdfGVhFj2" role="33vP2m">
-              <property role="BaHAW" value="robustness" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh$PWM" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh$PWN" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh$PWO" role="1XwpL7">
+                  <property role="1XweGQ" value="r:4399c8bd-b0a1-454c-b0ff-74fed25055ef" />
+                  <node concept="1j_P7g" id="xRVdUh$PWP" role="1j$8Uc">
+                    <property role="1j_P7h" value="robustness" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh$PWQ" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh$PWR" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh$PWS" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh$PWT" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -2089,9 +2227,23 @@
           <node concept="3cpWsn" id="5EwdfGVhM2i" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="5EwdfGVhM2g" role="1tU5fm" />
-            <node concept="BaHAS" id="5EwdfGVhM2j" role="33vP2m">
-              <property role="BaHAW" value="robustness" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh$RL5" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh$RL6" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh$RL7" role="1XwpL7">
+                  <property role="1XweGQ" value="r:4399c8bd-b0a1-454c-b0ff-74fed25055ef" />
+                  <node concept="1j_P7g" id="xRVdUh$RL8" role="1j$8Uc">
+                    <property role="1j_P7h" value="robustness" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh$RL9" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh$RLa" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh$RLb" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh$RLc" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -2264,9 +2416,23 @@
           <node concept="3cpWsn" id="5EwdfGVhKap" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="5EwdfGVhKan" role="1tU5fm" />
-            <node concept="BaHAS" id="5EwdfGVhKaq" role="33vP2m">
-              <property role="BaHAW" value="robustness" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh$Rnq" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh$Rnr" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh$Rns" role="1XwpL7">
+                  <property role="1XweGQ" value="r:4399c8bd-b0a1-454c-b0ff-74fed25055ef" />
+                  <node concept="1j_P7g" id="xRVdUh$Rnt" role="1j$8Uc">
+                    <property role="1j_P7h" value="robustness" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh$Rnu" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh$Rnv" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh$Rnw" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh$Rnx" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -2396,9 +2562,23 @@
           <node concept="3cpWsn" id="6KXBYUq_A9w" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="6KXBYUq_A9u" role="1tU5fm" />
-            <node concept="BaHAS" id="6KXBYUq_A9x" role="33vP2m">
-              <property role="BaHAW" value="robustness" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh$Rti" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh$Rtj" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh$Rtk" role="1XwpL7">
+                  <property role="1XweGQ" value="r:4399c8bd-b0a1-454c-b0ff-74fed25055ef" />
+                  <node concept="1j_P7g" id="xRVdUh$Rtl" role="1j$8Uc">
+                    <property role="1j_P7h" value="robustness" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh$Rtm" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh$Rtn" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh$Rto" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh$Rtp" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -2659,9 +2839,23 @@
           <node concept="3cpWsn" id="5EwdfGVhJk3" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="5EwdfGVhJk1" role="1tU5fm" />
-            <node concept="BaHAS" id="5EwdfGVhJk4" role="33vP2m">
-              <property role="BaHAW" value="robustness" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh$QV5" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh$QV6" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh$QV7" role="1XwpL7">
+                  <property role="1XweGQ" value="r:4399c8bd-b0a1-454c-b0ff-74fed25055ef" />
+                  <node concept="1j_P7g" id="xRVdUh$QV8" role="1j$8Uc">
+                    <property role="1j_P7h" value="robustness" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh$QV9" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh$QVa" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh$QVb" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh$QVc" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -2837,9 +3031,23 @@
           <node concept="3cpWsn" id="5EwdfGVhRsZ" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="5EwdfGVhRsX" role="1tU5fm" />
-            <node concept="BaHAS" id="5EwdfGVhRt0" role="33vP2m">
-              <property role="BaHAW" value="robustness" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh$NPd" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh$Nvv" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh$NGN" role="1XwpL7">
+                  <property role="1XweGQ" value="r:4399c8bd-b0a1-454c-b0ff-74fed25055ef" />
+                  <node concept="1j_P7g" id="xRVdUh$NGO" role="1j$8Uc">
+                    <property role="1j_P7h" value="robustness" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh$O04" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh$Os6" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh$O7b" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh$OO5" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -3080,9 +3288,23 @@
           <node concept="3cpWsn" id="5EwdfGVhSRV" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="5EwdfGVhSRT" role="1tU5fm" />
-            <node concept="BaHAS" id="5EwdfGVhSRW" role="33vP2m">
-              <property role="BaHAW" value="robustness" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh$P0B" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh$P0C" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh$P0D" role="1XwpL7">
+                  <property role="1XweGQ" value="r:4399c8bd-b0a1-454c-b0ff-74fed25055ef" />
+                  <node concept="1j_P7g" id="xRVdUh$P0E" role="1j$8Uc">
+                    <property role="1j_P7h" value="robustness" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh$P0F" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh$P0G" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh$P0H" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh$P0I" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>

--- a/code/languages/com.mbeddr.analyses/tests/test.analyses.cbmc/models/test/analyses/cbmc/statemachine@tests.mps
+++ b/code/languages/com.mbeddr.analyses/tests/test.analyses.cbmc/models/test/analyses/cbmc/statemachine@tests.mps
@@ -91,6 +91,15 @@
     <language id="63e0e566-5131-447e-90e3-12ea330e1a00" name="com.mbeddr.mpsutil.blutil">
       <concept id="6451706574537082687" name="com.mbeddr.mpsutil.blutil.structure.ShortStaticMethodCall" flags="ng" index="NRdvd" />
     </language>
+    <language id="446c26eb-2b7b-4bf0-9b35-f83fa582753e" name="jetbrains.mps.lang.modelapi">
+      <concept id="361130699826193248" name="jetbrains.mps.lang.modelapi.structure.ModelPointer" flags="ng" index="1dCxOl">
+        <property id="1863527487546097494" name="modelId" index="1XweGQ" />
+        <child id="679099339649067980" name="name" index="1j$8Uc" />
+      </concept>
+      <concept id="679099339649053840" name="jetbrains.mps.lang.modelapi.structure.ModelName" flags="ng" index="1j_P7g">
+        <property id="679099339649053841" name="value" index="1j_P7h" />
+      </concept>
+    </language>
     <language id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest">
       <concept id="8427750732757990717" name="jetbrains.mps.baseLanguage.unitTest.structure.BinaryAssert" flags="nn" index="3tpDYu">
         <child id="8427750732757990725" name="actual" index="3tpDZA" />
@@ -102,11 +111,14 @@
       </concept>
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
-      <concept id="559557797393017698" name="jetbrains.mps.lang.smodel.structure.ModelReferenceExpression" flags="nn" index="BaHAS">
-        <property id="559557797393021807" name="stereotype" index="BaGAP" />
-        <property id="559557797393017702" name="name" index="BaHAW" />
+      <concept id="4065387505485742666" name="jetbrains.mps.lang.smodel.structure.ModelPointer_ResolveOperation" flags="ng" index="2yCiCJ" />
+      <concept id="4065387505485742749" name="jetbrains.mps.lang.smodel.structure.AbstractPointerResolveOperation" flags="ng" index="2yCiFS">
+        <child id="3648723375513868575" name="repositoryArg" index="Vysub" />
       </concept>
       <concept id="1143226024141" name="jetbrains.mps.lang.smodel.structure.SModelType" flags="in" index="H_c77" />
+      <concept id="1863527487546129879" name="jetbrains.mps.lang.smodel.structure.ModelPointerExpression" flags="ng" index="1Xw6AR">
+        <child id="1863527487546132519" name="modelRef" index="1XwpL7" />
+      </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
@@ -139,9 +151,23 @@
           <node concept="3cpWsn" id="47H95zxg6pL" role="3cpWs9">
             <property role="TrG5h" value="crtModel" />
             <node concept="H_c77" id="47H95zxg6pJ" role="1tU5fm" />
-            <node concept="BaHAS" id="47H95zxg6pM" role="33vP2m">
-              <property role="BaHAW" value="statemachines" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh$YFa" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh$YFb" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh$YFc" role="1XwpL7">
+                  <property role="1XweGQ" value="r:502ce762-1afc-4b7e-9144-0e69dffc9737" />
+                  <node concept="1j_P7g" id="xRVdUh$YFd" role="1j$8Uc">
+                    <property role="1j_P7h" value="statemachines" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh$YFe" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh$YFf" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh$YFg" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh$YFh" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -346,9 +372,23 @@
           <node concept="3cpWsn" id="5EwdfGVhX7R" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="5EwdfGVhX7P" role="1tU5fm" />
-            <node concept="BaHAS" id="5EwdfGVhX7S" role="33vP2m">
-              <property role="BaHAW" value="statemachines" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh$Wo$" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh$W0A" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh$Wew" role="1XwpL7">
+                  <property role="1XweGQ" value="r:502ce762-1afc-4b7e-9144-0e69dffc9737" />
+                  <node concept="1j_P7g" id="xRVdUh$Wex" role="1j$8Uc">
+                    <property role="1j_P7h" value="statemachines" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh$W$B" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh$X7T" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh$WLk" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh$Xxy" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -544,9 +584,23 @@
           <node concept="3cpWsn" id="5EwdfGVhUZn" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="5EwdfGVhUZl" role="1tU5fm" />
-            <node concept="BaHAS" id="5EwdfGVhUZo" role="33vP2m">
-              <property role="BaHAW" value="statemachines" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh$U29" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh$TJj" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh$TSF" role="1XwpL7">
+                  <property role="1XweGQ" value="r:502ce762-1afc-4b7e-9144-0e69dffc9737" />
+                  <node concept="1j_P7g" id="xRVdUh$TSG" role="1j$8Uc">
+                    <property role="1j_P7h" value="statemachines" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh$Ubj" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh$UGN" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh$Uju" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh$Vvk" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -719,9 +773,23 @@
           <node concept="3cpWsn" id="5EwdfGVhZ3q" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="5EwdfGVhZ3o" role="1tU5fm" />
-            <node concept="BaHAS" id="5EwdfGVhZ3r" role="33vP2m">
-              <property role="BaHAW" value="statemachines" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh$XYT" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh$XYU" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh$XYV" role="1XwpL7">
+                  <property role="1XweGQ" value="r:502ce762-1afc-4b7e-9144-0e69dffc9737" />
+                  <node concept="1j_P7g" id="xRVdUh$XYW" role="1j$8Uc">
+                    <property role="1j_P7h" value="statemachines" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh$XYX" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh$XYY" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh$XYZ" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh$XZ0" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>

--- a/code/languages/com.mbeddr.analyses/tests/test.analyses.cbmc/models/test/analyses/cbmc/statemachines_complex@tests.mps
+++ b/code/languages/com.mbeddr.analyses/tests/test.analyses.cbmc/models/test/analyses/cbmc/statemachines_complex@tests.mps
@@ -90,6 +90,15 @@
     <language id="63e0e566-5131-447e-90e3-12ea330e1a00" name="com.mbeddr.mpsutil.blutil">
       <concept id="6451706574537082687" name="com.mbeddr.mpsutil.blutil.structure.ShortStaticMethodCall" flags="ng" index="NRdvd" />
     </language>
+    <language id="446c26eb-2b7b-4bf0-9b35-f83fa582753e" name="jetbrains.mps.lang.modelapi">
+      <concept id="361130699826193248" name="jetbrains.mps.lang.modelapi.structure.ModelPointer" flags="ng" index="1dCxOl">
+        <property id="1863527487546097494" name="modelId" index="1XweGQ" />
+        <child id="679099339649067980" name="name" index="1j$8Uc" />
+      </concept>
+      <concept id="679099339649053840" name="jetbrains.mps.lang.modelapi.structure.ModelName" flags="ng" index="1j_P7g">
+        <property id="679099339649053841" name="value" index="1j_P7h" />
+      </concept>
+    </language>
     <language id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest">
       <concept id="8427750732757990717" name="jetbrains.mps.baseLanguage.unitTest.structure.BinaryAssert" flags="nn" index="3tpDYu">
         <child id="8427750732757990725" name="actual" index="3tpDZA" />
@@ -101,9 +110,12 @@
       </concept>
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
-      <concept id="559557797393017698" name="jetbrains.mps.lang.smodel.structure.ModelReferenceExpression" flags="nn" index="BaHAS">
-        <property id="559557797393021807" name="stereotype" index="BaGAP" />
-        <property id="559557797393017702" name="name" index="BaHAW" />
+      <concept id="4065387505485742666" name="jetbrains.mps.lang.smodel.structure.ModelPointer_ResolveOperation" flags="ng" index="2yCiCJ" />
+      <concept id="4065387505485742749" name="jetbrains.mps.lang.smodel.structure.AbstractPointerResolveOperation" flags="ng" index="2yCiFS">
+        <child id="3648723375513868575" name="repositoryArg" index="Vysub" />
+      </concept>
+      <concept id="1863527487546129879" name="jetbrains.mps.lang.smodel.structure.ModelPointerExpression" flags="ng" index="1Xw6AR">
+        <child id="1863527487546132519" name="modelRef" index="1XwpL7" />
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
@@ -145,9 +157,23 @@
                   <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
                 </node>
               </node>
-              <node concept="BaHAS" id="P13yCX$NY2" role="37wK5m">
-                <property role="BaHAW" value="statemachines_complex" />
-                <property role="BaGAP" value="" />
+              <node concept="2OqwBi" id="xRVdUh$Wo$" role="37wK5m">
+                <node concept="1Xw6AR" id="xRVdUh$ZrL" role="2Oq$k0">
+                  <node concept="1dCxOl" id="xRVdUh$Z$8" role="1XwpL7">
+                    <property role="1XweGQ" value="r:567d20f7-a95d-41de-892b-d8cdbd170044" />
+                    <node concept="1j_P7g" id="xRVdUh$Z$9" role="1j$8Uc">
+                      <property role="1j_P7h" value="statemachines_complex" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2yCiCJ" id="xRVdUh$W$B" role="2OqNvi">
+                  <node concept="2OqwBi" id="xRVdUh$X7T" role="Vysub">
+                    <node concept="1jxXqW" id="xRVdUh$WLk" role="2Oq$k0" />
+                    <node concept="liA8E" id="xRVdUh$Xxy" role="2OqNvi">
+                      <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                    </node>
+                  </node>
+                </node>
               </node>
             </node>
             <node concept="_YKpA" id="P13yCX$NY3" role="1tU5fm">

--- a/code/languages/com.mbeddr.analyses/tests/test.analyses.cbmc/models/test/analyses/cbmc/stubbing@tests.mps
+++ b/code/languages/com.mbeddr.analyses/tests/test.analyses.cbmc/models/test/analyses/cbmc/stubbing@tests.mps
@@ -85,6 +85,15 @@
     <language id="63e0e566-5131-447e-90e3-12ea330e1a00" name="com.mbeddr.mpsutil.blutil">
       <concept id="6451706574537082687" name="com.mbeddr.mpsutil.blutil.structure.ShortStaticMethodCall" flags="ng" index="NRdvd" />
     </language>
+    <language id="446c26eb-2b7b-4bf0-9b35-f83fa582753e" name="jetbrains.mps.lang.modelapi">
+      <concept id="361130699826193248" name="jetbrains.mps.lang.modelapi.structure.ModelPointer" flags="ng" index="1dCxOl">
+        <property id="1863527487546097494" name="modelId" index="1XweGQ" />
+        <child id="679099339649067980" name="name" index="1j$8Uc" />
+      </concept>
+      <concept id="679099339649053840" name="jetbrains.mps.lang.modelapi.structure.ModelName" flags="ng" index="1j_P7g">
+        <property id="679099339649053841" name="value" index="1j_P7h" />
+      </concept>
+    </language>
     <language id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest">
       <concept id="8427750732757990717" name="jetbrains.mps.baseLanguage.unitTest.structure.BinaryAssert" flags="nn" index="3tpDYu">
         <child id="8427750732757990725" name="actual" index="3tpDZA" />
@@ -96,9 +105,12 @@
       </concept>
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
-      <concept id="559557797393017698" name="jetbrains.mps.lang.smodel.structure.ModelReferenceExpression" flags="nn" index="BaHAS">
-        <property id="559557797393021807" name="stereotype" index="BaGAP" />
-        <property id="559557797393017702" name="name" index="BaHAW" />
+      <concept id="4065387505485742666" name="jetbrains.mps.lang.smodel.structure.ModelPointer_ResolveOperation" flags="ng" index="2yCiCJ" />
+      <concept id="4065387505485742749" name="jetbrains.mps.lang.smodel.structure.AbstractPointerResolveOperation" flags="ng" index="2yCiFS">
+        <child id="3648723375513868575" name="repositoryArg" index="Vysub" />
+      </concept>
+      <concept id="1863527487546129879" name="jetbrains.mps.lang.smodel.structure.ModelPointerExpression" flags="ng" index="1Xw6AR">
+        <child id="1863527487546132519" name="modelRef" index="1XwpL7" />
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
@@ -137,9 +149,23 @@
                   <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
                 </node>
               </node>
-              <node concept="BaHAS" id="7DvJ5MZxlZT" role="37wK5m">
-                <property role="BaHAW" value="stubbing" />
-                <property role="BaGAP" value="" />
+              <node concept="2OqwBi" id="xRVdUh_05A" role="37wK5m">
+                <node concept="1Xw6AR" id="xRVdUh$ZSC" role="2Oq$k0">
+                  <node concept="1dCxOl" id="xRVdUh$ZZh" role="1XwpL7">
+                    <property role="1XweGQ" value="r:a0ab8dd7-68cf-4da2-9f6c-90c32d6631f9" />
+                    <node concept="1j_P7g" id="xRVdUh$ZZi" role="1j$8Uc">
+                      <property role="1j_P7h" value="stubbing" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2yCiCJ" id="xRVdUh_0eL" role="2OqNvi">
+                  <node concept="2OqwBi" id="xRVdUh_0AJ" role="Vysub">
+                    <node concept="1jxXqW" id="xRVdUh_0jQ" role="2Oq$k0" />
+                    <node concept="liA8E" id="xRVdUh_0Xp" role="2OqNvi">
+                      <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                    </node>
+                  </node>
+                </node>
               </node>
               <node concept="Xl_RD" id="7DvJ5MZxlZU" role="37wK5m">
                 <property role="Xl_RC" value="smoke_sut" />

--- a/code/languages/com.mbeddr.analyses/tests/test.analyses.cbmc/models/test/analyses/cbmc/vacuity@tests.mps
+++ b/code/languages/com.mbeddr.analyses/tests/test.analyses.cbmc/models/test/analyses/cbmc/vacuity@tests.mps
@@ -81,6 +81,15 @@
     <language id="63e0e566-5131-447e-90e3-12ea330e1a00" name="com.mbeddr.mpsutil.blutil">
       <concept id="6451706574537082687" name="com.mbeddr.mpsutil.blutil.structure.ShortStaticMethodCall" flags="ng" index="NRdvd" />
     </language>
+    <language id="446c26eb-2b7b-4bf0-9b35-f83fa582753e" name="jetbrains.mps.lang.modelapi">
+      <concept id="361130699826193248" name="jetbrains.mps.lang.modelapi.structure.ModelPointer" flags="ng" index="1dCxOl">
+        <property id="1863527487546097494" name="modelId" index="1XweGQ" />
+        <child id="679099339649067980" name="name" index="1j$8Uc" />
+      </concept>
+      <concept id="679099339649053840" name="jetbrains.mps.lang.modelapi.structure.ModelName" flags="ng" index="1j_P7g">
+        <property id="679099339649053841" name="value" index="1j_P7h" />
+      </concept>
+    </language>
     <language id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest">
       <concept id="8427750732757990717" name="jetbrains.mps.baseLanguage.unitTest.structure.BinaryAssert" flags="nn" index="3tpDYu">
         <child id="8427750732757990725" name="actual" index="3tpDZA" />
@@ -92,11 +101,14 @@
       </concept>
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
-      <concept id="559557797393017698" name="jetbrains.mps.lang.smodel.structure.ModelReferenceExpression" flags="nn" index="BaHAS">
-        <property id="559557797393021807" name="stereotype" index="BaGAP" />
-        <property id="559557797393017702" name="name" index="BaHAW" />
+      <concept id="4065387505485742666" name="jetbrains.mps.lang.smodel.structure.ModelPointer_ResolveOperation" flags="ng" index="2yCiCJ" />
+      <concept id="4065387505485742749" name="jetbrains.mps.lang.smodel.structure.AbstractPointerResolveOperation" flags="ng" index="2yCiFS">
+        <child id="3648723375513868575" name="repositoryArg" index="Vysub" />
       </concept>
       <concept id="1143226024141" name="jetbrains.mps.lang.smodel.structure.SModelType" flags="in" index="H_c77" />
+      <concept id="1863527487546129879" name="jetbrains.mps.lang.smodel.structure.ModelPointerExpression" flags="ng" index="1Xw6AR">
+        <child id="1863527487546132519" name="modelRef" index="1XwpL7" />
+      </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
@@ -125,9 +137,23 @@
           <node concept="3cpWsn" id="3$vwvl9IH5l" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="3$vwvl9IH5j" role="1tU5fm" />
-            <node concept="BaHAS" id="3$vwvl9IH5m" role="33vP2m">
-              <property role="BaHAW" value="vacuity" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh_1ng" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh_1eU" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh_1in" role="1XwpL7">
+                  <property role="1XweGQ" value="r:9a79b4e7-3f57-4707-84ee-47fb50f75f20" />
+                  <node concept="1j_P7g" id="xRVdUh_1io" role="1j$8Uc">
+                    <property role="1j_P7h" value="vacuity" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh_1uB" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh_1NB" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh_1yd" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh_28N" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -223,9 +249,23 @@
           <node concept="3cpWsn" id="3$vwvl9IJ1A" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="3$vwvl9IJ1$" role="1tU5fm" />
-            <node concept="BaHAS" id="3$vwvl9IJ1B" role="33vP2m">
-              <property role="BaHAW" value="vacuity" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh_2cO" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh_2cP" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh_2cQ" role="1XwpL7">
+                  <property role="1XweGQ" value="r:9a79b4e7-3f57-4707-84ee-47fb50f75f20" />
+                  <node concept="1j_P7g" id="xRVdUh_2cR" role="1j$8Uc">
+                    <property role="1j_P7h" value="vacuity" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh_2cS" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh_2cT" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh_2cU" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh_2cV" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>

--- a/code/languages/com.mbeddr.analyses/tests/test.analyses.cbmc/models/test/analyses/cbmc/verification_case@tests.mps
+++ b/code/languages/com.mbeddr.analyses/tests/test.analyses.cbmc/models/test/analyses/cbmc/verification_case@tests.mps
@@ -85,6 +85,15 @@
     <language id="63e0e566-5131-447e-90e3-12ea330e1a00" name="com.mbeddr.mpsutil.blutil">
       <concept id="6451706574537082687" name="com.mbeddr.mpsutil.blutil.structure.ShortStaticMethodCall" flags="ng" index="NRdvd" />
     </language>
+    <language id="446c26eb-2b7b-4bf0-9b35-f83fa582753e" name="jetbrains.mps.lang.modelapi">
+      <concept id="361130699826193248" name="jetbrains.mps.lang.modelapi.structure.ModelPointer" flags="ng" index="1dCxOl">
+        <property id="1863527487546097494" name="modelId" index="1XweGQ" />
+        <child id="679099339649067980" name="name" index="1j$8Uc" />
+      </concept>
+      <concept id="679099339649053840" name="jetbrains.mps.lang.modelapi.structure.ModelName" flags="ng" index="1j_P7g">
+        <property id="679099339649053841" name="value" index="1j_P7h" />
+      </concept>
+    </language>
     <language id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest">
       <concept id="8427750732757990717" name="jetbrains.mps.baseLanguage.unitTest.structure.BinaryAssert" flags="nn" index="3tpDYu">
         <child id="8427750732757990725" name="actual" index="3tpDZA" />
@@ -96,11 +105,14 @@
       </concept>
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
-      <concept id="559557797393017698" name="jetbrains.mps.lang.smodel.structure.ModelReferenceExpression" flags="nn" index="BaHAS">
-        <property id="559557797393021807" name="stereotype" index="BaGAP" />
-        <property id="559557797393017702" name="name" index="BaHAW" />
+      <concept id="4065387505485742666" name="jetbrains.mps.lang.smodel.structure.ModelPointer_ResolveOperation" flags="ng" index="2yCiCJ" />
+      <concept id="4065387505485742749" name="jetbrains.mps.lang.smodel.structure.AbstractPointerResolveOperation" flags="ng" index="2yCiFS">
+        <child id="3648723375513868575" name="repositoryArg" index="Vysub" />
       </concept>
       <concept id="1143226024141" name="jetbrains.mps.lang.smodel.structure.SModelType" flags="in" index="H_c77" />
+      <concept id="1863527487546129879" name="jetbrains.mps.lang.smodel.structure.ModelPointerExpression" flags="ng" index="1Xw6AR">
+        <child id="1863527487546132519" name="modelRef" index="1XwpL7" />
+      </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
@@ -125,9 +137,23 @@
           <node concept="3cpWsn" id="5EwdfGVi4pD" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="5EwdfGVi4pB" role="1tU5fm" />
-            <node concept="BaHAS" id="5EwdfGVi4pE" role="33vP2m">
-              <property role="BaHAW" value="verification_case" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh_3XJ" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh_3XK" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh_3XL" role="1XwpL7">
+                  <property role="1XweGQ" value="r:412b8cbb-d078-4ab7-84eb-4d56ecf62b70" />
+                  <node concept="1j_P7g" id="xRVdUh_3XM" role="1j$8Uc">
+                    <property role="1j_P7h" value="verification_case" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh_3XN" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh_3XO" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh_3XP" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh_3XQ" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -256,9 +282,23 @@
           <node concept="3cpWsn" id="5EwdfGVi3zA" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="5EwdfGVi3z$" role="1tU5fm" />
-            <node concept="BaHAS" id="5EwdfGVi3zB" role="33vP2m">
-              <property role="BaHAW" value="verification_case" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh_2JM" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh_2xa" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh_2BK" role="1XwpL7">
+                  <property role="1XweGQ" value="r:412b8cbb-d078-4ab7-84eb-4d56ecf62b70" />
+                  <node concept="1j_P7g" id="xRVdUh_2BL" role="1j$8Uc">
+                    <property role="1j_P7h" value="verification_case" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh_2Uh" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh_3lz" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh_310" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh_3Ha" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>

--- a/code/languages/com.mbeddr.analyses/tests/test.analyses.cbmc/models/test/analyses/cbmc/verification_config@tests.mps
+++ b/code/languages/com.mbeddr.analyses/tests/test.analyses.cbmc/models/test/analyses/cbmc/verification_config@tests.mps
@@ -79,6 +79,15 @@
     <language id="63e0e566-5131-447e-90e3-12ea330e1a00" name="com.mbeddr.mpsutil.blutil">
       <concept id="6451706574537082687" name="com.mbeddr.mpsutil.blutil.structure.ShortStaticMethodCall" flags="ng" index="NRdvd" />
     </language>
+    <language id="446c26eb-2b7b-4bf0-9b35-f83fa582753e" name="jetbrains.mps.lang.modelapi">
+      <concept id="361130699826193248" name="jetbrains.mps.lang.modelapi.structure.ModelPointer" flags="ng" index="1dCxOl">
+        <property id="1863527487546097494" name="modelId" index="1XweGQ" />
+        <child id="679099339649067980" name="name" index="1j$8Uc" />
+      </concept>
+      <concept id="679099339649053840" name="jetbrains.mps.lang.modelapi.structure.ModelName" flags="ng" index="1j_P7g">
+        <property id="679099339649053841" name="value" index="1j_P7h" />
+      </concept>
+    </language>
     <language id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest">
       <concept id="8427750732757990717" name="jetbrains.mps.baseLanguage.unitTest.structure.BinaryAssert" flags="nn" index="3tpDYu">
         <child id="8427750732757990725" name="actual" index="3tpDZA" />
@@ -90,11 +99,14 @@
       <concept id="1171985735491" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertSame" flags="nn" index="3vMLTj" />
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
-      <concept id="559557797393017698" name="jetbrains.mps.lang.smodel.structure.ModelReferenceExpression" flags="nn" index="BaHAS">
-        <property id="559557797393021807" name="stereotype" index="BaGAP" />
-        <property id="559557797393017702" name="name" index="BaHAW" />
+      <concept id="4065387505485742666" name="jetbrains.mps.lang.smodel.structure.ModelPointer_ResolveOperation" flags="ng" index="2yCiCJ" />
+      <concept id="4065387505485742749" name="jetbrains.mps.lang.smodel.structure.AbstractPointerResolveOperation" flags="ng" index="2yCiFS">
+        <child id="3648723375513868575" name="repositoryArg" index="Vysub" />
       </concept>
       <concept id="1143226024141" name="jetbrains.mps.lang.smodel.structure.SModelType" flags="in" index="H_c77" />
+      <concept id="1863527487546129879" name="jetbrains.mps.lang.smodel.structure.ModelPointerExpression" flags="ng" index="1Xw6AR">
+        <child id="1863527487546132519" name="modelRef" index="1XwpL7" />
+      </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
@@ -123,9 +135,23 @@
           <node concept="3cpWsn" id="71B0VArZX1N" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="71B0VArZX1L" role="1tU5fm" />
-            <node concept="BaHAS" id="71B0VArZX1O" role="33vP2m">
-              <property role="BaHAW" value="verification_config" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh_4Lv" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh_4C2" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh_4Gb" role="1XwpL7">
+                  <property role="1XweGQ" value="r:09fd7539-f4d4-492d-8807-ba46578db599" />
+                  <node concept="1j_P7g" id="xRVdUh_4Gc" role="1j$8Uc">
+                    <property role="1j_P7h" value="verification_config" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh_4Tg" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh_5f6" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh_4Xh" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh_5$G" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -215,9 +241,23 @@
           <node concept="3cpWsn" id="71B0VArZWIW" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="71B0VArZWIU" role="1tU5fm" />
-            <node concept="BaHAS" id="71B0VArZWIX" role="33vP2m">
-              <property role="BaHAW" value="verification_config" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh_5D8" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh_5D9" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh_5Da" role="1XwpL7">
+                  <property role="1XweGQ" value="r:09fd7539-f4d4-492d-8807-ba46578db599" />
+                  <node concept="1j_P7g" id="xRVdUh_5Db" role="1j$8Uc">
+                    <property role="1j_P7h" value="verification_config" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh_5Dc" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh_5Dd" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh_5De" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh_5Df" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>

--- a/code/languages/com.mbeddr.analyses/tests/test.analyses.spin/models/_010_spin_arguments@tests.mps
+++ b/code/languages/com.mbeddr.analyses/tests/test.analyses.spin/models/_010_spin_arguments@tests.mps
@@ -97,17 +97,29 @@
     <language id="63e0e566-5131-447e-90e3-12ea330e1a00" name="com.mbeddr.mpsutil.blutil">
       <concept id="6451706574537082687" name="com.mbeddr.mpsutil.blutil.structure.ShortStaticMethodCall" flags="ng" index="NRdvd" />
     </language>
+    <language id="446c26eb-2b7b-4bf0-9b35-f83fa582753e" name="jetbrains.mps.lang.modelapi">
+      <concept id="361130699826193248" name="jetbrains.mps.lang.modelapi.structure.ModelPointer" flags="ng" index="1dCxOl">
+        <property id="1863527487546097494" name="modelId" index="1XweGQ" />
+        <child id="679099339649067980" name="name" index="1j$8Uc" />
+      </concept>
+      <concept id="679099339649053840" name="jetbrains.mps.lang.modelapi.structure.ModelName" flags="ng" index="1j_P7g">
+        <property id="679099339649053841" name="value" index="1j_P7h" />
+      </concept>
+    </language>
     <language id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest">
       <concept id="1171981022339" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertTrue" flags="nn" index="3vwNmj">
         <child id="1171981057159" name="condition" index="3vwVQn" />
       </concept>
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
-      <concept id="559557797393017698" name="jetbrains.mps.lang.smodel.structure.ModelReferenceExpression" flags="nn" index="BaHAS">
-        <property id="559557797393021807" name="stereotype" index="BaGAP" />
-        <property id="559557797393017702" name="name" index="BaHAW" />
+      <concept id="4065387505485742666" name="jetbrains.mps.lang.smodel.structure.ModelPointer_ResolveOperation" flags="ng" index="2yCiCJ" />
+      <concept id="4065387505485742749" name="jetbrains.mps.lang.smodel.structure.AbstractPointerResolveOperation" flags="ng" index="2yCiFS">
+        <child id="3648723375513868575" name="repositoryArg" index="Vysub" />
       </concept>
       <concept id="1143226024141" name="jetbrains.mps.lang.smodel.structure.SModelType" flags="in" index="H_c77" />
+      <concept id="1863527487546129879" name="jetbrains.mps.lang.smodel.structure.ModelPointerExpression" flags="ng" index="1Xw6AR">
+        <child id="1863527487546132519" name="modelRef" index="1XwpL7" />
+      </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
@@ -132,9 +144,23 @@
           <node concept="3cpWsn" id="1TY2kgDXU3p" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="1TY2kgDXU3n" role="1tU5fm" />
-            <node concept="BaHAS" id="1TY2kgDXU3q" role="33vP2m">
-              <property role="BaHAW" value="_010_spin_arguments" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUhzEvU" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUhzE1b" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUhzE7O" role="1XwpL7">
+                  <property role="1XweGQ" value="r:ecbc3a4f-4ac4-41dc-b2ca-aa2bb3e7f48c" />
+                  <node concept="1j_P7g" id="xRVdUhzE7P" role="1j$8Uc">
+                    <property role="1j_P7h" value="_010_spin_arguments" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUhzEHb" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUhzF6T" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUhzEN8" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUhzFF4" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -237,9 +263,23 @@
           <node concept="3cpWsn" id="1frDWv8azVR" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="1frDWv8azVP" role="1tU5fm" />
-            <node concept="BaHAS" id="1frDWv8azVS" role="33vP2m">
-              <property role="BaHAW" value="_010_spin_arguments" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUhzFLk" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUhzFLl" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUhzFLm" role="1XwpL7">
+                  <property role="1XweGQ" value="r:ecbc3a4f-4ac4-41dc-b2ca-aa2bb3e7f48c" />
+                  <node concept="1j_P7g" id="xRVdUhzFLn" role="1j$8Uc">
+                    <property role="1j_P7h" value="_010_spin_arguments" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUhzFLo" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUhzFLp" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUhzFLq" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUhzFLr" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>

--- a/code/languages/com.mbeddr.analyses/tests/test.analyses.spin/models/_020_promela@tests.mps
+++ b/code/languages/com.mbeddr.analyses/tests/test.analyses.spin/models/_020_promela@tests.mps
@@ -83,6 +83,15 @@
         <child id="1081773367580" name="leftExpression" index="3uHU7B" />
       </concept>
     </language>
+    <language id="446c26eb-2b7b-4bf0-9b35-f83fa582753e" name="jetbrains.mps.lang.modelapi">
+      <concept id="361130699826193248" name="jetbrains.mps.lang.modelapi.structure.ModelPointer" flags="ng" index="1dCxOl">
+        <property id="1863527487546097494" name="modelId" index="1XweGQ" />
+        <child id="679099339649067980" name="name" index="1j$8Uc" />
+      </concept>
+      <concept id="679099339649053840" name="jetbrains.mps.lang.modelapi.structure.ModelName" flags="ng" index="1j_P7g">
+        <property id="679099339649053841" name="value" index="1j_P7h" />
+      </concept>
+    </language>
     <language id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest">
       <concept id="8427750732757990717" name="jetbrains.mps.baseLanguage.unitTest.structure.BinaryAssert" flags="nn" index="3tpDYu">
         <child id="8427750732757990725" name="actual" index="3tpDZA" />
@@ -94,11 +103,14 @@
       </concept>
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
-      <concept id="559557797393017698" name="jetbrains.mps.lang.smodel.structure.ModelReferenceExpression" flags="nn" index="BaHAS">
-        <property id="559557797393021807" name="stereotype" index="BaGAP" />
-        <property id="559557797393017702" name="name" index="BaHAW" />
+      <concept id="4065387505485742666" name="jetbrains.mps.lang.smodel.structure.ModelPointer_ResolveOperation" flags="ng" index="2yCiCJ" />
+      <concept id="4065387505485742749" name="jetbrains.mps.lang.smodel.structure.AbstractPointerResolveOperation" flags="ng" index="2yCiFS">
+        <child id="3648723375513868575" name="repositoryArg" index="Vysub" />
       </concept>
       <concept id="1143226024141" name="jetbrains.mps.lang.smodel.structure.SModelType" flags="in" index="H_c77" />
+      <concept id="1863527487546129879" name="jetbrains.mps.lang.smodel.structure.ModelPointerExpression" flags="ng" index="1Xw6AR">
+        <child id="1863527487546132519" name="modelRef" index="1XwpL7" />
+      </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
@@ -128,9 +140,23 @@
                   <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
                 </node>
               </node>
-              <node concept="BaHAS" id="2s6qLQkl_Jv" role="37wK5m">
-                <property role="BaHAW" value="_020_promela" />
-                <property role="BaGAP" value="" />
+              <node concept="2OqwBi" id="xRVdUhzHCz" role="37wK5m">
+                <node concept="1Xw6AR" id="xRVdUhzHC$" role="2Oq$k0">
+                  <node concept="1dCxOl" id="xRVdUhzHC_" role="1XwpL7">
+                    <property role="1XweGQ" value="r:96fc0a69-4c23-4263-8df2-60e3d1d7fd3b" />
+                    <node concept="1j_P7g" id="xRVdUhzHCA" role="1j$8Uc">
+                      <property role="1j_P7h" value="_020_promela" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2yCiCJ" id="xRVdUhzHCB" role="2OqNvi">
+                  <node concept="2OqwBi" id="xRVdUhzHCC" role="Vysub">
+                    <node concept="1jxXqW" id="xRVdUhzHCD" role="2Oq$k0" />
+                    <node concept="liA8E" id="xRVdUhzHCE" role="2OqNvi">
+                      <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                    </node>
+                  </node>
+                </node>
               </node>
               <node concept="Xl_RD" id="13EXNGXNHou" role="37wK5m">
                 <property role="Xl_RC" value="hello" />
@@ -197,9 +223,23 @@
           <node concept="3cpWsn" id="1ieRNjmuW67" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="1ieRNjmuW65" role="1tU5fm" />
-            <node concept="BaHAS" id="1ieRNjmuW68" role="33vP2m">
-              <property role="BaHAW" value="_020_promela" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUhzHKH" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUhzHKI" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUhzHKJ" role="1XwpL7">
+                  <property role="1XweGQ" value="r:96fc0a69-4c23-4263-8df2-60e3d1d7fd3b" />
+                  <node concept="1j_P7g" id="xRVdUhzHKK" role="1j$8Uc">
+                    <property role="1j_P7h" value="_020_promela" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUhzHKL" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUhzHKM" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUhzHKN" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUhzHKO" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -283,9 +323,23 @@
           <node concept="3cpWsn" id="1ieRNjmuSyZ" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="1ieRNjmuSyX" role="1tU5fm" />
-            <node concept="BaHAS" id="1ieRNjmuSz0" role="33vP2m">
-              <property role="BaHAW" value="_020_promela" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUhzGxi" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUhzG81" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUhzGca" role="1XwpL7">
+                  <property role="1XweGQ" value="r:96fc0a69-4c23-4263-8df2-60e3d1d7fd3b" />
+                  <node concept="1j_P7g" id="xRVdUhzGcb" role="1j$8Uc">
+                    <property role="1j_P7h" value="_020_promela" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUhzGEc" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUhzH1s" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUhzGHa" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUhzHl4" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -380,9 +434,23 @@
                   <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
                 </node>
               </node>
-              <node concept="BaHAS" id="2s6qLQklB61" role="37wK5m">
-                <property role="BaHAW" value="_020_promela" />
-                <property role="BaGAP" value="" />
+              <node concept="2OqwBi" id="xRVdUhzI4c" role="37wK5m">
+                <node concept="1Xw6AR" id="xRVdUhzI4d" role="2Oq$k0">
+                  <node concept="1dCxOl" id="xRVdUhzI4e" role="1XwpL7">
+                    <property role="1XweGQ" value="r:96fc0a69-4c23-4263-8df2-60e3d1d7fd3b" />
+                    <node concept="1j_P7g" id="xRVdUhzI4f" role="1j$8Uc">
+                      <property role="1j_P7h" value="_020_promela" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2yCiCJ" id="xRVdUhzI4g" role="2OqNvi">
+                  <node concept="2OqwBi" id="xRVdUhzI4h" role="Vysub">
+                    <node concept="1jxXqW" id="xRVdUhzI4i" role="2Oq$k0" />
+                    <node concept="liA8E" id="xRVdUhzI4j" role="2OqNvi">
+                      <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                    </node>
+                  </node>
+                </node>
               </node>
               <node concept="Xl_RD" id="54ptZbPSAqi" role="37wK5m">
                 <property role="Xl_RC" value="multiple_choice_test" />
@@ -480,9 +548,23 @@
                   <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
                 </node>
               </node>
-              <node concept="BaHAS" id="2s6qLQklBTS" role="37wK5m">
-                <property role="BaHAW" value="_020_promela" />
-                <property role="BaGAP" value="" />
+              <node concept="2OqwBi" id="xRVdUhzIre" role="37wK5m">
+                <node concept="1Xw6AR" id="xRVdUhzIrf" role="2Oq$k0">
+                  <node concept="1dCxOl" id="xRVdUhzIrg" role="1XwpL7">
+                    <property role="1XweGQ" value="r:96fc0a69-4c23-4263-8df2-60e3d1d7fd3b" />
+                    <node concept="1j_P7g" id="xRVdUhzIrh" role="1j$8Uc">
+                      <property role="1j_P7h" value="_020_promela" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2yCiCJ" id="xRVdUhzIri" role="2OqNvi">
+                  <node concept="2OqwBi" id="xRVdUhzIrj" role="Vysub">
+                    <node concept="1jxXqW" id="xRVdUhzIrk" role="2Oq$k0" />
+                    <node concept="liA8E" id="xRVdUhzIrl" role="2OqNvi">
+                      <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                    </node>
+                  </node>
+                </node>
               </node>
               <node concept="Xl_RD" id="1RC3LaKCwC_" role="37wK5m">
                 <property role="Xl_RC" value="select_test" />
@@ -580,9 +662,23 @@
                   <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
                 </node>
               </node>
-              <node concept="BaHAS" id="5p$33BW3gtZ" role="37wK5m">
-                <property role="BaHAW" value="_020_promela" />
-                <property role="BaGAP" value="" />
+              <node concept="2OqwBi" id="xRVdUhzHpA" role="37wK5m">
+                <node concept="1Xw6AR" id="xRVdUhzHpB" role="2Oq$k0">
+                  <node concept="1dCxOl" id="xRVdUhzHpC" role="1XwpL7">
+                    <property role="1XweGQ" value="r:96fc0a69-4c23-4263-8df2-60e3d1d7fd3b" />
+                    <node concept="1j_P7g" id="xRVdUhzHpD" role="1j$8Uc">
+                      <property role="1j_P7h" value="_020_promela" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2yCiCJ" id="xRVdUhzHpE" role="2OqNvi">
+                  <node concept="2OqwBi" id="xRVdUhzHpF" role="Vysub">
+                    <node concept="1jxXqW" id="xRVdUhzHpG" role="2Oq$k0" />
+                    <node concept="liA8E" id="xRVdUhzHpH" role="2OqNvi">
+                      <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                    </node>
+                  </node>
+                </node>
               </node>
               <node concept="Xl_RD" id="5p$33BW3gu0" role="37wK5m">
                 <property role="Xl_RC" value="for_test" />

--- a/code/languages/com.mbeddr.analyses/tests/test.analyses.spin/models/_030_promela_c_suv@tests.mps
+++ b/code/languages/com.mbeddr.analyses/tests/test.analyses.spin/models/_030_promela_c_suv@tests.mps
@@ -94,6 +94,15 @@
     <language id="63e0e566-5131-447e-90e3-12ea330e1a00" name="com.mbeddr.mpsutil.blutil">
       <concept id="6451706574537082687" name="com.mbeddr.mpsutil.blutil.structure.ShortStaticMethodCall" flags="ng" index="NRdvd" />
     </language>
+    <language id="446c26eb-2b7b-4bf0-9b35-f83fa582753e" name="jetbrains.mps.lang.modelapi">
+      <concept id="361130699826193248" name="jetbrains.mps.lang.modelapi.structure.ModelPointer" flags="ng" index="1dCxOl">
+        <property id="1863527487546097494" name="modelId" index="1XweGQ" />
+        <child id="679099339649067980" name="name" index="1j$8Uc" />
+      </concept>
+      <concept id="679099339649053840" name="jetbrains.mps.lang.modelapi.structure.ModelName" flags="ng" index="1j_P7g">
+        <property id="679099339649053841" name="value" index="1j_P7h" />
+      </concept>
+    </language>
     <language id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest">
       <concept id="8427750732757990717" name="jetbrains.mps.baseLanguage.unitTest.structure.BinaryAssert" flags="nn" index="3tpDYu">
         <child id="8427750732757990725" name="actual" index="3tpDZA" />
@@ -105,11 +114,14 @@
       </concept>
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
-      <concept id="559557797393017698" name="jetbrains.mps.lang.smodel.structure.ModelReferenceExpression" flags="nn" index="BaHAS">
-        <property id="559557797393021807" name="stereotype" index="BaGAP" />
-        <property id="559557797393017702" name="name" index="BaHAW" />
+      <concept id="4065387505485742666" name="jetbrains.mps.lang.smodel.structure.ModelPointer_ResolveOperation" flags="ng" index="2yCiCJ" />
+      <concept id="4065387505485742749" name="jetbrains.mps.lang.smodel.structure.AbstractPointerResolveOperation" flags="ng" index="2yCiFS">
+        <child id="3648723375513868575" name="repositoryArg" index="Vysub" />
       </concept>
       <concept id="1143226024141" name="jetbrains.mps.lang.smodel.structure.SModelType" flags="in" index="H_c77" />
+      <concept id="1863527487546129879" name="jetbrains.mps.lang.smodel.structure.ModelPointerExpression" flags="ng" index="1Xw6AR">
+        <child id="1863527487546132519" name="modelRef" index="1XwpL7" />
+      </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
@@ -134,9 +146,23 @@
           <node concept="3cpWsn" id="3tIDuP5sifu" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="3tIDuP5sifs" role="1tU5fm" />
-            <node concept="BaHAS" id="3tIDuP5sifv" role="33vP2m">
-              <property role="BaHAW" value="_030_promela_c_suv_mbeddr_core" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="1cDqQHFXUoN" role="33vP2m">
+              <node concept="1Xw6AR" id="1cDqQHFXU6Q" role="2Oq$k0">
+                <node concept="1dCxOl" id="1cDqQHFXUf_" role="1XwpL7">
+                  <property role="1XweGQ" value="r:0aef4ea3-08ec-44a0-9b3c-c675bdae5d40" />
+                  <node concept="1j_P7g" id="1cDqQHFXUfA" role="1j$8Uc">
+                    <property role="1j_P7h" value="_030_promela_c_suv_mbeddr_core" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="1cDqQHFXU_O" role="2OqNvi">
+                <node concept="2OqwBi" id="1cDqQHFXUVH" role="Vysub">
+                  <node concept="1jxXqW" id="1cDqQHFXUDH" role="2Oq$k0" />
+                  <node concept="liA8E" id="1cDqQHFXWo_" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -223,9 +249,23 @@
           <node concept="3cpWsn" id="3tIDuP5sjCL" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="3tIDuP5sjCJ" role="1tU5fm" />
-            <node concept="BaHAS" id="3tIDuP5sjCM" role="33vP2m">
-              <property role="BaHAW" value="_030_promela_c_suv_mbeddr_core" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="1cDqQHFXWu9" role="33vP2m">
+              <node concept="1Xw6AR" id="1cDqQHFXWua" role="2Oq$k0">
+                <node concept="1dCxOl" id="1cDqQHFXWub" role="1XwpL7">
+                  <property role="1XweGQ" value="r:0aef4ea3-08ec-44a0-9b3c-c675bdae5d40" />
+                  <node concept="1j_P7g" id="1cDqQHFXWuc" role="1j$8Uc">
+                    <property role="1j_P7h" value="_030_promela_c_suv_mbeddr_core" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="1cDqQHFXWud" role="2OqNvi">
+                <node concept="2OqwBi" id="1cDqQHFXWue" role="Vysub">
+                  <node concept="1jxXqW" id="1cDqQHFXWuf" role="2Oq$k0" />
+                  <node concept="liA8E" id="1cDqQHFXWug" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -312,9 +352,23 @@
           <node concept="3cpWsn" id="3tIDuP5skRl" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="3tIDuP5skRj" role="1tU5fm" />
-            <node concept="BaHAS" id="3tIDuP5skRm" role="33vP2m">
-              <property role="BaHAW" value="_030_promela_c_suv_mbeddr_core" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="1cDqQHFXWBA" role="33vP2m">
+              <node concept="1Xw6AR" id="1cDqQHFXWBB" role="2Oq$k0">
+                <node concept="1dCxOl" id="1cDqQHFXWBC" role="1XwpL7">
+                  <property role="1XweGQ" value="r:0aef4ea3-08ec-44a0-9b3c-c675bdae5d40" />
+                  <node concept="1j_P7g" id="1cDqQHFXWBD" role="1j$8Uc">
+                    <property role="1j_P7h" value="_030_promela_c_suv_mbeddr_core" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="1cDqQHFXWBE" role="2OqNvi">
+                <node concept="2OqwBi" id="1cDqQHFXWBF" role="Vysub">
+                  <node concept="1jxXqW" id="1cDqQHFXWBG" role="2Oq$k0" />
+                  <node concept="liA8E" id="1cDqQHFXWBH" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -401,9 +455,23 @@
           <node concept="3cpWsn" id="1ieRNjmuN5u" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="1ieRNjmuN5s" role="1tU5fm" />
-            <node concept="BaHAS" id="1ieRNjmuN5v" role="33vP2m">
-              <property role="BaHAW" value="_030_promela_c_suv_mbeddr_core" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="1cDqQHFXWHq" role="33vP2m">
+              <node concept="1Xw6AR" id="1cDqQHFXWHr" role="2Oq$k0">
+                <node concept="1dCxOl" id="1cDqQHFXWHs" role="1XwpL7">
+                  <property role="1XweGQ" value="r:0aef4ea3-08ec-44a0-9b3c-c675bdae5d40" />
+                  <node concept="1j_P7g" id="1cDqQHFXWHt" role="1j$8Uc">
+                    <property role="1j_P7h" value="_030_promela_c_suv_mbeddr_core" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="1cDqQHFXWHu" role="2OqNvi">
+                <node concept="2OqwBi" id="1cDqQHFXWHv" role="Vysub">
+                  <node concept="1jxXqW" id="1cDqQHFXWHw" role="2Oq$k0" />
+                  <node concept="liA8E" id="1cDqQHFXWHx" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -489,9 +557,23 @@
           <node concept="3cpWsn" id="1ieRNjmuNiL" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="1ieRNjmuNiJ" role="1tU5fm" />
-            <node concept="BaHAS" id="1ieRNjmuNiM" role="33vP2m">
-              <property role="BaHAW" value="_030_promela_c_suv_mbeddr_core" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="1cDqQHFXWPz" role="33vP2m">
+              <node concept="1Xw6AR" id="1cDqQHFXWP$" role="2Oq$k0">
+                <node concept="1dCxOl" id="1cDqQHFXWP_" role="1XwpL7">
+                  <property role="1XweGQ" value="r:0aef4ea3-08ec-44a0-9b3c-c675bdae5d40" />
+                  <node concept="1j_P7g" id="1cDqQHFXWPA" role="1j$8Uc">
+                    <property role="1j_P7h" value="_030_promela_c_suv_mbeddr_core" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="1cDqQHFXWPB" role="2OqNvi">
+                <node concept="2OqwBi" id="1cDqQHFXWPC" role="Vysub">
+                  <node concept="1jxXqW" id="1cDqQHFXWPD" role="2Oq$k0" />
+                  <node concept="liA8E" id="1cDqQHFXWPE" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -577,9 +659,23 @@
           <node concept="3cpWsn" id="1ieRNjmuNQQ" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="1ieRNjmuNQO" role="1tU5fm" />
-            <node concept="BaHAS" id="1ieRNjmuNQR" role="33vP2m">
-              <property role="BaHAW" value="_030_promela_c_suv_mbeddr_core" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="1cDqQHFXWU2" role="33vP2m">
+              <node concept="1Xw6AR" id="1cDqQHFXWU3" role="2Oq$k0">
+                <node concept="1dCxOl" id="1cDqQHFXWU4" role="1XwpL7">
+                  <property role="1XweGQ" value="r:0aef4ea3-08ec-44a0-9b3c-c675bdae5d40" />
+                  <node concept="1j_P7g" id="1cDqQHFXWU5" role="1j$8Uc">
+                    <property role="1j_P7h" value="_030_promela_c_suv_mbeddr_core" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="1cDqQHFXWU6" role="2OqNvi">
+                <node concept="2OqwBi" id="1cDqQHFXWU7" role="Vysub">
+                  <node concept="1jxXqW" id="1cDqQHFXWU8" role="2Oq$k0" />
+                  <node concept="liA8E" id="1cDqQHFXWU9" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -663,9 +759,23 @@
           <node concept="3cpWsn" id="1ieRNjmuOqD" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="1ieRNjmuOqB" role="1tU5fm" />
-            <node concept="BaHAS" id="1ieRNjmuOqE" role="33vP2m">
-              <property role="BaHAW" value="_030_promela_c_suv_mbeddr_core" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="1cDqQHFXWYr" role="33vP2m">
+              <node concept="1Xw6AR" id="1cDqQHFXWYs" role="2Oq$k0">
+                <node concept="1dCxOl" id="1cDqQHFXWYt" role="1XwpL7">
+                  <property role="1XweGQ" value="r:0aef4ea3-08ec-44a0-9b3c-c675bdae5d40" />
+                  <node concept="1j_P7g" id="1cDqQHFXWYu" role="1j$8Uc">
+                    <property role="1j_P7h" value="_030_promela_c_suv_mbeddr_core" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="1cDqQHFXWYv" role="2OqNvi">
+                <node concept="2OqwBi" id="1cDqQHFXWYw" role="Vysub">
+                  <node concept="1jxXqW" id="1cDqQHFXWYx" role="2Oq$k0" />
+                  <node concept="liA8E" id="1cDqQHFXWYy" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -797,9 +907,23 @@
           <node concept="3cpWsn" id="3tIDuP5t5qL" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="3tIDuP5t5qM" role="1tU5fm" />
-            <node concept="BaHAS" id="3tIDuP5t5qN" role="33vP2m">
-              <property role="BaHAW" value="_030_promela_c_suv_mbeddr_core" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="1cDqQHFXX48" role="33vP2m">
+              <node concept="1Xw6AR" id="1cDqQHFXX49" role="2Oq$k0">
+                <node concept="1dCxOl" id="1cDqQHFXX4a" role="1XwpL7">
+                  <property role="1XweGQ" value="r:0aef4ea3-08ec-44a0-9b3c-c675bdae5d40" />
+                  <node concept="1j_P7g" id="1cDqQHFXX4b" role="1j$8Uc">
+                    <property role="1j_P7h" value="_030_promela_c_suv_mbeddr_core" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="1cDqQHFXX4c" role="2OqNvi">
+                <node concept="2OqwBi" id="1cDqQHFXX4d" role="Vysub">
+                  <node concept="1jxXqW" id="1cDqQHFXX4e" role="2Oq$k0" />
+                  <node concept="liA8E" id="1cDqQHFXX4f" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -873,9 +997,23 @@
           <node concept="3cpWsn" id="3tIDuP5t7Oe" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="3tIDuP5t7Of" role="1tU5fm" />
-            <node concept="BaHAS" id="3tIDuP5t7Og" role="33vP2m">
-              <property role="BaHAW" value="_030_promela_c_suv_mbeddr_core" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="1cDqQHFXXbV" role="33vP2m">
+              <node concept="1Xw6AR" id="1cDqQHFXXbW" role="2Oq$k0">
+                <node concept="1dCxOl" id="1cDqQHFXXbX" role="1XwpL7">
+                  <property role="1XweGQ" value="r:0aef4ea3-08ec-44a0-9b3c-c675bdae5d40" />
+                  <node concept="1j_P7g" id="1cDqQHFXXbY" role="1j$8Uc">
+                    <property role="1j_P7h" value="_030_promela_c_suv_mbeddr_core" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="1cDqQHFXXbZ" role="2OqNvi">
+                <node concept="2OqwBi" id="1cDqQHFXXc0" role="Vysub">
+                  <node concept="1jxXqW" id="1cDqQHFXXc1" role="2Oq$k0" />
+                  <node concept="liA8E" id="1cDqQHFXXc2" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -949,9 +1087,23 @@
           <node concept="3cpWsn" id="3tIDuP5t7OD" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="3tIDuP5t7OE" role="1tU5fm" />
-            <node concept="BaHAS" id="3tIDuP5t7OF" role="33vP2m">
-              <property role="BaHAW" value="_030_promela_c_suv_mbeddr_core" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="1cDqQHFXXg4" role="33vP2m">
+              <node concept="1Xw6AR" id="1cDqQHFXXg5" role="2Oq$k0">
+                <node concept="1dCxOl" id="1cDqQHFXXg6" role="1XwpL7">
+                  <property role="1XweGQ" value="r:0aef4ea3-08ec-44a0-9b3c-c675bdae5d40" />
+                  <node concept="1j_P7g" id="1cDqQHFXXg7" role="1j$8Uc">
+                    <property role="1j_P7h" value="_030_promela_c_suv_mbeddr_core" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="1cDqQHFXXg8" role="2OqNvi">
+                <node concept="2OqwBi" id="1cDqQHFXXg9" role="Vysub">
+                  <node concept="1jxXqW" id="1cDqQHFXXga" role="2Oq$k0" />
+                  <node concept="liA8E" id="1cDqQHFXXgb" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -1049,9 +1201,23 @@
           <node concept="3cpWsn" id="Hdy9e32QbK" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="Hdy9e32QbL" role="1tU5fm" />
-            <node concept="BaHAS" id="Hdy9e32QbM" role="33vP2m">
-              <property role="BaHAW" value="_030_promela_c_suv_mbeddr_core" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="1cDqQHFXXqo" role="33vP2m">
+              <node concept="1Xw6AR" id="1cDqQHFXXqp" role="2Oq$k0">
+                <node concept="1dCxOl" id="1cDqQHFXXqq" role="1XwpL7">
+                  <property role="1XweGQ" value="r:0aef4ea3-08ec-44a0-9b3c-c675bdae5d40" />
+                  <node concept="1j_P7g" id="1cDqQHFXXqr" role="1j$8Uc">
+                    <property role="1j_P7h" value="_030_promela_c_suv_mbeddr_core" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="1cDqQHFXXqs" role="2OqNvi">
+                <node concept="2OqwBi" id="1cDqQHFXXqt" role="Vysub">
+                  <node concept="1jxXqW" id="1cDqQHFXXqu" role="2Oq$k0" />
+                  <node concept="liA8E" id="1cDqQHFXXqv" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -1138,9 +1304,23 @@
           <node concept="3cpWsn" id="Hdy9e33afC" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="Hdy9e33afD" role="1tU5fm" />
-            <node concept="BaHAS" id="Hdy9e33afE" role="33vP2m">
-              <property role="BaHAW" value="_030_promela_c_suv_mbeddr_core" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="1cDqQHFXXzP" role="33vP2m">
+              <node concept="1Xw6AR" id="1cDqQHFXXzQ" role="2Oq$k0">
+                <node concept="1dCxOl" id="1cDqQHFXXzR" role="1XwpL7">
+                  <property role="1XweGQ" value="r:0aef4ea3-08ec-44a0-9b3c-c675bdae5d40" />
+                  <node concept="1j_P7g" id="1cDqQHFXXzS" role="1j$8Uc">
+                    <property role="1j_P7h" value="_030_promela_c_suv_mbeddr_core" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="1cDqQHFXXzT" role="2OqNvi">
+                <node concept="2OqwBi" id="1cDqQHFXXzU" role="Vysub">
+                  <node concept="1jxXqW" id="1cDqQHFXXzV" role="2Oq$k0" />
+                  <node concept="liA8E" id="1cDqQHFXXzW" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -1231,9 +1411,23 @@
           <node concept="3cpWsn" id="3tIDuP5tl3C" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="3tIDuP5tl3A" role="1tU5fm" />
-            <node concept="BaHAS" id="3tIDuP5tl3D" role="33vP2m">
-              <property role="BaHAW" value="_030_promela_c_suv_statemachines" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="1cDqQHFXXFW" role="33vP2m">
+              <node concept="1Xw6AR" id="1cDqQHFXXTG" role="2Oq$k0">
+                <node concept="1dCxOl" id="1cDqQHFXY0t" role="1XwpL7">
+                  <property role="1XweGQ" value="r:203382d6-24f6-42c7-ace8-cd27646ae264" />
+                  <node concept="1j_P7g" id="1cDqQHFXY0u" role="1j$8Uc">
+                    <property role="1j_P7h" value="_030_promela_c_suv_statemachines" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="1cDqQHFXXG0" role="2OqNvi">
+                <node concept="2OqwBi" id="1cDqQHFXXG1" role="Vysub">
+                  <node concept="1jxXqW" id="1cDqQHFXXG2" role="2Oq$k0" />
+                  <node concept="liA8E" id="1cDqQHFXXG3" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>

--- a/code/languages/com.mbeddr.analyses/tests/test.analyses.spin/models/_100_harness_patterns@tests.mps
+++ b/code/languages/com.mbeddr.analyses/tests/test.analyses.spin/models/_100_harness_patterns@tests.mps
@@ -75,6 +75,15 @@
     <language id="63e0e566-5131-447e-90e3-12ea330e1a00" name="com.mbeddr.mpsutil.blutil">
       <concept id="6451706574537082687" name="com.mbeddr.mpsutil.blutil.structure.ShortStaticMethodCall" flags="ng" index="NRdvd" />
     </language>
+    <language id="446c26eb-2b7b-4bf0-9b35-f83fa582753e" name="jetbrains.mps.lang.modelapi">
+      <concept id="361130699826193248" name="jetbrains.mps.lang.modelapi.structure.ModelPointer" flags="ng" index="1dCxOl">
+        <property id="1863527487546097494" name="modelId" index="1XweGQ" />
+        <child id="679099339649067980" name="name" index="1j$8Uc" />
+      </concept>
+      <concept id="679099339649053840" name="jetbrains.mps.lang.modelapi.structure.ModelName" flags="ng" index="1j_P7g">
+        <property id="679099339649053841" name="value" index="1j_P7h" />
+      </concept>
+    </language>
     <language id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest">
       <concept id="8427750732757990717" name="jetbrains.mps.baseLanguage.unitTest.structure.BinaryAssert" flags="nn" index="3tpDYu">
         <child id="8427750732757990725" name="actual" index="3tpDZA" />
@@ -97,13 +106,16 @@
       </concept>
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
-      <concept id="559557797393017698" name="jetbrains.mps.lang.smodel.structure.ModelReferenceExpression" flags="nn" index="BaHAS">
-        <property id="559557797393021807" name="stereotype" index="BaGAP" />
-        <property id="559557797393017702" name="name" index="BaHAW" />
+      <concept id="4065387505485742666" name="jetbrains.mps.lang.smodel.structure.ModelPointer_ResolveOperation" flags="ng" index="2yCiCJ" />
+      <concept id="4065387505485742749" name="jetbrains.mps.lang.smodel.structure.AbstractPointerResolveOperation" flags="ng" index="2yCiFS">
+        <child id="3648723375513868575" name="repositoryArg" index="Vysub" />
       </concept>
       <concept id="1143226024141" name="jetbrains.mps.lang.smodel.structure.SModelType" flags="in" index="H_c77" />
       <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
         <reference id="1138405853777" name="concept" index="ehGHo" />
+      </concept>
+      <concept id="1863527487546129879" name="jetbrains.mps.lang.smodel.structure.ModelPointerExpression" flags="ng" index="1Xw6AR">
+        <child id="1863527487546132519" name="modelRef" index="1XwpL7" />
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
@@ -129,9 +141,23 @@
           <node concept="3cpWsn" id="3tIDuP5sifu" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="3tIDuP5sifs" role="1tU5fm" />
-            <node concept="BaHAS" id="3tIDuP5sifv" role="33vP2m">
-              <property role="BaHAW" value="_100_harness_patterns__100_kinds_of_suv" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUhzQqL" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUhzQjr" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUhzQn3" role="1XwpL7">
+                  <property role="1XweGQ" value="r:fc020c44-5da9-4331-aec8-51f6a16ac5af" />
+                  <node concept="1j_P7g" id="xRVdUhzQn4" role="1j$8Uc">
+                    <property role="1j_P7h" value="_100_harness_patterns__100_kinds_of_suv" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUhzQwW" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUhzQKg" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUhzQzn" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUhzR44" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -199,9 +225,23 @@
           <node concept="3cpWsn" id="2lN4cj_VABW" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="2lN4cj_VABX" role="1tU5fm" />
-            <node concept="BaHAS" id="2lN4cj_VABY" role="33vP2m">
-              <property role="BaHAW" value="_100_harness_patterns__010_assignments" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUhzJUC" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUhzJJc" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUhzJMQ" role="1XwpL7">
+                  <property role="1XweGQ" value="r:c4050cc9-414f-496e-ac70-4294f0a3ffe2" />
+                  <node concept="1j_P7g" id="xRVdUhzJMR" role="1j$8Uc">
+                    <property role="1j_P7h" value="_100_harness_patterns__010_assignments" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUhzK4R" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUhzKjE" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUhzK7k" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUhzKBw" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -299,9 +339,23 @@
           <node concept="3cpWsn" id="2s6qLQkru2R" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="2s6qLQkru2S" role="1tU5fm" />
-            <node concept="BaHAS" id="2s6qLQkru2T" role="33vP2m">
-              <property role="BaHAW" value="_100_harness_patterns__010_assignments" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUhzKEC" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUhzKED" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUhzKEE" role="1XwpL7">
+                  <property role="1XweGQ" value="r:c4050cc9-414f-496e-ac70-4294f0a3ffe2" />
+                  <node concept="1j_P7g" id="xRVdUhzKEF" role="1j$8Uc">
+                    <property role="1j_P7h" value="_100_harness_patterns__010_assignments" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUhzKEG" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUhzKEH" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUhzKEI" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUhzKEJ" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -385,9 +439,23 @@
           <node concept="3cpWsn" id="1GXRyrSXytl" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="1GXRyrSXytm" role="1tU5fm" />
-            <node concept="BaHAS" id="1GXRyrSXytn" role="33vP2m">
-              <property role="BaHAW" value="_100_harness_patterns__010_assignments" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUhzKI0" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUhzKI1" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUhzKI2" role="1XwpL7">
+                  <property role="1XweGQ" value="r:c4050cc9-414f-496e-ac70-4294f0a3ffe2" />
+                  <node concept="1j_P7g" id="xRVdUhzKI3" role="1j$8Uc">
+                    <property role="1j_P7h" value="_100_harness_patterns__010_assignments" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUhzKI4" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUhzKI5" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUhzKI6" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUhzKI7" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -499,9 +567,23 @@
           <node concept="3cpWsn" id="1BFQdmK1ZoS" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="1BFQdmK1ZoT" role="1tU5fm" />
-            <node concept="BaHAS" id="1BFQdmK1ZoU" role="33vP2m">
-              <property role="BaHAW" value="_100_harness_patterns__010_assignments" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUhzKLo" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUhzKLp" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUhzKLq" role="1XwpL7">
+                  <property role="1XweGQ" value="r:c4050cc9-414f-496e-ac70-4294f0a3ffe2" />
+                  <node concept="1j_P7g" id="xRVdUhzKLr" role="1j$8Uc">
+                    <property role="1j_P7h" value="_100_harness_patterns__010_assignments" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUhzKLs" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUhzKLt" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUhzKLu" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUhzKLv" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -603,9 +685,23 @@
           <node concept="3cpWsn" id="4b2d3GUkOCx" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="4b2d3GUkOCy" role="1tU5fm" />
-            <node concept="BaHAS" id="4b2d3GUkOCz" role="33vP2m">
-              <property role="BaHAW" value="_100_harness_patterns__020_nondet_choice" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUhzL59" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUhzKTH" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUhzKXn" role="1XwpL7">
+                  <property role="1XweGQ" value="r:9c3f6990-fd18-4a00-84dc-aa38e70ba7d6" />
+                  <node concept="1j_P7g" id="xRVdUhzKXo" role="1j$8Uc">
+                    <property role="1j_P7h" value="_100_harness_patterns__020_nondet_choice" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUhzLfo" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUhzLub" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUhzLhP" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUhzLM1" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -830,9 +926,23 @@
           <node concept="3cpWsn" id="4b2d3GUmUQw" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="4b2d3GUmUQx" role="1tU5fm" />
-            <node concept="BaHAS" id="4b2d3GUmUQy" role="33vP2m">
-              <property role="BaHAW" value="_100_harness_patterns__100_kinds_of_suv" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUhzRjA" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUhzRcc" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUhzRfQ" role="1XwpL7">
+                  <property role="1XweGQ" value="r:fc020c44-5da9-4331-aec8-51f6a16ac5af" />
+                  <node concept="1j_P7g" id="xRVdUhzRfR" role="1j$8Uc">
+                    <property role="1j_P7h" value="_100_harness_patterns__100_kinds_of_suv" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUhzRpN" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUhzRDb" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUhzRsg" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUhzSa3" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -949,9 +1059,23 @@
           <node concept="3cpWsn" id="4b2d3GUszdv" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="4b2d3GUszdw" role="1tU5fm" />
-            <node concept="BaHAS" id="4b2d3GUszdx" role="33vP2m">
-              <property role="BaHAW" value="_100_harness_patterns__030_assume" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUhzM8k" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUhzLWS" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUhzM0y" role="1XwpL7">
+                  <property role="1XweGQ" value="r:2b021939-5c11-4488-b74d-bbb914b6a217" />
+                  <node concept="1j_P7g" id="xRVdUhzM0z" role="1j$8Uc">
+                    <property role="1j_P7h" value="_100_harness_patterns__030_assume" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUhzMex" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUhzMtT" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUhzMgY" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUhzMYL" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -1042,9 +1166,23 @@
           <node concept="3cpWsn" id="3jcp2EdydAD" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="3jcp2EdydAE" role="1tU5fm" />
-            <node concept="BaHAS" id="3jcp2EdydAF" role="33vP2m">
-              <property role="BaHAW" value="_100_harness_patterns__030_assume" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUhzN1D" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUhzN1E" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUhzN1F" role="1XwpL7">
+                  <property role="1XweGQ" value="r:2b021939-5c11-4488-b74d-bbb914b6a217" />
+                  <node concept="1j_P7g" id="xRVdUhzN1G" role="1j$8Uc">
+                    <property role="1j_P7h" value="_100_harness_patterns__030_assume" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUhzN1H" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUhzN1I" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUhzN1J" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUhzN1K" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -1132,9 +1270,23 @@
           <node concept="3cpWsn" id="1BFQdmK6qho" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="1BFQdmK6qhp" role="1tU5fm" />
-            <node concept="BaHAS" id="1BFQdmK6qhq" role="33vP2m">
-              <property role="BaHAW" value="_100_harness_patterns__000_logger" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUhzIK_" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUhzI_9" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUhzICN" role="1XwpL7">
+                  <property role="1XweGQ" value="r:ea5c9d07-c438-4b9a-9893-cf1de7b80ba2" />
+                  <node concept="1j_P7g" id="xRVdUhzICO" role="1j$8Uc">
+                    <property role="1j_P7h" value="_100_harness_patterns__000_logger" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUhzIUm" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUhzJ9I" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUhzIWN" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUhzJt$" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -1254,9 +1406,23 @@
           <node concept="3cpWsn" id="4ly_4leUz$s" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="4ly_4leUz$t" role="1tU5fm" />
-            <node concept="BaHAS" id="4ly_4leUz$u" role="33vP2m">
-              <property role="BaHAW" value="_100_harness_patterns__040_loops" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUhzNk_" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUhzNdf" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUhzNgR" role="1XwpL7">
+                  <property role="1XweGQ" value="r:77a690cb-1cbe-43c4-bd4b-312c2b0467b6" />
+                  <node concept="1j_P7g" id="xRVdUhzNgS" role="1j$8Uc">
+                    <property role="1j_P7h" value="_100_harness_patterns__040_loops" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUhzNqK" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUhzNE4" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUhzNtb" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUhzNXb" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -1320,9 +1486,23 @@
           <node concept="3cpWsn" id="4ly_4leUYWr" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="4ly_4leUYWs" role="1tU5fm" />
-            <node concept="BaHAS" id="4ly_4leUYWt" role="33vP2m">
-              <property role="BaHAW" value="_100_harness_patterns__040_loops" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUhzO01" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUhzO02" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUhzO03" role="1XwpL7">
+                  <property role="1XweGQ" value="r:77a690cb-1cbe-43c4-bd4b-312c2b0467b6" />
+                  <node concept="1j_P7g" id="xRVdUhzO04" role="1j$8Uc">
+                    <property role="1j_P7h" value="_100_harness_patterns__040_loops" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUhzO05" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUhzO06" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUhzO07" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUhzO08" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -1390,9 +1570,23 @@
           <node concept="3cpWsn" id="63QgsF$OnAH" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="63QgsF$OnAI" role="1tU5fm" />
-            <node concept="BaHAS" id="63QgsF$OnAJ" role="33vP2m">
-              <property role="BaHAW" value="_100_harness_patterns__200_multiple_assertions" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUhzS$t" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUhzSo9" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUhzSug" role="1XwpL7">
+                  <property role="1XweGQ" value="r:3dfe35a7-adea-4048-8acb-80b654070849" />
+                  <node concept="1j_P7g" id="xRVdUhzSuh" role="1j$8Uc">
+                    <property role="1j_P7h" value="_100_harness_patterns__200_multiple_assertions" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUhzSH7" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUhzT1p" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUhzSM1" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUhzTnG" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -1560,9 +1754,23 @@
           <node concept="3cpWsn" id="63QgsF$TmSL" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="63QgsF$TmSM" role="1tU5fm" />
-            <node concept="BaHAS" id="63QgsF$TmSN" role="33vP2m">
-              <property role="BaHAW" value="_100_harness_patterns__200_multiple_assertions" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUhzTEH" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUhzTyP" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUhzTAI" role="1XwpL7">
+                  <property role="1XweGQ" value="r:3dfe35a7-adea-4048-8acb-80b654070849" />
+                  <node concept="1j_P7g" id="xRVdUhzTAJ" role="1j$8Uc">
+                    <property role="1j_P7h" value="_100_harness_patterns__200_multiple_assertions" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUhzTKF" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUhzU0x" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUhzTNn" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUhzUjT" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -1635,9 +1843,23 @@
           <node concept="3cpWsn" id="46FswZ79z$$" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="46FswZ79z$_" role="1tU5fm" />
-            <node concept="BaHAS" id="46FswZ79z$A" role="33vP2m">
-              <property role="BaHAW" value="_100_harness_patterns__040_loops" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUhzOfV" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUhzO8x" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUhzOcb" role="1XwpL7">
+                  <property role="1XweGQ" value="r:77a690cb-1cbe-43c4-bd4b-312c2b0467b6" />
+                  <node concept="1j_P7g" id="xRVdUhzOcc" role="1j$8Uc">
+                    <property role="1j_P7h" value="_100_harness_patterns__040_loops" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUhzOlE" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUhzO$t" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUhzOo7" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUhzOSj" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -1746,9 +1968,23 @@
           <node concept="3cpWsn" id="1U8LoddT13Z" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="1U8LoddT140" role="1tU5fm" />
-            <node concept="BaHAS" id="1U8LoddT141" role="33vP2m">
-              <property role="BaHAW" value="_100_harness_patterns__050_combinatorial" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUhzPck" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUhzP4s" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUhzP8l" role="1XwpL7">
+                  <property role="1XweGQ" value="r:cacbf3cf-3290-4434-ba12-18fb65924af3" />
+                  <node concept="1j_P7g" id="xRVdUhzP8m" role="1j$8Uc">
+                    <property role="1j_P7h" value="_100_harness_patterns__050_combinatorial" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUhzPiK" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUhzPxQ" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUhzPls" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUhzPPV" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -1817,9 +2053,23 @@
           <node concept="3cpWsn" id="1U8LoddT5X7" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="1U8LoddT5X8" role="1tU5fm" />
-            <node concept="BaHAS" id="1U8LoddT5X9" role="33vP2m">
-              <property role="BaHAW" value="_100_harness_patterns__050_combinatorial" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUhzPT2" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUhzPT3" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUhzPT4" role="1XwpL7">
+                  <property role="1XweGQ" value="r:cacbf3cf-3290-4434-ba12-18fb65924af3" />
+                  <node concept="1j_P7g" id="xRVdUhzPT5" role="1j$8Uc">
+                    <property role="1j_P7h" value="_100_harness_patterns__050_combinatorial" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUhzPT6" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUhzPT7" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUhzPT8" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUhzPT9" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -1892,9 +2142,23 @@
           <node concept="3cpWsn" id="5NkG1_QHnGd" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="5NkG1_QHnGe" role="1tU5fm" />
-            <node concept="BaHAS" id="5NkG1_QHnGf" role="33vP2m">
-              <property role="BaHAW" value="_100_harness_patterns__050_combinatorial" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUhzQ7n" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUhzQ7o" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUhzQ7p" role="1XwpL7">
+                  <property role="1XweGQ" value="r:cacbf3cf-3290-4434-ba12-18fb65924af3" />
+                  <node concept="1j_P7g" id="xRVdUhzQ7q" role="1j$8Uc">
+                    <property role="1j_P7h" value="_100_harness_patterns__050_combinatorial" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUhzQ7r" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUhzQ7s" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUhzQ7t" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUhzQ7u" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -1963,9 +2227,23 @@
           <node concept="3cpWsn" id="5NkG1_QHnGA" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="5NkG1_QHnGB" role="1tU5fm" />
-            <node concept="BaHAS" id="5NkG1_QHnGC" role="33vP2m">
-              <property role="BaHAW" value="_100_harness_patterns__050_combinatorial" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUhzQaI" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUhzQaJ" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUhzQaK" role="1XwpL7">
+                  <property role="1XweGQ" value="r:cacbf3cf-3290-4434-ba12-18fb65924af3" />
+                  <node concept="1j_P7g" id="xRVdUhzQaL" role="1j$8Uc">
+                    <property role="1j_P7h" value="_100_harness_patterns__050_combinatorial" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUhzQaM" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUhzQaN" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUhzQaO" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUhzQaP" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>

--- a/code/languages/com.mbeddr.analyses/tests/test.analyses.spin/models/_130_harness_patterns_internal_state@tests.mps
+++ b/code/languages/com.mbeddr.analyses/tests/test.analyses.spin/models/_130_harness_patterns_internal_state@tests.mps
@@ -75,6 +75,15 @@
     <language id="63e0e566-5131-447e-90e3-12ea330e1a00" name="com.mbeddr.mpsutil.blutil">
       <concept id="6451706574537082687" name="com.mbeddr.mpsutil.blutil.structure.ShortStaticMethodCall" flags="ng" index="NRdvd" />
     </language>
+    <language id="446c26eb-2b7b-4bf0-9b35-f83fa582753e" name="jetbrains.mps.lang.modelapi">
+      <concept id="361130699826193248" name="jetbrains.mps.lang.modelapi.structure.ModelPointer" flags="ng" index="1dCxOl">
+        <property id="1863527487546097494" name="modelId" index="1XweGQ" />
+        <child id="679099339649067980" name="name" index="1j$8Uc" />
+      </concept>
+      <concept id="679099339649053840" name="jetbrains.mps.lang.modelapi.structure.ModelName" flags="ng" index="1j_P7g">
+        <property id="679099339649053841" name="value" index="1j_P7h" />
+      </concept>
+    </language>
     <language id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest">
       <concept id="8427750732757990717" name="jetbrains.mps.baseLanguage.unitTest.structure.BinaryAssert" flags="nn" index="3tpDYu">
         <child id="8427750732757990725" name="actual" index="3tpDZA" />
@@ -97,13 +106,16 @@
       </concept>
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
-      <concept id="559557797393017698" name="jetbrains.mps.lang.smodel.structure.ModelReferenceExpression" flags="nn" index="BaHAS">
-        <property id="559557797393021807" name="stereotype" index="BaGAP" />
-        <property id="559557797393017702" name="name" index="BaHAW" />
+      <concept id="4065387505485742666" name="jetbrains.mps.lang.smodel.structure.ModelPointer_ResolveOperation" flags="ng" index="2yCiCJ" />
+      <concept id="4065387505485742749" name="jetbrains.mps.lang.smodel.structure.AbstractPointerResolveOperation" flags="ng" index="2yCiFS">
+        <child id="3648723375513868575" name="repositoryArg" index="Vysub" />
       </concept>
       <concept id="1143226024141" name="jetbrains.mps.lang.smodel.structure.SModelType" flags="in" index="H_c77" />
       <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
         <reference id="1138405853777" name="concept" index="ehGHo" />
+      </concept>
+      <concept id="1863527487546129879" name="jetbrains.mps.lang.smodel.structure.ModelPointerExpression" flags="ng" index="1Xw6AR">
+        <child id="1863527487546132519" name="modelRef" index="1XwpL7" />
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
@@ -129,9 +141,23 @@
           <node concept="3cpWsn" id="n$tw_alm$p" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="n$tw_alm$I" role="1tU5fm" />
-            <node concept="BaHAS" id="n$tw_alm$J" role="33vP2m">
-              <property role="BaHAW" value="_130_harness_patterns_internal_state" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUhzVqP" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUhzVqQ" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUhzVqR" role="1XwpL7">
+                  <property role="1XweGQ" value="r:32c20488-90fa-407c-b820-7a839471641a" />
+                  <node concept="1j_P7g" id="xRVdUhzVqS" role="1j$8Uc">
+                    <property role="1j_P7h" value="_130_harness_patterns_internal_state" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUhzVqT" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUhzVqU" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUhzVqV" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUhzVqW" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -285,9 +311,23 @@
           <node concept="3cpWsn" id="n$tw_apwIT" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="n$tw_apwIU" role="1tU5fm" />
-            <node concept="BaHAS" id="n$tw_apwIV" role="33vP2m">
-              <property role="BaHAW" value="_130_harness_patterns_internal_state" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUhzVtX" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUhzVtY" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUhzVtZ" role="1XwpL7">
+                  <property role="1XweGQ" value="r:32c20488-90fa-407c-b820-7a839471641a" />
+                  <node concept="1j_P7g" id="xRVdUhzVu0" role="1j$8Uc">
+                    <property role="1j_P7h" value="_130_harness_patterns_internal_state" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUhzVu1" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUhzVu2" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUhzVu3" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUhzVu4" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -473,9 +513,23 @@
           <node concept="3cpWsn" id="n$tw_alm_s" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="n$tw_almA1" role="1tU5fm" />
-            <node concept="BaHAS" id="n$tw_almA2" role="33vP2m">
-              <property role="BaHAW" value="_130_harness_patterns_internal_state" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUhzUAQ" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUhzUvs" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUhzUz6" role="1XwpL7">
+                  <property role="1XweGQ" value="r:32c20488-90fa-407c-b820-7a839471641a" />
+                  <node concept="1j_P7g" id="xRVdUhzUz7" role="1j$8Uc">
+                    <property role="1j_P7h" value="_130_harness_patterns_internal_state" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUhzUG_" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUhzUVo" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUhzUJ2" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUhzVex" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -601,9 +655,23 @@
           <node concept="3cpWsn" id="n$tw_alm_G" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="n$tw_almAj" role="1tU5fm" />
-            <node concept="BaHAS" id="n$tw_almAk" role="33vP2m">
-              <property role="BaHAW" value="_130_harness_patterns_internal_state" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUhzVhp" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUhzVhq" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUhzVhr" role="1XwpL7">
+                  <property role="1XweGQ" value="r:32c20488-90fa-407c-b820-7a839471641a" />
+                  <node concept="1j_P7g" id="xRVdUhzVhs" role="1j$8Uc">
+                    <property role="1j_P7h" value="_130_harness_patterns_internal_state" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUhzVht" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUhzVhu" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUhzVhv" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUhzVhw" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>

--- a/code/languages/com.mbeddr.analyses/tests/test.analyses.spin/models/_200_robustness@tests.mps
+++ b/code/languages/com.mbeddr.analyses/tests/test.analyses.spin/models/_200_robustness@tests.mps
@@ -78,6 +78,15 @@
     <language id="63e0e566-5131-447e-90e3-12ea330e1a00" name="com.mbeddr.mpsutil.blutil">
       <concept id="6451706574537082687" name="com.mbeddr.mpsutil.blutil.structure.ShortStaticMethodCall" flags="ng" index="NRdvd" />
     </language>
+    <language id="446c26eb-2b7b-4bf0-9b35-f83fa582753e" name="jetbrains.mps.lang.modelapi">
+      <concept id="361130699826193248" name="jetbrains.mps.lang.modelapi.structure.ModelPointer" flags="ng" index="1dCxOl">
+        <property id="1863527487546097494" name="modelId" index="1XweGQ" />
+        <child id="679099339649067980" name="name" index="1j$8Uc" />
+      </concept>
+      <concept id="679099339649053840" name="jetbrains.mps.lang.modelapi.structure.ModelName" flags="ng" index="1j_P7g">
+        <property id="679099339649053841" name="value" index="1j_P7h" />
+      </concept>
+    </language>
     <language id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest">
       <concept id="8427750732757990717" name="jetbrains.mps.baseLanguage.unitTest.structure.BinaryAssert" flags="nn" index="3tpDYu">
         <child id="8427750732757990725" name="actual" index="3tpDZA" />
@@ -89,11 +98,14 @@
       </concept>
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
-      <concept id="559557797393017698" name="jetbrains.mps.lang.smodel.structure.ModelReferenceExpression" flags="nn" index="BaHAS">
-        <property id="559557797393021807" name="stereotype" index="BaGAP" />
-        <property id="559557797393017702" name="name" index="BaHAW" />
+      <concept id="4065387505485742666" name="jetbrains.mps.lang.smodel.structure.ModelPointer_ResolveOperation" flags="ng" index="2yCiCJ" />
+      <concept id="4065387505485742749" name="jetbrains.mps.lang.smodel.structure.AbstractPointerResolveOperation" flags="ng" index="2yCiFS">
+        <child id="3648723375513868575" name="repositoryArg" index="Vysub" />
       </concept>
       <concept id="1143226024141" name="jetbrains.mps.lang.smodel.structure.SModelType" flags="in" index="H_c77" />
+      <concept id="1863527487546129879" name="jetbrains.mps.lang.smodel.structure.ModelPointerExpression" flags="ng" index="1Xw6AR">
+        <child id="1863527487546132519" name="modelRef" index="1XwpL7" />
+      </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
@@ -196,16 +208,30 @@
             </node>
           </node>
         </node>
-        <node concept="1X3_iC" id="4J_W74PblfE" role="lGtFl">
+        <node concept="1X3_iC" id="xRVdUhzW87" role="lGtFl">
           <property role="3V$3am" value="statement" />
           <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
           <node concept="3cpWs8" id="4l47ydye$kS" role="8Wnug">
             <node concept="3cpWsn" id="4l47ydye$kT" role="3cpWs9">
               <property role="TrG5h" value="m" />
               <node concept="H_c77" id="4l47ydye$kU" role="1tU5fm" />
-              <node concept="BaHAS" id="4l47ydye$kV" role="33vP2m">
-                <property role="BaHAW" value="_200_robustness_spin" />
-                <property role="BaGAP" value="" />
+              <node concept="2OqwBi" id="xRVdUhzV_T" role="33vP2m">
+                <node concept="1Xw6AR" id="xRVdUhzVyv" role="2Oq$k0">
+                  <node concept="1dCxOl" id="xRVdUhzV$9" role="1XwpL7">
+                    <property role="1XweGQ" value="r:0208d9e1-21da-425a-be52-ba0982761ebd" />
+                    <node concept="1j_P7g" id="xRVdUhzV$a" role="1j$8Uc">
+                      <property role="1j_P7h" value="_200_robustness_spin" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2yCiCJ" id="xRVdUhzVE6" role="2OqNvi">
+                  <node concept="2OqwBi" id="xRVdUhzVPu" role="Vysub">
+                    <node concept="1jxXqW" id="xRVdUhzVEz" role="2Oq$k0" />
+                    <node concept="liA8E" id="xRVdUhzW7k" role="2OqNvi">
+                      <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                    </node>
+                  </node>
+                </node>
               </node>
             </node>
           </node>

--- a/code/languages/com.mbeddr.analyses/tests/test.analyses.var/models/test/analyses/var/bulk@tests.mps
+++ b/code/languages/com.mbeddr.analyses/tests/test.analyses.var/models/test/analyses/var/bulk@tests.mps
@@ -80,6 +80,15 @@
         <child id="1199569916463" name="body" index="1bW5cS" />
       </concept>
     </language>
+    <language id="446c26eb-2b7b-4bf0-9b35-f83fa582753e" name="jetbrains.mps.lang.modelapi">
+      <concept id="361130699826193248" name="jetbrains.mps.lang.modelapi.structure.ModelPointer" flags="ng" index="1dCxOl">
+        <property id="1863527487546097494" name="modelId" index="1XweGQ" />
+        <child id="679099339649067980" name="name" index="1j$8Uc" />
+      </concept>
+      <concept id="679099339649053840" name="jetbrains.mps.lang.modelapi.structure.ModelName" flags="ng" index="1j_P7g">
+        <property id="679099339649053841" name="value" index="1j_P7h" />
+      </concept>
+    </language>
     <language id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest">
       <concept id="8427750732757990717" name="jetbrains.mps.baseLanguage.unitTest.structure.BinaryAssert" flags="nn" index="3tpDYu">
         <child id="8427750732757990725" name="actual" index="3tpDZA" />
@@ -88,13 +97,16 @@
       <concept id="1171978097730" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertEquals" flags="nn" index="3vlDli" />
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
-      <concept id="559557797393017698" name="jetbrains.mps.lang.smodel.structure.ModelReferenceExpression" flags="nn" index="BaHAS">
-        <property id="559557797393021807" name="stereotype" index="BaGAP" />
-        <property id="559557797393017702" name="name" index="BaHAW" />
+      <concept id="4065387505485742666" name="jetbrains.mps.lang.smodel.structure.ModelPointer_ResolveOperation" flags="ng" index="2yCiCJ" />
+      <concept id="4065387505485742749" name="jetbrains.mps.lang.smodel.structure.AbstractPointerResolveOperation" flags="ng" index="2yCiFS">
+        <child id="3648723375513868575" name="repositoryArg" index="Vysub" />
       </concept>
       <concept id="1143226024141" name="jetbrains.mps.lang.smodel.structure.SModelType" flags="in" index="H_c77" />
       <concept id="4040588429969021681" name="jetbrains.mps.lang.smodel.structure.ModuleReferenceExpression" flags="nn" index="3rM5sP">
         <property id="4040588429969021683" name="moduleId" index="3rM5sR" />
+      </concept>
+      <concept id="1863527487546129879" name="jetbrains.mps.lang.smodel.structure.ModelPointerExpression" flags="ng" index="1Xw6AR">
+        <child id="1863527487546132519" name="modelRef" index="1XwpL7" />
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
@@ -244,9 +256,23 @@
           <node concept="3cpWsn" id="1X8myJOVHEb" role="3cpWs9">
             <property role="TrG5h" value="fm" />
             <node concept="H_c77" id="1X8myJOVHE6" role="1tU5fm" />
-            <node concept="BaHAS" id="1X8myJOVHNv" role="33vP2m">
-              <property role="BaHAW" value="test.analyses.var.testcode.fm" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh_6z_" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh_6or" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh_6ti" role="1XwpL7">
+                  <property role="1XweGQ" value="r:10781da5-69e3-49a7-8e25-f6ac0e69d1d1" />
+                  <node concept="1j_P7g" id="xRVdUh_6tj" role="1j$8Uc">
+                    <property role="1j_P7h" value="test.analyses.var.testcode.fm" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh_6Gl" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh_70N" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh_6Ll" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh_7nc" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -353,9 +379,23 @@
           <node concept="3cpWsn" id="1X8myJOVIW2" role="3cpWs9">
             <property role="TrG5h" value="cm" />
             <node concept="H_c77" id="1X8myJOVIW3" role="1tU5fm" />
-            <node concept="BaHAS" id="1X8myJOVIW4" role="33vP2m">
-              <property role="BaHAW" value="test.analyses.var.testcode.cm" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh_7GG" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh_7xy" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh_7Ap" role="1XwpL7">
+                  <property role="1XweGQ" value="r:27f6515e-36f1-4566-93ac-af92dd58218d" />
+                  <node concept="1j_P7g" id="xRVdUh_7Aq" role="1j$8Uc">
+                    <property role="1j_P7h" value="test.analyses.var.testcode.cm" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh_7Ps" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh_89U" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh_7Us" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh_8wj" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -462,9 +502,23 @@
           <node concept="3cpWsn" id="1X8myJOVGCM" role="3cpWs9">
             <property role="TrG5h" value="var_c" />
             <node concept="H_c77" id="1X8myJOVGCH" role="1tU5fm" />
-            <node concept="BaHAS" id="1X8myJOVGME" role="33vP2m">
-              <property role="BaHAW" value="test.analyses.var.testcode.var_c" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh_8Qh" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh_8EN" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh_8JO" role="1XwpL7">
+                  <property role="1XweGQ" value="r:5eb7ec10-0d6c-42c0-9b79-129d7d125c7b" />
+                  <node concept="1j_P7g" id="xRVdUh_8JP" role="1j$8Uc">
+                    <property role="1j_P7h" value="test.analyses.var.testcode.var_c" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh_8Zb" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh_9jX" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh_94l" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh_9F4" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>

--- a/code/languages/com.mbeddr.analyses/tests/test.analyses.var/models/test/analyses/var/cm@tests.mps
+++ b/code/languages/com.mbeddr.analyses/tests/test.analyses.var/models/test/analyses/var/cm@tests.mps
@@ -86,6 +86,15 @@
     <language id="63e0e566-5131-447e-90e3-12ea330e1a00" name="com.mbeddr.mpsutil.blutil">
       <concept id="6451706574537082687" name="com.mbeddr.mpsutil.blutil.structure.ShortStaticMethodCall" flags="ng" index="NRdvd" />
     </language>
+    <language id="446c26eb-2b7b-4bf0-9b35-f83fa582753e" name="jetbrains.mps.lang.modelapi">
+      <concept id="361130699826193248" name="jetbrains.mps.lang.modelapi.structure.ModelPointer" flags="ng" index="1dCxOl">
+        <property id="1863527487546097494" name="modelId" index="1XweGQ" />
+        <child id="679099339649067980" name="name" index="1j$8Uc" />
+      </concept>
+      <concept id="679099339649053840" name="jetbrains.mps.lang.modelapi.structure.ModelName" flags="ng" index="1j_P7g">
+        <property id="679099339649053841" name="value" index="1j_P7h" />
+      </concept>
+    </language>
     <language id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest">
       <concept id="8427750732757990717" name="jetbrains.mps.baseLanguage.unitTest.structure.BinaryAssert" flags="nn" index="3tpDYu">
         <child id="8427750732757990725" name="actual" index="3tpDZA" />
@@ -100,11 +109,14 @@
       </concept>
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
-      <concept id="559557797393017698" name="jetbrains.mps.lang.smodel.structure.ModelReferenceExpression" flags="nn" index="BaHAS">
-        <property id="559557797393021807" name="stereotype" index="BaGAP" />
-        <property id="559557797393017702" name="name" index="BaHAW" />
+      <concept id="4065387505485742666" name="jetbrains.mps.lang.smodel.structure.ModelPointer_ResolveOperation" flags="ng" index="2yCiCJ" />
+      <concept id="4065387505485742749" name="jetbrains.mps.lang.smodel.structure.AbstractPointerResolveOperation" flags="ng" index="2yCiFS">
+        <child id="3648723375513868575" name="repositoryArg" index="Vysub" />
       </concept>
       <concept id="1143226024141" name="jetbrains.mps.lang.smodel.structure.SModelType" flags="in" index="H_c77" />
+      <concept id="1863527487546129879" name="jetbrains.mps.lang.smodel.structure.ModelPointerExpression" flags="ng" index="1Xw6AR">
+        <child id="1863527487546132519" name="modelRef" index="1XwpL7" />
+      </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
@@ -138,9 +150,23 @@
           <node concept="3cpWsn" id="3$vwvl9TySs" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="3$vwvl9TySq" role="1tU5fm" />
-            <node concept="BaHAS" id="3$vwvl9TySt" role="33vP2m">
-              <property role="BaHAW" value="test.analyses.var.testcode.cm" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh_b8Q" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh_b8R" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh_b8S" role="1XwpL7">
+                  <property role="1XweGQ" value="r:27f6515e-36f1-4566-93ac-af92dd58218d" />
+                  <node concept="1j_P7g" id="xRVdUh_b8T" role="1j$8Uc">
+                    <property role="1j_P7h" value="test.analyses.var.testcode.cm" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh_b8U" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh_b8V" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh_b8W" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh_b8X" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -221,9 +247,23 @@
           <node concept="3cpWsn" id="3$vwvl9Tzcn" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="3$vwvl9Tzcl" role="1tU5fm" />
-            <node concept="BaHAS" id="3$vwvl9Tzco" role="33vP2m">
-              <property role="BaHAW" value="test.analyses.var.testcode.cm" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh_bbB" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh_bbC" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh_bbD" role="1XwpL7">
+                  <property role="1XweGQ" value="r:27f6515e-36f1-4566-93ac-af92dd58218d" />
+                  <node concept="1j_P7g" id="xRVdUh_bbE" role="1j$8Uc">
+                    <property role="1j_P7h" value="test.analyses.var.testcode.cm" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh_bbF" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh_bbG" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh_bbH" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh_bbI" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -270,9 +310,23 @@
           <node concept="3cpWsn" id="3$vwvl9Tzvw" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="3$vwvl9Tzvu" role="1tU5fm" />
-            <node concept="BaHAS" id="3$vwvl9Tzvx" role="33vP2m">
-              <property role="BaHAW" value="test.analyses.var.testcode.cm" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh_beo" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh_bep" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh_beq" role="1XwpL7">
+                  <property role="1XweGQ" value="r:27f6515e-36f1-4566-93ac-af92dd58218d" />
+                  <node concept="1j_P7g" id="xRVdUh_ber" role="1j$8Uc">
+                    <property role="1j_P7h" value="test.analyses.var.testcode.cm" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh_bes" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh_bet" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh_beu" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh_bev" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -335,9 +389,23 @@
           <node concept="3cpWsn" id="3$vwvl9T$oM" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="3$vwvl9T$oK" role="1tU5fm" />
-            <node concept="BaHAS" id="3$vwvl9T$oN" role="33vP2m">
-              <property role="BaHAW" value="test.analyses.var.testcode.cm" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh_bh9" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh_bha" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh_bhb" role="1XwpL7">
+                  <property role="1XweGQ" value="r:27f6515e-36f1-4566-93ac-af92dd58218d" />
+                  <node concept="1j_P7g" id="xRVdUh_bhc" role="1j$8Uc">
+                    <property role="1j_P7h" value="test.analyses.var.testcode.cm" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh_bhd" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh_bhe" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh_bhf" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh_bhg" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -392,9 +460,23 @@
           <node concept="3cpWsn" id="3$vwvl9T$Gb" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="3$vwvl9T$G9" role="1tU5fm" />
-            <node concept="BaHAS" id="3$vwvl9T$Gc" role="33vP2m">
-              <property role="BaHAW" value="test.analyses.var.testcode.cm" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh_bjU" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh_bjV" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh_bjW" role="1XwpL7">
+                  <property role="1XweGQ" value="r:27f6515e-36f1-4566-93ac-af92dd58218d" />
+                  <node concept="1j_P7g" id="xRVdUh_bjX" role="1j$8Uc">
+                    <property role="1j_P7h" value="test.analyses.var.testcode.cm" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh_bjY" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh_bjZ" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh_bk0" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh_bk1" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -505,9 +587,23 @@
           <node concept="3cpWsn" id="3$vwvl9T_1d" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="3$vwvl9T_1b" role="1tU5fm" />
-            <node concept="BaHAS" id="3$vwvl9T_1e" role="33vP2m">
-              <property role="BaHAW" value="test.analyses.var.testcode.cm" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh_bmF" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh_bmG" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh_bmH" role="1XwpL7">
+                  <property role="1XweGQ" value="r:27f6515e-36f1-4566-93ac-af92dd58218d" />
+                  <node concept="1j_P7g" id="xRVdUh_bmI" role="1j$8Uc">
+                    <property role="1j_P7h" value="test.analyses.var.testcode.cm" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh_bmJ" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh_bmK" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh_bmL" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh_bmM" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -557,9 +653,23 @@
           <node concept="3cpWsn" id="68jd02E9zT4" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="68jd02E9zT2" role="1tU5fm" />
-            <node concept="BaHAS" id="68jd02E9zT5" role="33vP2m">
-              <property role="BaHAW" value="test.analyses.var.testcode.cm" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh_a18" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh_9Wo" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh_9Y1" role="1XwpL7">
+                  <property role="1XweGQ" value="r:27f6515e-36f1-4566-93ac-af92dd58218d" />
+                  <node concept="1j_P7g" id="xRVdUh_9Y2" role="1j$8Uc">
+                    <property role="1j_P7h" value="test.analyses.var.testcode.cm" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh_a6E" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh_akG" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh_a8s" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh_aBT" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -607,9 +717,23 @@
           <node concept="3cpWsn" id="68jd02EcGzA" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="68jd02EcGzB" role="1tU5fm" />
-            <node concept="BaHAS" id="68jd02EcGzC" role="33vP2m">
-              <property role="BaHAW" value="test.analyses.var.testcode.cm" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh_aEm" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh_aEn" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh_aEo" role="1XwpL7">
+                  <property role="1XweGQ" value="r:27f6515e-36f1-4566-93ac-af92dd58218d" />
+                  <node concept="1j_P7g" id="xRVdUh_aEp" role="1j$8Uc">
+                    <property role="1j_P7h" value="test.analyses.var.testcode.cm" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh_aEq" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh_aEr" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh_aEs" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh_aEt" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -657,9 +781,23 @@
           <node concept="3cpWsn" id="4qsm5C8v23M" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="4qsm5C8v23N" role="1tU5fm" />
-            <node concept="BaHAS" id="4qsm5C8v23O" role="33vP2m">
-              <property role="BaHAW" value="test.analyses.var.testcode.cm" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh_aH5" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh_aH6" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh_aH7" role="1XwpL7">
+                  <property role="1XweGQ" value="r:27f6515e-36f1-4566-93ac-af92dd58218d" />
+                  <node concept="1j_P7g" id="xRVdUh_aH8" role="1j$8Uc">
+                    <property role="1j_P7h" value="test.analyses.var.testcode.cm" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh_aH9" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh_aHa" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh_aHb" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh_aHc" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -747,9 +885,23 @@
           <node concept="3cpWsn" id="4qsm5C8v243" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="4qsm5C8v244" role="1tU5fm" />
-            <node concept="BaHAS" id="4qsm5C8v245" role="33vP2m">
-              <property role="BaHAW" value="test.analyses.var.testcode.cm" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh_aJM" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh_aJN" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh_aJO" role="1XwpL7">
+                  <property role="1XweGQ" value="r:27f6515e-36f1-4566-93ac-af92dd58218d" />
+                  <node concept="1j_P7g" id="xRVdUh_aJP" role="1j$8Uc">
+                    <property role="1j_P7h" value="test.analyses.var.testcode.cm" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh_aJQ" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh_aJR" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh_aJS" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh_aJT" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>

--- a/code/languages/com.mbeddr.analyses/tests/test.analyses.var/models/test/analyses/var/fm@tests.mps
+++ b/code/languages/com.mbeddr.analyses/tests/test.analyses.var/models/test/analyses/var/fm@tests.mps
@@ -76,6 +76,15 @@
     <language id="63e0e566-5131-447e-90e3-12ea330e1a00" name="com.mbeddr.mpsutil.blutil">
       <concept id="6451706574537082687" name="com.mbeddr.mpsutil.blutil.structure.ShortStaticMethodCall" flags="ng" index="NRdvd" />
     </language>
+    <language id="446c26eb-2b7b-4bf0-9b35-f83fa582753e" name="jetbrains.mps.lang.modelapi">
+      <concept id="361130699826193248" name="jetbrains.mps.lang.modelapi.structure.ModelPointer" flags="ng" index="1dCxOl">
+        <property id="1863527487546097494" name="modelId" index="1XweGQ" />
+        <child id="679099339649067980" name="name" index="1j$8Uc" />
+      </concept>
+      <concept id="679099339649053840" name="jetbrains.mps.lang.modelapi.structure.ModelName" flags="ng" index="1j_P7g">
+        <property id="679099339649053841" name="value" index="1j_P7h" />
+      </concept>
+    </language>
     <language id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest">
       <concept id="8427750732757990717" name="jetbrains.mps.baseLanguage.unitTest.structure.BinaryAssert" flags="nn" index="3tpDYu">
         <child id="8427750732757990725" name="actual" index="3tpDZA" />
@@ -90,11 +99,14 @@
       </concept>
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
-      <concept id="559557797393017698" name="jetbrains.mps.lang.smodel.structure.ModelReferenceExpression" flags="nn" index="BaHAS">
-        <property id="559557797393021807" name="stereotype" index="BaGAP" />
-        <property id="559557797393017702" name="name" index="BaHAW" />
+      <concept id="4065387505485742666" name="jetbrains.mps.lang.smodel.structure.ModelPointer_ResolveOperation" flags="ng" index="2yCiCJ" />
+      <concept id="4065387505485742749" name="jetbrains.mps.lang.smodel.structure.AbstractPointerResolveOperation" flags="ng" index="2yCiFS">
+        <child id="3648723375513868575" name="repositoryArg" index="Vysub" />
       </concept>
       <concept id="1143226024141" name="jetbrains.mps.lang.smodel.structure.SModelType" flags="in" index="H_c77" />
+      <concept id="1863527487546129879" name="jetbrains.mps.lang.smodel.structure.ModelPointerExpression" flags="ng" index="1Xw6AR">
+        <child id="1863527487546132519" name="modelRef" index="1XwpL7" />
+      </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
@@ -120,9 +132,23 @@
           <node concept="3cpWsn" id="4$3mDZ0lOie" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="4$3mDZ0lOic" role="1tU5fm" />
-            <node concept="BaHAS" id="4$3mDZ0lOif" role="33vP2m">
-              <property role="BaHAW" value="test.analyses.var.testcode.fm" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh_ds6" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh_ds7" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh_ds8" role="1XwpL7">
+                  <property role="1XweGQ" value="r:10781da5-69e3-49a7-8e25-f6ac0e69d1d1" />
+                  <node concept="1j_P7g" id="xRVdUh_ds9" role="1j$8Uc">
+                    <property role="1j_P7h" value="test.analyses.var.testcode.fm" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh_dsa" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh_dsb" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh_dsc" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh_dsd" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -196,9 +222,23 @@
           <node concept="3cpWsn" id="4$3mDZ0lOkc" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="4$3mDZ0lOka" role="1tU5fm" />
-            <node concept="BaHAS" id="4$3mDZ0lOkd" role="33vP2m">
-              <property role="BaHAW" value="test.analyses.var.testcode.fm" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh_dvH" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh_dvI" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh_dvJ" role="1XwpL7">
+                  <property role="1XweGQ" value="r:10781da5-69e3-49a7-8e25-f6ac0e69d1d1" />
+                  <node concept="1j_P7g" id="xRVdUh_dvK" role="1j$8Uc">
+                    <property role="1j_P7h" value="test.analyses.var.testcode.fm" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh_dvL" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh_dvM" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh_dvN" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh_dvO" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -287,9 +327,23 @@
           <node concept="3cpWsn" id="4$3mDZ0lOma" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="4$3mDZ0lOm8" role="1tU5fm" />
-            <node concept="BaHAS" id="4$3mDZ0lOmb" role="33vP2m">
-              <property role="BaHAW" value="test.analyses.var.testcode.fm" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh_dzi" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh_dzj" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh_dzk" role="1XwpL7">
+                  <property role="1XweGQ" value="r:10781da5-69e3-49a7-8e25-f6ac0e69d1d1" />
+                  <node concept="1j_P7g" id="xRVdUh_dzl" role="1j$8Uc">
+                    <property role="1j_P7h" value="test.analyses.var.testcode.fm" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh_dzm" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh_dzn" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh_dzo" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh_dzp" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -337,9 +391,23 @@
           <node concept="3cpWsn" id="4$3mDZ0lOo8" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="4$3mDZ0lOo6" role="1tU5fm" />
-            <node concept="BaHAS" id="4$3mDZ0lOo9" role="33vP2m">
-              <property role="BaHAW" value="test.analyses.var.testcode.fm" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh_dAn" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh_dAo" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh_dAp" role="1XwpL7">
+                  <property role="1XweGQ" value="r:10781da5-69e3-49a7-8e25-f6ac0e69d1d1" />
+                  <node concept="1j_P7g" id="xRVdUh_dAq" role="1j$8Uc">
+                    <property role="1j_P7h" value="test.analyses.var.testcode.fm" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh_dAr" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh_dAs" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh_dAt" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh_dAu" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -387,9 +455,23 @@
           <node concept="3cpWsn" id="4$3mDZ0lOq6" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="4$3mDZ0lOq4" role="1tU5fm" />
-            <node concept="BaHAS" id="4$3mDZ0lOq7" role="33vP2m">
-              <property role="BaHAW" value="test.analyses.var.testcode.fm" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh_dDs" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh_dDt" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh_dDu" role="1XwpL7">
+                  <property role="1XweGQ" value="r:10781da5-69e3-49a7-8e25-f6ac0e69d1d1" />
+                  <node concept="1j_P7g" id="xRVdUh_dDv" role="1j$8Uc">
+                    <property role="1j_P7h" value="test.analyses.var.testcode.fm" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh_dDw" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh_dDx" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh_dDy" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh_dDz" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -437,9 +519,23 @@
           <node concept="3cpWsn" id="4$3mDZ0lOs4" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="4$3mDZ0lOs2" role="1tU5fm" />
-            <node concept="BaHAS" id="4$3mDZ0lOs5" role="33vP2m">
-              <property role="BaHAW" value="test.analyses.var.testcode.fm" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh_dGz" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh_dG$" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh_dG_" role="1XwpL7">
+                  <property role="1XweGQ" value="r:10781da5-69e3-49a7-8e25-f6ac0e69d1d1" />
+                  <node concept="1j_P7g" id="xRVdUh_dGA" role="1j$8Uc">
+                    <property role="1j_P7h" value="test.analyses.var.testcode.fm" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh_dGB" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh_dGC" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh_dGD" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh_dGE" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -487,9 +583,23 @@
           <node concept="3cpWsn" id="4$3mDZ0lOu2" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="4$3mDZ0lOu0" role="1tU5fm" />
-            <node concept="BaHAS" id="4$3mDZ0lOu3" role="33vP2m">
-              <property role="BaHAW" value="test.analyses.var.testcode.fm" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh_dJC" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh_dJD" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh_dJE" role="1XwpL7">
+                  <property role="1XweGQ" value="r:10781da5-69e3-49a7-8e25-f6ac0e69d1d1" />
+                  <node concept="1j_P7g" id="xRVdUh_dJF" role="1j$8Uc">
+                    <property role="1j_P7h" value="test.analyses.var.testcode.fm" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh_dJG" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh_dJH" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh_dJI" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh_dJJ" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -550,9 +660,23 @@
           <node concept="3cpWsn" id="3$vwvl9TCJn" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="3$vwvl9TCJl" role="1tU5fm" />
-            <node concept="BaHAS" id="3$vwvl9TCJo" role="33vP2m">
-              <property role="BaHAW" value="test.analyses.var.testcode.fm" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh_cA2" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh_cA3" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh_cA4" role="1XwpL7">
+                  <property role="1XweGQ" value="r:10781da5-69e3-49a7-8e25-f6ac0e69d1d1" />
+                  <node concept="1j_P7g" id="xRVdUh_cA5" role="1j$8Uc">
+                    <property role="1j_P7h" value="test.analyses.var.testcode.fm" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh_cA6" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh_cA7" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh_cA8" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh_cA9" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -600,9 +724,23 @@
           <node concept="3cpWsn" id="3$vwvl9TD2X" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="3$vwvl9TD2V" role="1tU5fm" />
-            <node concept="BaHAS" id="3$vwvl9TD2Y" role="33vP2m">
-              <property role="BaHAW" value="test.analyses.var.testcode.fm" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh_cDn" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh_cDo" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh_cDp" role="1XwpL7">
+                  <property role="1XweGQ" value="r:10781da5-69e3-49a7-8e25-f6ac0e69d1d1" />
+                  <node concept="1j_P7g" id="xRVdUh_cDq" role="1j$8Uc">
+                    <property role="1j_P7h" value="test.analyses.var.testcode.fm" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh_cDr" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh_cDs" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh_cDt" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh_cDu" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -660,9 +798,23 @@
           <node concept="3cpWsn" id="3$vwvl9TDm_" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="3$vwvl9TDmz" role="1tU5fm" />
-            <node concept="BaHAS" id="3$vwvl9TDmA" role="33vP2m">
-              <property role="BaHAW" value="test.analyses.var.testcode.fm" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh_cGG" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh_cGH" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh_cGI" role="1XwpL7">
+                  <property role="1XweGQ" value="r:10781da5-69e3-49a7-8e25-f6ac0e69d1d1" />
+                  <node concept="1j_P7g" id="xRVdUh_cGJ" role="1j$8Uc">
+                    <property role="1j_P7h" value="test.analyses.var.testcode.fm" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh_cGK" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh_cGL" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh_cGM" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh_cGN" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -720,9 +872,23 @@
           <node concept="3cpWsn" id="3$vwvl9TDEr" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="3$vwvl9TDEp" role="1tU5fm" />
-            <node concept="BaHAS" id="3$vwvl9TDEs" role="33vP2m">
-              <property role="BaHAW" value="test.analyses.var.testcode.fm" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh_cK1" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh_cK2" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh_cK3" role="1XwpL7">
+                  <property role="1XweGQ" value="r:10781da5-69e3-49a7-8e25-f6ac0e69d1d1" />
+                  <node concept="1j_P7g" id="xRVdUh_cK4" role="1j$8Uc">
+                    <property role="1j_P7h" value="test.analyses.var.testcode.fm" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh_cK5" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh_cK6" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh_cK7" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh_cK8" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -786,9 +952,23 @@
           <node concept="3cpWsn" id="3$vwvl9TDWz" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="3$vwvl9TDWx" role="1tU5fm" />
-            <node concept="BaHAS" id="3$vwvl9TDW$" role="33vP2m">
-              <property role="BaHAW" value="test.analyses.var.testcode.fm" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh_cNo" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh_cNp" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh_cNq" role="1XwpL7">
+                  <property role="1XweGQ" value="r:10781da5-69e3-49a7-8e25-f6ac0e69d1d1" />
+                  <node concept="1j_P7g" id="xRVdUh_cNr" role="1j$8Uc">
+                    <property role="1j_P7h" value="test.analyses.var.testcode.fm" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh_cNs" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh_cNt" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh_cNu" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh_cNv" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -861,9 +1041,23 @@
           <node concept="3cpWsn" id="3$vwvl9TEgD" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="3$vwvl9TEgB" role="1tU5fm" />
-            <node concept="BaHAS" id="3$vwvl9TEgE" role="33vP2m">
-              <property role="BaHAW" value="test.analyses.var.testcode.fm" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh_cQH" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh_cQI" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh_cQJ" role="1XwpL7">
+                  <property role="1XweGQ" value="r:10781da5-69e3-49a7-8e25-f6ac0e69d1d1" />
+                  <node concept="1j_P7g" id="xRVdUh_cQK" role="1j$8Uc">
+                    <property role="1j_P7h" value="test.analyses.var.testcode.fm" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh_cQL" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh_cQM" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh_cQN" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh_cQO" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -936,9 +1130,23 @@
           <node concept="3cpWsn" id="3$vwvl9TEzH" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="3$vwvl9TEzF" role="1tU5fm" />
-            <node concept="BaHAS" id="3$vwvl9TEzI" role="33vP2m">
-              <property role="BaHAW" value="test.analyses.var.testcode.fm" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh_cU2" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh_cU3" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh_cU4" role="1XwpL7">
+                  <property role="1XweGQ" value="r:10781da5-69e3-49a7-8e25-f6ac0e69d1d1" />
+                  <node concept="1j_P7g" id="xRVdUh_cU5" role="1j$8Uc">
+                    <property role="1j_P7h" value="test.analyses.var.testcode.fm" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh_cU6" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh_cU7" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh_cU8" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh_cU9" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -1011,9 +1219,23 @@
           <node concept="3cpWsn" id="3$vwvl9TFce" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="3$vwvl9TFcc" role="1tU5fm" />
-            <node concept="BaHAS" id="3$vwvl9TFcf" role="33vP2m">
-              <property role="BaHAW" value="test.analyses.var.testcode.fm" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh_cXp" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh_cXq" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh_cXr" role="1XwpL7">
+                  <property role="1XweGQ" value="r:10781da5-69e3-49a7-8e25-f6ac0e69d1d1" />
+                  <node concept="1j_P7g" id="xRVdUh_cXs" role="1j$8Uc">
+                    <property role="1j_P7h" value="test.analyses.var.testcode.fm" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh_cXt" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh_cXu" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh_cXv" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh_cXw" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -1089,9 +1311,23 @@
           <node concept="3cpWsn" id="3$vwvl9TFuQ" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="3$vwvl9TFuO" role="1tU5fm" />
-            <node concept="BaHAS" id="3$vwvl9TFuR" role="33vP2m">
-              <property role="BaHAW" value="test.analyses.var.testcode.fm" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh_d0I" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh_d0J" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh_d0K" role="1XwpL7">
+                  <property role="1XweGQ" value="r:10781da5-69e3-49a7-8e25-f6ac0e69d1d1" />
+                  <node concept="1j_P7g" id="xRVdUh_d0L" role="1j$8Uc">
+                    <property role="1j_P7h" value="test.analyses.var.testcode.fm" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh_d0M" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh_d0N" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh_d0O" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh_d0P" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -1142,9 +1378,23 @@
           <node concept="3cpWsn" id="3$vwvl9TAMz" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="3$vwvl9TAMx" role="1tU5fm" />
-            <node concept="BaHAS" id="3$vwvl9TAM$" role="33vP2m">
-              <property role="BaHAW" value="test.analyses.var.testcode.fm" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh_b$N" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh_bw3" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh_bxI" role="1XwpL7">
+                  <property role="1XweGQ" value="r:10781da5-69e3-49a7-8e25-f6ac0e69d1d1" />
+                  <node concept="1j_P7g" id="xRVdUh_bxJ" role="1j$8Uc">
+                    <property role="1j_P7h" value="test.analyses.var.testcode.fm" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh_bEl" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh_bRF" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh_bG7" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh_caQ" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -1192,9 +1442,23 @@
           <node concept="3cpWsn" id="3$vwvl9TC4r" role="3cpWs9">
             <property role="TrG5h" value="m" />
             <node concept="H_c77" id="3$vwvl9TC4p" role="1tU5fm" />
-            <node concept="BaHAS" id="3$vwvl9TC4s" role="33vP2m">
-              <property role="BaHAW" value="test.analyses.var.testcode.fm" />
-              <property role="BaGAP" value="" />
+            <node concept="2OqwBi" id="xRVdUh_cd3" role="33vP2m">
+              <node concept="1Xw6AR" id="xRVdUh_cd4" role="2Oq$k0">
+                <node concept="1dCxOl" id="xRVdUh_cd5" role="1XwpL7">
+                  <property role="1XweGQ" value="r:10781da5-69e3-49a7-8e25-f6ac0e69d1d1" />
+                  <node concept="1j_P7g" id="xRVdUh_cd6" role="1j$8Uc">
+                    <property role="1j_P7h" value="test.analyses.var.testcode.fm" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2yCiCJ" id="xRVdUh_cd7" role="2OqNvi">
+                <node concept="2OqwBi" id="xRVdUh_cd8" role="Vysub">
+                  <node concept="1jxXqW" id="xRVdUh_cd9" role="2Oq$k0" />
+                  <node concept="liA8E" id="xRVdUh_cda" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>

--- a/code/languages/com.mbeddr.analyses/tests/test.analyses.var/models/test/analyses/var/var_c@tests.mps
+++ b/code/languages/com.mbeddr.analyses/tests/test.analyses.var/models/test/analyses/var/var_c@tests.mps
@@ -14,6 +14,7 @@
   <imports>
     <import index="oe3g" ref="r:6529d99e-f27c-4f0d-b5a8-fdfbedcb1e34(com.mbeddr.analyses.sat4j.fm.testing)" />
     <import index="vy7l" ref="r:86500bb5-b61d-4584-98de-8e87c2a6a247(com.mbeddr.analyses.sat4j.fm.analyses)" />
+    <import index="w1kc" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel(MPS.Core/)" />
     <import index="z1c3" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.project(MPS.Core/)" implicit="true" />
   </imports>
   <registry>
@@ -109,6 +110,15 @@
       <concept id="1205769003971" name="jetbrains.mps.baseLanguage.classifiers.structure.DefaultClassifierMethodDeclaration" flags="ng" index="2XrIbr" />
       <concept id="1205769149993" name="jetbrains.mps.baseLanguage.classifiers.structure.DefaultClassifierMethodCallOperation" flags="nn" index="2XshWL" />
     </language>
+    <language id="446c26eb-2b7b-4bf0-9b35-f83fa582753e" name="jetbrains.mps.lang.modelapi">
+      <concept id="361130699826193248" name="jetbrains.mps.lang.modelapi.structure.ModelPointer" flags="ng" index="1dCxOl">
+        <property id="1863527487546097494" name="modelId" index="1XweGQ" />
+        <child id="679099339649067980" name="name" index="1j$8Uc" />
+      </concept>
+      <concept id="679099339649053840" name="jetbrains.mps.lang.modelapi.structure.ModelName" flags="ng" index="1j_P7g">
+        <property id="679099339649053841" name="value" index="1j_P7h" />
+      </concept>
+    </language>
     <language id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest">
       <concept id="8427750732757990717" name="jetbrains.mps.baseLanguage.unitTest.structure.BinaryAssert" flags="nn" index="3tpDYu">
         <child id="8427750732757990725" name="actual" index="3tpDZA" />
@@ -129,11 +139,14 @@
       </concept>
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
-      <concept id="559557797393017698" name="jetbrains.mps.lang.smodel.structure.ModelReferenceExpression" flags="nn" index="BaHAS">
-        <property id="559557797393021807" name="stereotype" index="BaGAP" />
-        <property id="559557797393017702" name="name" index="BaHAW" />
+      <concept id="4065387505485742666" name="jetbrains.mps.lang.smodel.structure.ModelPointer_ResolveOperation" flags="ng" index="2yCiCJ" />
+      <concept id="4065387505485742749" name="jetbrains.mps.lang.smodel.structure.AbstractPointerResolveOperation" flags="ng" index="2yCiFS">
+        <child id="3648723375513868575" name="repositoryArg" index="Vysub" />
       </concept>
       <concept id="1143226024141" name="jetbrains.mps.lang.smodel.structure.SModelType" flags="in" index="H_c77" />
+      <concept id="1863527487546129879" name="jetbrains.mps.lang.smodel.structure.ModelPointerExpression" flags="ng" index="1Xw6AR">
+        <child id="1863527487546132519" name="modelRef" index="1XwpL7" />
+      </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
@@ -158,9 +171,21 @@
       <node concept="H_c77" id="44j14BHqmv1" role="3clF45" />
       <node concept="3clFbS" id="44j14BHqmkO" role="3clF47">
         <node concept="3clFbF" id="44j14BHqmv9" role="3cqZAp">
-          <node concept="BaHAS" id="44j14BHqmvb" role="3clFbG">
-            <property role="BaHAW" value="test.analyses.var.testcode.var_c" />
-            <property role="BaGAP" value="" />
+          <node concept="2OqwBi" id="xRVdUh_fn_" role="3clFbG">
+            <node concept="1Xw6AR" id="xRVdUh_fl_" role="2Oq$k0">
+              <node concept="1dCxOl" id="xRVdUh_flR" role="1XwpL7">
+                <property role="1XweGQ" value="r:5eb7ec10-0d6c-42c0-9b79-129d7d125c7b" />
+                <node concept="1j_P7g" id="xRVdUh_flS" role="1j$8Uc">
+                  <property role="1j_P7h" value="test.analyses.var.testcode.var_c" />
+                </node>
+              </node>
+            </node>
+            <node concept="2yCiCJ" id="xRVdUh_frK" role="2OqNvi">
+              <node concept="2YIFZM" id="xRVdUh_fti" role="Vysub">
+                <ref role="37wK5l" to="w1kc:~MPSModuleRepository.getInstance()" resolve="getInstance" />
+                <ref role="1Pybhc" to="w1kc:~MPSModuleRepository" resolve="MPSModuleRepository" />
+              </node>
+            </node>
           </node>
         </node>
       </node>

--- a/code/languages/com.mbeddr.analyses/tests/test.analyses.var/models/test/analyses/var/var_req@tests.mps
+++ b/code/languages/com.mbeddr.analyses/tests/test.analyses.var/models/test/analyses/var/var_req@tests.mps
@@ -86,6 +86,15 @@
       <concept id="1205769003971" name="jetbrains.mps.baseLanguage.classifiers.structure.DefaultClassifierMethodDeclaration" flags="ng" index="2XrIbr" />
       <concept id="1205769149993" name="jetbrains.mps.baseLanguage.classifiers.structure.DefaultClassifierMethodCallOperation" flags="nn" index="2XshWL" />
     </language>
+    <language id="446c26eb-2b7b-4bf0-9b35-f83fa582753e" name="jetbrains.mps.lang.modelapi">
+      <concept id="361130699826193248" name="jetbrains.mps.lang.modelapi.structure.ModelPointer" flags="ng" index="1dCxOl">
+        <property id="1863527487546097494" name="modelId" index="1XweGQ" />
+        <child id="679099339649067980" name="name" index="1j$8Uc" />
+      </concept>
+      <concept id="679099339649053840" name="jetbrains.mps.lang.modelapi.structure.ModelName" flags="ng" index="1j_P7g">
+        <property id="679099339649053841" name="value" index="1j_P7h" />
+      </concept>
+    </language>
     <language id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest">
       <concept id="8427750732757990717" name="jetbrains.mps.baseLanguage.unitTest.structure.BinaryAssert" flags="nn" index="3tpDYu">
         <child id="8427750732757990725" name="actual" index="3tpDZA" />
@@ -97,11 +106,14 @@
       </concept>
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
-      <concept id="559557797393017698" name="jetbrains.mps.lang.smodel.structure.ModelReferenceExpression" flags="nn" index="BaHAS">
-        <property id="559557797393021807" name="stereotype" index="BaGAP" />
-        <property id="559557797393017702" name="name" index="BaHAW" />
+      <concept id="4065387505485742666" name="jetbrains.mps.lang.smodel.structure.ModelPointer_ResolveOperation" flags="ng" index="2yCiCJ" />
+      <concept id="4065387505485742749" name="jetbrains.mps.lang.smodel.structure.AbstractPointerResolveOperation" flags="ng" index="2yCiFS">
+        <child id="3648723375513868575" name="repositoryArg" index="Vysub" />
       </concept>
       <concept id="1143226024141" name="jetbrains.mps.lang.smodel.structure.SModelType" flags="in" index="H_c77" />
+      <concept id="1863527487546129879" name="jetbrains.mps.lang.smodel.structure.ModelPointerExpression" flags="ng" index="1Xw6AR">
+        <child id="1863527487546132519" name="modelRef" index="1XwpL7" />
+      </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
@@ -125,9 +137,23 @@
       <node concept="H_c77" id="7t39SXUO40I" role="3clF45" />
       <node concept="3clFbS" id="7t39SXUO40J" role="3clF47">
         <node concept="3clFbF" id="7t39SXUO40K" role="3cqZAp">
-          <node concept="BaHAS" id="7t39SXUO40L" role="3clFbG">
-            <property role="BaHAW" value="test.analyses.var.testcode.var_req" />
-            <property role="BaGAP" value="" />
+          <node concept="2OqwBi" id="xRVdUh_fGf" role="3clFbG">
+            <node concept="1Xw6AR" id="xRVdUh_fEf" role="2Oq$k0">
+              <node concept="1dCxOl" id="xRVdUh_fEx" role="1XwpL7">
+                <property role="1XweGQ" value="r:60ad5476-52b9-430d-9451-18fd6793514f" />
+                <node concept="1j_P7g" id="xRVdUh_fEy" role="1j$8Uc">
+                  <property role="1j_P7h" value="test.analyses.var.testcode.var_req" />
+                </node>
+              </node>
+            </node>
+            <node concept="2yCiCJ" id="xRVdUh_fJW" role="2OqNvi">
+              <node concept="2OqwBi" id="xRVdUh_fVg" role="Vysub">
+                <node concept="1jxXqW" id="xRVdUh_fKn" role="2Oq$k0" />
+                <node concept="liA8E" id="xRVdUh_gd4" role="2OqNvi">
+                  <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                </node>
+              </node>
+            </node>
           </node>
         </node>
       </node>

--- a/code/languages/com.mbeddr.core/languages/com.mbeddr.core.qa/languageModels/behavior.mps
+++ b/code/languages/com.mbeddr.core/languages/com.mbeddr.core.qa/languageModels/behavior.mps
@@ -39,6 +39,7 @@
     <import index="mhbf" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.model(MPS.OpenAPI/)" />
     <import index="dush" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.persistence(MPS.OpenAPI/)" />
     <import index="tpce" ref="r:00000000-0000-4000-0000-011c89590292(jetbrains.mps.lang.structure.structure)" implicit="true" />
+    <import index="xlb7" ref="r:cf42fd0a-68d2-493b-8b77-961658617704(jetbrains.mps.lang.modelapi.behavior)" implicit="true" />
   </imports>
   <registry>
     <language id="af65afd8-f0dd-4942-87d9-63a55f2a9db1" name="jetbrains.mps.lang.behavior">
@@ -847,14 +848,32 @@
                 <node concept="1bVj0M" id="2WJ8cS_wlwv" role="23t8la">
                   <node concept="3clFbS" id="2WJ8cS_wlww" role="1bW5cS">
                     <node concept="3clFbF" id="2WJ8cS_wlwx" role="3cqZAp">
-                      <node concept="BsUDl" id="2WJ8cS_wlwy" role="3clFbG">
-                        <ref role="37wK5l" node="2WJ8cS_vWVE" resolve="resolveModelByName" />
-                        <node concept="2OqwBi" id="2WJ8cS_wlwz" role="37wK5m">
-                          <node concept="37vLTw" id="2WJ8cS_wlw$" role="2Oq$k0">
-                            <ref role="3cqZAo" node="2WJ8cS_wlwA" resolve="it" />
+                      <node concept="2OqwBi" id="xRVdUh_$gq" role="3clFbG">
+                        <node concept="2OqwBi" id="xRVdUh_ztX" role="2Oq$k0">
+                          <node concept="2OqwBi" id="xRVdUh_yEl" role="2Oq$k0">
+                            <node concept="37vLTw" id="xRVdUh_yhP" role="2Oq$k0">
+                              <ref role="3cqZAo" node="2WJ8cS_wlwA" resolve="it" />
+                            </node>
+                            <node concept="3TrEf2" id="xRVdUh_zbd" role="2OqNvi">
+                              <ref role="3Tt5mk" to="tp25:1Bs_61$ngwB" resolve="modelRef" />
+                            </node>
                           </node>
-                          <node concept="3TrcHB" id="7d6ZyVlXBQn" role="2OqNvi">
-                            <ref role="3TsBF5" to="tp25:v3WHCwUiHA" resolve="name" />
+                          <node concept="2qgKlT" id="xRVdUh_zJX" role="2OqNvi">
+                            <ref role="37wK5l" to="xlb7:1Bs_61$mvvu" resolve="toModelReference" />
+                          </node>
+                        </node>
+                        <node concept="liA8E" id="xRVdUh_$td" role="2OqNvi">
+                          <ref role="37wK5l" to="mhbf:~SModelReference.resolve(org.jetbrains.mps.openapi.module.SRepository)" resolve="resolve" />
+                          <node concept="2OqwBi" id="xRVdUh_AnU" role="37wK5m">
+                            <node concept="2JrnkZ" id="xRVdUh_Abn" role="2Oq$k0">
+                              <node concept="2OqwBi" id="xRVdUh__eJ" role="2JrQYb">
+                                <node concept="13iPFW" id="xRVdUh_$zT" role="2Oq$k0" />
+                                <node concept="I4A8Y" id="xRVdUh__AM" role="2OqNvi" />
+                              </node>
+                            </node>
+                            <node concept="liA8E" id="xRVdUh_A_O" role="2OqNvi">
+                              <ref role="37wK5l" to="mhbf:~SModel.getRepository()" resolve="getRepository" />
+                            </node>
                           </node>
                         </node>
                       </node>

--- a/code/languages/com.mbeddr.core/languages/com.mbeddr.core.qa/languageModels/structure.mps
+++ b/code/languages/com.mbeddr.core/languages/com.mbeddr.core.qa/languageModels/structure.mps
@@ -95,7 +95,7 @@
       <property role="20lbJX" value="fLJekj6/_1__n" />
       <property role="20kJfa" value="scope" />
       <property role="IQ2ns" value="347451455539224234" />
-      <ref role="20lvS9" to="tp25:v3WHCwUiHy" resolve="ModelReferenceExpression" />
+      <ref role="20lvS9" to="tp25:1Bs_61$nfRn" resolve="ModelPointerExpression" />
     </node>
   </node>
   <node concept="1TIwiD" id="jipk886TUF">

--- a/code/languages/com.mbeddr.core/tests/test.ts.core/models/tests1@tests.mps
+++ b/code/languages/com.mbeddr.core/tests/test.ts.core/models/tests1@tests.mps
@@ -450,6 +450,15 @@
       <concept id="7755897872837262970" name="com.mbeddr.core.unittest.structure.AssertGreater" flags="ng" index="2N3$9Z" />
       <concept id="8811614583515780719" name="com.mbeddr.core.unittest.structure.TypeExpression" flags="ng" index="1AljaC" />
     </language>
+    <language id="446c26eb-2b7b-4bf0-9b35-f83fa582753e" name="jetbrains.mps.lang.modelapi">
+      <concept id="361130699826193248" name="jetbrains.mps.lang.modelapi.structure.ModelPointer" flags="ng" index="1dCxOl">
+        <property id="1863527487546097494" name="modelId" index="1XweGQ" />
+        <child id="679099339649067980" name="name" index="1j$8Uc" />
+      </concept>
+      <concept id="679099339649053840" name="jetbrains.mps.lang.modelapi.structure.ModelName" flags="ng" index="1j_P7g">
+        <property id="679099339649053841" name="value" index="1j_P7h" />
+      </concept>
+    </language>
     <language id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest">
       <concept id="8427750732757990717" name="jetbrains.mps.baseLanguage.unitTest.structure.BinaryAssert" flags="nn" index="3tpDYu">
         <child id="8427750732757990725" name="actual" index="3tpDZA" />
@@ -478,10 +487,6 @@
         <child id="6733348108486823193" name="leftExpression" index="1m5AlR" />
         <child id="3906496115198199033" name="conceptArgument" index="3oSUPX" />
       </concept>
-      <concept id="559557797393017698" name="jetbrains.mps.lang.smodel.structure.ModelReferenceExpression" flags="nn" index="BaHAS">
-        <property id="559557797393021807" name="stereotype" index="BaGAP" />
-        <property id="559557797393017702" name="name" index="BaHAW" />
-      </concept>
       <concept id="1171500988903" name="jetbrains.mps.lang.smodel.structure.Node_GetChildrenOperation" flags="nn" index="32TBzR" />
       <concept id="1139621453865" name="jetbrains.mps.lang.smodel.structure.Node_IsInstanceOfOperation" flags="nn" index="1mIQ4w">
         <child id="1177027386292" name="conceptArgument" index="cj9EA" />
@@ -495,6 +500,9 @@
       </concept>
       <concept id="1138056143562" name="jetbrains.mps.lang.smodel.structure.SLinkAccess" flags="nn" index="3TrEf2">
         <reference id="1138056516764" name="link" index="3Tt5mk" />
+      </concept>
+      <concept id="1863527487546129879" name="jetbrains.mps.lang.smodel.structure.ModelPointerExpression" flags="ng" index="1Xw6AR">
+        <child id="1863527487546132519" name="modelRef" index="1XwpL7" />
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
@@ -26420,9 +26428,13 @@
     </node>
   </node>
   <node concept="2wNmnh" id="KILMQH1yKg">
-    <node concept="BaHAS" id="KILMQH1yKh" role="2wNm1v">
-      <property role="BaHAW" value="tests.ts.core.tests1" />
-      <property role="BaGAP" value="tests" />
+    <node concept="1Xw6AR" id="xRVdUhyv4S" role="2wNm1v">
+      <node concept="1dCxOl" id="xRVdUhyv50" role="1XwpL7">
+        <property role="1XweGQ" value="r:0c020a2a-0fae-4359-90ba-63fdf45caa94" />
+        <node concept="1j_P7g" id="xRVdUhyv51" role="1j$8Uc">
+          <property role="1j_P7h" value="tests.ts.core.tests1@tests" />
+        </node>
+      </node>
     </node>
   </node>
   <node concept="rcWEw" id="12K3RfpFq2T">

--- a/code/languages/com.mbeddr.ext/languages/com.mbeddr.ext.units/generator/template/main@generator.mps
+++ b/code/languages/com.mbeddr.ext/languages/com.mbeddr.ext.units/generator/template/main@generator.mps
@@ -18,6 +18,7 @@
     <import index="vs0r" ref="r:f7764ca4-8c75-4049-922b-08516400a727(com.mbeddr.core.base.structure)" />
     <import index="mj1l" ref="r:c371cf98-dcc8-4a43-8eb8-8a8096de18b2(com.mbeddr.core.expressions.structure)" />
     <import index="x27k" ref="r:75ecab8a-8931-4140-afc6-4b46398710fc(com.mbeddr.core.modules.structure)" />
+    <import index="mhbf" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.model(MPS.OpenAPI/)" implicit="true" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
   </imports>
   <registry>
@@ -25,6 +26,7 @@
       <concept id="1082485599095" name="jetbrains.mps.baseLanguage.structure.BlockStatement" flags="nn" index="9aQIb">
         <child id="1082485599096" name="statements" index="9aQI4" />
       </concept>
+      <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
@@ -169,20 +171,32 @@
         <reference id="7308356872494660982" name="arg" index="39I4aG" />
       </concept>
     </language>
+    <language id="446c26eb-2b7b-4bf0-9b35-f83fa582753e" name="jetbrains.mps.lang.modelapi">
+      <concept id="361130699826193248" name="jetbrains.mps.lang.modelapi.structure.ModelPointer" flags="ng" index="1dCxOl">
+        <property id="1863527487546097494" name="modelId" index="1XweGQ" />
+        <child id="679099339649067980" name="name" index="1j$8Uc" />
+      </concept>
+      <concept id="679099339649053840" name="jetbrains.mps.lang.modelapi.structure.ModelName" flags="ng" index="1j_P7g">
+        <property id="679099339649053841" name="value" index="1j_P7h" />
+      </concept>
+    </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
       <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
         <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
       </concept>
       <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
+      <concept id="4065387505485742666" name="jetbrains.mps.lang.smodel.structure.ModelPointer_ResolveOperation" flags="ng" index="2yCiCJ" />
+      <concept id="4065387505485742749" name="jetbrains.mps.lang.smodel.structure.AbstractPointerResolveOperation" flags="ng" index="2yCiFS">
+        <child id="3648723375513868575" name="repositoryArg" index="Vysub" />
+      </concept>
       <concept id="2396822768958367367" name="jetbrains.mps.lang.smodel.structure.AbstractTypeCastExpression" flags="nn" index="$5XWr">
         <child id="6733348108486823193" name="leftExpression" index="1m5AlR" />
         <child id="3906496115198199033" name="conceptArgument" index="3oSUPX" />
       </concept>
-      <concept id="559557797393017698" name="jetbrains.mps.lang.smodel.structure.ModelReferenceExpression" flags="nn" index="BaHAS">
-        <property id="559557797393021807" name="stereotype" index="BaGAP" />
-        <property id="559557797393017702" name="name" index="BaHAW" />
-      </concept>
       <concept id="1143234257716" name="jetbrains.mps.lang.smodel.structure.Node_GetModelOperation" flags="nn" index="I4A8Y" />
+      <concept id="1145404486709" name="jetbrains.mps.lang.smodel.structure.SemanticDowncastExpression" flags="nn" index="2JrnkZ">
+        <child id="1145404616321" name="leftExpression" index="2JrQYb" />
+      </concept>
       <concept id="1139621453865" name="jetbrains.mps.lang.smodel.structure.Node_IsInstanceOfOperation" flags="nn" index="1mIQ4w">
         <child id="1177027386292" name="conceptArgument" index="cj9EA" />
       </concept>
@@ -198,6 +212,9 @@
       </concept>
       <concept id="1138056282393" name="jetbrains.mps.lang.smodel.structure.SLinkListAccess" flags="nn" index="3Tsc0h">
         <reference id="1138056546658" name="link" index="3TtcxE" />
+      </concept>
+      <concept id="1863527487546129879" name="jetbrains.mps.lang.smodel.structure.ModelPointerExpression" flags="ng" index="1Xw6AR">
+        <child id="1863527487546132519" name="modelRef" index="1XwpL7" />
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
@@ -335,9 +352,33 @@
                   </node>
                   <node concept="I4A8Y" id="53wbATGQoiA" role="2OqNvi" />
                 </node>
-                <node concept="BaHAS" id="53wbATGQsE0" role="3uHU7w">
-                  <property role="BaHAW" value="com.mbeddr.ext.units.siunits" />
-                  <property role="BaGAP" value="" />
+                <node concept="2OqwBi" id="6M7zmThqvRF" role="3uHU7w">
+                  <node concept="1Xw6AR" id="6M7zmThqvRG" role="2Oq$k0">
+                    <node concept="1dCxOl" id="6M7zmThqvRH" role="1XwpL7">
+                      <property role="1XweGQ" value="r:679066bc-2da8-4932-a09c-5d2b3d47b911" />
+                      <node concept="1j_P7g" id="6M7zmThqvRI" role="1j$8Uc">
+                        <property role="1j_P7h" value="com.mbeddr.ext.units.siunits" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2yCiCJ" id="6M7zmThqvRJ" role="2OqNvi">
+                    <node concept="2OqwBi" id="6M7zmThqvRK" role="Vysub">
+                      <node concept="2JrnkZ" id="6M7zmThqvRL" role="2Oq$k0">
+                        <node concept="2OqwBi" id="6M7zmThqvRM" role="2JrQYb">
+                          <node concept="2OqwBi" id="6M7zmThqvRN" role="2Oq$k0">
+                            <node concept="30H73N" id="6M7zmThqvRO" role="2Oq$k0" />
+                            <node concept="3TrEf2" id="6M7zmThqvRP" role="2OqNvi">
+                              <ref role="3Tt5mk" to="vs0r:DubiFAXDKB" resolve="chunk" />
+                            </node>
+                          </node>
+                          <node concept="I4A8Y" id="6M7zmThqvRQ" role="2OqNvi" />
+                        </node>
+                      </node>
+                      <node concept="liA8E" id="6M7zmThqvRR" role="2OqNvi">
+                        <ref role="37wK5l" to="mhbf:~SModel.getRepository()" resolve="getRepository" />
+                      </node>
+                    </node>
+                  </node>
                 </node>
               </node>
               <node concept="2OqwBi" id="6ZM2l12AdcC" role="3uHU7B">
@@ -375,9 +416,33 @@
                   </node>
                   <node concept="I4A8Y" id="53wbATGQvqr" role="2OqNvi" />
                 </node>
-                <node concept="BaHAS" id="53wbATGQvqs" role="3uHU7w">
-                  <property role="BaHAW" value="com.mbeddr.ext.units.siunits" />
-                  <property role="BaGAP" value="" />
+                <node concept="2OqwBi" id="6M7zmThqwe2" role="3uHU7w">
+                  <node concept="1Xw6AR" id="6M7zmThqwe3" role="2Oq$k0">
+                    <node concept="1dCxOl" id="6M7zmThqwe4" role="1XwpL7">
+                      <property role="1XweGQ" value="r:679066bc-2da8-4932-a09c-5d2b3d47b911" />
+                      <node concept="1j_P7g" id="6M7zmThqwe5" role="1j$8Uc">
+                        <property role="1j_P7h" value="com.mbeddr.ext.units.siunits" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2yCiCJ" id="6M7zmThqwe6" role="2OqNvi">
+                    <node concept="2OqwBi" id="6M7zmThqwe7" role="Vysub">
+                      <node concept="2JrnkZ" id="6M7zmThqwe8" role="2Oq$k0">
+                        <node concept="2OqwBi" id="6M7zmThqwe9" role="2JrQYb">
+                          <node concept="2OqwBi" id="6M7zmThqwea" role="2Oq$k0">
+                            <node concept="30H73N" id="6M7zmThqweb" role="2Oq$k0" />
+                            <node concept="3TrEf2" id="6M7zmThqwec" role="2OqNvi">
+                              <ref role="3Tt5mk" to="vs0r:DubiFAXDKB" resolve="chunk" />
+                            </node>
+                          </node>
+                          <node concept="I4A8Y" id="6M7zmThqwed" role="2OqNvi" />
+                        </node>
+                      </node>
+                      <node concept="liA8E" id="6M7zmThqwee" role="2OqNvi">
+                        <ref role="37wK5l" to="mhbf:~SModel.getRepository()" resolve="getRepository" />
+                      </node>
+                    </node>
+                  </node>
                 </node>
               </node>
               <node concept="2OqwBi" id="53wbATGQv4P" role="3uHU7B">

--- a/code/languages/com.mbeddr.ext/tests/test.ext.components.nodes_tracing/models/_assessment.mps
+++ b/code/languages/com.mbeddr.ext/tests/test.ext.components.nodes_tracing/models/_assessment.mps
@@ -40,10 +40,18 @@
         <child id="97836352113025274" name="scope" index="3kyFlu" />
       </concept>
     </language>
+    <language id="446c26eb-2b7b-4bf0-9b35-f83fa582753e" name="jetbrains.mps.lang.modelapi">
+      <concept id="361130699826193248" name="jetbrains.mps.lang.modelapi.structure.ModelPointer" flags="ng" index="1dCxOl">
+        <property id="1863527487546097494" name="modelId" index="1XweGQ" />
+        <child id="679099339649067980" name="name" index="1j$8Uc" />
+      </concept>
+      <concept id="679099339649053840" name="jetbrains.mps.lang.modelapi.structure.ModelName" flags="ng" index="1j_P7g">
+        <property id="679099339649053841" name="value" index="1j_P7h" />
+      </concept>
+    </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
-      <concept id="559557797393017698" name="jetbrains.mps.lang.smodel.structure.ModelReferenceExpression" flags="nn" index="BaHAS">
-        <property id="559557797393021807" name="stereotype" index="BaGAP" />
-        <property id="559557797393017702" name="name" index="BaHAW" />
+      <concept id="1863527487546129879" name="jetbrains.mps.lang.smodel.structure.ModelPointerExpression" flags="ng" index="1Xw6AR">
+        <child id="1863527487546132519" name="modelRef" index="1XwpL7" />
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
@@ -63,9 +71,13 @@
           <property role="cMvJE" value="com.mbeddr.ext.components" />
         </node>
         <node concept="cMvJF" id="73SKUHF8vQY" role="3kyFlu">
-          <node concept="BaHAS" id="73SKUHF8vR0" role="cMvJC">
-            <property role="BaHAW" value="components_code" />
-            <property role="BaGAP" value="" />
+          <node concept="1Xw6AR" id="xRVdUhA2vn" role="cMvJC">
+            <node concept="1dCxOl" id="xRVdUhA2vv" role="1XwpL7">
+              <property role="1XweGQ" value="r:963c4b27-5f46-4fe9-ad5b-ba7dee75e8c4" />
+              <node concept="1j_P7g" id="xRVdUhA2vw" role="1j$8Uc">
+                <property role="1j_P7h" value="components_code" />
+              </node>
+            </node>
           </node>
         </node>
       </node>

--- a/code/languages/com.mbeddr.ext/tests/test.ext.components.nodes_tracing/models/components_nodes_tracing@tests.mps
+++ b/code/languages/com.mbeddr.ext/tests/test.ext.components.nodes_tracing/models/components_nodes_tracing@tests.mps
@@ -38,10 +38,18 @@
       </concept>
       <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
     </language>
+    <language id="446c26eb-2b7b-4bf0-9b35-f83fa582753e" name="jetbrains.mps.lang.modelapi">
+      <concept id="361130699826193248" name="jetbrains.mps.lang.modelapi.structure.ModelPointer" flags="ng" index="1dCxOl">
+        <property id="1863527487546097494" name="modelId" index="1XweGQ" />
+        <child id="679099339649067980" name="name" index="1j$8Uc" />
+      </concept>
+      <concept id="679099339649053840" name="jetbrains.mps.lang.modelapi.structure.ModelName" flags="ng" index="1j_P7g">
+        <property id="679099339649053841" name="value" index="1j_P7h" />
+      </concept>
+    </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
-      <concept id="559557797393017698" name="jetbrains.mps.lang.smodel.structure.ModelReferenceExpression" flags="nn" index="BaHAS">
-        <property id="559557797393021807" name="stereotype" index="BaGAP" />
-        <property id="559557797393017702" name="name" index="BaHAW" />
+      <concept id="1863527487546129879" name="jetbrains.mps.lang.smodel.structure.ModelPointerExpression" flags="ng" index="1Xw6AR">
+        <child id="1863527487546132519" name="modelRef" index="1XwpL7" />
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
@@ -57,9 +65,13 @@
       <node concept="3cqZAl" id="73SKUHF91YH" role="3clF45" />
       <node concept="3clFbS" id="73SKUHF91YI" role="3clF47">
         <node concept="1xIcmD" id="73SKUHF91YN" role="3cqZAp">
-          <node concept="BaHAS" id="73SKUHF91YO" role="1xIeA0">
-            <property role="BaHAW" value="components_code" />
-            <property role="BaGAP" value="" />
+          <node concept="1Xw6AR" id="xRVdUh_vma" role="1xIeA0">
+            <node concept="1dCxOl" id="xRVdUh_vmi" role="1XwpL7">
+              <property role="1XweGQ" value="r:963c4b27-5f46-4fe9-ad5b-ba7dee75e8c4" />
+              <node concept="1j_P7g" id="xRVdUh_vmj" role="1j$8Uc">
+                <property role="1j_P7h" value="components_code" />
+              </node>
+            </node>
           </node>
           <node concept="Xl_RD" id="73SKUHF91YP" role="1xDQ1B">
             <property role="Xl_RC" value="ComponentsTracingTest" />

--- a/code/languages/com.mbeddr.ext/tests/test.ext.math.nodes_tracing/models/math_nodes_tracing@tests.mps
+++ b/code/languages/com.mbeddr.ext/tests/test.ext.math.nodes_tracing/models/math_nodes_tracing@tests.mps
@@ -38,10 +38,18 @@
       </concept>
       <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
     </language>
+    <language id="446c26eb-2b7b-4bf0-9b35-f83fa582753e" name="jetbrains.mps.lang.modelapi">
+      <concept id="361130699826193248" name="jetbrains.mps.lang.modelapi.structure.ModelPointer" flags="ng" index="1dCxOl">
+        <property id="1863527487546097494" name="modelId" index="1XweGQ" />
+        <child id="679099339649067980" name="name" index="1j$8Uc" />
+      </concept>
+      <concept id="679099339649053840" name="jetbrains.mps.lang.modelapi.structure.ModelName" flags="ng" index="1j_P7g">
+        <property id="679099339649053841" name="value" index="1j_P7h" />
+      </concept>
+    </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
-      <concept id="559557797393017698" name="jetbrains.mps.lang.smodel.structure.ModelReferenceExpression" flags="nn" index="BaHAS">
-        <property id="559557797393021807" name="stereotype" index="BaGAP" />
-        <property id="559557797393017702" name="name" index="BaHAW" />
+      <concept id="1863527487546129879" name="jetbrains.mps.lang.smodel.structure.ModelPointerExpression" flags="ng" index="1Xw6AR">
+        <child id="1863527487546132519" name="modelRef" index="1XwpL7" />
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
@@ -57,12 +65,16 @@
       <node concept="3cqZAl" id="6RWcftEdqKk" role="3clF45" />
       <node concept="3clFbS" id="6RWcftEdqKl" role="3clF47">
         <node concept="1xIcmD" id="2qCdpHNSr96" role="3cqZAp">
-          <node concept="BaHAS" id="2qCdpHNSr97" role="1xIeA0">
-            <property role="BaHAW" value="math_code" />
-            <property role="BaGAP" value="" />
-          </node>
           <node concept="Xl_RD" id="2qCdpHNSr98" role="1xDQ1B">
             <property role="Xl_RC" value="ExponentialTest" />
+          </node>
+          <node concept="1Xw6AR" id="xRVdUh_vlV" role="1xIeA0">
+            <node concept="1dCxOl" id="xRVdUh_vlW" role="1XwpL7">
+              <property role="1XweGQ" value="r:f5f820fe-0f38-4972-8532-3a5869434431" />
+              <node concept="1j_P7g" id="xRVdUh_vlX" role="1j$8Uc">
+                <property role="1j_P7h" value="math_code" />
+              </node>
+            </node>
           </node>
         </node>
       </node>
@@ -72,12 +84,16 @@
       <node concept="3cqZAl" id="63QgsF$VN0j" role="3clF45" />
       <node concept="3clFbS" id="63QgsF$VN0n" role="3clF47">
         <node concept="1xIcmD" id="63QgsF$VN0_" role="3cqZAp">
-          <node concept="BaHAS" id="63QgsF$VN0A" role="1xIeA0">
-            <property role="BaHAW" value="math_code" />
-            <property role="BaGAP" value="" />
-          </node>
           <node concept="Xl_RD" id="63QgsF$VN0B" role="1xDQ1B">
             <property role="Xl_RC" value="SumTest" />
+          </node>
+          <node concept="1Xw6AR" id="xRVdUh_vlM" role="1xIeA0">
+            <node concept="1dCxOl" id="xRVdUh_vlN" role="1XwpL7">
+              <property role="1XweGQ" value="r:f5f820fe-0f38-4972-8532-3a5869434431" />
+              <node concept="1j_P7g" id="xRVdUh_vlO" role="1j$8Uc">
+                <property role="1j_P7h" value="math_code" />
+              </node>
+            </node>
           </node>
         </node>
       </node>
@@ -87,12 +103,16 @@
       <node concept="3cqZAl" id="63QgsF$VN1l" role="3clF45" />
       <node concept="3clFbS" id="63QgsF$VN1p" role="3clF47">
         <node concept="1xIcmD" id="63QgsF$VN1H" role="3cqZAp">
-          <node concept="BaHAS" id="63QgsF$VN1I" role="1xIeA0">
-            <property role="BaHAW" value="math_code" />
-            <property role="BaGAP" value="" />
-          </node>
           <node concept="Xl_RD" id="63QgsF$VN1J" role="1xDQ1B">
             <property role="Xl_RC" value="ProductTest" />
+          </node>
+          <node concept="1Xw6AR" id="xRVdUh_vlD" role="1xIeA0">
+            <node concept="1dCxOl" id="xRVdUh_vlE" role="1XwpL7">
+              <property role="1XweGQ" value="r:f5f820fe-0f38-4972-8532-3a5869434431" />
+              <node concept="1j_P7g" id="xRVdUh_vlF" role="1j$8Uc">
+                <property role="1j_P7h" value="math_code" />
+              </node>
+            </node>
           </node>
         </node>
       </node>
@@ -102,12 +122,16 @@
       <node concept="3cqZAl" id="63QgsF$Wbm2" role="3clF45" />
       <node concept="3clFbS" id="63QgsF$Wbm6" role="3clF47">
         <node concept="1xIcmD" id="63QgsF$Wbn9" role="3cqZAp">
-          <node concept="BaHAS" id="63QgsF$Wbna" role="1xIeA0">
-            <property role="BaHAW" value="math_code" />
-            <property role="BaGAP" value="" />
-          </node>
           <node concept="Xl_RD" id="63QgsF$Wbnb" role="1xDQ1B">
             <property role="Xl_RC" value="LogSqrtTest" />
+          </node>
+          <node concept="1Xw6AR" id="xRVdUh_vlw" role="1xIeA0">
+            <node concept="1dCxOl" id="xRVdUh_vlx" role="1XwpL7">
+              <property role="1XweGQ" value="r:f5f820fe-0f38-4972-8532-3a5869434431" />
+              <node concept="1j_P7g" id="xRVdUh_vly" role="1j$8Uc">
+                <property role="1j_P7h" value="math_code" />
+              </node>
+            </node>
           </node>
         </node>
       </node>
@@ -117,9 +141,13 @@
       <node concept="3cqZAl" id="63QgsF$Wboh" role="3clF45" />
       <node concept="3clFbS" id="63QgsF$Wbol" role="3clF47">
         <node concept="1xIcmD" id="63QgsF$WboP" role="3cqZAp">
-          <node concept="BaHAS" id="63QgsF$WboQ" role="1xIeA0">
-            <property role="BaHAW" value="math_code" />
-            <property role="BaGAP" value="" />
+          <node concept="1Xw6AR" id="xRVdUh_vlh" role="1xIeA0">
+            <node concept="1dCxOl" id="xRVdUh_vlp" role="1XwpL7">
+              <property role="1XweGQ" value="r:f5f820fe-0f38-4972-8532-3a5869434431" />
+              <node concept="1j_P7g" id="xRVdUh_vlq" role="1j$8Uc">
+                <property role="1j_P7h" value="math_code" />
+              </node>
+            </node>
           </node>
           <node concept="Xl_RD" id="63QgsF$WboR" role="1xDQ1B">
             <property role="Xl_RC" value="FractionAbsTest" />

--- a/code/languages/com.mbeddr.ext/tests/test.ext.statemachine.nodes_tracing/models/sm_nodes_tracing@tests.mps
+++ b/code/languages/com.mbeddr.ext/tests/test.ext.statemachine.nodes_tracing/models/sm_nodes_tracing@tests.mps
@@ -37,10 +37,18 @@
       </concept>
       <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
     </language>
+    <language id="446c26eb-2b7b-4bf0-9b35-f83fa582753e" name="jetbrains.mps.lang.modelapi">
+      <concept id="361130699826193248" name="jetbrains.mps.lang.modelapi.structure.ModelPointer" flags="ng" index="1dCxOl">
+        <property id="1863527487546097494" name="modelId" index="1XweGQ" />
+        <child id="679099339649067980" name="name" index="1j$8Uc" />
+      </concept>
+      <concept id="679099339649053840" name="jetbrains.mps.lang.modelapi.structure.ModelName" flags="ng" index="1j_P7g">
+        <property id="679099339649053841" name="value" index="1j_P7h" />
+      </concept>
+    </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
-      <concept id="559557797393017698" name="jetbrains.mps.lang.smodel.structure.ModelReferenceExpression" flags="nn" index="BaHAS">
-        <property id="559557797393021807" name="stereotype" index="BaGAP" />
-        <property id="559557797393017702" name="name" index="BaHAW" />
+      <concept id="1863527487546129879" name="jetbrains.mps.lang.smodel.structure.ModelPointerExpression" flags="ng" index="1Xw6AR">
+        <child id="1863527487546132519" name="modelRef" index="1XwpL7" />
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
@@ -56,9 +64,13 @@
       <node concept="3cqZAl" id="EEDqFMwhtk" role="3clF45" />
       <node concept="3clFbS" id="EEDqFMwhto" role="3clF47">
         <node concept="1xIcmD" id="EEDqFMwhtz" role="3cqZAp">
-          <node concept="BaHAS" id="EEDqFMwht$" role="1xIeA0">
-            <property role="BaHAW" value="sm_code" />
-            <property role="BaGAP" value="" />
+          <node concept="1Xw6AR" id="xRVdUh_vk$" role="1xIeA0">
+            <node concept="1dCxOl" id="xRVdUh_vkG" role="1XwpL7">
+              <property role="1XweGQ" value="r:e7ec37da-9b0c-445d-8cf7-3e043620f94d" />
+              <node concept="1j_P7g" id="xRVdUh_vkH" role="1j$8Uc">
+                <property role="1j_P7h" value="sm_code" />
+              </node>
+            </node>
           </node>
           <node concept="Xl_RD" id="EEDqFMwht_" role="1xDQ1B">
             <property role="Xl_RC" value="SM1" />
@@ -71,9 +83,13 @@
       <node concept="3cqZAl" id="6RWcftDLAqv" role="3clF45" />
       <node concept="3clFbS" id="6RWcftDLAqz" role="3clF47">
         <node concept="1xIcmD" id="6RWcftDLCCw" role="3cqZAp">
-          <node concept="BaHAS" id="6RWcftDLCCx" role="1xIeA0">
-            <property role="BaHAW" value="sm_code" />
-            <property role="BaGAP" value="" />
+          <node concept="1Xw6AR" id="xRVdUh_vkl" role="1xIeA0">
+            <node concept="1dCxOl" id="xRVdUh_vkt" role="1XwpL7">
+              <property role="1XweGQ" value="r:e7ec37da-9b0c-445d-8cf7-3e043620f94d" />
+              <node concept="1j_P7g" id="xRVdUh_vku" role="1j$8Uc">
+                <property role="1j_P7h" value="sm_code" />
+              </node>
+            </node>
           </node>
           <node concept="Xl_RD" id="6RWcftDLCCy" role="1xDQ1B">
             <property role="Xl_RC" value="SM2" />

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.ecoreimporter.testing/generator/template/main@generator.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.ecoreimporter.testing/generator/template/main@generator.mps
@@ -11,6 +11,7 @@
     <import index="p76z" ref="r:62e76a73-7fd3-4d03-9b49-0da2a82f5479(com.mbeddr.mpsutil.ecore.testing.runtime.main)" />
     <import index="fwk" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.textgen.trace(MPS.Core/)" />
     <import index="mhbf" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.model(MPS.OpenAPI/)" />
+    <import index="w1kc" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel(MPS.Core/)" />
     <import index="68mc" ref="r:2a10821d-612f-4a73-b7b0-ed6b57106321(com.mbeddr.mpsutil.filepicker.structure)" implicit="true" />
   </imports>
   <registry>
@@ -103,11 +104,20 @@
       <concept id="1216860049635" name="jetbrains.mps.lang.generator.generationContext.structure.TemplateFunctionParameter_generationContext" flags="nn" index="1iwH7S" />
       <concept id="1217026863835" name="jetbrains.mps.lang.generator.generationContext.structure.GenerationContextOp_GetOriginalInputModel" flags="nn" index="1st3f0" />
     </language>
+    <language id="446c26eb-2b7b-4bf0-9b35-f83fa582753e" name="jetbrains.mps.lang.modelapi">
+      <concept id="361130699826193248" name="jetbrains.mps.lang.modelapi.structure.ModelPointer" flags="ng" index="1dCxOl">
+        <property id="1863527487546097494" name="modelId" index="1XweGQ" />
+        <child id="679099339649067980" name="name" index="1j$8Uc" />
+      </concept>
+      <concept id="679099339649053840" name="jetbrains.mps.lang.modelapi.structure.ModelName" flags="ng" index="1j_P7g">
+        <property id="679099339649053841" name="value" index="1j_P7h" />
+      </concept>
+    </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
       <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
-      <concept id="559557797393017698" name="jetbrains.mps.lang.smodel.structure.ModelReferenceExpression" flags="nn" index="BaHAS">
-        <property id="559557797393021807" name="stereotype" index="BaGAP" />
-        <property id="559557797393017702" name="name" index="BaHAW" />
+      <concept id="4065387505485742666" name="jetbrains.mps.lang.smodel.structure.ModelPointer_ResolveOperation" flags="ng" index="2yCiCJ" />
+      <concept id="4065387505485742749" name="jetbrains.mps.lang.smodel.structure.AbstractPointerResolveOperation" flags="ng" index="2yCiFS">
+        <child id="3648723375513868575" name="repositoryArg" index="Vysub" />
       </concept>
       <concept id="1145404486709" name="jetbrains.mps.lang.smodel.structure.SemanticDowncastExpression" flags="nn" index="2JrnkZ">
         <child id="1145404616321" name="leftExpression" index="2JrQYb" />
@@ -117,6 +127,9 @@
       </concept>
       <concept id="1138056143562" name="jetbrains.mps.lang.smodel.structure.SLinkAccess" flags="nn" index="3TrEf2">
         <reference id="1138056516764" name="link" index="3Tt5mk" />
+      </concept>
+      <concept id="1863527487546129879" name="jetbrains.mps.lang.smodel.structure.ModelPointerExpression" flags="ng" index="1Xw6AR">
+        <child id="1863527487546132519" name="modelRef" index="1XwpL7" />
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
@@ -239,21 +252,33 @@
                   <node concept="37vLTw" id="7ESlTHs29bB" role="37wK5m">
                     <ref role="3cqZAo" node="6m31kJuBYFy" resolve="ecoreFile" />
                   </node>
-                  <node concept="BaHAS" id="7ESlTHs1G05" role="37wK5m">
-                    <property role="BaHAW" value="test.com.mbeddr.mpsutil.ecoreimporter.runtime.testLanguageMatch.structure" />
-                    <property role="BaGAP" value="" />
-                    <node concept="29HgVG" id="7ESlTHs1G06" role="lGtFl">
-                      <node concept="3NFfHV" id="7ESlTHs1G07" role="3NFExx">
-                        <node concept="3clFbS" id="7ESlTHs1G08" role="2VODD2">
-                          <node concept="3clFbF" id="7ESlTHs1G09" role="3cqZAp">
-                            <node concept="2OqwBi" id="7ESlTHs1G0a" role="3clFbG">
-                              <node concept="30H73N" id="7ESlTHs1G0b" role="2Oq$k0" />
-                              <node concept="3TrEf2" id="7ESlTHs1G0c" role="2OqNvi">
-                                <ref role="3Tt5mk" to="3yw8:rt4C5olSG_" resolve="referenceLanguage" />
+                  <node concept="2OqwBi" id="6M7zmThrotC" role="37wK5m">
+                    <node concept="1Xw6AR" id="6M7zmThro70" role="2Oq$k0">
+                      <node concept="1dCxOl" id="6M7zmThrodK" role="1XwpL7">
+                        <property role="1XweGQ" value="r:1764e886-bde7-4513-8b69-527af62b45d0" />
+                        <node concept="1j_P7g" id="6M7zmThrodL" role="1j$8Uc">
+                          <property role="1j_P7h" value="com.mbeddr.mpsutil.ecoreimporter.runtime.importerruntime" />
+                        </node>
+                      </node>
+                      <node concept="29HgVG" id="6M7zmThroO6" role="lGtFl">
+                        <node concept="3NFfHV" id="6M7zmThroO7" role="3NFExx">
+                          <node concept="3clFbS" id="6M7zmThroO8" role="2VODD2">
+                            <node concept="3clFbF" id="6M7zmThroOe" role="3cqZAp">
+                              <node concept="2OqwBi" id="6M7zmThroO9" role="3clFbG">
+                                <node concept="3TrEf2" id="6M7zmThroOc" role="2OqNvi">
+                                  <ref role="3Tt5mk" to="3yw8:rt4C5olSG_" resolve="referenceLanguage" />
+                                </node>
+                                <node concept="30H73N" id="6M7zmThroOd" role="2Oq$k0" />
                               </node>
                             </node>
                           </node>
                         </node>
+                      </node>
+                    </node>
+                    <node concept="2yCiCJ" id="6M7zmThroDm" role="2OqNvi">
+                      <node concept="2YIFZM" id="6M7zmThroHL" role="Vysub">
+                        <ref role="37wK5l" to="w1kc:~MPSModuleRepository.getInstance()" resolve="getInstance" />
+                        <ref role="1Pybhc" to="w1kc:~MPSModuleRepository" resolve="MPSModuleRepository" />
                       </node>
                     </node>
                   </node>
@@ -361,39 +386,63 @@
                   </node>
                 </node>
               </node>
-              <node concept="BaHAS" id="4MUcKNHouQm" role="37wK5m">
-                <property role="BaHAW" value="test.com.mbeddr.mpsutil.ecoreimporter.runtime.testLanguageMatch.structure" />
-                <property role="BaGAP" value="" />
-                <node concept="29HgVG" id="4MUcKNHouQn" role="lGtFl">
-                  <node concept="3NFfHV" id="4MUcKNHouQo" role="3NFExx">
-                    <node concept="3clFbS" id="4MUcKNHouQp" role="2VODD2">
-                      <node concept="3clFbF" id="4MUcKNHouQq" role="3cqZAp">
-                        <node concept="2OqwBi" id="4MUcKNHouQr" role="3clFbG">
-                          <node concept="30H73N" id="4MUcKNHouQs" role="2Oq$k0" />
-                          <node concept="3TrEf2" id="4MUcKNHowxy" role="2OqNvi">
-                            <ref role="3Tt5mk" to="3yw8:4MUcKNHoqI0" resolve="referenceLanguage" />
+              <node concept="2OqwBi" id="6M7zmThrki5" role="37wK5m">
+                <node concept="1Xw6AR" id="6M7zmThrjLy" role="2Oq$k0">
+                  <node concept="1dCxOl" id="6M7zmThrjTg" role="1XwpL7">
+                    <property role="1XweGQ" value="r:1764e886-bde7-4513-8b69-527af62b45d0" />
+                    <node concept="1j_P7g" id="6M7zmThrjTh" role="1j$8Uc">
+                      <property role="1j_P7h" value="com.mbeddr.mpsutil.ecoreimporter.runtime.importerruntime" />
+                    </node>
+                  </node>
+                  <node concept="29HgVG" id="6M7zmThrl1t" role="lGtFl">
+                    <node concept="3NFfHV" id="6M7zmThrl1u" role="3NFExx">
+                      <node concept="3clFbS" id="6M7zmThrl1v" role="2VODD2">
+                        <node concept="3clFbF" id="6M7zmThrl1_" role="3cqZAp">
+                          <node concept="2OqwBi" id="6M7zmThrl1w" role="3clFbG">
+                            <node concept="3TrEf2" id="6M7zmThrl1z" role="2OqNvi">
+                              <ref role="3Tt5mk" to="3yw8:4MUcKNHoqI0" resolve="referenceLanguage" />
+                            </node>
+                            <node concept="30H73N" id="6M7zmThrl1$" role="2Oq$k0" />
                           </node>
                         </node>
                       </node>
                     </node>
                   </node>
                 </node>
+                <node concept="2yCiCJ" id="6M7zmThrkrt" role="2OqNvi">
+                  <node concept="2YIFZM" id="6M7zmThrkOK" role="Vysub">
+                    <ref role="37wK5l" to="w1kc:~MPSModuleRepository.getInstance()" resolve="getInstance" />
+                    <ref role="1Pybhc" to="w1kc:~MPSModuleRepository" resolve="MPSModuleRepository" />
+                  </node>
+                </node>
               </node>
-              <node concept="BaHAS" id="4MUcKNHovi9" role="37wK5m">
-                <property role="BaHAW" value="test.com.mbeddr.mpsutil.ecoreimporter.runtime.testLanguageMatch.structure" />
-                <property role="BaGAP" value="" />
-                <node concept="29HgVG" id="4MUcKNHovia" role="lGtFl">
-                  <node concept="3NFfHV" id="4MUcKNHovib" role="3NFExx">
-                    <node concept="3clFbS" id="4MUcKNHovic" role="2VODD2">
-                      <node concept="3clFbF" id="4MUcKNHovid" role="3cqZAp">
-                        <node concept="2OqwBi" id="4MUcKNHovie" role="3clFbG">
-                          <node concept="30H73N" id="4MUcKNHovif" role="2Oq$k0" />
-                          <node concept="3TrEf2" id="4MUcKNHow4$" role="2OqNvi">
-                            <ref role="3Tt5mk" to="3yw8:4MUcKNHoqI5" resolve="referenceInstance" />
+              <node concept="2OqwBi" id="6M7zmThrkWn" role="37wK5m">
+                <node concept="1Xw6AR" id="6M7zmThrkWo" role="2Oq$k0">
+                  <node concept="1dCxOl" id="6M7zmThrkWp" role="1XwpL7">
+                    <property role="1XweGQ" value="r:1764e886-bde7-4513-8b69-527af62b45d0" />
+                    <node concept="1j_P7g" id="6M7zmThrkWq" role="1j$8Uc">
+                      <property role="1j_P7h" value="com.mbeddr.mpsutil.ecoreimporter.runtime.importerruntime" />
+                    </node>
+                  </node>
+                  <node concept="29HgVG" id="6M7zmThrloY" role="lGtFl">
+                    <node concept="3NFfHV" id="6M7zmThrloZ" role="3NFExx">
+                      <node concept="3clFbS" id="6M7zmThrlp0" role="2VODD2">
+                        <node concept="3clFbF" id="6M7zmThrlp6" role="3cqZAp">
+                          <node concept="2OqwBi" id="6M7zmThrlp1" role="3clFbG">
+                            <node concept="3TrEf2" id="6M7zmThrlp4" role="2OqNvi">
+                              <ref role="3Tt5mk" to="3yw8:4MUcKNHoqI5" resolve="referenceInstance" />
+                            </node>
+                            <node concept="30H73N" id="6M7zmThrlp5" role="2Oq$k0" />
                           </node>
                         </node>
                       </node>
                     </node>
+                  </node>
+                </node>
+                <node concept="2yCiCJ" id="6M7zmThrkWr" role="2OqNvi">
+                  <node concept="2YIFZM" id="6M7zmThrkWs" role="Vysub">
+                    <ref role="37wK5l" to="w1kc:~MPSModuleRepository.getInstance()" resolve="getInstance" />
+                    <ref role="1Pybhc" to="w1kc:~MPSModuleRepository" resolve="MPSModuleRepository" />
                   </node>
                 </node>
               </node>

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.ecoreimporter.testing/models/com/mbeddr/mpsutil/ecore/testing/structure.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.ecoreimporter.testing/models/com/mbeddr/mpsutil/ecore/testing/structure.mps
@@ -51,7 +51,7 @@
       <property role="20lmBu" value="fLJjDmT/aggregation" />
       <property role="20kJfa" value="referenceLanguage" />
       <property role="20lbJX" value="fLJekj4/_1" />
-      <ref role="20lvS9" to="tp25:v3WHCwUiHy" resolve="ModelReferenceExpression" />
+      <ref role="20lvS9" to="tp25:1Bs_61$nfRn" resolve="ModelPointerExpression" />
     </node>
   </node>
   <node concept="1TIwiD" id="4MUcKNHoqHY">
@@ -71,14 +71,14 @@
       <property role="20lmBu" value="fLJjDmT/aggregation" />
       <property role="20kJfa" value="referenceLanguage" />
       <property role="20lbJX" value="fLJekj4/_1" />
-      <ref role="20lvS9" to="tp25:v3WHCwUiHy" resolve="ModelReferenceExpression" />
+      <ref role="20lvS9" to="tp25:1Bs_61$nfRn" resolve="ModelPointerExpression" />
     </node>
     <node concept="1TJgyj" id="4MUcKNHoqI5" role="1TKVEi">
       <property role="IQ2ns" value="5528787623165930373" />
       <property role="20lmBu" value="fLJjDmT/aggregation" />
       <property role="20kJfa" value="referenceInstance" />
       <property role="20lbJX" value="fLJekj4/_1" />
-      <ref role="20lvS9" to="tp25:v3WHCwUiHy" resolve="ModelReferenceExpression" />
+      <ref role="20lvS9" to="tp25:1Bs_61$nfRn" resolve="ModelPointerExpression" />
     </node>
   </node>
 </model>

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.lantest.baselang/models/behavior.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.lantest.baselang/models/behavior.mps
@@ -127,8 +127,8 @@
       <node concept="3clFbS" id="3Ts5Ln3HLy4" role="3clF47">
         <node concept="3clFbF" id="3Ts5Ln3HO9l" role="3cqZAp">
           <node concept="2ShNRf" id="3Ts5Ln3HO9j" role="3clFbG">
-            <node concept="HV5vD" id="3Ts5Ln3KKtb" role="2ShVmc">
-              <ref role="HV5vE" to="v5ts:7rZVxqnwei_" resolve="DefaultModelSaver" />
+            <node concept="1pGfFk" id="6M7zmThqxY5" role="2ShVmc">
+              <ref role="37wK5l" to="v5ts:7rZVxqnweRL" resolve="DefaultModelSaver" />
             </node>
           </node>
         </node>

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.lantest.baselang/models/structure.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.lantest.baselang/models/structure.mps
@@ -49,21 +49,21 @@
       <property role="20lbJX" value="fLJekj4/_1" />
       <property role="20kJfa" value="modelWithBuggyRoots" />
       <property role="IQ2ns" value="4493491910455121568" />
-      <ref role="20lvS9" to="tp25:v3WHCwUiHy" resolve="ModelReferenceExpression" />
+      <ref role="20lvS9" to="tp25:1Bs_61$nfRn" resolve="ModelPointerExpression" />
     </node>
     <node concept="1TJgyj" id="3Ts5Ln3Ldqx" role="1TKVEi">
       <property role="20lmBu" value="fLJjDmT/aggregation" />
       <property role="20lbJX" value="fLJekj4/_1" />
       <property role="20kJfa" value="originalModel" />
       <property role="IQ2ns" value="4493491910455121569" />
-      <ref role="20lvS9" to="tp25:v3WHCwUiHy" resolve="ModelReferenceExpression" />
+      <ref role="20lvS9" to="tp25:1Bs_61$nfRn" resolve="ModelPointerExpression" />
     </node>
     <node concept="1TJgyj" id="3Ts5Ln3NdYJ" role="1TKVEi">
       <property role="IQ2ns" value="4493491910455648175" />
       <property role="20lmBu" value="fLJjDmT/aggregation" />
       <property role="20kJfa" value="temporaryModel" />
       <property role="20lbJX" value="fLJekj4/_1" />
-      <ref role="20lvS9" to="tp25:v3WHCwUiHy" resolve="ModelReferenceExpression" />
+      <ref role="20lvS9" to="tp25:1Bs_61$nfRn" resolve="ModelPointerExpression" />
     </node>
     <node concept="PrWs8" id="3Ts5Ln3HLxM" role="PzmwI">
       <ref role="PrY4T" to="gfdq:33cGTVo609o" resolve="ILanguageSpecificConfig" />

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.lantest/languageModels/structure.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.lantest/languageModels/structure.mps
@@ -104,21 +104,21 @@
       <property role="20lbJX" value="fLJekj4/_1" />
       <property role="20kJfa" value="modelWhereResultsAreSaved" />
       <property role="IQ2ns" value="3642470604913215366" />
-      <ref role="20lvS9" to="tp25:v3WHCwUiHy" resolve="ModelReferenceExpression" />
+      <ref role="20lvS9" to="tp25:1Bs_61$nfRn" resolve="ModelPointerExpression" />
     </node>
     <node concept="1TJgyj" id="52eR6w5Qnsd" role="1TKVEi">
       <property role="20lmBu" value="fLJjDmT/aggregation" />
       <property role="20lbJX" value="fLJekj4/_1" />
       <property role="20kJfa" value="temporaryModel" />
       <property role="IQ2ns" value="5804819309059995405" />
-      <ref role="20lvS9" to="tp25:v3WHCwUiHy" resolve="ModelReferenceExpression" />
+      <ref role="20lvS9" to="tp25:1Bs_61$nfRn" resolve="ModelPointerExpression" />
     </node>
     <node concept="1TJgyj" id="1EeUs_TucP_" role="1TKVEi">
       <property role="IQ2ns" value="1913723943214697829" />
       <property role="20lmBu" value="fLJjDmT/aggregation" />
       <property role="20kJfa" value="modelWithBuggyRootsAfterChecking" />
       <property role="20lbJX" value="fLJekj4/_1" />
-      <ref role="20lvS9" to="tp25:v3WHCwUiHy" resolve="ModelReferenceExpression" />
+      <ref role="20lvS9" to="tp25:1Bs_61$nfRn" resolve="ModelPointerExpression" />
     </node>
     <node concept="1TJgyj" id="2zqpPfizDaF" role="1TKVEi">
       <property role="IQ2ns" value="2943778916152545963" />

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.nodes_tracing.test/generator/template/main@generator.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.nodes_tracing.test/generator/template/main@generator.mps
@@ -15,6 +15,7 @@
     <import index="8oaq" ref="b0f8641f-bd77-4421-8425-30d9088a82f7/java:org.apache.commons.io(org.apache.commons/)" />
     <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" />
+    <import index="w1kc" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel(MPS.Core/)" />
   </imports>
   <registry>
     <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
@@ -62,6 +63,10 @@
       <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
       <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
       <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
+      <concept id="1070534934090" name="jetbrains.mps.baseLanguage.structure.CastExpression" flags="nn" index="10QFUN">
+        <child id="1070534934091" name="type" index="10QFUM" />
+        <child id="1070534934092" name="expression" index="10QFUP" />
+      </concept>
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <property id="1176718929932" name="isFinal" index="3TUv4t" />
         <child id="1068431790190" name="initializer" index="33vP2m" />
@@ -102,6 +107,9 @@
       </concept>
       <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
       <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
+      <concept id="1079359253375" name="jetbrains.mps.baseLanguage.structure.ParenthesizedExpression" flags="nn" index="1eOMI4">
+        <child id="1079359253376" name="expression" index="1eOMHV" />
+      </concept>
       <concept id="1081516740877" name="jetbrains.mps.baseLanguage.structure.NotExpression" flags="nn" index="3fqX7Q">
         <child id="1081516765348" name="expression" index="3fr31v" />
       </concept>
@@ -191,6 +199,10 @@
       <concept id="1138411891628" name="jetbrains.mps.lang.smodel.structure.SNodeOperation" flags="nn" index="eCIE_">
         <child id="1144104376918" name="parameter" index="1xVPHs" />
       </concept>
+      <concept id="4065387505485742666" name="jetbrains.mps.lang.smodel.structure.ModelPointer_ResolveOperation" flags="ng" index="2yCiCJ" />
+      <concept id="4065387505485742749" name="jetbrains.mps.lang.smodel.structure.AbstractPointerResolveOperation" flags="ng" index="2yCiFS">
+        <child id="3648723375513868575" name="repositoryArg" index="Vysub" />
+      </concept>
       <concept id="1143226024141" name="jetbrains.mps.lang.smodel.structure.SModelType" flags="in" index="H_c77" />
       <concept id="1145383075378" name="jetbrains.mps.lang.smodel.structure.SNodeListType" flags="in" index="2I9FWS">
         <reference id="1145383142433" name="elementConcept" index="2I9WkF" />
@@ -226,6 +238,7 @@
       <concept id="1138056143562" name="jetbrains.mps.lang.smodel.structure.SLinkAccess" flags="nn" index="3TrEf2">
         <reference id="1138056516764" name="link" index="3Tt5mk" />
       </concept>
+      <concept id="1863527487546132619" name="jetbrains.mps.lang.smodel.structure.SModelPointerType" flags="ig" index="1XwpNF" />
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
@@ -271,15 +284,42 @@
           <property role="TrG5h" value="test" />
           <node concept="3cqZAl" id="7HmzdkqVDXh" role="3clF45" />
           <node concept="3clFbS" id="7HmzdkqVDXI" role="3clF47">
-            <node concept="3cpWs8" id="7HmzdkqVXoO" role="3cqZAp">
-              <node concept="3cpWsn" id="7HmzdkqVXoR" role="3cpWs9">
-                <property role="TrG5h" value="m" />
-                <node concept="H_c77" id="7HmzdkqVXoM" role="1tU5fm" />
-                <node concept="10Nm6u" id="7HmzdkqVXAS" role="33vP2m" />
-              </node>
-            </node>
             <node concept="9aQIb" id="7HmzdkqVLMO" role="3cqZAp">
               <node concept="3clFbS" id="7HmzdkqVLMQ" role="9aQI4">
+                <node concept="3cpWs8" id="xRVdUh_i7T" role="3cqZAp">
+                  <node concept="3cpWsn" id="xRVdUh_i7U" role="3cpWs9">
+                    <property role="TrG5h" value="model" />
+                    <node concept="H_c77" id="xRVdUh_gPi" role="1tU5fm" />
+                    <node concept="2OqwBi" id="xRVdUh_pGa" role="33vP2m">
+                      <node concept="1eOMI4" id="xRVdUh_noX" role="2Oq$k0">
+                        <node concept="10QFUN" id="xRVdUh_noU" role="1eOMHV">
+                          <node concept="1XwpNF" id="xRVdUh_nZb" role="10QFUM" />
+                          <node concept="10Nm6u" id="xRVdUh_p1m" role="10QFUP" />
+                        </node>
+                        <node concept="29HgVG" id="xRVdUh_tsa" role="lGtFl">
+                          <node concept="3NFfHV" id="xRVdUh_tsb" role="3NFExx">
+                            <node concept="3clFbS" id="xRVdUh_tsc" role="2VODD2">
+                              <node concept="3clFbF" id="xRVdUh_tsi" role="3cqZAp">
+                                <node concept="2OqwBi" id="xRVdUh_tsd" role="3clFbG">
+                                  <node concept="3TrEf2" id="xRVdUh_tsg" role="2OqNvi">
+                                    <ref role="3Tt5mk" to="ls3:7HmzdkqVAll" resolve="mre" />
+                                  </node>
+                                  <node concept="30H73N" id="xRVdUh_tsh" role="2Oq$k0" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="2yCiCJ" id="xRVdUh_ql1" role="2OqNvi">
+                        <node concept="2YIFZM" id="xRVdUh_sBQ" role="Vysub">
+                          <ref role="37wK5l" to="w1kc:~MPSModuleRepository.getInstance()" resolve="getInstance" />
+                          <ref role="1Pybhc" to="w1kc:~MPSModuleRepository" resolve="MPSModuleRepository" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
                 <node concept="3cpWs8" id="7HmzdkqTYuz" role="3cqZAp">
                   <node concept="3cpWsn" id="7HmzdkqTYu$" role="3cpWs9">
                     <property role="TrG5h" value="outputPath" />
@@ -287,22 +327,8 @@
                     <node concept="2YIFZM" id="5uY69zv5Ss0" role="33vP2m">
                       <ref role="1Pybhc" to="do90:5uY69zv5FFj" resolve="PathsUtils" />
                       <ref role="37wK5l" to="do90:3hNQKr2Cac0" resolve="computePathToGeneratedDirectory" />
-                      <node concept="37vLTw" id="5uY69zv5TR9" role="37wK5m">
-                        <ref role="3cqZAo" node="7HmzdkqVXoR" resolve="m" />
-                        <node concept="29HgVG" id="5uY69zv5TRa" role="lGtFl">
-                          <node concept="3NFfHV" id="5uY69zv5TRb" role="3NFExx">
-                            <node concept="3clFbS" id="5uY69zv5TRc" role="2VODD2">
-                              <node concept="3clFbF" id="5uY69zv5TRd" role="3cqZAp">
-                                <node concept="2OqwBi" id="5uY69zv5TRe" role="3clFbG">
-                                  <node concept="3TrEf2" id="5uY69zv5TRf" role="2OqNvi">
-                                    <ref role="3Tt5mk" to="ls3:7HmzdkqVAll" resolve="mre" />
-                                  </node>
-                                  <node concept="30H73N" id="5uY69zv5TRg" role="2Oq$k0" />
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
+                      <node concept="37vLTw" id="xRVdUh_i83" role="37wK5m">
+                        <ref role="3cqZAo" node="xRVdUh_i7U" resolve="model" />
                       </node>
                     </node>
                   </node>
@@ -314,22 +340,8 @@
                       <ref role="2I9WkF" to="tpck:h0TrEE$" resolve="INamedConcept" />
                     </node>
                     <node concept="2OqwBi" id="7HmzdkqWLq9" role="33vP2m">
-                      <node concept="37vLTw" id="7HmzdkqWLqa" role="2Oq$k0">
-                        <ref role="3cqZAo" node="7HmzdkqVXoR" resolve="m" />
-                        <node concept="29HgVG" id="7HmzdkqWTmL" role="lGtFl">
-                          <node concept="3NFfHV" id="7HmzdkqWTmM" role="3NFExx">
-                            <node concept="3clFbS" id="7HmzdkqWTmN" role="2VODD2">
-                              <node concept="3clFbF" id="7HmzdkqWTmT" role="3cqZAp">
-                                <node concept="2OqwBi" id="7HmzdkqWTmO" role="3clFbG">
-                                  <node concept="3TrEf2" id="7HmzdkqWTmR" role="2OqNvi">
-                                    <ref role="3Tt5mk" to="ls3:7HmzdkqVAll" resolve="mre" />
-                                  </node>
-                                  <node concept="30H73N" id="7HmzdkqWTmS" role="2Oq$k0" />
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
+                      <node concept="37vLTw" id="xRVdUh_i84" role="2Oq$k0">
+                        <ref role="3cqZAo" node="xRVdUh_i7U" resolve="model" />
                       </node>
                       <node concept="2RRcyG" id="7HmzdkqWLqb" role="2OqNvi">
                         <ref role="2RRcyH" to="tpck:h0TrEE$" resolve="INamedConcept" />

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.nodes_tracing.test/models/structure.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.nodes_tracing.test/models/structure.mps
@@ -153,7 +153,7 @@
       <property role="20lmBu" value="fLJjDmT/aggregation" />
       <property role="20kJfa" value="mre" />
       <property role="20lbJX" value="fLJekj4/_1" />
-      <ref role="20lvS9" to="tp25:v3WHCwUiHy" resolve="ModelReferenceExpression" />
+      <ref role="20lvS9" to="tp25:1Bs_61$nfRn" resolve="ModelPointerExpression" />
     </node>
     <node concept="1TJgyj" id="7HmzdkqWuMM" role="1TKVEi">
       <property role="IQ2ns" value="8887445761570237618" />

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.spreferences.context/languageModels/actions.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.spreferences.context/languageModels/actions.mps
@@ -11,12 +11,18 @@
     <import index="tp25" ref="r:00000000-0000-4000-0000-011c89590301(jetbrains.mps.lang.smodel.structure)" />
     <import index="18ew" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.util(MPS.Core/)" />
     <import index="lko4" ref="5e845763-f4ca-40bf-b31f-74e236ffed75/r:552d1838-c20c-4ca5-87f5-7e0a99875373(com.mbeddr.mpsutil.spreferences.context/com.mbeddr.mpsutil.spreferences.context.structure)" implicit="true" />
+    <import index="dvox" ref="r:9dfd3567-3b1f-4edb-85a0-3981ca2bfd8c(jetbrains.mps.lang.modelapi.structure)" implicit="true" />
+    <import index="xlb7" ref="r:cf42fd0a-68d2-493b-8b77-961658617704(jetbrains.mps.lang.modelapi.behavior)" implicit="true" />
   </imports>
   <registry>
     <language id="13744753-c81f-424a-9c1b-cf8943bf4e86" name="jetbrains.mps.lang.sharedConcepts">
       <concept id="1161622665029" name="jetbrains.mps.lang.sharedConcepts.structure.ConceptFunctionParameter_model" flags="nn" index="1Q6Npb" />
     </language>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
+        <child id="1068498886297" name="rValue" index="37vLTx" />
+        <child id="1068498886295" name="lValue" index="37vLTJ" />
+      </concept>
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
@@ -24,15 +30,13 @@
       <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
         <child id="1137022507850" name="body" index="2VODD2" />
       </concept>
-      <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
-        <reference id="1144433194310" name="classConcept" index="1Pybhc" />
-      </concept>
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <child id="1068431790190" name="initializer" index="33vP2m" />
       </concept>
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
+      <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
       </concept>
@@ -63,15 +67,13 @@
       <concept id="5584396657084912703" name="jetbrains.mps.lang.actions.structure.NodeSetupFunction_NewNode" flags="nn" index="1r4Lsj" />
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
-      <concept id="1138661924179" name="jetbrains.mps.lang.smodel.structure.Property_SetOperation" flags="nn" index="tyxLq">
-        <child id="1138662048170" name="value" index="tz02z" />
-      </concept>
+      <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
       <concept id="1138757581985" name="jetbrains.mps.lang.smodel.structure.Link_SetNewChildOperation" flags="nn" index="zfrQC" />
+      <concept id="2644386474300074836" name="jetbrains.mps.lang.smodel.structure.ConceptIdRefExpression" flags="nn" index="35c_gC">
+        <reference id="2644386474300074837" name="conceptDeclaration" index="35c_gD" />
+      </concept>
       <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
         <reference id="1138405853777" name="concept" index="ehGHo" />
-      </concept>
-      <concept id="1138056022639" name="jetbrains.mps.lang.smodel.structure.SPropertyAccess" flags="nn" index="3TrcHB">
-        <reference id="1138056395725" name="property" index="3TsBF5" />
       </concept>
       <concept id="1138056143562" name="jetbrains.mps.lang.smodel.structure.SLinkAccess" flags="nn" index="3TrEf2">
         <reference id="1138056516764" name="link" index="3Tt5mk" />
@@ -92,7 +94,7 @@
             <node concept="3cpWsn" id="KILMQGUUr5" role="3cpWs9">
               <property role="TrG5h" value="refExpr" />
               <node concept="3Tqbb2" id="KILMQGUUqZ" role="1tU5fm">
-                <ref role="ehGHo" to="tp25:v3WHCwUiHy" resolve="ModelReferenceExpression" />
+                <ref role="ehGHo" to="tp25:1Bs_61$nfRn" resolve="ModelPointerExpression" />
               </node>
               <node concept="2OqwBi" id="KILMQGUUr6" role="33vP2m">
                 <node concept="2OqwBi" id="KILMQGUUr7" role="2Oq$k0">
@@ -105,40 +107,24 @@
               </node>
             </node>
           </node>
-          <node concept="3clFbF" id="v3WHCwUqIo" role="3cqZAp">
-            <node concept="2OqwBi" id="v3WHCwUqIv" role="3clFbG">
-              <node concept="2OqwBi" id="v3WHCwUqIq" role="2Oq$k0">
-                <node concept="37vLTw" id="KILMQGV29b" role="2Oq$k0">
+          <node concept="3clFbF" id="xRVdUhyhA$" role="3cqZAp">
+            <node concept="37vLTI" id="xRVdUhykF1" role="3clFbG">
+              <node concept="2OqwBi" id="xRVdUhyl5S" role="37vLTx">
+                <node concept="35c_gC" id="xRVdUhykJ0" role="2Oq$k0">
+                  <ref role="35c_gD" to="dvox:k2ZBl8Cedw" resolve="ModelPointer" />
+                </node>
+                <node concept="2qgKlT" id="xRVdUhylm$" role="2OqNvi">
+                  <ref role="37wK5l" to="xlb7:_GDk1qZ2JP" resolve="create" />
+                  <node concept="1Q6Npb" id="xRVdUhyltB" role="37wK5m" />
+                  <node concept="1Q6Npb" id="xRVdUhylDj" role="37wK5m" />
+                </node>
+              </node>
+              <node concept="2OqwBi" id="xRVdUhyhLe" role="37vLTJ">
+                <node concept="37vLTw" id="xRVdUhyhAy" role="2Oq$k0">
                   <ref role="3cqZAo" node="KILMQGUUr5" resolve="refExpr" />
                 </node>
-                <node concept="3TrcHB" id="v3WHCwUqIu" role="2OqNvi">
-                  <ref role="3TsBF5" to="tp25:v3WHCwUiHA" resolve="name" />
-                </node>
-              </node>
-              <node concept="tyxLq" id="v3WHCwUqIz" role="2OqNvi">
-                <node concept="2YIFZM" id="791rit5f63$" role="tz02z">
-                  <ref role="1Pybhc" to="18ew:~SNodeOperations" resolve="SNodeOperations" />
-                  <ref role="37wK5l" to="18ew:~SNodeOperations.getModelLongName(org.jetbrains.mps.openapi.model.SModel)" resolve="getModelLongName" />
-                  <node concept="1Q6Npb" id="KILMQGVaSe" role="37wK5m" />
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="3clFbF" id="v3WHCwUqIE" role="3cqZAp">
-            <node concept="2OqwBi" id="v3WHCwUqIL" role="3clFbG">
-              <node concept="2OqwBi" id="v3WHCwUqIG" role="2Oq$k0">
-                <node concept="37vLTw" id="KILMQGVi4r" role="2Oq$k0">
-                  <ref role="3cqZAo" node="KILMQGUUr5" resolve="refExpr" />
-                </node>
-                <node concept="3TrcHB" id="v3WHCwUqIK" role="2OqNvi">
-                  <ref role="3TsBF5" to="tp25:v3WHCwUjHJ" resolve="stereotype" />
-                </node>
-              </node>
-              <node concept="tyxLq" id="v3WHCwUqIP" role="2OqNvi">
-                <node concept="2YIFZM" id="791rit5f66L" role="tz02z">
-                  <ref role="37wK5l" to="w1kc:~SModelStereotype.getStereotype(org.jetbrains.mps.openapi.model.SModel)" resolve="getStereotype" />
-                  <ref role="1Pybhc" to="w1kc:~SModelStereotype" resolve="SModelStereotype" />
-                  <node concept="1Q6Npb" id="KILMQGVaUe" role="37wK5m" />
+                <node concept="3TrEf2" id="xRVdUhyhXm" role="2OqNvi">
+                  <ref role="3Tt5mk" to="tp25:1Bs_61$ngwB" resolve="modelRef" />
                 </node>
               </node>
             </node>

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.spreferences.context/languageModels/structure.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.spreferences.context/languageModels/structure.mps
@@ -41,7 +41,7 @@
       <property role="20lmBu" value="fLJjDmT/aggregation" />
       <property role="20kJfa" value="redirectToModel" />
       <property role="IQ2ns" value="877857976371881842" />
-      <ref role="20lvS9" to="tp25:v3WHCwUiHy" resolve="ModelReferenceExpression" />
+      <ref role="20lvS9" to="tp25:1Bs_61$nfRn" resolve="ModelPointerExpression" />
     </node>
   </node>
 </model>

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.spreferences/generator/template/main@generator.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.spreferences/generator/template/main@generator.mps
@@ -207,18 +207,32 @@
     <language id="d7706f63-9be2-479c-a3da-ae92af1e64d5" name="jetbrains.mps.lang.generator.generationContext">
       <concept id="1216860049635" name="jetbrains.mps.lang.generator.generationContext.structure.TemplateFunctionParameter_generationContext" flags="nn" index="1iwH7S" />
     </language>
+    <language id="446c26eb-2b7b-4bf0-9b35-f83fa582753e" name="jetbrains.mps.lang.modelapi">
+      <concept id="361130699826193249" name="jetbrains.mps.lang.modelapi.structure.ModulePointer" flags="ng" index="1dCxOk">
+        <property id="1863527487546097500" name="moduleId" index="1XweGW" />
+        <property id="1863527487545993577" name="moduleName" index="1XxBO9" />
+      </concept>
+      <concept id="361130699826193248" name="jetbrains.mps.lang.modelapi.structure.ModelPointer" flags="ng" index="1dCxOl">
+        <property id="1863527487546097494" name="modelId" index="1XweGQ" />
+        <child id="679099339649067980" name="name" index="1j$8Uc" />
+        <child id="1863527487546123100" name="moduleRef" index="1Xw7sW" />
+      </concept>
+      <concept id="679099339649053840" name="jetbrains.mps.lang.modelapi.structure.ModelName" flags="ng" index="1j_P7g">
+        <property id="679099339649053841" name="value" index="1j_P7h" />
+      </concept>
+    </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
       <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
         <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
       </concept>
       <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
+      <concept id="4065387505485742666" name="jetbrains.mps.lang.smodel.structure.ModelPointer_ResolveOperation" flags="ng" index="2yCiCJ" />
+      <concept id="4065387505485742749" name="jetbrains.mps.lang.smodel.structure.AbstractPointerResolveOperation" flags="ng" index="2yCiFS">
+        <child id="3648723375513868575" name="repositoryArg" index="Vysub" />
+      </concept>
       <concept id="2396822768958367367" name="jetbrains.mps.lang.smodel.structure.AbstractTypeCastExpression" flags="nn" index="$5XWr">
         <child id="6733348108486823193" name="leftExpression" index="1m5AlR" />
         <child id="3906496115198199033" name="conceptArgument" index="3oSUPX" />
-      </concept>
-      <concept id="559557797393017698" name="jetbrains.mps.lang.smodel.structure.ModelReferenceExpression" flags="nn" index="BaHAS">
-        <property id="559557797393021807" name="stereotype" index="BaGAP" />
-        <property id="559557797393017702" name="name" index="BaHAW" />
       </concept>
       <concept id="1143226024141" name="jetbrains.mps.lang.smodel.structure.SModelType" flags="in" index="H_c77" />
       <concept id="1145383075378" name="jetbrains.mps.lang.smodel.structure.SNodeListType" flags="in" index="2I9FWS">
@@ -255,6 +269,9 @@
       </concept>
       <concept id="1138056282393" name="jetbrains.mps.lang.smodel.structure.SLinkListAccess" flags="nn" index="3Tsc0h">
         <reference id="1138056546658" name="link" index="3TtcxE" />
+      </concept>
+      <concept id="1863527487546129879" name="jetbrains.mps.lang.smodel.structure.ModelPointerExpression" flags="ng" index="1Xw6AR">
+        <child id="1863527487546132519" name="modelRef" index="1XwpL7" />
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
@@ -750,10 +767,32 @@
                                           <node concept="37vLTw" id="1MMv7XpBrOS" role="37wK5m">
                                             <ref role="3cqZAo" node="1m7X3OECQvR" resolve="model" />
                                           </node>
-                                          <node concept="BaHAS" id="1MMv7XpBrSc" role="37wK5m">
-                                            <property role="BaHAW" value="java.util" />
-                                            <property role="BaGAP" value="java_stub" />
-                                            <node concept="29HgVG" id="1MMv7XpBu2t" role="lGtFl" />
+                                          <node concept="2OqwBi" id="xRVdUhxjk8" role="37wK5m">
+                                            <node concept="1Xw6AR" id="xRVdUhxhTu" role="2Oq$k0">
+                                              <node concept="1dCxOl" id="xRVdUhxhVJ" role="1XwpL7">
+                                                <property role="1XweGQ" value="java:java.util" />
+                                                <node concept="1j_P7g" id="xRVdUhxhVK" role="1j$8Uc">
+                                                  <property role="1j_P7h" value="java.util@java_stub" />
+                                                </node>
+                                                <node concept="1dCxOk" id="xRVdUhxhVL" role="1Xw7sW">
+                                                  <property role="1XweGW" value="6354ebe7-c22a-4a0f-ac54-50b52ab9b065" />
+                                                  <property role="1XxBO9" value="JDK" />
+                                                </node>
+                                              </node>
+                                              <node concept="29HgVG" id="xRVdUhxkgS" role="lGtFl" />
+                                            </node>
+                                            <node concept="2yCiCJ" id="xRVdUhxjqg" role="2OqNvi">
+                                              <node concept="2OqwBi" id="xRVdUhxjVe" role="Vysub">
+                                                <node concept="2JrnkZ" id="xRVdUhxjN6" role="2Oq$k0">
+                                                  <node concept="37vLTw" id="xRVdUhxjs7" role="2JrQYb">
+                                                    <ref role="3cqZAo" node="1m7X3OECQvR" resolve="model" />
+                                                  </node>
+                                                </node>
+                                                <node concept="liA8E" id="xRVdUhxk4V" role="2OqNvi">
+                                                  <ref role="37wK5l" to="mhbf:~SModel.getRepository()" resolve="getRepository" />
+                                                </node>
+                                              </node>
+                                            </node>
                                           </node>
                                         </node>
                                         <node concept="1WS0z7" id="1MMv7XpBscc" role="lGtFl">
@@ -987,7 +1026,7 @@
                                                 <ref role="3cqZAo" node="5hBYkCKoZs8" resolve="solution" />
                                               </node>
                                               <node concept="liA8E" id="3nSWiUopN79" role="2OqNvi">
-                                                <ref role="37wK5l" to="z1c3:~AbstractModule.isReadOnly()" resolve="isReadOnly" />
+                                                <ref role="37wK5l" to="z1c3:~Solution.isReadOnly()" resolve="isReadOnly" />
                                               </node>
                                             </node>
                                           </node>

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.spreferences/languageModels/structure.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.spreferences/languageModels/structure.mps
@@ -61,7 +61,7 @@
       <property role="20kJfa" value="importedModels" />
       <property role="20lbJX" value="fLJekj5/_0__n" />
       <property role="IQ2ns" value="1551477140197679196" />
-      <ref role="20lvS9" to="tp25:v3WHCwUiHy" resolve="ModelReferenceExpression" />
+      <ref role="20lvS9" to="tp25:1Bs_61$nfRn" resolve="ModelPointerExpression" />
     </node>
     <node concept="1TJgyj" id="5f$4wDDr7VZ" role="1TKVEi">
       <property role="20lmBu" value="fLJjDmT/aggregation" />

--- a/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.lantest.rt/models/com/mbeddr/mpsutil/lantest/rt/synthesis/gen.mps
+++ b/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.lantest.rt/models/com/mbeddr/mpsutil/lantest/rt/synthesis/gen.mps
@@ -61,7 +61,7 @@
     <import index="mk8z" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.progress(MPS.Core/)" />
     <import index="qhup" ref="b0f8641f-bd77-4421-8425-30d9088a82f7/java:org.apache.commons.lang3.mutable(org.apache.commons/)" />
     <import index="dush" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.persistence(MPS.OpenAPI/)" />
-    <import index="tpeu" ref="r:00000000-0000-4000-0000-011c895902fa(jetbrains.mps.lang.smodel.behavior)" implicit="true" />
+    <import index="xlb7" ref="r:cf42fd0a-68d2-493b-8b77-961658617704(jetbrains.mps.lang.modelapi.behavior)" implicit="true" />
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
@@ -280,6 +280,11 @@
       <concept id="5351203823916750322" name="jetbrains.mps.baseLanguage.structure.TryUniversalStatement" flags="nn" index="3J1_TO">
         <child id="8276990574886367510" name="catchClause" index="1zxBo5" />
         <child id="8276990574886367508" name="body" index="1zxBo7" />
+      </concept>
+      <concept id="1163668896201" name="jetbrains.mps.baseLanguage.structure.TernaryOperatorExpression" flags="nn" index="3K4zz7">
+        <child id="1163668914799" name="condition" index="3K4Cdx" />
+        <child id="1163668922816" name="ifTrue" index="3K4E3e" />
+        <child id="1163668934364" name="ifFalse" index="3K4GZi" />
       </concept>
       <concept id="5497648299878491908" name="jetbrains.mps.baseLanguage.structure.BaseVariableReference" flags="nn" index="1M0zk4">
         <reference id="5497648299878491909" name="baseVariableDeclaration" index="1M0zk5" />
@@ -9408,15 +9413,61 @@
       <property role="DiZV1" value="false" />
       <property role="2aFKle" value="false" />
       <node concept="3clFbS" id="24J8fn3VMYJ" role="3clF47">
-        <node concept="3cpWs6" id="24J8fn3VO7h" role="3cqZAp">
-          <node concept="1rXfSq" id="24J8fn3VO8V" role="3cqZAk">
-            <ref role="37wK5l" node="24J8fn3VuqG" resolve="getModelByName" />
-            <node concept="2OqwBi" id="24J8fn3VOiv" role="37wK5m">
-              <node concept="37vLTw" id="24J8fn3VOad" role="2Oq$k0">
-                <ref role="3cqZAo" node="24J8fn3VMZc" resolve="mre" />
+        <node concept="3cpWs8" id="6M7zmThqH_d" role="3cqZAp">
+          <node concept="3cpWsn" id="6M7zmThqH_e" role="3cpWs9">
+            <property role="TrG5h" value="repository" />
+            <node concept="3uibUv" id="6M7zmThqH$K" role="1tU5fm">
+              <ref role="3uigEE" to="lui2:~SRepository" resolve="SRepository" />
+            </node>
+            <node concept="3K4zz7" id="6M7zmThqI$H" role="33vP2m">
+              <node concept="2YIFZM" id="6M7zmThqILb" role="3K4GZi">
+                <ref role="37wK5l" to="w1kc:~MPSModuleRepository.getInstance()" resolve="getInstance" />
+                <ref role="1Pybhc" to="w1kc:~MPSModuleRepository" resolve="MPSModuleRepository" />
               </node>
-              <node concept="2qgKlT" id="24J8fn3VOs9" role="2OqNvi">
-                <ref role="37wK5l" to="tpeu:7K4mn_BeEzv" resolve="getFQName" />
+              <node concept="3y3z36" id="6M7zmThqIpp" role="3K4Cdx">
+                <node concept="10Nm6u" id="6M7zmThqIzd" role="3uHU7w" />
+                <node concept="2OqwBi" id="6M7zmThqI2s" role="3uHU7B">
+                  <node concept="37vLTw" id="6M7zmThqHSS" role="2Oq$k0">
+                    <ref role="3cqZAo" node="24J8fn3VMZc" resolve="mre" />
+                  </node>
+                  <node concept="I4A8Y" id="6M7zmThqIjF" role="2OqNvi" />
+                </node>
+              </node>
+              <node concept="2OqwBi" id="6M7zmThqH_f" role="3K4E3e">
+                <node concept="2JrnkZ" id="6M7zmThqH_g" role="2Oq$k0">
+                  <node concept="2OqwBi" id="6M7zmThqH_h" role="2JrQYb">
+                    <node concept="37vLTw" id="6M7zmThqH_i" role="2Oq$k0">
+                      <ref role="3cqZAo" node="24J8fn3VMZc" resolve="mre" />
+                    </node>
+                    <node concept="I4A8Y" id="6M7zmThqH_j" role="2OqNvi" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="6M7zmThqH_k" role="2OqNvi">
+                  <ref role="37wK5l" to="mhbf:~SModel.getRepository()" resolve="getRepository" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="6M7zmThqIWF" role="3cqZAp">
+          <node concept="2OqwBi" id="6M7zmThqIWH" role="3cqZAk">
+            <node concept="2OqwBi" id="6M7zmThqIWI" role="2Oq$k0">
+              <node concept="2OqwBi" id="6M7zmThqIWJ" role="2Oq$k0">
+                <node concept="37vLTw" id="6M7zmThqIWK" role="2Oq$k0">
+                  <ref role="3cqZAo" node="24J8fn3VMZc" resolve="mre" />
+                </node>
+                <node concept="3TrEf2" id="6M7zmThqIWL" role="2OqNvi">
+                  <ref role="3Tt5mk" to="tp25:1Bs_61$ngwB" resolve="modelRef" />
+                </node>
+              </node>
+              <node concept="2qgKlT" id="6M7zmThqIWM" role="2OqNvi">
+                <ref role="37wK5l" to="xlb7:1Bs_61$mvvu" resolve="toModelReference" />
+              </node>
+            </node>
+            <node concept="liA8E" id="6M7zmThqIWN" role="2OqNvi">
+              <ref role="37wK5l" to="mhbf:~SModelReference.resolve(org.jetbrains.mps.openapi.module.SRepository)" resolve="resolve" />
+              <node concept="37vLTw" id="6M7zmThqIWO" role="37wK5m">
+                <ref role="3cqZAo" node="6M7zmThqH_e" resolve="repository" />
               </node>
             </node>
           </node>
@@ -9427,113 +9478,10 @@
       <node concept="37vLTG" id="24J8fn3VMZc" role="3clF46">
         <property role="TrG5h" value="mre" />
         <node concept="3Tqbb2" id="24J8fn3VNnc" role="1tU5fm">
-          <ref role="ehGHo" to="tp25:v3WHCwUiHy" resolve="ModelReferenceExpression" />
+          <ref role="ehGHo" to="tp25:1Bs_61$nfRn" resolve="ModelPointerExpression" />
         </node>
       </node>
     </node>
-    <node concept="2tJIrI" id="24J8fn3VMX0" role="jymVt" />
-    <node concept="Wx3nA" id="24J8fn3Vuqz" role="jymVt">
-      <property role="2dlcS1" value="false" />
-      <property role="2dld4O" value="false" />
-      <property role="TrG5h" value="name2Model" />
-      <property role="3TUv4t" value="false" />
-      <node concept="3Tm6S6" id="24J8fn3Vuq$" role="1B3o_S" />
-      <node concept="3rvAFt" id="24J8fn3Vuq_" role="1tU5fm">
-        <node concept="17QB3L" id="24J8fn3VuLT" role="3rvQeY" />
-        <node concept="H_c77" id="24J8fn3VuZs" role="3rvSg0" />
-      </node>
-      <node concept="2ShNRf" id="24J8fn3VuqC" role="33vP2m">
-        <node concept="3rGOSV" id="24J8fn3VuqD" role="2ShVmc">
-          <node concept="17QB3L" id="24J8fn3V$70" role="3rHrn6" />
-          <node concept="H_c77" id="24J8fn3V$Kn" role="3rHtpV" />
-        </node>
-      </node>
-    </node>
-    <node concept="2YIFZL" id="24J8fn3VuqG" role="jymVt">
-      <property role="TrG5h" value="getModelByName" />
-      <property role="od$2w" value="false" />
-      <property role="DiZV1" value="false" />
-      <property role="2aFKle" value="false" />
-      <node concept="3clFbS" id="24J8fn3VuqH" role="3clF47">
-        <node concept="3clFbJ" id="24J8fn3VuqI" role="3cqZAp">
-          <node concept="3clFbS" id="24J8fn3VuqJ" role="3clFbx">
-            <node concept="3cpWs6" id="24J8fn3VuqK" role="3cqZAp">
-              <node concept="3EllGN" id="24J8fn3VuqL" role="3cqZAk">
-                <node concept="37vLTw" id="24J8fn3VuqM" role="3ElVtu">
-                  <ref role="3cqZAo" node="24J8fn3Vur9" resolve="fullyQualifiedName" />
-                </node>
-                <node concept="37vLTw" id="24J8fn3Vure" role="3ElQJh">
-                  <ref role="3cqZAo" node="24J8fn3Vuqz" resolve="name2Model" />
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="3y3z36" id="24J8fn3VGZZ" role="3clFbw">
-            <node concept="10Nm6u" id="24J8fn3VHBA" role="3uHU7w" />
-            <node concept="3EllGN" id="24J8fn3VuqO" role="3uHU7B">
-              <node concept="37vLTw" id="24J8fn3VuqP" role="3ElVtu">
-                <ref role="3cqZAo" node="24J8fn3Vur9" resolve="fullyQualifiedName" />
-              </node>
-              <node concept="37vLTw" id="24J8fn3Vurj" role="3ElQJh">
-                <ref role="3cqZAo" node="24J8fn3Vuqz" resolve="name2Model" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3cpWs8" id="24J8fn3VIG5" role="3cqZAp">
-          <node concept="3cpWsn" id="24J8fn3VIG8" role="3cpWs9">
-            <property role="TrG5h" value="res" />
-            <node concept="H_c77" id="24J8fn3VIG3" role="1tU5fm" />
-            <node concept="2OqwBi" id="3YjQI$iK27E" role="33vP2m">
-              <node concept="2OqwBi" id="3YjQI$iK8NT" role="2Oq$k0">
-                <node concept="2YIFZM" id="3YjQI$iK8NU" role="2Oq$k0">
-                  <ref role="37wK5l" to="dush:~PersistenceFacade.getInstance()" resolve="getInstance" />
-                  <ref role="1Pybhc" to="dush:~PersistenceFacade" resolve="PersistenceFacade" />
-                </node>
-                <node concept="liA8E" id="3YjQI$iK8NV" role="2OqNvi">
-                  <ref role="37wK5l" to="dush:~PersistenceFacade.createModelReference(java.lang.String)" resolve="createModelReference" />
-                  <node concept="37vLTw" id="3YjQI$iZL_8" role="37wK5m">
-                    <ref role="3cqZAo" node="24J8fn3Vur9" resolve="fullyQualifiedName" />
-                  </node>
-                </node>
-              </node>
-              <node concept="liA8E" id="3YjQI$iK27G" role="2OqNvi">
-                <ref role="37wK5l" to="mhbf:~SModelReference.resolve(org.jetbrains.mps.openapi.module.SRepository)" resolve="resolve" />
-                <node concept="10Nm6u" id="3YjQI$iK27H" role="37wK5m" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="24J8fn3Vur0" role="3cqZAp">
-          <node concept="37vLTI" id="24J8fn3Vur1" role="3clFbG">
-            <node concept="37vLTw" id="24J8fn3VLeG" role="37vLTx">
-              <ref role="3cqZAo" node="24J8fn3VIG8" resolve="res" />
-            </node>
-            <node concept="3EllGN" id="24J8fn3Vur3" role="37vLTJ">
-              <node concept="37vLTw" id="24J8fn3Vur4" role="3ElVtu">
-                <ref role="3cqZAo" node="24J8fn3Vur9" resolve="fullyQualifiedName" />
-              </node>
-              <node concept="37vLTw" id="24J8fn3Vuro" role="3ElQJh">
-                <ref role="3cqZAo" node="24J8fn3Vuqz" resolve="name2Model" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="24J8fn3Vur5" role="3cqZAp">
-          <node concept="37vLTw" id="24J8fn3VL4O" role="3clFbG">
-            <ref role="3cqZAo" node="24J8fn3VIG8" resolve="res" />
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm6S6" id="24J8fn3Vur7" role="1B3o_S" />
-      <node concept="H_c77" id="24J8fn3V_n$" role="3clF45" />
-      <node concept="37vLTG" id="24J8fn3Vur9" role="3clF46">
-        <property role="TrG5h" value="fullyQualifiedName" />
-        <node concept="17QB3L" id="24J8fn3VD6U" role="1tU5fm" />
-      </node>
-    </node>
-    <node concept="2tJIrI" id="24J8fn3Vueq" role="jymVt" />
-    <node concept="2tJIrI" id="24J8fn3Vuev" role="jymVt" />
   </node>
 </model>
 

--- a/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.lantest.sandbox/models/com.mbeddr.mpsutil.lantest.baseLanguage.sandbox.harness.mps
+++ b/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.lantest.sandbox/models/com.mbeddr.mpsutil.lantest.baseLanguage.sandbox.harness.mps
@@ -74,6 +74,15 @@
         <child id="4493491910455121568" name="modelWithBuggyRoots" index="3XAc6P" />
       </concept>
     </language>
+    <language id="446c26eb-2b7b-4bf0-9b35-f83fa582753e" name="jetbrains.mps.lang.modelapi">
+      <concept id="361130699826193248" name="jetbrains.mps.lang.modelapi.structure.ModelPointer" flags="ng" index="1dCxOl">
+        <property id="1863527487546097494" name="modelId" index="1XweGQ" />
+        <child id="679099339649067980" name="name" index="1j$8Uc" />
+      </concept>
+      <concept id="679099339649053840" name="jetbrains.mps.lang.modelapi.structure.ModelName" flags="ng" index="1j_P7g">
+        <property id="679099339649053841" name="value" index="1j_P7h" />
+      </concept>
+    </language>
     <language id="5ef691b5-60ce-4ece-a04e-25e642dfa128" name="com.mbeddr.mpsutil.lantest">
       <concept id="3465332537548487647" name="com.mbeddr.mpsutil.lantest.structure.RandomConceptChooser" flags="ng" index="1emTa" />
       <concept id="5961733595646916849" name="com.mbeddr.mpsutil.lantest.structure.InterestingLanguages" flags="ng" index="cHURJ">
@@ -106,9 +115,8 @@
       <concept id="3262406899569270472" name="com.mbeddr.mpsutil.lantest.structure.RandomDescendantSeed" flags="ng" index="1$QBG2" />
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
-      <concept id="559557797393017698" name="jetbrains.mps.lang.smodel.structure.ModelReferenceExpression" flags="nn" index="BaHAS">
-        <property id="559557797393021807" name="stereotype" index="BaGAP" />
-        <property id="559557797393017702" name="name" index="BaHAW" />
+      <concept id="1863527487546129879" name="jetbrains.mps.lang.smodel.structure.ModelPointerExpression" flags="ng" index="1Xw6AR">
+        <child id="1863527487546132519" name="modelRef" index="1XwpL7" />
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
@@ -127,33 +135,57 @@
     <property role="3zPyIU" value="true" />
     <property role="3zPyLd" value="true" />
     <property role="2$dOGW" value="d:\temp\lantest_log\" />
-    <node concept="BaHAS" id="6fGXG$6dmgV" role="1saM0L">
-      <property role="BaHAW" value="com.mbeddr.mpsutil.lantest.baseLanguage.sandbox.res" />
-      <property role="BaGAP" value="" />
+    <node concept="1Xw6AR" id="6M7zmThr149" role="1saM0L">
+      <node concept="1dCxOl" id="6M7zmThr14h" role="1XwpL7">
+        <property role="1XweGQ" value="r:2dc08e6d-1990-47d1-bd77-9d77426649a3" />
+        <node concept="1j_P7g" id="6M7zmThr14i" role="1j$8Uc">
+          <property role="1j_P7h" value="com.mbeddr.mpsutil.lantest.baseLanguage.sandbox.res" />
+        </node>
+      </node>
     </node>
     <node concept="1emTa" id="6fGXG$6dmjf" role="1emjp" />
-    <node concept="BaHAS" id="6fGXG$6dmgZ" role="1llUH_">
-      <property role="BaHAW" value="com.mbeddr.mpsutil.lantest.baseLanguage.sandbox.temp" />
-      <property role="BaGAP" value="" />
+    <node concept="1Xw6AR" id="6M7zmThr14o" role="1llUH_">
+      <node concept="1dCxOl" id="6M7zmThr14t" role="1XwpL7">
+        <property role="1XweGQ" value="r:1c11b1c8-3655-40e2-aae5-12841140b9e2" />
+        <node concept="1j_P7g" id="6M7zmThr14u" role="1j$8Uc">
+          <property role="1j_P7h" value="com.mbeddr.mpsutil.lantest.baseLanguage.sandbox.temp" />
+        </node>
+      </node>
     </node>
     <node concept="1$QBG2" id="3cUcim$dilZ" role="1$QBHO" />
     <node concept="3XUKX$" id="3Ts5Ln3IakA" role="3CPbyU">
-      <node concept="BaHAS" id="3Ts5Ln3Mpq4" role="3XAc6P">
-        <property role="BaHAW" value="com.mbeddr.mpsutil.lantest.baseLanguage.sandbox.buggy_classes" />
-        <property role="BaGAP" value="" />
+      <node concept="1Xw6AR" id="6M7zmThr14$" role="3XAc6P">
+        <node concept="1dCxOl" id="6M7zmThr14G" role="1XwpL7">
+          <property role="1XweGQ" value="r:407675bb-7c3b-49b9-8926-fa5faf7c2b42" />
+          <node concept="1j_P7g" id="6M7zmThr14H" role="1j$8Uc">
+            <property role="1j_P7h" value="com.mbeddr.mpsutil.lantest.baseLanguage.sandbox.buggy_classes" />
+          </node>
+        </node>
       </node>
-      <node concept="BaHAS" id="3Ts5Ln3Mpqj" role="3XAc6O">
-        <property role="BaHAW" value="com.mbeddr.mpsutil.lantest.baseLanguage.sandbox.harness" />
-        <property role="BaGAP" value="" />
+      <node concept="1Xw6AR" id="6M7zmThr14N" role="3XAc6O">
+        <node concept="1dCxOl" id="6M7zmThr14V" role="1XwpL7">
+          <property role="1XweGQ" value="r:2d2645ad-14bb-4c7e-b57f-e39dbec743b7" />
+          <node concept="1j_P7g" id="6M7zmThr14W" role="1j$8Uc">
+            <property role="1j_P7h" value="com.mbeddr.mpsutil.lantest.baseLanguage.sandbox.harness" />
+          </node>
+        </node>
       </node>
-      <node concept="BaHAS" id="3Ts5Ln3NpTN" role="3X$cyU">
-        <property role="BaHAW" value="com.mbeddr.mpsutil.lantest.baseLanguage.sandbox.temp" />
-        <property role="BaGAP" value="" />
+      <node concept="1Xw6AR" id="6M7zmThr152" role="3X$cyU">
+        <node concept="1dCxOl" id="6M7zmThr15a" role="1XwpL7">
+          <property role="1XweGQ" value="r:1c11b1c8-3655-40e2-aae5-12841140b9e2" />
+          <node concept="1j_P7g" id="6M7zmThr15b" role="1j$8Uc">
+            <property role="1j_P7h" value="com.mbeddr.mpsutil.lantest.baseLanguage.sandbox.temp" />
+          </node>
+        </node>
       </node>
     </node>
-    <node concept="BaHAS" id="5upaw7gLyQU" role="1zXyiG">
-      <property role="BaHAW" value="com.mbeddr.mpsutil.lantest.baseLanguage.sandbox.buggy_classes" />
-      <property role="BaGAP" value="" />
+    <node concept="1Xw6AR" id="6M7zmThr15h" role="1zXyiG">
+      <node concept="1dCxOl" id="6M7zmThr15m" role="1XwpL7">
+        <property role="1XweGQ" value="r:407675bb-7c3b-49b9-8926-fa5faf7c2b42" />
+        <node concept="1j_P7g" id="6M7zmThr15n" role="1j$8Uc">
+          <property role="1j_P7h" value="com.mbeddr.mpsutil.lantest.baseLanguage.sandbox.buggy_classes" />
+        </node>
+      </node>
     </node>
     <node concept="fhwn3" id="4saLLt23Vzi" role="fhwmk">
       <ref role="fhwn$" node="3Ts5Ln3HLtD" resolve="Seed" />

--- a/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.lantest.sandbox/models/com.mbeddr.mpsutil.lantest.demolang.sandbox.harness.mps
+++ b/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.lantest.sandbox/models/com.mbeddr.mpsutil.lantest.demolang.sandbox.harness.mps
@@ -56,10 +56,6 @@
       </concept>
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
-      <concept id="559557797393017698" name="jetbrains.mps.lang.smodel.structure.ModelReferenceExpression" flags="nn" index="BaHAS">
-        <property id="559557797393021807" name="stereotype" index="BaGAP" />
-        <property id="559557797393017702" name="name" index="BaHAW" />
-      </concept>
       <concept id="1863527487546129879" name="jetbrains.mps.lang.smodel.structure.ModelPointerExpression" flags="ng" index="1Xw6AR">
         <child id="1863527487546132519" name="modelRef" index="1XwpL7" />
       </concept>
@@ -85,17 +81,29 @@
     </node>
     <node concept="1$QBG2" id="7CYS5pZsXEB" role="1$QBHO" />
     <node concept="1emTa" id="7CYS5pZsYt5" role="1emjp" />
-    <node concept="BaHAS" id="7CYS5pZsWPk" role="1saM0L">
-      <property role="BaHAW" value="com.mbeddr.mpsutil.lantest.demolang.sandbox.res" />
-      <property role="BaGAP" value="" />
+    <node concept="1Xw6AR" id="6M7zmThr1u$" role="1saM0L">
+      <node concept="1dCxOl" id="6M7zmThr1uG" role="1XwpL7">
+        <property role="1XweGQ" value="r:2ae91a41-9e8b-4c07-bcef-aff998edf1cd" />
+        <node concept="1j_P7g" id="6M7zmThr1uH" role="1j$8Uc">
+          <property role="1j_P7h" value="com.mbeddr.mpsutil.lantest.demolang.sandbox.res" />
+        </node>
+      </node>
     </node>
-    <node concept="BaHAS" id="7CYS5pZsWPl" role="1llUH_">
-      <property role="BaHAW" value="com.mbeddr.mpsutil.lantest.demolang.sandbox.temp" />
-      <property role="BaGAP" value="" />
+    <node concept="1Xw6AR" id="6M7zmThr1uN" role="1llUH_">
+      <node concept="1dCxOl" id="6M7zmThr1uV" role="1XwpL7">
+        <property role="1XweGQ" value="r:19a0125d-be57-4439-b7aa-7d8753335411" />
+        <node concept="1j_P7g" id="6M7zmThr1uW" role="1j$8Uc">
+          <property role="1j_P7h" value="com.mbeddr.mpsutil.lantest.demolang.sandbox.temp" />
+        </node>
+      </node>
     </node>
-    <node concept="BaHAS" id="7CYS5pZsWPm" role="1zXyiG">
-      <property role="BaHAW" value="com.mbeddr.mpsutil.lantest.demolang.sandbox.found_bugs" />
-      <property role="BaGAP" value="" />
+    <node concept="1Xw6AR" id="6M7zmThr1v2" role="1zXyiG">
+      <node concept="1dCxOl" id="6M7zmThr1v7" role="1XwpL7">
+        <property role="1XweGQ" value="r:1ec02bfe-761a-48d2-942b-2902aafbd332" />
+        <node concept="1j_P7g" id="6M7zmThr1v8" role="1j$8Uc">
+          <property role="1j_P7h" value="com.mbeddr.mpsutil.lantest.demolang.sandbox.found_bugs" />
+        </node>
+      </node>
     </node>
     <node concept="fhwn3" id="7CYS5pZsYta" role="fhwmk">
       <ref role="fhwn$" node="6IRBYJf1hNt" resolve="Starting_family" />

--- a/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.spreferences.demoplugin/models/com/mbeddr/mpsutil/spreferences/demoplugin/plugin.mps
+++ b/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.spreferences.demoplugin/models/com/mbeddr/mpsutil/spreferences/demoplugin/plugin.mps
@@ -42,17 +42,30 @@
         <property id="1068580123138" name="value" index="3clFbU" />
       </concept>
     </language>
-    <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
-      <concept id="559557797393017698" name="jetbrains.mps.lang.smodel.structure.ModelReferenceExpression" flags="nn" index="BaHAS">
-        <property id="559557797393021807" name="stereotype" index="BaGAP" />
-        <property id="559557797393017702" name="name" index="BaHAW" />
+    <language id="446c26eb-2b7b-4bf0-9b35-f83fa582753e" name="jetbrains.mps.lang.modelapi">
+      <concept id="361130699826193249" name="jetbrains.mps.lang.modelapi.structure.ModulePointer" flags="ng" index="1dCxOk">
+        <property id="1863527487546097500" name="moduleId" index="1XweGW" />
+        <property id="1863527487545993577" name="moduleName" index="1XxBO9" />
       </concept>
+      <concept id="361130699826193248" name="jetbrains.mps.lang.modelapi.structure.ModelPointer" flags="ng" index="1dCxOl">
+        <property id="1863527487546097494" name="modelId" index="1XweGQ" />
+        <child id="679099339649067980" name="name" index="1j$8Uc" />
+        <child id="1863527487546123100" name="moduleRef" index="1Xw7sW" />
+      </concept>
+      <concept id="679099339649053840" name="jetbrains.mps.lang.modelapi.structure.ModelName" flags="ng" index="1j_P7g">
+        <property id="679099339649053841" name="value" index="1j_P7h" />
+      </concept>
+    </language>
+    <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
       <concept id="4040588429969021681" name="jetbrains.mps.lang.smodel.structure.ModuleReferenceExpression" flags="nn" index="3rM5sP">
         <property id="4040588429969021683" name="moduleId" index="3rM5sR" />
       </concept>
       <concept id="4040588429969069898" name="jetbrains.mps.lang.smodel.structure.LanguageReferenceExpression" flags="nn" index="3rNLEe" />
       <concept id="1138056022639" name="jetbrains.mps.lang.smodel.structure.SPropertyAccess" flags="nn" index="3TrcHB">
         <reference id="1138056395725" name="property" index="3TsBF5" />
+      </concept>
+      <concept id="1863527487546129879" name="jetbrains.mps.lang.smodel.structure.ModelPointerExpression" flags="ng" index="1Xw6AR">
+        <child id="1863527487546132519" name="modelRef" index="1XwpL7" />
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
@@ -85,9 +98,17 @@
     <property role="1O$AU$" value="false" />
     <ref role="30zxtE" to="tpee:fz12cDA" resolve="ClassConcept" />
     <node concept="Z6TxH" id="1MMv7Xp$GfP" role="Z6TxG">
-      <node concept="BaHAS" id="1MMv7XpB8X_" role="Z6dhx">
-        <property role="BaHAW" value="java.util" />
-        <property role="BaGAP" value="java_stub" />
+      <node concept="1Xw6AR" id="xRVdUhxtcF" role="Z6dhx">
+        <node concept="1dCxOl" id="xRVdUhxtcN" role="1XwpL7">
+          <property role="1XweGQ" value="java:java.util" />
+          <node concept="1j_P7g" id="xRVdUhxtcO" role="1j$8Uc">
+            <property role="1j_P7h" value="java.util@java_stub" />
+          </node>
+          <node concept="1dCxOk" id="xRVdUhxtcP" role="1Xw7sW">
+            <property role="1XweGW" value="6354ebe7-c22a-4a0f-ac54-50b52ab9b065" />
+            <property role="1XxBO9" value="JDK" />
+          </node>
+        </node>
       </node>
       <node concept="3rNLEe" id="1MMv7Xp_aPu" role="Z6dgs">
         <property role="3rM5sR" value="f3061a53-9226-4cc5-a443-f952ceaf5816" />

--- a/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.spreferences.runtime/models/com/mbeddr/mpsutil/spreferences/runtime.mps
+++ b/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.spreferences.runtime/models/com/mbeddr/mpsutil/spreferences/runtime.mps
@@ -63,6 +63,8 @@
     <import index="6f4m" ref="528ff3b9-5fc4-40dd-931f-c6ce3650640e/r:f69c3fa1-0e30-4980-84e2-190ae44e4c3d(jetbrains.mps.lang.migration.runtime/jetbrains.mps.lang.migration.runtime.base)" />
     <import index="1m72" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.components(MPS.IDEA/)" />
     <import index="4o98" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.core.platform(MPS.Core/)" />
+    <import index="tp25" ref="r:00000000-0000-4000-0000-011c89590301(jetbrains.mps.lang.smodel.structure)" implicit="true" />
+    <import index="xlb7" ref="r:cf42fd0a-68d2-493b-8b77-961658617704(jetbrains.mps.lang.modelapi.behavior)" implicit="true" />
   </imports>
   <registry>
     <language id="a247e09e-2435-45ba-b8d2-07e93feba96a" name="jetbrains.mps.baseLanguage.tuples">
@@ -2745,51 +2747,38 @@
           <node concept="3clFbS" id="KILMQGVVB4" role="2LFqv$">
             <node concept="3clFbJ" id="KILMQGWMP1" role="3cqZAp">
               <node concept="3clFbS" id="KILMQGWMP2" role="3clFbx">
-                <node concept="3cpWs8" id="KILMQGWOy9" role="3cqZAp">
-                  <node concept="3cpWsn" id="KILMQGWOyc" role="3cpWs9">
-                    <property role="TrG5h" value="modelName" />
-                    <node concept="17QB3L" id="KILMQGWOy7" role="1tU5fm" />
-                    <node concept="2OqwBi" id="KILMQH0h8k" role="33vP2m">
-                      <node concept="2OqwBi" id="KILMQH0fwf" role="2Oq$k0">
-                        <node concept="2GrUjf" id="KILMQH0fjz" role="2Oq$k0">
-                          <ref role="2Gs0qQ" node="KILMQGVVB2" resolve="rootNode" />
-                        </node>
-                        <node concept="3TrEf2" id="KILMQH0gwR" role="2OqNvi">
-                          <ref role="3Tt5mk" to="lko4:KILMQGSUtM" resolve="redirectToModel" />
-                        </node>
-                      </node>
-                      <node concept="2qgKlT" id="KILMQH0n3o" role="2OqNvi">
-                        <ref role="37wK5l" to="tpeu:7K4mn_BeEzv" resolve="getFQName" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
                 <node concept="3cpWs8" id="KILMQH0CD0" role="3cqZAp">
                   <node concept="3cpWsn" id="KILMQH0CD1" role="3cpWs9">
                     <property role="TrG5h" value="redirect" />
                     <node concept="3uibUv" id="KILMQH0CCD" role="1tU5fm">
                       <ref role="3uigEE" to="mhbf:~SModel" resolve="SModel" />
                     </node>
-                    <node concept="2OqwBi" id="3YjQI$iK27E" role="33vP2m">
-                      <node concept="2OqwBi" id="3YjQI$iK8NT" role="2Oq$k0">
-                        <node concept="2YIFZM" id="3YjQI$iK8NU" role="2Oq$k0">
-                          <ref role="1Pybhc" to="dush:~PersistenceFacade" resolve="PersistenceFacade" />
-                          <ref role="37wK5l" to="dush:~PersistenceFacade.getInstance()" resolve="getInstance" />
-                        </node>
-                        <node concept="liA8E" id="3YjQI$iK8NV" role="2OqNvi">
-                          <ref role="37wK5l" to="dush:~PersistenceFacade.createModelReference(java.lang.String)" resolve="createModelReference" />
-                          <node concept="37vLTw" id="3YjQI$j26dg" role="37wK5m">
-                            <ref role="3cqZAo" node="KILMQGWOyc" resolve="modelName" />
+                    <node concept="2OqwBi" id="xRVdUhyeS7" role="33vP2m">
+                      <node concept="2OqwBi" id="xRVdUhyeS8" role="2Oq$k0">
+                        <node concept="2OqwBi" id="xRVdUhyeS9" role="2Oq$k0">
+                          <node concept="2OqwBi" id="xRVdUhyeSa" role="2Oq$k0">
+                            <node concept="2GrUjf" id="xRVdUhyeSb" role="2Oq$k0">
+                              <ref role="2Gs0qQ" node="KILMQGVVB2" resolve="rootNode" />
+                            </node>
+                            <node concept="3TrEf2" id="xRVdUhyeSc" role="2OqNvi">
+                              <ref role="3Tt5mk" to="lko4:KILMQGSUtM" resolve="redirectToModel" />
+                            </node>
                           </node>
+                          <node concept="3TrEf2" id="xRVdUhyeSd" role="2OqNvi">
+                            <ref role="3Tt5mk" to="tp25:1Bs_61$ngwB" resolve="modelRef" />
+                          </node>
+                        </node>
+                        <node concept="2qgKlT" id="xRVdUhyeSe" role="2OqNvi">
+                          <ref role="37wK5l" to="xlb7:1Bs_61$mvvu" resolve="toModelReference" />
                         </node>
                       </node>
-                      <node concept="liA8E" id="3YjQI$iK27G" role="2OqNvi">
+                      <node concept="liA8E" id="xRVdUhyeSf" role="2OqNvi">
                         <ref role="37wK5l" to="mhbf:~SModelReference.resolve(org.jetbrains.mps.openapi.module.SRepository)" resolve="resolve" />
-                        <node concept="2OqwBi" id="3YjQI$j2fkc" role="37wK5m">
-                          <node concept="37vLTw" id="3YjQI$j27G2" role="2Oq$k0">
+                        <node concept="2OqwBi" id="xRVdUhyeSg" role="37wK5m">
+                          <node concept="37vLTw" id="xRVdUhyeSh" role="2Oq$k0">
                             <ref role="3cqZAo" node="KILMQGVMR4" resolve="model" />
                           </node>
-                          <node concept="liA8E" id="3YjQI$j2gTo" role="2OqNvi">
+                          <node concept="liA8E" id="xRVdUhyeSi" role="2OqNvi">
                             <ref role="37wK5l" to="mhbf:~SModel.getRepository()" resolve="getRepository" />
                           </node>
                         </node>

--- a/code/languages/com.mbeddr.mpsutil/tests/test.com.mbeddr.mpsutil.ecore.modelImportExport/models/test/com/mbeddr/mpsutil/ecore/modelImportExport@tests.mps
+++ b/code/languages/com.mbeddr.mpsutil/tests/test.com.mbeddr.mpsutil.ecore.modelImportExport/models/test/com/mbeddr/mpsutil/ecore/modelImportExport@tests.mps
@@ -37,6 +37,15 @@
       </concept>
       <concept id="6156524541423588207" name="com.mbeddr.mpsutil.filepicker.structure.SolutionRelativeFilePicker" flags="ng" index="3NXOOs" />
     </language>
+    <language id="446c26eb-2b7b-4bf0-9b35-f83fa582753e" name="jetbrains.mps.lang.modelapi">
+      <concept id="361130699826193248" name="jetbrains.mps.lang.modelapi.structure.ModelPointer" flags="ng" index="1dCxOl">
+        <property id="1863527487546097494" name="modelId" index="1XweGQ" />
+        <child id="679099339649067980" name="name" index="1j$8Uc" />
+      </concept>
+      <concept id="679099339649053840" name="jetbrains.mps.lang.modelapi.structure.ModelName" flags="ng" index="1j_P7g">
+        <property id="679099339649053841" name="value" index="1j_P7h" />
+      </concept>
+    </language>
     <language id="d08b2078-ada5-40fa-a3c5-d721088dc626" name="com.mbeddr.mpsutil.ecore.testing">
       <concept id="5528787623165930366" name="com.mbeddr.mpsutil.ecore.testing.structure.AssertInstanceImportExportStatement" flags="ng" index="2xQTxM">
         <child id="5528787623165930367" name="pathToEcoreFile" index="2xQTxN" />
@@ -45,9 +54,8 @@
       </concept>
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
-      <concept id="559557797393017698" name="jetbrains.mps.lang.smodel.structure.ModelReferenceExpression" flags="nn" index="BaHAS">
-        <property id="559557797393021807" name="stereotype" index="BaGAP" />
-        <property id="559557797393017702" name="name" index="BaHAW" />
+      <concept id="1863527487546129879" name="jetbrains.mps.lang.smodel.structure.ModelPointerExpression" flags="ng" index="1Xw6AR">
+        <child id="1863527487546132519" name="modelRef" index="1XwpL7" />
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
@@ -68,13 +76,21 @@
             <property role="3kgbRO" value="false" />
             <property role="3N1Lgt" value="EMF_Meta_Models/modelImporterExporterTest1.ecore" />
           </node>
-          <node concept="BaHAS" id="4MUcKNHp2Nk" role="2xQTyc">
-            <property role="BaHAW" value="test.com.mbeddr.mpsutil.ecoretransformation.modelImportExport.testLanguage1.structure" />
-            <property role="BaGAP" value="" />
+          <node concept="1Xw6AR" id="6M7zmThrmSL" role="2xQTyc">
+            <node concept="1dCxOl" id="6M7zmThrmSY" role="1XwpL7">
+              <property role="1XweGQ" value="r:a2ab0e11-c0a6-46d5-8588-aaa50ac954c5" />
+              <node concept="1j_P7g" id="6M7zmThrmSZ" role="1j$8Uc">
+                <property role="1j_P7h" value="test.com.mbeddr.mpsutil.ecoretransformation.modelImportExport.testLanguage1.structure" />
+              </node>
+            </node>
           </node>
-          <node concept="BaHAS" id="4MUcKNHp2Nm" role="2xQTy9">
-            <property role="BaHAW" value="test.com.mbeddr.mpsutil.ecore.modelImportExport.testInstance1" />
-            <property role="BaGAP" value="" />
+          <node concept="1Xw6AR" id="6M7zmThrmTd" role="2xQTy9">
+            <node concept="1dCxOl" id="6M7zmThrmTt" role="1XwpL7">
+              <property role="1XweGQ" value="r:057f1e33-9c13-431f-bf95-fe15efaa6624" />
+              <node concept="1j_P7g" id="6M7zmThrmTu" role="1j$8Uc">
+                <property role="1j_P7h" value="test.com.mbeddr.mpsutil.ecore.modelImportExport.testInstance1" />
+              </node>
+            </node>
           </node>
         </node>
       </node>
@@ -89,13 +105,21 @@
             <property role="3kgbRO" value="false" />
             <property role="3N1Lgt" value="EMF_Meta_Models/modelImporterExporterTest2.ecore" />
           </node>
-          <node concept="BaHAS" id="2Q$Xn1yHuVD" role="2xQTyc">
-            <property role="BaHAW" value="test.com.mbeddr.mpsutil.ecoretransformation.modelImportExport.testLanguage2.structure" />
-            <property role="BaGAP" value="" />
+          <node concept="1Xw6AR" id="6M7zmThrmTG" role="2xQTyc">
+            <node concept="1dCxOl" id="6M7zmThrmTW" role="1XwpL7">
+              <property role="1XweGQ" value="r:9f4fe936-9a84-4faf-afe9-9c15141d78dc" />
+              <node concept="1j_P7g" id="6M7zmThrmTX" role="1j$8Uc">
+                <property role="1j_P7h" value="test.com.mbeddr.mpsutil.ecoretransformation.modelImportExport.testLanguage2.structure" />
+              </node>
+            </node>
           </node>
-          <node concept="BaHAS" id="2Q$Xn1yHuVE" role="2xQTy9">
-            <property role="BaHAW" value="test.com.mbeddr.mpsutil.ecore.modelImportExport.testInstance2" />
-            <property role="BaGAP" value="" />
+          <node concept="1Xw6AR" id="6M7zmThrmUb" role="2xQTy9">
+            <node concept="1dCxOl" id="6M7zmThrmUr" role="1XwpL7">
+              <property role="1XweGQ" value="r:c7e76692-1c08-4e97-a02d-1b3b061c60b7" />
+              <node concept="1j_P7g" id="6M7zmThrmUs" role="1j$8Uc">
+                <property role="1j_P7h" value="test.com.mbeddr.mpsutil.ecore.modelImportExport.testInstance2" />
+              </node>
+            </node>
           </node>
         </node>
       </node>
@@ -110,13 +134,21 @@
             <property role="3kgbRO" value="false" />
             <property role="3N1Lgt" value="EMF_Meta_Models/modelImporterExporterTest3.ecore" />
           </node>
-          <node concept="BaHAS" id="2Q$Xn1yHv39" role="2xQTyc">
-            <property role="BaHAW" value="test.com.mbeddr.mpsutil.ecoretransformation.modelImportExport.testLanguage3.structure" />
-            <property role="BaGAP" value="" />
+          <node concept="1Xw6AR" id="6M7zmThrmUE" role="2xQTyc">
+            <node concept="1dCxOl" id="6M7zmThrmUU" role="1XwpL7">
+              <property role="1XweGQ" value="r:623b1867-06d7-4ae0-8ba0-23b3df1d9ee6" />
+              <node concept="1j_P7g" id="6M7zmThrmUV" role="1j$8Uc">
+                <property role="1j_P7h" value="test.com.mbeddr.mpsutil.ecoretransformation.modelImportExport.testLanguage3.structure" />
+              </node>
+            </node>
           </node>
-          <node concept="BaHAS" id="2Q$Xn1yHv3a" role="2xQTy9">
-            <property role="BaHAW" value="test.com.mbeddr.mpsutil.ecore.modelImportExport.testInstance3" />
-            <property role="BaGAP" value="" />
+          <node concept="1Xw6AR" id="6M7zmThrmV9" role="2xQTy9">
+            <node concept="1dCxOl" id="6M7zmThrmVp" role="1XwpL7">
+              <property role="1XweGQ" value="r:99dd2057-5849-4bcf-a138-6cde7b85fc9d" />
+              <node concept="1j_P7g" id="6M7zmThrmVq" role="1j$8Uc">
+                <property role="1j_P7h" value="test.com.mbeddr.mpsutil.ecore.modelImportExport.testInstance3" />
+              </node>
+            </node>
           </node>
         </node>
       </node>
@@ -131,13 +163,21 @@
             <property role="3kgbRO" value="false" />
             <property role="3N1Lgt" value="EMF_Meta_Models/modelImporterExporterTest4.ecore" />
           </node>
-          <node concept="BaHAS" id="2Q$Xn1yHvdR" role="2xQTyc">
-            <property role="BaHAW" value="test.com.mbeddr.mpsutil.ecoretransformation.modelImportExport.testLanguage4.structure" />
-            <property role="BaGAP" value="" />
+          <node concept="1Xw6AR" id="6M7zmThrmVC" role="2xQTyc">
+            <node concept="1dCxOl" id="6M7zmThrmVS" role="1XwpL7">
+              <property role="1XweGQ" value="r:954b62dd-4ac9-44be-929a-9ed73901b1a9" />
+              <node concept="1j_P7g" id="6M7zmThrmVT" role="1j$8Uc">
+                <property role="1j_P7h" value="test.com.mbeddr.mpsutil.ecoretransformation.modelImportExport.testLanguage4.structure" />
+              </node>
+            </node>
           </node>
-          <node concept="BaHAS" id="2Q$Xn1yHvdS" role="2xQTy9">
-            <property role="BaHAW" value="test.com.mbeddr.mpsutil.ecore.modelImportExport.testInstance4" />
-            <property role="BaGAP" value="" />
+          <node concept="1Xw6AR" id="6M7zmThrmW7" role="2xQTy9">
+            <node concept="1dCxOl" id="6M7zmThrmWn" role="1XwpL7">
+              <property role="1XweGQ" value="r:6d5c6304-102c-40c9-9764-6f53d2b29f0d" />
+              <node concept="1j_P7g" id="6M7zmThrmWo" role="1j$8Uc">
+                <property role="1j_P7h" value="test.com.mbeddr.mpsutil.ecore.modelImportExport.testInstance4" />
+              </node>
+            </node>
           </node>
         </node>
       </node>
@@ -152,13 +192,21 @@
             <property role="3kgbRO" value="false" />
             <property role="3N1Lgt" value="EMF_Meta_Models/modelImporterExporterTest5.ecore" />
           </node>
-          <node concept="BaHAS" id="2Q$Xn1yHvve" role="2xQTyc">
-            <property role="BaHAW" value="test.com.mbeddr.mpsutil.ecoretransformation.modelImportExport.testLanguage5.structure" />
-            <property role="BaGAP" value="" />
+          <node concept="1Xw6AR" id="6M7zmThrmWA" role="2xQTyc">
+            <node concept="1dCxOl" id="6M7zmThrmWQ" role="1XwpL7">
+              <property role="1XweGQ" value="r:a81d9b7a-7028-4fa8-81ed-41f4b1cca939" />
+              <node concept="1j_P7g" id="6M7zmThrmWR" role="1j$8Uc">
+                <property role="1j_P7h" value="test.com.mbeddr.mpsutil.ecoretransformation.modelImportExport.testLanguage5.structure" />
+              </node>
+            </node>
           </node>
-          <node concept="BaHAS" id="2Q$Xn1yHvvf" role="2xQTy9">
-            <property role="BaHAW" value="test.com.mbeddr.mpsutil.ecore.modelImportExport.testInstance5" />
-            <property role="BaGAP" value="" />
+          <node concept="1Xw6AR" id="6M7zmThrmX5" role="2xQTy9">
+            <node concept="1dCxOl" id="6M7zmThrmXl" role="1XwpL7">
+              <property role="1XweGQ" value="r:ca11f989-0c62-4a05-ad71-160413139366" />
+              <node concept="1j_P7g" id="6M7zmThrmXm" role="1j$8Uc">
+                <property role="1j_P7h" value="test.com.mbeddr.mpsutil.ecore.modelImportExport.testInstance5" />
+              </node>
+            </node>
           </node>
         </node>
       </node>
@@ -173,13 +221,21 @@
             <property role="3kgbRO" value="false" />
             <property role="3N1Lgt" value="EMF_Meta_Models/modelImporterExporterTest6.ecore" />
           </node>
-          <node concept="BaHAS" id="2Q$Xn1yHvHE" role="2xQTyc">
-            <property role="BaHAW" value="test.com.mbeddr.mpsutil.ecoretransformation.modelImportExport.testLanguage6.structure" />
-            <property role="BaGAP" value="" />
+          <node concept="1Xw6AR" id="6M7zmThrmX$" role="2xQTyc">
+            <node concept="1dCxOl" id="6M7zmThrmXO" role="1XwpL7">
+              <property role="1XweGQ" value="r:c6945cc5-0fc8-4f34-ac60-e0b47fe7039c" />
+              <node concept="1j_P7g" id="6M7zmThrmXP" role="1j$8Uc">
+                <property role="1j_P7h" value="test.com.mbeddr.mpsutil.ecoretransformation.modelImportExport.testLanguage6.structure" />
+              </node>
+            </node>
           </node>
-          <node concept="BaHAS" id="2Q$Xn1yHvHF" role="2xQTy9">
-            <property role="BaHAW" value="test.com.mbeddr.mpsutil.ecore.modelImportExport.testInstance6" />
-            <property role="BaGAP" value="" />
+          <node concept="1Xw6AR" id="6M7zmThrmY3" role="2xQTy9">
+            <node concept="1dCxOl" id="6M7zmThrmYj" role="1XwpL7">
+              <property role="1XweGQ" value="r:d26f10bc-a521-4dff-b73d-981c8a51b04a" />
+              <node concept="1j_P7g" id="6M7zmThrmYk" role="1j$8Uc">
+                <property role="1j_P7h" value="test.com.mbeddr.mpsutil.ecore.modelImportExport.testInstance6" />
+              </node>
+            </node>
           </node>
         </node>
       </node>

--- a/code/languages/com.mbeddr.mpsutil/tests/test.com.mbeddr.mpsutil.ecoreimporter.runtime/models/test/com/mbeddr/mpsutil/ecoreimporter/importer@tests.mps
+++ b/code/languages/com.mbeddr.mpsutil/tests/test.com.mbeddr.mpsutil.ecoreimporter.runtime/models/test/com/mbeddr/mpsutil/ecoreimporter/importer@tests.mps
@@ -7,6 +7,7 @@
     <use id="d08b2078-ada5-40fa-a3c5-d721088dc626" name="com.mbeddr.mpsutil.ecore.testing" version="0" />
     <use id="d3a0fd26-445a-466c-900e-10444ddfed52" name="com.mbeddr.mpsutil.filepicker" version="0" />
     <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="11" />
+    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="17" />
   </languages>
   <imports />
   <registry>
@@ -40,6 +41,15 @@
       </concept>
       <concept id="6156524541423588207" name="com.mbeddr.mpsutil.filepicker.structure.SolutionRelativeFilePicker" flags="ng" index="3NXOOs" />
     </language>
+    <language id="446c26eb-2b7b-4bf0-9b35-f83fa582753e" name="jetbrains.mps.lang.modelapi">
+      <concept id="361130699826193248" name="jetbrains.mps.lang.modelapi.structure.ModelPointer" flags="ng" index="1dCxOl">
+        <property id="1863527487546097494" name="modelId" index="1XweGQ" />
+        <child id="679099339649067980" name="name" index="1j$8Uc" />
+      </concept>
+      <concept id="679099339649053840" name="jetbrains.mps.lang.modelapi.structure.ModelName" flags="ng" index="1j_P7g">
+        <property id="679099339649053841" name="value" index="1j_P7h" />
+      </concept>
+    </language>
     <language id="d08b2078-ada5-40fa-a3c5-d721088dc626" name="com.mbeddr.mpsutil.ecore.testing">
       <concept id="494571880817472209" name="com.mbeddr.mpsutil.ecore.testing.structure.AssertImportStatement" flags="ng" index="1uQa1g">
         <child id="494571880822833049" name="pathToEcoreFile" index="1uyAOo" />
@@ -47,9 +57,8 @@
       </concept>
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
-      <concept id="559557797393017698" name="jetbrains.mps.lang.smodel.structure.ModelReferenceExpression" flags="nn" index="BaHAS">
-        <property id="559557797393021807" name="stereotype" index="BaGAP" />
-        <property id="559557797393017702" name="name" index="BaHAW" />
+      <concept id="1863527487546129879" name="jetbrains.mps.lang.smodel.structure.ModelPointerExpression" flags="ng" index="1Xw6AR">
+        <child id="1863527487546132519" name="modelRef" index="1XwpL7" />
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
@@ -139,9 +148,13 @@
             <property role="3kgbRO" value="false" />
             <property role="3N1Lgt" value="test_Ecore_Files/all_in_one.ecore" />
           </node>
-          <node concept="BaHAS" id="7FLq2$J$EAJ" role="1uyDA$">
-            <property role="BaHAW" value="test.com.mbeddr.mpsutil.ecoreimporter.allInOne" />
-            <property role="BaGAP" value="" />
+          <node concept="1Xw6AR" id="xRVdUhx7R9" role="1uyDA$">
+            <node concept="1dCxOl" id="xRVdUhx7Rp" role="1XwpL7">
+              <property role="1XweGQ" value="r:9c9eecd0-a4b4-4af6-bdbb-d7ad6681eddb" />
+              <node concept="1j_P7g" id="xRVdUhx7Rq" role="1j$8Uc">
+                <property role="1j_P7h" value="test.com.mbeddr.mpsutil.ecoreimporter.allInOne" />
+              </node>
+            </node>
           </node>
         </node>
       </node>
@@ -211,9 +224,13 @@
             <property role="3kgbRO" value="false" />
             <property role="3N1Lgt" value="test_Ecore_Files/enum_Interface.ecore" />
           </node>
-          <node concept="BaHAS" id="7FLq2$J$_PV" role="1uyDA$">
-            <property role="BaHAW" value="test.com.mbeddr.mpsutil.ecoreimporter.enumInterface" />
-            <property role="BaGAP" value="" />
+          <node concept="1Xw6AR" id="xRVdUhx7O4" role="1uyDA$">
+            <node concept="1dCxOl" id="xRVdUhx7Ok" role="1XwpL7">
+              <property role="1XweGQ" value="r:97f0f375-f988-4fd7-96f6-6064fa5b9b7f" />
+              <node concept="1j_P7g" id="xRVdUhx7Ol" role="1j$8Uc">
+                <property role="1j_P7h" value="test.com.mbeddr.mpsutil.ecoreimporter.enumInterface" />
+              </node>
+            </node>
           </node>
         </node>
       </node>
@@ -259,9 +276,13 @@
             <property role="3kgbRO" value="false" />
             <property role="3N1Lgt" value="test_Ecore_Files/enum_no_unique_internal_value.ecore" />
           </node>
-          <node concept="BaHAS" id="7FLq2$J$A9E" role="1uyDA$">
-            <property role="BaHAW" value="test.com.mbeddr.mpsutil.ecoreimporter.enumNoUniqueInternalValue" />
-            <property role="BaGAP" value="" />
+          <node concept="1Xw6AR" id="xRVdUhx7Oz" role="1uyDA$">
+            <node concept="1dCxOl" id="xRVdUhx7ON" role="1XwpL7">
+              <property role="1XweGQ" value="r:d34f07ab-f738-4b41-a5fe-21dc79baecc8" />
+              <node concept="1j_P7g" id="xRVdUhx7OO" role="1j$8Uc">
+                <property role="1j_P7h" value="test.com.mbeddr.mpsutil.ecoreimporter.enumNoUniqueInternalValue" />
+              </node>
+            </node>
           </node>
         </node>
       </node>
@@ -331,9 +352,13 @@
             <property role="3kgbRO" value="false" />
             <property role="3N1Lgt" value="test_Ecore_Files/enum_super_class.ecore" />
           </node>
-          <node concept="BaHAS" id="7FLq2$J$AaI" role="1uyDA$">
-            <property role="BaHAW" value="test.com.mbeddr.mpsutil.ecoreimporter.enumSuperClass" />
-            <property role="BaGAP" value="" />
+          <node concept="1Xw6AR" id="xRVdUhx7P2" role="1uyDA$">
+            <node concept="1dCxOl" id="xRVdUhx7Pi" role="1XwpL7">
+              <property role="1XweGQ" value="r:c1945d1b-81c3-4ff8-8578-2eb07c318c2d" />
+              <node concept="1j_P7g" id="xRVdUhx7Pj" role="1j$8Uc">
+                <property role="1j_P7h" value="test.com.mbeddr.mpsutil.ecoreimporter.enumSuperClass" />
+              </node>
+            </node>
           </node>
         </node>
       </node>
@@ -382,9 +407,13 @@
             <property role="3kgbRO" value="false" />
             <property role="3N1Lgt" value="test_Ecore_Files/simple_class_enum_property.ecore" />
           </node>
-          <node concept="BaHAS" id="7FLq2$J$AbM" role="1uyDA$">
-            <property role="BaHAW" value="test.com.mbeddr.mpsutil.ecoreimporter.simpleClassEnumProperty" />
-            <property role="BaGAP" value="" />
+          <node concept="1Xw6AR" id="xRVdUhx7Px" role="1uyDA$">
+            <node concept="1dCxOl" id="xRVdUhx7PL" role="1XwpL7">
+              <property role="1XweGQ" value="r:6f8eedfa-a422-40d0-a419-04fb00303d35" />
+              <node concept="1j_P7g" id="xRVdUhx7PM" role="1j$8Uc">
+                <property role="1j_P7h" value="test.com.mbeddr.mpsutil.ecoreimporter.simpleClassEnumProperty" />
+              </node>
+            </node>
           </node>
         </node>
       </node>
@@ -436,9 +465,13 @@
             <property role="3kgbRO" value="false" />
             <property role="3N1Lgt" value="test_Ecore_Files/simple_class_varying_property_withenum.ecore" />
           </node>
-          <node concept="BaHAS" id="7FLq2$J$ARq" role="1uyDA$">
-            <property role="BaHAW" value="test.com.mbeddr.mpsutil.ecoreimporter.simpleClassVaryingPropertyWithEnum" />
-            <property role="BaGAP" value="" />
+          <node concept="1Xw6AR" id="xRVdUhx7Q0" role="1uyDA$">
+            <node concept="1dCxOl" id="xRVdUhx7Qg" role="1XwpL7">
+              <property role="1XweGQ" value="r:30d958b4-8ee9-4446-b41a-31c9e96713b0" />
+              <node concept="1j_P7g" id="xRVdUhx7Qh" role="1j$8Uc">
+                <property role="1j_P7h" value="test.com.mbeddr.mpsutil.ecoreimporter.simpleClassVaryingPropertyWithEnum" />
+              </node>
+            </node>
           </node>
         </node>
       </node>
@@ -472,9 +505,13 @@
             <property role="3kgbRO" value="false" />
             <property role="3N1Lgt" value="test_Ecore_Files/simple_enum.ecore" />
           </node>
-          <node concept="BaHAS" id="7FLq2$J$ASQ" role="1uyDA$">
-            <property role="BaHAW" value="test.com.mbeddr.mpsutil.ecoreimporter.simpleEnum" />
-            <property role="BaGAP" value="" />
+          <node concept="1Xw6AR" id="xRVdUhx7Qv" role="1uyDA$">
+            <node concept="1dCxOl" id="xRVdUhx7QJ" role="1XwpL7">
+              <property role="1XweGQ" value="r:9d45cf3f-c9f8-4605-a72d-217aa128ef62" />
+              <node concept="1j_P7g" id="xRVdUhx7QK" role="1j$8Uc">
+                <property role="1j_P7h" value="test.com.mbeddr.mpsutil.ecoreimporter.simpleEnum" />
+              </node>
+            </node>
           </node>
         </node>
       </node>
@@ -517,9 +554,13 @@
             <property role="3kgbRO" value="false" />
             <property role="3N1Lgt" value="test_Ecore_Files/class_interface.ecore" />
           </node>
-          <node concept="BaHAS" id="7FLq2$J$Brw" role="1uyDA$">
-            <property role="BaHAW" value="test.com.mbeddr.mpsutil.ecoreimporter.classInterface" />
-            <property role="BaGAP" value="" />
+          <node concept="1Xw6AR" id="xRVdUhx7zJ" role="1uyDA$">
+            <node concept="1dCxOl" id="xRVdUhx7zZ" role="1XwpL7">
+              <property role="1XweGQ" value="r:759239e1-aaab-447e-9998-345334066850" />
+              <node concept="1j_P7g" id="xRVdUhx7$0" role="1j$8Uc">
+                <property role="1j_P7h" value="test.com.mbeddr.mpsutil.ecoreimporter.classInterface" />
+              </node>
+            </node>
           </node>
         </node>
       </node>
@@ -556,9 +597,13 @@
             <property role="3kgbRO" value="false" />
             <property role="3N1Lgt" value="test_Ecore_Files/class_multiple_interface.ecore" />
           </node>
-          <node concept="BaHAS" id="7FLq2$J$BrA" role="1uyDA$">
-            <property role="BaHAW" value="test.com.mbeddr.mpsutil.ecoreimporter.classMultipleInterface" />
-            <property role="BaGAP" value="" />
+          <node concept="1Xw6AR" id="xRVdUhx7$e" role="1uyDA$">
+            <node concept="1dCxOl" id="xRVdUhx7$u" role="1XwpL7">
+              <property role="1XweGQ" value="r:8ce71c62-0c05-4cdd-938d-98d554cdc469" />
+              <node concept="1j_P7g" id="xRVdUhx7$v" role="1j$8Uc">
+                <property role="1j_P7h" value="test.com.mbeddr.mpsutil.ecoreimporter.classMultipleInterface" />
+              </node>
+            </node>
           </node>
         </node>
       </node>
@@ -604,9 +649,13 @@
             <property role="3kgbRO" value="false" />
             <property role="3N1Lgt" value="test_Ecore_Files/class_multiple_interface_superclass.ecore" />
           </node>
-          <node concept="BaHAS" id="7FLq2$J$BrG" role="1uyDA$">
-            <property role="BaHAW" value="test.com.mbeddr.mpsutil.ecoreimporter.classMultipleInterfaceSuperClass" />
-            <property role="BaGAP" value="" />
+          <node concept="1Xw6AR" id="xRVdUhx7$H" role="1uyDA$">
+            <node concept="1dCxOl" id="xRVdUhx7$X" role="1XwpL7">
+              <property role="1XweGQ" value="r:b43fd521-97fc-4505-81ed-dafccabe242f" />
+              <node concept="1j_P7g" id="xRVdUhx7$Y" role="1j$8Uc">
+                <property role="1j_P7h" value="test.com.mbeddr.mpsutil.ecoreimporter.classMultipleInterfaceSuperClass" />
+              </node>
+            </node>
           </node>
         </node>
       </node>
@@ -646,9 +695,13 @@
             <property role="3kgbRO" value="false" />
             <property role="3N1Lgt" value="test_Ecore_Files/multiple_inheritance.ecore" />
           </node>
-          <node concept="BaHAS" id="7FLq2$J$BrM" role="1uyDA$">
-            <property role="BaHAW" value="test.com.mbeddr.mpsutil.ecoreimporter.multipleInheritance" />
-            <property role="BaGAP" value="" />
+          <node concept="1Xw6AR" id="xRVdUhx7_c" role="1uyDA$">
+            <node concept="1dCxOl" id="xRVdUhx7_s" role="1XwpL7">
+              <property role="1XweGQ" value="r:8297613c-09b3-4cd4-9f49-bf917d23c61a" />
+              <node concept="1j_P7g" id="xRVdUhx7_t" role="1j$8Uc">
+                <property role="1j_P7h" value="test.com.mbeddr.mpsutil.ecoreimporter.multipleInheritance" />
+              </node>
+            </node>
           </node>
         </node>
       </node>
@@ -700,9 +753,13 @@
             <property role="3kgbRO" value="false" />
             <property role="3N1Lgt" value="test_Ecore_Files/multiple_inheritance_interface.ecore" />
           </node>
-          <node concept="BaHAS" id="7FLq2$J$BrS" role="1uyDA$">
-            <property role="BaHAW" value="test.com.mbeddr.mpsutil.ecoreimporter.multipleInterfaceInheritance" />
-            <property role="BaGAP" value="" />
+          <node concept="1Xw6AR" id="xRVdUhx7_F" role="1uyDA$">
+            <node concept="1dCxOl" id="xRVdUhx7_V" role="1XwpL7">
+              <property role="1XweGQ" value="r:4f5e1cd3-ac4c-4545-9cac-03bdb8e11577" />
+              <node concept="1j_P7g" id="xRVdUhx7_W" role="1j$8Uc">
+                <property role="1j_P7h" value="test.com.mbeddr.mpsutil.ecoreimporter.multipleInterfaceInheritance" />
+              </node>
+            </node>
           </node>
         </node>
       </node>
@@ -745,9 +802,13 @@
             <property role="3kgbRO" value="false" />
             <property role="3N1Lgt" value="test_Ecore_Files/super_class.ecore" />
           </node>
-          <node concept="BaHAS" id="7FLq2$J$BrY" role="1uyDA$">
-            <property role="BaHAW" value="test.com.mbeddr.mpsutil.ecoreimporter.runtime.superClass.structure" />
-            <property role="BaGAP" value="" />
+          <node concept="1Xw6AR" id="xRVdUhx7Mz" role="1uyDA$">
+            <node concept="1dCxOl" id="xRVdUhx7MN" role="1XwpL7">
+              <property role="1XweGQ" value="r:3abec9c0-5690-481b-814f-57264551dde4" />
+              <node concept="1j_P7g" id="xRVdUhx7MO" role="1j$8Uc">
+                <property role="1j_P7h" value="test.com.mbeddr.mpsutil.ecoreimporter.superClass" />
+              </node>
+            </node>
           </node>
         </node>
       </node>
@@ -793,9 +854,13 @@
             <property role="3kgbRO" value="false" />
             <property role="3N1Lgt" value="test_Ecore_Files/class_multiple_reference.ecore" />
           </node>
-          <node concept="BaHAS" id="7FLq2$J$DJQ" role="1uyDA$">
-            <property role="BaHAW" value="test.com.mbeddr.mpsutil.ecoreimporter.classMultipleReference" />
-            <property role="BaGAP" value="" />
+          <node concept="1Xw6AR" id="xRVdUhx7xg" role="1uyDA$">
+            <node concept="1dCxOl" id="xRVdUhx7xw" role="1XwpL7">
+              <property role="1XweGQ" value="r:19401f7e-1c25-4f0d-94e2-cc76977ecaba" />
+              <node concept="1j_P7g" id="xRVdUhx7xx" role="1j$8Uc">
+                <property role="1j_P7h" value="test.com.mbeddr.mpsutil.ecoreimporter.classMultipleReference" />
+              </node>
+            </node>
           </node>
         </node>
       </node>
@@ -838,9 +903,13 @@
             <property role="3kgbRO" value="false" />
             <property role="3N1Lgt" value="test_Ecore_Files/class_reference.ecore" />
           </node>
-          <node concept="BaHAS" id="7FLq2$J$DJW" role="1uyDA$">
-            <property role="BaHAW" value="test.com.mbeddr.mpsutil.ecoreimporter.classReference" />
-            <property role="BaGAP" value="" />
+          <node concept="1Xw6AR" id="xRVdUhx7xJ" role="1uyDA$">
+            <node concept="1dCxOl" id="xRVdUhx7xZ" role="1XwpL7">
+              <property role="1XweGQ" value="r:6ae8cfc4-1f15-4893-851b-2e5e3d3e0e07" />
+              <node concept="1j_P7g" id="xRVdUhx7y0" role="1j$8Uc">
+                <property role="1j_P7h" value="test.com.mbeddr.mpsutil.ecoreimporter.classReference" />
+              </node>
+            </node>
           </node>
         </node>
       </node>
@@ -898,9 +967,13 @@
             <property role="3kgbRO" value="false" />
             <property role="3N1Lgt" value="test_Ecore_Files/class_reference_child.ecore" />
           </node>
-          <node concept="BaHAS" id="7FLq2$J$DK2" role="1uyDA$">
-            <property role="BaHAW" value="test.com.mbeddr.mpsutil.ecoreimporter.classReferenceChild" />
-            <property role="BaGAP" value="" />
+          <node concept="1Xw6AR" id="xRVdUhx7ye" role="1uyDA$">
+            <node concept="1dCxOl" id="xRVdUhx7yu" role="1XwpL7">
+              <property role="1XweGQ" value="r:a47c6f0f-0593-4288-bd9f-51f0ebcedf42" />
+              <node concept="1j_P7g" id="xRVdUhx7yv" role="1j$8Uc">
+                <property role="1j_P7h" value="test.com.mbeddr.mpsutil.ecoreimporter.classReferenceChild" />
+              </node>
+            </node>
           </node>
         </node>
       </node>
@@ -940,9 +1013,13 @@
             <property role="3kgbRO" value="false" />
             <property role="3N1Lgt" value="test_Ecore_Files/empty_class.ecore" />
           </node>
-          <node concept="BaHAS" id="7FLq2$J$AMg" role="1uyDA$">
-            <property role="BaHAW" value="test.com.mbeddr.mpsutil.ecoreimporter.emptyClass" />
-            <property role="BaGAP" value="" />
+          <node concept="1Xw6AR" id="xRVdUhx79T" role="1uyDA$">
+            <node concept="1dCxOl" id="xRVdUhx7v3" role="1XwpL7">
+              <property role="1XweGQ" value="r:cda59b28-30ad-4e78-992e-f2596e438a60" />
+              <node concept="1j_P7g" id="xRVdUhx7v4" role="1j$8Uc">
+                <property role="1j_P7h" value="test.com.mbeddr.mpsutil.ecoreimporter.emptyClass" />
+              </node>
+            </node>
           </node>
         </node>
       </node>
@@ -1018,9 +1095,13 @@
             <property role="3kgbRO" value="false" />
             <property role="3N1Lgt" value="test_Ecore_Files/class_nonmpstypes.ecore" />
           </node>
-          <node concept="BaHAS" id="7FLq2$J$AMm" role="1uyDA$">
-            <property role="BaHAW" value="test.com.mbeddr.mpsutil.ecoreimporter.classNonMPSTypes" />
-            <property role="BaGAP" value="" />
+          <node concept="1Xw6AR" id="xRVdUhx7vi" role="1uyDA$">
+            <node concept="1dCxOl" id="xRVdUhx7vy" role="1XwpL7">
+              <property role="1XweGQ" value="r:eaa88d19-3d7d-4ad7-8501-ce8f218af3df" />
+              <node concept="1j_P7g" id="xRVdUhx7vz" role="1j$8Uc">
+                <property role="1j_P7h" value="test.com.mbeddr.mpsutil.ecoreimporter.classNonMPSTypes" />
+              </node>
+            </node>
           </node>
         </node>
       </node>
@@ -1054,9 +1135,13 @@
             <property role="3kgbRO" value="false" />
             <property role="3N1Lgt" value="test_Ecore_Files/simple_class_one_property.ecore" />
           </node>
-          <node concept="BaHAS" id="7FLq2$J$AMs" role="1uyDA$">
-            <property role="BaHAW" value="test.com.mbeddr.mpsutil.ecoreimporter.simpleClassOneProperty" />
-            <property role="BaGAP" value="" />
+          <node concept="1Xw6AR" id="xRVdUhx7vL" role="1uyDA$">
+            <node concept="1dCxOl" id="xRVdUhx7w1" role="1XwpL7">
+              <property role="1XweGQ" value="r:0bd43909-5b2a-44c0-890b-81fb9dd62d8d" />
+              <node concept="1j_P7g" id="xRVdUhx7w2" role="1j$8Uc">
+                <property role="1j_P7h" value="test.com.mbeddr.mpsutil.ecoreimporter.simpleClassOneProperty" />
+              </node>
+            </node>
           </node>
         </node>
       </node>
@@ -1102,9 +1187,13 @@
             <property role="3kgbRO" value="false" />
             <property role="3N1Lgt" value="test_Ecore_Files/simple_class_multiple_property.ecore" />
           </node>
-          <node concept="BaHAS" id="7FLq2$J$AMy" role="1uyDA$">
-            <property role="BaHAW" value="test.com.mbeddr.mpsutil.ecoreimporter.simpleClassMultipleProperty" />
-            <property role="BaGAP" value="" />
+          <node concept="1Xw6AR" id="xRVdUhx7wg" role="1uyDA$">
+            <node concept="1dCxOl" id="xRVdUhx7ww" role="1XwpL7">
+              <property role="1XweGQ" value="r:ed127a32-e62a-48b7-bda3-7cc19ac5f16b" />
+              <node concept="1j_P7g" id="xRVdUhx7wx" role="1j$8Uc">
+                <property role="1j_P7h" value="test.com.mbeddr.mpsutil.ecoreimporter.simpleClassMultipleProperty" />
+              </node>
+            </node>
           </node>
         </node>
       </node>

--- a/code/languages/com.mbeddr.mpsutil/tests/test.com.mbeddr.mpsutil.ecoreimporter.runtime/models/test/com/mbeddr/mpsutil/ecoreimporter/testingframework@tests.mps
+++ b/code/languages/com.mbeddr.mpsutil/tests/test.com.mbeddr.mpsutil.ecoreimporter.runtime/models/test/com/mbeddr/mpsutil/ecoreimporter/testingframework@tests.mps
@@ -6,6 +6,7 @@
     <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="11" />
     <use id="d08b2078-ada5-40fa-a3c5-d721088dc626" name="com.mbeddr.mpsutil.ecore.testing" version="0" />
     <use id="d3a0fd26-445a-466c-900e-10444ddfed52" name="com.mbeddr.mpsutil.filepicker" version="0" />
+    <use id="446c26eb-2b7b-4bf0-9b35-f83fa582753e" name="jetbrains.mps.lang.modelapi" version="0" />
   </languages>
   <imports>
     <import index="guwi" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.io(JDK/)" />
@@ -102,6 +103,15 @@
       </concept>
       <concept id="6156524541423588207" name="com.mbeddr.mpsutil.filepicker.structure.SolutionRelativeFilePicker" flags="ng" index="3NXOOs" />
     </language>
+    <language id="446c26eb-2b7b-4bf0-9b35-f83fa582753e" name="jetbrains.mps.lang.modelapi">
+      <concept id="361130699826193248" name="jetbrains.mps.lang.modelapi.structure.ModelPointer" flags="ng" index="1dCxOl">
+        <property id="1863527487546097494" name="modelId" index="1XweGQ" />
+        <child id="679099339649067980" name="name" index="1j$8Uc" />
+      </concept>
+      <concept id="679099339649053840" name="jetbrains.mps.lang.modelapi.structure.ModelName" flags="ng" index="1j_P7g">
+        <property id="679099339649053841" name="value" index="1j_P7h" />
+      </concept>
+    </language>
     <language id="d08b2078-ada5-40fa-a3c5-d721088dc626" name="com.mbeddr.mpsutil.ecore.testing">
       <concept id="494571880817472209" name="com.mbeddr.mpsutil.ecore.testing.structure.AssertImportStatement" flags="ng" index="1uQa1g">
         <child id="494571880822833049" name="pathToEcoreFile" index="1uyAOo" />
@@ -109,9 +119,8 @@
       </concept>
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
-      <concept id="559557797393017698" name="jetbrains.mps.lang.smodel.structure.ModelReferenceExpression" flags="nn" index="BaHAS">
-        <property id="559557797393021807" name="stereotype" index="BaGAP" />
-        <property id="559557797393017702" name="name" index="BaHAW" />
+      <concept id="1863527487546129879" name="jetbrains.mps.lang.smodel.structure.ModelPointerExpression" flags="ng" index="1Xw6AR">
+        <child id="1863527487546132519" name="modelRef" index="1XwpL7" />
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
@@ -132,9 +141,13 @@
             <property role="3kgbRO" value="false" />
             <property role="3N1Lgt" value="test_Ecore_Files/testingFrameworkReferenceLanguage.ecore" />
           </node>
-          <node concept="BaHAS" id="7ESlTHsclfi" role="1uyDA$">
-            <property role="BaHAW" value="test.com.mbeddr.mpsutil.ecoreimporter.testingFrameworkTestLanguageMatch" />
-            <property role="BaGAP" value="" />
+          <node concept="1Xw6AR" id="xRVdUhx77N" role="1uyDA$">
+            <node concept="1dCxOl" id="xRVdUhx783" role="1XwpL7">
+              <property role="1XweGQ" value="r:679ddd2a-675f-4aaf-8311-c8eecf410a8f" />
+              <node concept="1j_P7g" id="xRVdUhx784" role="1j$8Uc">
+                <property role="1j_P7h" value="test.com.mbeddr.mpsutil.ecoreimporter.testingFrameworkTestLanguageMatch" />
+              </node>
+            </node>
           </node>
         </node>
       </node>
@@ -160,9 +173,13 @@
                 <property role="3kgbRO" value="false" />
                 <property role="3N1Lgt" value="test_Ecore_Files/testingFrameworkReferenceLanguage.ecore" />
               </node>
-              <node concept="BaHAS" id="7ESlTHsclfC" role="1uyDA$">
-                <property role="BaHAW" value="test.com.mbeddr.mpsutil.ecoreimporter.testFailDifferentNumberOfChildren" />
-                <property role="BaGAP" value="" />
+              <node concept="1Xw6AR" id="xRVdUhx78i" role="1uyDA$">
+                <node concept="1dCxOl" id="xRVdUhx78v" role="1XwpL7">
+                  <property role="1XweGQ" value="r:d146aed2-5e94-444c-91f0-f6e336f68f7b" />
+                  <node concept="1j_P7g" id="xRVdUhx78w" role="1j$8Uc">
+                    <property role="1j_P7h" value="test.com.mbeddr.mpsutil.ecoreimporter.testFailDifferentNumberOfChildren" />
+                  </node>
+                </node>
               </node>
             </node>
           </node>
@@ -246,9 +263,13 @@
                 <property role="3kgbRO" value="false" />
                 <property role="3N1Lgt" value="test_Ecore_Files/testingFrameworkReferenceLanguage.ecore" />
               </node>
-              <node concept="BaHAS" id="rt4C5olTyi" role="1uyDA$">
-                <property role="BaHAW" value="test.com.mbeddr.mpsutil.ecoreimporter.testFailDifferentPropertyName" />
-                <property role="BaGAP" value="" />
+              <node concept="1Xw6AR" id="xRVdUhx78I" role="1uyDA$">
+                <node concept="1dCxOl" id="xRVdUhx78Y" role="1XwpL7">
+                  <property role="1XweGQ" value="r:3d0ae378-91a0-4a0f-bcbb-9817b26ecf2a" />
+                  <node concept="1j_P7g" id="xRVdUhx78Z" role="1j$8Uc">
+                    <property role="1j_P7h" value="test.com.mbeddr.mpsutil.ecoreimporter.testFailDifferentPropertyName" />
+                  </node>
+                </node>
               </node>
             </node>
           </node>

--- a/code/languages/com.mbeddr.mpsutil/tests/test.com.mbeddr.mpsutil.ecoreimporter.runtime/test.com.mbeddr.mpsutil.ecore.metaModelImport.msd
+++ b/code/languages/com.mbeddr.mpsutil/tests/test.com.mbeddr.mpsutil.ecoreimporter.runtime/test.com.mbeddr.mpsutil.ecore.metaModelImport.msd
@@ -26,8 +26,12 @@
     <language slang="l:d3a0fd26-445a-466c-900e-10444ddfed52:com.mbeddr.mpsutil.filepicker" version="0" />
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
     <language slang="l:443f4c36-fcf5-4eb6-9500-8d06ed259e3e:jetbrains.mps.baseLanguage.classifiers" version="0" />
+    <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
+    <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
     <language slang="l:f61473f9-130f-42f6-b98d-6c438812c2f6:jetbrains.mps.baseLanguage.unitTest" version="1" />
     <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
+    <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
+    <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="17" />
     <language slang="l:c72da2b9-7cce-4447-8389-f407dc1158b7:jetbrains.mps.lang.structure" version="9" />
     <language slang="l:8585453e-6bfb-4d80-98de-b16074f1d86c:jetbrains.mps.lang.test" version="5" />
     <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />


### PR DESCRIPTION
…ssion

The warning "Use of SModelRepository.getModelDescriptor(String) is
ineffective, please refactor to use SModelReference" is logged when it
used and there were a lot of them in the build log. It was deprecated
many years ago.