### PR TITLE
doc: add support for multiple doc includes

### DIFF
--- a/code/languages/com.mbeddr.build/solutions/com.mbeddr.platform/models/com/mbeddr/platform/build.mps
+++ b/code/languages/com.mbeddr.build/solutions/com.mbeddr.platform/models/com/mbeddr/platform/build.mps
@@ -19208,6 +19208,11 @@
             </node>
           </node>
         </node>
+        <node concept="1SiIV0" id="7U$sKL0_nhI" role="3bR37C">
+          <node concept="3bR9La" id="7U$sKL0_nhJ" role="1SiIV1">
+            <ref role="3bR37D" node="5fGcQI947Ca" resolve="com.mbeddr.mpsutil.common" />
+          </node>
+        </node>
       </node>
       <node concept="1E1JtD" id="7tNo_gxoK97" role="2G$12L">
         <property role="BnDLt" value="true" />

--- a/code/languages/com.mbeddr.core/languages/com.mbeddr.core.base/languageModels/behavior.mps
+++ b/code/languages/com.mbeddr.core/languages/com.mbeddr.core.base/languageModels/behavior.mps
@@ -15614,7 +15614,7 @@
       <property role="13i0iv" value="false" />
       <property role="13i0it" value="false" />
       <property role="TrG5h" value="getDependencyGraph" />
-      <node concept="3Tm6S6" id="17fjvcLFUts" role="1B3o_S" />
+      <node concept="3Tmbuc" id="3lxJBjik3dn" role="1B3o_S" />
       <node concept="3clFbS" id="17fjvcLC_kD" role="3clF47">
         <node concept="3cpWs8" id="17fjvcLCCDh" role="3cqZAp">
           <node concept="3cpWsn" id="17fjvcLCCDi" role="3cpWs9">

--- a/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc.gen_xhtml/languageModels/plugin.mps
+++ b/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc.gen_xhtml/languageModels/plugin.mps
@@ -796,15 +796,8 @@
                   <node concept="Xl_RD" id="10MSw5ZOEYA" role="2k5Stb">
                     <property role="Xl_RC" value="Invalid node reference" />
                   </node>
-                  <node concept="2OqwBi" id="2nF6pGLyFJD" role="2k6f33">
-                    <node concept="37vLTw" id="2nF6pGLyFJE" role="2Oq$k0">
-                      <ref role="3cqZAo" node="10MSw5ZOuPI" resolve="genContext" />
-                    </node>
-                    <node concept="12$id9" id="2nF6pGLyFJF" role="2OqNvi">
-                      <node concept="37vLTw" id="2nF6pGLyFMe" role="12$y8L">
-                        <ref role="3cqZAo" node="10MSw5ZOuOX" resolve="word" />
-                      </node>
-                    </node>
+                  <node concept="37vLTw" id="7WLbt3cwNmm" role="2k6f33">
+                    <ref role="3cqZAo" node="10MSw5ZOuOX" resolve="word" />
                   </node>
                 </node>
               </node>

--- a/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/doc.mpl
+++ b/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/doc.mpl
@@ -174,6 +174,7 @@
     <dependency reexport="false">d3a0fd26-445a-466c-900e-10444ddfed52(com.mbeddr.mpsutil.filepicker)</dependency>
     <dependency reexport="false">a1250a4d-c090-42c3-ad7c-d298a3357dd4(jetbrains.mps.make.runtime)</dependency>
     <dependency reexport="false">f8e20673-3f65-44e9-84c0-c4a4b6ede37e(jetbrains.mps.make.facets)</dependency>
+    <dependency reexport="false">c7a315e6-1d93-4186-85bc-2dfafd1ccc21(com.mbeddr.mpsutil.common)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:53a2e8ff-4795-41ec-949d-d5c6bc4895de:com.mbeddr.mpsutil.breadcrumb.editor" version="0" />
@@ -252,6 +253,7 @@
     <module reference="9e24fcdc-a232-4d24-8c95-1f525946191a(com.mbeddr.core.base.pluginSolution)" version="0" />
     <module reference="2374bc90-7e37-41f1-a9c4-c2e35194c36a(com.mbeddr.doc)" version="0" />
     <module reference="63e0e566-5131-447e-90e3-12ea330e1a00(com.mbeddr.mpsutil.blutil)" version="0" />
+    <module reference="c7a315e6-1d93-4186-85bc-2dfafd1ccc21(com.mbeddr.mpsutil.common)" version="0" />
     <module reference="d3a0fd26-445a-466c-900e-10444ddfed52(com.mbeddr.mpsutil.filepicker)" version="0" />
     <module reference="b33d119e-196d-4497-977c-5c167b21fe33(com.mbeddr.mpsutil.framecell)" version="0" />
     <module reference="04e1f940-330e-483b-9a6a-1648b396a81c(com.mbeddr.mpsutil.hyperlink)" version="0" />

--- a/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/generator/template/com/mbeddr/doc/generator/template/main@generator.mps
+++ b/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/generator/template/com/mbeddr/doc/generator/template/main@generator.mps
@@ -32,6 +32,11 @@
     <import index="rqen" ref="r:4fc6545d-39fa-4c9a-b98d-9868767dc0c0(com.mbeddr.doc.generator.template.utils)" />
     <import index="68mc" ref="r:2a10821d-612f-4a73-b7b0-ed6b57106321(com.mbeddr.mpsutil.filepicker.structure)" />
     <import index="z726" ref="r:6b7eb85f-64d8-4de6-8906-0e18804729df(com.mbeddr.doc.editor)" />
+    <import index="fwk" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.textgen.trace(MPS.Core/)" />
+    <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
+    <import index="w1kc" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel(MPS.Core/)" />
+    <import index="1ctc" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util.stream(JDK/)" />
+    <import index="82uw" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util.function(JDK/)" />
     <import index="tpcb" ref="r:00000000-0000-4000-0000-011c89590297(jetbrains.mps.lang.editor.behavior)" implicit="true" />
   </imports>
   <registry>
@@ -39,6 +44,10 @@
       <concept id="1161622665029" name="jetbrains.mps.lang.sharedConcepts.structure.ConceptFunctionParameter_model" flags="nn" index="1Q6Npb" />
     </language>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1224071154655" name="jetbrains.mps.baseLanguage.structure.AsExpression" flags="nn" index="0kSF2">
+        <child id="1224071154657" name="classifierType" index="0kSFW" />
+        <child id="1224071154656" name="expression" index="0kSFX" />
+      </concept>
       <concept id="1082485599095" name="jetbrains.mps.baseLanguage.structure.BlockStatement" flags="nn" index="9aQIb">
         <child id="1082485599096" name="statements" index="9aQI4" />
       </concept>
@@ -48,6 +57,9 @@
       </concept>
       <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="1732176556423009631" name="jetbrains.mps.baseLanguage.structure.MultiLineComment" flags="ng" index="2lOVwT">
+        <child id="1732176556423038857" name="lines" index="2lOMFJ" />
+      </concept>
       <concept id="8118189177080264853" name="jetbrains.mps.baseLanguage.structure.AlternativeType" flags="ig" index="nSUau">
         <child id="8118189177080264854" name="alternative" index="nSUat" />
       </concept>
@@ -91,6 +103,7 @@
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
+      <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
       <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
       <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
       <concept id="1225271221393" name="jetbrains.mps.baseLanguage.structure.NPENotEqualsExpression" flags="nn" index="17QLQc" />
@@ -129,6 +142,7 @@
       <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
+        <child id="4972241301747169160" name="typeArgument" index="3PaCim" />
       </concept>
       <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk" />
       <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
@@ -348,6 +362,11 @@
       </concept>
       <concept id="5045161044515397667" name="jetbrains.mps.lang.smodel.structure.Node_PointerOperation" flags="ng" index="iZEcu" />
       <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
+      <concept id="4693937538533521280" name="jetbrains.mps.lang.smodel.structure.OfConceptOperation" flags="ng" index="v3k3i">
+        <child id="4693937538533538124" name="requestedConcept" index="v3oSu" />
+      </concept>
+      <concept id="8758390115029295477" name="jetbrains.mps.lang.smodel.structure.SReferenceType" flags="in" index="2z4iKi" />
+      <concept id="8758390115028452779" name="jetbrains.mps.lang.smodel.structure.Node_GetReferencesOperation" flags="nn" index="2z74zc" />
       <concept id="2396822768958367367" name="jetbrains.mps.lang.smodel.structure.AbstractTypeCastExpression" flags="nn" index="$5XWr">
         <child id="6733348108486823193" name="leftExpression" index="1m5AlR" />
         <child id="3906496115198199033" name="conceptArgument" index="3oSUPX" />
@@ -364,6 +383,7 @@
       </concept>
       <concept id="7504436213544206332" name="jetbrains.mps.lang.smodel.structure.Node_ContainingLinkOperation" flags="nn" index="2NL2c5" />
       <concept id="1171305280644" name="jetbrains.mps.lang.smodel.structure.Node_GetDescendantsOperation" flags="nn" index="2Rf3mk" />
+      <concept id="1171310072040" name="jetbrains.mps.lang.smodel.structure.Node_GetContainingRootOperation" flags="nn" index="2Rxl7S" />
       <concept id="1171315804604" name="jetbrains.mps.lang.smodel.structure.Model_RootsOperation" flags="nn" index="2RRcyG">
         <reference id="1171315804605" name="concept" index="2RRcyH" />
       </concept>
@@ -374,6 +394,7 @@
         <child id="1145567471833" name="createdType" index="2T96Bj" />
       </concept>
       <concept id="1171407110247" name="jetbrains.mps.lang.smodel.structure.Node_GetAncestorOperation" flags="nn" index="2Xjw5R" />
+      <concept id="4124388153790980106" name="jetbrains.mps.lang.smodel.structure.Reference_GetTargetOperation" flags="nn" index="2ZHEkA" />
       <concept id="2644386474301421077" name="jetbrains.mps.lang.smodel.structure.LinkIdRefExpression" flags="nn" index="359W_D">
         <reference id="2644386474301421078" name="conceptDeclaration" index="359W_E" />
         <reference id="2644386474301421079" name="linkDeclaration" index="359W_F" />
@@ -385,6 +406,8 @@
         <child id="1177027386292" name="conceptArgument" index="cj9EA" />
       </concept>
       <concept id="1171999116870" name="jetbrains.mps.lang.smodel.structure.Node_IsNullOperation" flags="nn" index="3w_OXm" />
+      <concept id="1172008320231" name="jetbrains.mps.lang.smodel.structure.Node_IsNotNullOperation" flags="nn" index="3x8VRR" />
+      <concept id="1144100932627" name="jetbrains.mps.lang.smodel.structure.OperationParm_Inclusion" flags="ng" index="1xIGOp" />
       <concept id="1144101972840" name="jetbrains.mps.lang.smodel.structure.OperationParm_Concept" flags="ng" index="1xMEDy">
         <child id="1207343664468" name="conceptArgument" index="ri$Ld" />
       </concept>
@@ -451,6 +474,9 @@
         <child id="540871147943773366" name="argument" index="25WWJ7" />
       </concept>
       <concept id="1204980550705" name="jetbrains.mps.baseLanguage.collections.structure.VisitAllOperation" flags="nn" index="2es0OD" />
+      <concept id="1151688443754" name="jetbrains.mps.baseLanguage.collections.structure.ListType" flags="in" index="_YKpA">
+        <child id="1151688676805" name="elementType" index="_ZDj9" />
+      </concept>
       <concept id="1151689724996" name="jetbrains.mps.baseLanguage.collections.structure.SequenceType" flags="in" index="A3Dl8">
         <child id="1151689745422" name="elementType" index="A3Ik2" />
       </concept>
@@ -463,14 +489,25 @@
       <concept id="1153944233411" name="jetbrains.mps.baseLanguage.collections.structure.ForEachVariableReference" flags="nn" index="2GrUjf">
         <reference id="1153944258490" name="variable" index="2Gs0qQ" />
       </concept>
+      <concept id="1235566554328" name="jetbrains.mps.baseLanguage.collections.structure.AnyOperation" flags="nn" index="2HwmR7" />
       <concept id="1203518072036" name="jetbrains.mps.baseLanguage.collections.structure.SmartClosureParameterDeclaration" flags="ig" index="Rh6nW" />
       <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="nn" index="TSZUe" />
       <concept id="1162934736510" name="jetbrains.mps.baseLanguage.collections.structure.GetElementOperation" flags="nn" index="34jXtK" />
+      <concept id="1175845471038" name="jetbrains.mps.baseLanguage.collections.structure.ReverseOperation" flags="nn" index="35Qw8J" />
+      <concept id="1201792049884" name="jetbrains.mps.baseLanguage.collections.structure.TranslateOperation" flags="nn" index="3goQfb" />
+      <concept id="1197683403723" name="jetbrains.mps.baseLanguage.collections.structure.MapType" flags="in" index="3rvAFt">
+        <child id="1197683466920" name="keyType" index="3rvQeY" />
+        <child id="1197683475734" name="valueType" index="3rvSg0" />
+      </concept>
       <concept id="1165525191778" name="jetbrains.mps.baseLanguage.collections.structure.GetFirstOperation" flags="nn" index="1uHKPH" />
       <concept id="1225727723840" name="jetbrains.mps.baseLanguage.collections.structure.FindFirstOperation" flags="nn" index="1z4cxt" />
       <concept id="1202120902084" name="jetbrains.mps.baseLanguage.collections.structure.WhereOperation" flags="nn" index="3zZkjj" />
       <concept id="1202128969694" name="jetbrains.mps.baseLanguage.collections.structure.SelectOperation" flags="nn" index="3$u5V9" />
       <concept id="1184963466173" name="jetbrains.mps.baseLanguage.collections.structure.ToArrayOperation" flags="nn" index="3_kTaI" />
+      <concept id="1197932370469" name="jetbrains.mps.baseLanguage.collections.structure.MapElement" flags="nn" index="3EllGN">
+        <child id="1197932505799" name="map" index="3ElQJh" />
+        <child id="1197932525128" name="key" index="3ElVtu" />
+      </concept>
       <concept id="1172254888721" name="jetbrains.mps.baseLanguage.collections.structure.ContainsOperation" flags="nn" index="3JPx81" />
       <concept id="1180964022718" name="jetbrains.mps.baseLanguage.collections.structure.ConcatOperation" flags="nn" index="3QWeyG" />
     </language>
@@ -2828,245 +2865,1590 @@
     <property role="TrG5h" value="resolveRemainingIncludes" />
     <node concept="1pplIY" id="6NmtaR2qzDc" role="1pqMTA">
       <node concept="3clFbS" id="6NmtaR2qzDd" role="2VODD2">
-        <node concept="2Gpval" id="6NmtaR2$khB" role="3cqZAp">
-          <node concept="2GrKxI" id="6NmtaR2$khD" role="2Gsz3X">
-            <property role="TrG5h" value="inc" />
-          </node>
-          <node concept="2OqwBi" id="6NmtaR2$kr0" role="2GsD0m">
-            <node concept="1Q6Npb" id="6NmtaR2$kiI" role="2Oq$k0" />
-            <node concept="2SmgA7" id="6NmtaR2$kxg" role="2OqNvi">
-              <node concept="chp4Y" id="6NmtaR2$kxS" role="1dBWTz">
-                <ref role="cht4Q" to="2c95:5mf_X_Lbqjw" resolve="DocumentInclude" />
-              </node>
+        <node concept="2lOVwT" id="7U$sKL0$tep" role="3cqZAp">
+          <node concept="1PaTwC" id="7U$sKL0$teq" role="2lOMFJ">
+            <node concept="3oM_SD" id="7U$sKL0$ter" role="1PaTwD">
+              <property role="3oM_SC" value="Inverse" />
+            </node>
+            <node concept="3oM_SD" id="7U$sKL0$tx0" role="1PaTwD">
+              <property role="3oM_SC" value="topologically" />
+            </node>
+            <node concept="3oM_SD" id="7U$sKL0$tvB" role="1PaTwD">
+              <property role="3oM_SC" value="sorted" />
+            </node>
+            <node concept="3oM_SD" id="7U$sKL0$tvM" role="1PaTwD">
+              <property role="3oM_SC" value="iteration" />
+            </node>
+            <node concept="3oM_SD" id="7U$sKL0$twm" role="1PaTwD">
+              <property role="3oM_SC" value="is" />
+            </node>
+            <node concept="3oM_SD" id="7U$sKL0$twr" role="1PaTwD">
+              <property role="3oM_SC" value="imported" />
+            </node>
+            <node concept="3oM_SD" id="7U$sKL0$twD" role="1PaTwD">
+              <property role="3oM_SC" value="here." />
+            </node>
+            <node concept="3oM_SD" id="7U$sKL0$txw" role="1PaTwD">
+              <property role="3oM_SC" value="We" />
+            </node>
+            <node concept="3oM_SD" id="7U$sKL0$txL" role="1PaTwD">
+              <property role="3oM_SC" value="want" />
+            </node>
+            <node concept="3oM_SD" id="7U$sKL0$tyy" role="1PaTwD">
+              <property role="3oM_SC" value="to" />
+            </node>
+            <node concept="3oM_SD" id="7U$sKL0$tyP" role="1PaTwD">
+              <property role="3oM_SC" value="start" />
+            </node>
+            <node concept="3oM_SD" id="7U$sKL0$tz9" role="1PaTwD">
+              <property role="3oM_SC" value="including" />
+            </node>
+            <node concept="3oM_SD" id="7U$sKL0$t$z" role="1PaTwD">
+              <property role="3oM_SC" value="from" />
+            </node>
+            <node concept="3oM_SD" id="7U$sKL0$t$L" role="1PaTwD">
+              <property role="3oM_SC" value="the" />
+            </node>
+            <node concept="3oM_SD" id="7U$sKL0$t_0" role="1PaTwD">
+              <property role="3oM_SC" value="" />
             </node>
           </node>
-          <node concept="3clFbS" id="6NmtaR2$khH" role="2LFqv$">
-            <node concept="2Gpval" id="6NmtaR2$n4g" role="3cqZAp">
-              <node concept="2GrKxI" id="6NmtaR2$n4i" role="2Gsz3X">
-                <property role="TrG5h" value="content" />
-              </node>
-              <node concept="2OqwBi" id="6NmtaR2$oo2" role="2GsD0m">
-                <node concept="2OqwBi" id="6NmtaR2$nG4" role="2Oq$k0">
-                  <node concept="2OqwBi" id="6NmtaR2$ni$" role="2Oq$k0">
-                    <node concept="2GrUjf" id="6NmtaR2$n5J" role="2Oq$k0">
-                      <ref role="2Gs0qQ" node="6NmtaR2$khD" resolve="inc" />
-                    </node>
-                    <node concept="3TrEf2" id="6NmtaR2$nzn" role="2OqNvi">
-                      <ref role="3Tt5mk" to="2c95:5mf_X_Lbqjz" resolve="ref" />
-                    </node>
-                  </node>
-                  <node concept="3TrEf2" id="6NmtaR2$o2d" role="2OqNvi">
-                    <ref role="3Tt5mk" to="2c95:2TZO3DbvI5E" resolve="doc" />
-                  </node>
-                </node>
-                <node concept="3Tsc0h" id="6NmtaR2$oSo" role="2OqNvi">
-                  <ref role="3TtcxE" to="2c95:2TZO3Dbv6JU" resolve="contents" />
-                </node>
-              </node>
-              <node concept="3clFbS" id="6NmtaR2$n4m" role="2LFqv$">
-                <node concept="3clFbF" id="6NmtaR2$kyS" role="3cqZAp">
-                  <node concept="2OqwBi" id="6NmtaR2$kHl" role="3clFbG">
-                    <node concept="2GrUjf" id="6NmtaR2$kyR" role="2Oq$k0">
-                      <ref role="2Gs0qQ" node="6NmtaR2$khD" resolve="inc" />
-                    </node>
-                    <node concept="HtX7F" id="6NmtaR2$p5H" role="2OqNvi">
-                      <node concept="2GrUjf" id="6NmtaR2$p6m" role="HtX7I">
-                        <ref role="2Gs0qQ" node="6NmtaR2$n4i" resolve="content" />
-                      </node>
-                    </node>
-                  </node>
+          <node concept="1PaTwC" id="7U$sKL0$t_p" role="2lOMFJ">
+            <node concept="3oM_SD" id="7U$sKL0$tAY" role="1PaTwD">
+              <property role="3oM_SC" value="leaf" />
+            </node>
+            <node concept="3oM_SD" id="7U$sKL0$tB8" role="1PaTwD">
+              <property role="3oM_SC" value="towards" />
+            </node>
+            <node concept="3oM_SD" id="7U$sKL0$tBr" role="1PaTwD">
+              <property role="3oM_SC" value="the" />
+            </node>
+            <node concept="3oM_SD" id="7U$sKL0$tBB" role="1PaTwD">
+              <property role="3oM_SC" value="root" />
+            </node>
+            <node concept="3oM_SD" id="7U$sKL0$tCk" role="1PaTwD">
+              <property role="3oM_SC" value="to" />
+            </node>
+            <node concept="3oM_SD" id="7U$sKL0$tD9" role="1PaTwD">
+              <property role="3oM_SC" value="be" />
+            </node>
+            <node concept="3oM_SD" id="7U$sKL0$tDg" role="1PaTwD">
+              <property role="3oM_SC" value="able" />
+            </node>
+            <node concept="3oM_SD" id="7U$sKL0$tDN" role="1PaTwD">
+              <property role="3oM_SC" value="to" />
+            </node>
+            <node concept="3oM_SD" id="7U$sKL0$tDW" role="1PaTwD">
+              <property role="3oM_SC" value="include" />
+            </node>
+            <node concept="3oM_SD" id="7U$sKL0$tE6" role="1PaTwD">
+              <property role="3oM_SC" value="a" />
+            </node>
+            <node concept="3oM_SD" id="7U$sKL0$tEh" role="1PaTwD">
+              <property role="3oM_SC" value="document" />
+            </node>
+            <node concept="3oM_SD" id="7U$sKL0$tEH" role="1PaTwD">
+              <property role="3oM_SC" value="multiple" />
+            </node>
+            <node concept="3oM_SD" id="7U$sKL0$tFa" role="1PaTwD">
+              <property role="3oM_SC" value="times." />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="3lxJBjijfIG" role="3cqZAp">
+          <node concept="2OqwBi" id="3lxJBjijHrG" role="3clFbG">
+            <node concept="2OqwBi" id="3lxJBjijfRd" role="2Oq$k0">
+              <node concept="1Q6Npb" id="3lxJBjijfIF" role="2Oq$k0" />
+              <node concept="2SmgA7" id="3lxJBjijfXH" role="2OqNvi">
+                <node concept="chp4Y" id="7WLbt3cyyKT" role="1dBWTz">
+                  <ref role="cht4Q" to="2c95:5gTlpaky5gD" resolve="AbstractExport" />
                 </node>
               </node>
             </node>
-            <node concept="3SKdUt" id="7NleypLW8_r" role="3cqZAp">
-              <node concept="1PaTwC" id="59cfP9u6Nuj" role="1aUNEU">
-                <node concept="3oM_SD" id="59cfP9u6Nuk" role="1PaTwD">
-                  <property role="3oM_SC" value="also" />
-                </node>
-                <node concept="3oM_SD" id="59cfP9u6Nul" role="1PaTwD">
-                  <property role="3oM_SC" value="need" />
-                </node>
-                <node concept="3oM_SD" id="59cfP9u6Num" role="1PaTwD">
-                  <property role="3oM_SC" value="to" />
-                </node>
-                <node concept="3oM_SD" id="59cfP9u6Nun" role="1PaTwD">
-                  <property role="3oM_SC" value="delete" />
-                </node>
-                <node concept="3oM_SD" id="59cfP9u6Nuo" role="1PaTwD">
-                  <property role="3oM_SC" value="all" />
-                </node>
-                <node concept="3oM_SD" id="59cfP9u6Nup" role="1PaTwD">
-                  <property role="3oM_SC" value="dependsOn" />
-                </node>
-                <node concept="3oM_SD" id="59cfP9u6Nuq" role="1PaTwD">
-                  <property role="3oM_SC" value="refs" />
-                </node>
-                <node concept="3oM_SD" id="59cfP9u6Nur" role="1PaTwD">
-                  <property role="3oM_SC" value="to" />
-                </node>
-                <node concept="3oM_SD" id="59cfP9u6Nus" role="1PaTwD">
-                  <property role="3oM_SC" value="the" />
-                </node>
-                <node concept="3oM_SD" id="59cfP9u6Nut" role="1PaTwD">
-                  <property role="3oM_SC" value="document" />
-                </node>
-                <node concept="3oM_SD" id="59cfP9u6Nuu" role="1PaTwD">
-                  <property role="3oM_SC" value="before" />
-                </node>
-                <node concept="3oM_SD" id="59cfP9u6Nuv" role="1PaTwD">
-                  <property role="3oM_SC" value="removing" />
-                </node>
-                <node concept="3oM_SD" id="59cfP9u6Nuw" role="1PaTwD">
-                  <property role="3oM_SC" value="it" />
-                </node>
-                <node concept="3oM_SD" id="59cfP9u6Nux" role="1PaTwD">
-                  <property role="3oM_SC" value="(to" />
-                </node>
-                <node concept="3oM_SD" id="59cfP9u6Nuy" role="1PaTwD">
-                  <property role="3oM_SC" value="avoid" />
-                </node>
-                <node concept="3oM_SD" id="59cfP9u6Nuz" role="1PaTwD">
-                  <property role="3oM_SC" value="broken" />
-                </node>
-                <node concept="3oM_SD" id="59cfP9u6Nu$" role="1PaTwD">
-                  <property role="3oM_SC" value="refs" />
-                </node>
-                <node concept="3oM_SD" id="59cfP9u6Nu_" role="1PaTwD">
-                  <property role="3oM_SC" value="errors" />
-                </node>
-                <node concept="3oM_SD" id="59cfP9u6NuA" role="1PaTwD">
-                  <property role="3oM_SC" value="during" />
-                </node>
-                <node concept="3oM_SD" id="59cfP9u6NuB" role="1PaTwD">
-                  <property role="3oM_SC" value="generation)" />
-                </node>
-              </node>
-            </node>
-            <node concept="3cpWs8" id="7NleypPGigH" role="3cqZAp">
-              <node concept="3cpWsn" id="7NleypPGigI" role="3cpWs9">
-                <property role="TrG5h" value="dependsRefs" />
-                <node concept="A3Dl8" id="7NleypPGigx" role="1tU5fm">
-                  <node concept="3Tqbb2" id="7NleypPGig$" role="A3Ik2">
-                    <ref role="ehGHo" to="2c95:2TZO3DbvI5D" resolve="DocumentRef" />
-                  </node>
-                </node>
-                <node concept="2OqwBi" id="7NleypPGigJ" role="33vP2m">
-                  <node concept="2OqwBi" id="7NleypPGigK" role="2Oq$k0">
-                    <node concept="1Q6Npb" id="7NleypPGigL" role="2Oq$k0" />
-                    <node concept="2SmgA7" id="7NleypPGigM" role="2OqNvi">
-                      <node concept="chp4Y" id="7NleypPGigN" role="1dBWTz">
-                        <ref role="cht4Q" to="2c95:2TZO3DbvI5D" resolve="DocumentRef" />
+            <node concept="2es0OD" id="3lxJBjijK_g" role="2OqNvi">
+              <node concept="1bVj0M" id="3lxJBjijK_i" role="23t8la">
+                <node concept="3clFbS" id="3lxJBjijK_j" role="1bW5cS">
+                  <node concept="3clFbF" id="3lxJBjijKBF" role="3cqZAp">
+                    <node concept="2OqwBi" id="3lxJBjikdr1" role="3clFbG">
+                      <node concept="2OqwBi" id="3lxJBjikbCX" role="2Oq$k0">
+                        <node concept="2OqwBi" id="5FHtHFpWV6l" role="2Oq$k0">
+                          <node concept="2OqwBi" id="3lxJBjikar1" role="2Oq$k0">
+                            <node concept="2OqwBi" id="3lxJBjijLoP" role="2Oq$k0">
+                              <node concept="2OqwBi" id="3lxJBjijKPd" role="2Oq$k0">
+                                <node concept="37vLTw" id="3lxJBjijKBE" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="3lxJBjijK_k" resolve="export" />
+                                </node>
+                                <node concept="3TrEf2" id="3lxJBjijLdZ" role="2OqNvi">
+                                  <ref role="3Tt5mk" to="2c95:5gTlpaky6t1" resolve="root" />
+                                </node>
+                              </node>
+                              <node concept="3TrEf2" id="3lxJBjikacv" role="2OqNvi">
+                                <ref role="3Tt5mk" to="2c95:2TZO3DbvI5E" resolve="doc" />
+                              </node>
+                            </node>
+                            <node concept="2qgKlT" id="3lxJBjikaCS" role="2OqNvi">
+                              <ref role="37wK5l" to="4gky:3lxJBjijN4E" resolve="getTopologicalSortedDocuments" />
+                            </node>
+                          </node>
+                          <node concept="35Qw8J" id="5FHtHFpWXcH" role="2OqNvi" />
+                        </node>
+                        <node concept="v3k3i" id="3lxJBjikd7O" role="2OqNvi">
+                          <node concept="chp4Y" id="3lxJBjikdaX" role="v3oSu">
+                            <ref role="cht4Q" to="2c95:2TZO3DbuxwK" resolve="Document" />
+                          </node>
+                        </node>
                       </node>
-                    </node>
-                  </node>
-                  <node concept="3zZkjj" id="7NleypPGigO" role="2OqNvi">
-                    <node concept="1bVj0M" id="7NleypPGigP" role="23t8la">
-                      <property role="3yWfEV" value="true" />
-                      <node concept="3clFbS" id="7NleypPGigQ" role="1bW5cS">
-                        <node concept="3clFbF" id="7NleypPGigR" role="3cqZAp">
-                          <node concept="1Wc70l" id="7NleypPGigS" role="3clFbG">
-                            <node concept="1eOMI4" id="7NleypPGigT" role="3uHU7B">
-                              <node concept="17R0WA" id="7NleypPGigU" role="1eOMHV">
-                                <node concept="2OqwBi" id="7NleypPGigV" role="3uHU7w">
-                                  <node concept="2OqwBi" id="7NleypPGigW" role="2Oq$k0">
-                                    <node concept="2GrUjf" id="7NleypPGigX" role="2Oq$k0">
-                                      <ref role="2Gs0qQ" node="6NmtaR2$khD" resolve="inc" />
-                                    </node>
-                                    <node concept="3TrEf2" id="7NleypPGigY" role="2OqNvi">
-                                      <ref role="3Tt5mk" to="2c95:5mf_X_Lbqjz" resolve="ref" />
-                                    </node>
+                      <node concept="2es0OD" id="3lxJBjikdRe" role="2OqNvi">
+                        <node concept="1bVj0M" id="3lxJBjikdRg" role="23t8la">
+                          <node concept="3clFbS" id="3lxJBjikdRh" role="1bW5cS">
+                            <node concept="3clFbF" id="3lxJBjiqpQh" role="3cqZAp">
+                              <node concept="2OqwBi" id="3lxJBjiqtqg" role="3clFbG">
+                                <node concept="2OqwBi" id="3lxJBjiqq8o" role="2Oq$k0">
+                                  <node concept="37vLTw" id="3lxJBjiqpQg" role="2Oq$k0">
+                                    <ref role="3cqZAo" node="3lxJBjikdRi" resolve="document" />
                                   </node>
-                                  <node concept="3TrEf2" id="7NleypPGigZ" role="2OqNvi">
-                                    <ref role="3Tt5mk" to="2c95:2TZO3DbvI5E" resolve="doc" />
+                                  <node concept="2Rf3mk" id="3lxJBjiqqNO" role="2OqNvi">
+                                    <node concept="1xMEDy" id="3lxJBjiqqNQ" role="1xVPHs">
+                                      <node concept="chp4Y" id="3lxJBjiqqU3" role="ri$Ld">
+                                        <ref role="cht4Q" to="2c95:5mf_X_Lbqjw" resolve="DocumentInclude" />
+                                      </node>
+                                    </node>
                                   </node>
                                 </node>
-                                <node concept="2OqwBi" id="7NleypPGih0" role="3uHU7B">
-                                  <node concept="37vLTw" id="7NleypPGih1" role="2Oq$k0">
-                                    <ref role="3cqZAo" node="7NleypPGih9" resolve="ref" />
-                                  </node>
-                                  <node concept="3TrEf2" id="7NleypPGih2" role="2OqNvi">
-                                    <ref role="3Tt5mk" to="2c95:2TZO3DbvI5E" resolve="doc" />
+                                <node concept="2es0OD" id="3lxJBjiqwoh" role="2OqNvi">
+                                  <node concept="1bVj0M" id="3lxJBjiqwoj" role="23t8la">
+                                    <node concept="3clFbS" id="3lxJBjiqwok" role="1bW5cS">
+                                      <node concept="3cpWs8" id="5FHtHFpZYJJ" role="3cqZAp">
+                                        <node concept="3cpWsn" id="5FHtHFpZYJK" role="3cpWs9">
+                                          <property role="TrG5h" value="inlcudedContent" />
+                                          <node concept="2I9FWS" id="5FHtHFpZYfP" role="1tU5fm">
+                                            <ref role="2I9WkF" to="2c95:2TZO3DbuxwP" resolve="IDocumentContent" />
+                                          </node>
+                                          <node concept="2OqwBi" id="5FHtHFpZYJL" role="33vP2m">
+                                            <node concept="2OqwBi" id="5FHtHFpZYJM" role="2Oq$k0">
+                                              <node concept="2OqwBi" id="5FHtHFpZYJN" role="2Oq$k0">
+                                                <node concept="37vLTw" id="5FHtHFpZYJO" role="2Oq$k0">
+                                                  <ref role="3cqZAo" node="3lxJBjiqwol" resolve="include" />
+                                                </node>
+                                                <node concept="3TrEf2" id="5FHtHFpZYJP" role="2OqNvi">
+                                                  <ref role="3Tt5mk" to="2c95:5mf_X_Lbqjz" resolve="ref" />
+                                                </node>
+                                              </node>
+                                              <node concept="3TrEf2" id="5FHtHFpZYJQ" role="2OqNvi">
+                                                <ref role="3Tt5mk" to="2c95:2TZO3DbvI5E" resolve="doc" />
+                                              </node>
+                                            </node>
+                                            <node concept="3Tsc0h" id="5FHtHFpZYJR" role="2OqNvi">
+                                              <ref role="3TtcxE" to="2c95:2TZO3Dbv6JU" resolve="contents" />
+                                            </node>
+                                          </node>
+                                        </node>
+                                      </node>
+                                      <node concept="3cpWs8" id="5FHtHFpWm3k" role="3cqZAp">
+                                        <node concept="3cpWsn" id="5FHtHFpWm3l" role="3cpWs9">
+                                          <property role="TrG5h" value="includedContentCopy" />
+                                          <node concept="_YKpA" id="5FHtHFpWox1" role="1tU5fm">
+                                            <node concept="3Tqbb2" id="5FHtHFpWoJQ" role="_ZDj9" />
+                                          </node>
+                                          <node concept="2YIFZM" id="5FHtHFpWm3m" role="33vP2m">
+                                            <ref role="37wK5l" to="fwk:~TracingUtil.copyWithTrace(java.util.List)" resolve="copyWithTrace" />
+                                            <ref role="1Pybhc" to="fwk:~TracingUtil" resolve="TracingUtil" />
+                                            <node concept="37vLTw" id="5FHtHFpZYJS" role="37wK5m">
+                                              <ref role="3cqZAo" node="5FHtHFpZYJK" resolve="inlcudedContent" />
+                                            </node>
+                                          </node>
+                                        </node>
+                                      </node>
+                                      <node concept="3clFbF" id="3lxJBjiqwvY" role="3cqZAp">
+                                        <node concept="2OqwBi" id="3lxJBjiqDeb" role="3clFbG">
+                                          <node concept="37vLTw" id="5FHtHFpWn2l" role="2Oq$k0">
+                                            <ref role="3cqZAo" node="5FHtHFpWm3l" resolve="includedContentCopy" />
+                                          </node>
+                                          <node concept="2es0OD" id="3lxJBjiqFaS" role="2OqNvi">
+                                            <node concept="1bVj0M" id="3lxJBjiqFaU" role="23t8la">
+                                              <node concept="3clFbS" id="3lxJBjiqFaV" role="1bW5cS">
+                                                <node concept="3clFbF" id="3lxJBjiqG0y" role="3cqZAp">
+                                                  <node concept="2OqwBi" id="3lxJBjiqGTh" role="3clFbG">
+                                                    <node concept="37vLTw" id="3lxJBjiqG0x" role="2Oq$k0">
+                                                      <ref role="3cqZAo" node="3lxJBjiqwol" resolve="include" />
+                                                    </node>
+                                                    <node concept="HtX7F" id="3lxJBjiqHn4" role="2OqNvi">
+                                                      <node concept="37vLTw" id="5FHtHFpWnnq" role="HtX7I">
+                                                        <ref role="3cqZAo" node="3lxJBjiqFaW" resolve="newContent" />
+                                                      </node>
+                                                    </node>
+                                                  </node>
+                                                </node>
+                                              </node>
+                                              <node concept="Rh6nW" id="3lxJBjiqFaW" role="1bW2Oz">
+                                                <property role="TrG5h" value="newContent" />
+                                                <node concept="2jxLKc" id="3lxJBjiqFaX" role="1tU5fm" />
+                                              </node>
+                                            </node>
+                                          </node>
+                                        </node>
+                                      </node>
+                                      <node concept="3clFbH" id="7U$sKL0r3b2" role="3cqZAp" />
+                                      <node concept="2lOVwT" id="7U$sKL0qRVX" role="3cqZAp">
+                                        <node concept="1PaTwC" id="7U$sKL0qRVY" role="2lOMFJ">
+                                          <node concept="3oM_SD" id="7U$sKL0qRVZ" role="1PaTwD">
+                                            <property role="3oM_SC" value="The" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0qS7G" role="1PaTwD">
+                                            <property role="3oM_SC" value="part" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0rek7" role="1PaTwD">
+                                            <property role="3oM_SC" value="below" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0qS7R" role="1PaTwD">
+                                            <property role="3oM_SC" value="is" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0qS83" role="1PaTwD">
+                                            <property role="3oM_SC" value="responsible" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0qS8K" role="1PaTwD">
+                                            <property role="3oM_SC" value="for" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0qS9l" role="1PaTwD">
+                                            <property role="3oM_SC" value="updating" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0qS9s" role="1PaTwD">
+                                            <property role="3oM_SC" value="references." />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0qSa4" role="1PaTwD">
+                                            <property role="3oM_SC" value="" />
+                                          </node>
+                                        </node>
+                                        <node concept="1PaTwC" id="7U$sKL0qSam" role="2lOMFJ">
+                                          <node concept="3oM_SD" id="7U$sKL0qSal" role="1PaTwD">
+                                            <property role="3oM_SC" value="" />
+                                          </node>
+                                        </node>
+                                        <node concept="1PaTwC" id="7U$sKL0qSdc" role="2lOMFJ">
+                                          <node concept="3oM_SD" id="7U$sKL0qSdb" role="1PaTwD">
+                                            <property role="3oM_SC" value="Copy" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0qSd$" role="1PaTwD">
+                                            <property role="3oM_SC" value="with" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0qSdB" role="1PaTwD">
+                                            <property role="3oM_SC" value="trace" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0qSdY" role="1PaTwD">
+                                            <property role="3oM_SC" value="takes" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0qSe3" role="1PaTwD">
+                                            <property role="3oM_SC" value="care" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0qSe9" role="1PaTwD">
+                                            <property role="3oM_SC" value="of" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0qSeg" role="1PaTwD">
+                                            <property role="3oM_SC" value="updating" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0qSeK" role="1PaTwD">
+                                            <property role="3oM_SC" value="the" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0qSeT" role="1PaTwD">
+                                            <property role="3oM_SC" value="references" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0qSfb" role="1PaTwD">
+                                            <property role="3oM_SC" value="in" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0qSkP" role="1PaTwD">
+                                            <property role="3oM_SC" value="the" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0qSl1" role="1PaTwD">
+                                            <property role="3oM_SC" value="nodes" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0qSlm" role="1PaTwD">
+                                            <property role="3oM_SC" value="that" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0qSlG" role="1PaTwD">
+                                            <property role="3oM_SC" value="part" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0qSm3" role="1PaTwD">
+                                            <property role="3oM_SC" value="of" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0qSmj" role="1PaTwD">
+                                            <property role="3oM_SC" value="the" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0qSmG" role="1PaTwD">
+                                            <property role="3oM_SC" value="copy" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0qSmY" role="1PaTwD">
+                                            <property role="3oM_SC" value="operation." />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0qSnD" role="1PaTwD">
+                                            <property role="3oM_SC" value="" />
+                                          </node>
+                                        </node>
+                                        <node concept="1PaTwC" id="7U$sKL0qSoe" role="2lOMFJ">
+                                          <node concept="3oM_SD" id="7U$sKL0qSod" role="1PaTwD">
+                                            <property role="3oM_SC" value="This" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0qSpe" role="1PaTwD">
+                                            <property role="3oM_SC" value="means" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0qSpp" role="1PaTwD">
+                                            <property role="3oM_SC" value="that" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0rjPA" role="1PaTwD">
+                                            <property role="3oM_SC" value="when" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0qSq0" role="1PaTwD">
+                                            <property role="3oM_SC" value="we" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0rm05" role="1PaTwD">
+                                            <property role="3oM_SC" value="copy" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0qSqw" role="1PaTwD">
+                                            <property role="3oM_SC" value="content" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0rn9$" role="1PaTwD">
+                                            <property role="3oM_SC" value="of" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0rp1P" role="1PaTwD">
+                                            <property role="3oM_SC" value="the" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0rp28" role="1PaTwD">
+                                            <property role="3oM_SC" value="included" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0rrmJ" role="1PaTwD">
+                                            <property role="3oM_SC" value="document" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0qSrp" role="1PaTwD">
+                                            <property role="3oM_SC" value="into" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0qSul" role="1PaTwD">
+                                            <property role="3oM_SC" value="the" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0ruEv" role="1PaTwD">
+                                            <property role="3oM_SC" value="including" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0rz7u" role="1PaTwD">
+                                            <property role="3oM_SC" value="document" />
+                                          </node>
+                                        </node>
+                                        <node concept="1PaTwC" id="7U$sKL0qSyT" role="2lOMFJ">
+                                          <node concept="3oM_SD" id="7U$sKL0rAvh" role="1PaTwD">
+                                            <property role="3oM_SC" value="all" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0rJZn" role="1PaTwD">
+                                            <property role="3oM_SC" value="reference" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0rYy$" role="1PaTwD">
+                                            <property role="3oM_SC" value="internally" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0s1$M" role="1PaTwD">
+                                            <property role="3oM_SC" value="are" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0s2I5" role="1PaTwD">
+                                            <property role="3oM_SC" value="updated." />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0s4So" role="1PaTwD">
+                                            <property role="3oM_SC" value="For" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0s61H" role="1PaTwD">
+                                            <property role="3oM_SC" value="instance" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0s61P" role="1PaTwD">
+                                            <property role="3oM_SC" value="if" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0s61Y" role="1PaTwD">
+                                            <property role="3oM_SC" value="we" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0s628" role="1PaTwD">
+                                            <property role="3oM_SC" value="copy" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0sjUC" role="1PaTwD">
+                                            <property role="3oM_SC" value="two" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0thmi" role="1PaTwD">
+                                            <property role="3oM_SC" value="sections" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0so6r" role="1PaTwD">
+                                            <property role="3oM_SC" value="where" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0sraB" role="1PaTwD">
+                                            <property role="3oM_SC" value="one" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0s$6b" role="1PaTwD">
+                                            <property role="3oM_SC" value="references" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0s$Yp" role="1PaTwD">
+                                            <property role="3oM_SC" value="the" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0sAY1" role="1PaTwD">
+                                            <property role="3oM_SC" value="" />
+                                          </node>
+                                        </node>
+                                        <node concept="1PaTwC" id="7U$sKL0sAYl" role="2lOMFJ">
+                                          <node concept="3oM_SD" id="7U$sKL0sAYk" role="1PaTwD">
+                                            <property role="3oM_SC" value="other" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0sCmi" role="1PaTwD">
+                                            <property role="3oM_SC" value="the" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0sGEt" role="1PaTwD">
+                                            <property role="3oM_SC" value="references" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0sIWY" role="1PaTwD">
+                                            <property role="3oM_SC" value="in" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0sL7w" role="1PaTwD">
+                                            <property role="3oM_SC" value="the" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0sL7B" role="1PaTwD">
+                                            <property role="3oM_SC" value="copy" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0sMgX" role="1PaTwD">
+                                            <property role="3oM_SC" value="point" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0sP$x" role="1PaTwD">
+                                            <property role="3oM_SC" value="to" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0sP$F" role="1PaTwD">
+                                            <property role="3oM_SC" value="copy" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0sQI4" role="1PaTwD">
+                                            <property role="3oM_SC" value="as" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0sQIg" role="1PaTwD">
+                                            <property role="3oM_SC" value="well." />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0sftm" role="1PaTwD">
+                                            <property role="3oM_SC" value="" />
+                                          </node>
+                                        </node>
+                                        <node concept="1PaTwC" id="7U$sKL0qSCr" role="2lOMFJ">
+                                          <node concept="3oM_SD" id="7U$sKL0qSCq" role="1PaTwD">
+                                            <property role="3oM_SC" value="In" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0qSDS" role="1PaTwD">
+                                            <property role="3oM_SC" value="some" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0qSDV" role="1PaTwD">
+                                            <property role="3oM_SC" value="scenarios" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0qSEf" role="1PaTwD">
+                                            <property role="3oM_SC" value="this" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0qSE$" role="1PaTwD">
+                                            <property role="3oM_SC" value="isn't" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0qSFx" role="1PaTwD">
+                                            <property role="3oM_SC" value="enough" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0qSFC" role="1PaTwD">
+                                            <property role="3oM_SC" value="because" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0qSFK" role="1PaTwD">
+                                            <property role="3oM_SC" value="the" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0qSG1" role="1PaTwD">
+                                            <property role="3oM_SC" value="document" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0qSGr" role="1PaTwD">
+                                            <property role="3oM_SC" value="we" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0qSGA" role="1PaTwD">
+                                            <property role="3oM_SC" value="are" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0sXlj" role="1PaTwD">
+                                            <property role="3oM_SC" value="including" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0qSGM" role="1PaTwD">
+                                            <property role="3oM_SC" value="into" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0qSH7" role="1PaTwD">
+                                            <property role="3oM_SC" value="might" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0qSH_" role="1PaTwD">
+                                            <property role="3oM_SC" value="have" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0qSHO" role="1PaTwD">
+                                            <property role="3oM_SC" value="references" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0qSJf" role="1PaTwD">
+                                            <property role="3oM_SC" value="" />
+                                          </node>
+                                        </node>
+                                        <node concept="1PaTwC" id="7U$sKL0qSJV" role="2lOMFJ">
+                                          <node concept="3oM_SD" id="7U$sKL0sZvN" role="1PaTwD">
+                                            <property role="3oM_SC" value="into" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0t0Hk" role="1PaTwD">
+                                            <property role="3oM_SC" value="the" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0t2Vw" role="1PaTwD">
+                                            <property role="3oM_SC" value="included" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0qSLH" role="1PaTwD">
+                                            <property role="3oM_SC" value="document" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0qSLK" role="1PaTwD">
+                                            <property role="3oM_SC" value="as" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0qSMf" role="1PaTwD">
+                                            <property role="3oM_SC" value="well." />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0qSMk" role="1PaTwD">
+                                            <property role="3oM_SC" value="" />
+                                          </node>
+                                        </node>
+                                        <node concept="1PaTwC" id="7U$sKL0qSQy" role="2lOMFJ">
+                                          <node concept="3oM_SD" id="7U$sKL0t452" role="1PaTwD">
+                                            <property role="3oM_SC" value="For" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0tmWV" role="1PaTwD">
+                                            <property role="3oM_SC" value="instance" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0tkct" role="1PaTwD">
+                                            <property role="3oM_SC" value="a" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0qSMT" role="1PaTwD">
+                                            <property role="3oM_SC" value="section" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0qSN2" role="1PaTwD">
+                                            <property role="3oM_SC" value="of" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0qSNk" role="1PaTwD">
+                                            <property role="3oM_SC" value="the" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0qSNv" role="1PaTwD">
+                                            <property role="3oM_SC" value="included" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0qSO3" role="1PaTwD">
+                                            <property role="3oM_SC" value="document" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0qSOg" role="1PaTwD">
+                                            <property role="3oM_SC" value="is" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0qSOu" role="1PaTwD">
+                                            <property role="3oM_SC" value="referenced" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0qSPu" role="1PaTwD">
+                                            <property role="3oM_SC" value="inside" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0toJW" role="1PaTwD">
+                                            <property role="3oM_SC" value="of" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0ts3C" role="1PaTwD">
+                                            <property role="3oM_SC" value="text" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0ttd8" role="1PaTwD">
+                                            <property role="3oM_SC" value="in" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0qSPI" role="1PaTwD">
+                                            <property role="3oM_SC" value="the" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0t5ig" role="1PaTwD">
+                                            <property role="3oM_SC" value="including" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0qSSA" role="1PaTwD">
+                                            <property role="3oM_SC" value="document." />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0qSTi" role="1PaTwD">
+                                            <property role="3oM_SC" value="" />
+                                          </node>
+                                        </node>
+                                        <node concept="1PaTwC" id="7U$sKL0t7wx" role="2lOMFJ">
+                                          <node concept="3oM_SD" id="7U$sKL0t7ww" role="1PaTwD">
+                                            <property role="3oM_SC" value="This" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0qSTu" role="1PaTwD">
+                                            <property role="3oM_SC" value="code" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0qSUt" role="1PaTwD">
+                                            <property role="3oM_SC" value="takes" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0qSUz" role="1PaTwD">
+                                            <property role="3oM_SC" value="care" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0qSUE" role="1PaTwD">
+                                            <property role="3oM_SC" value="of" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0qSV2" role="1PaTwD">
+                                            <property role="3oM_SC" value="updating" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0qSVS" role="1PaTwD">
+                                            <property role="3oM_SC" value="these." />
+                                          </node>
+                                        </node>
+                                        <node concept="1PaTwC" id="7U$sKL0qSWb" role="2lOMFJ">
+                                          <node concept="3oM_SD" id="7U$sKL0qSWa" role="1PaTwD">
+                                            <property role="3oM_SC" value="" />
+                                          </node>
+                                        </node>
+                                        <node concept="1PaTwC" id="7U$sKL0qSYa" role="2lOMFJ">
+                                          <node concept="3oM_SD" id="7U$sKL0qSY9" role="1PaTwD">
+                                            <property role="3oM_SC" value="To" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0qT0a" role="1PaTwD">
+                                            <property role="3oM_SC" value="do" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0qT0l" role="1PaTwD">
+                                            <property role="3oM_SC" value="so" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0qT0D" role="1PaTwD">
+                                            <property role="3oM_SC" value="it" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0qT1j" role="1PaTwD">
+                                            <property role="3oM_SC" value="uses" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0qT1x" role="1PaTwD">
+                                            <property role="3oM_SC" value="the" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0qT1C" role="1PaTwD">
+                                            <property role="3oM_SC" value="generator" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0qT1K" role="1PaTwD">
+                                            <property role="3oM_SC" value="trace" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0qT29" role="1PaTwD">
+                                            <property role="3oM_SC" value="api." />
+                                          </node>
+                                        </node>
+                                        <node concept="1PaTwC" id="7U$sKL0umwD" role="2lOMFJ">
+                                          <node concept="3oM_SD" id="7U$sKL0tyG6" role="1PaTwD">
+                                            <property role="3oM_SC" value="First" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0tBdA" role="1PaTwD">
+                                            <property role="3oM_SC" value="we" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0tCmR" role="1PaTwD">
+                                            <property role="3oM_SC" value="collect" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0tCmV" role="1PaTwD">
+                                            <property role="3oM_SC" value="all" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0tDsV" role="1PaTwD">
+                                            <property role="3oM_SC" value="references" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0tM0z" role="1PaTwD">
+                                            <property role="3oM_SC" value="in" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0tM0E" role="1PaTwD">
+                                            <property role="3oM_SC" value="the" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0tN3G" role="1PaTwD">
+                                            <property role="3oM_SC" value="current" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0tUkH" role="1PaTwD">
+                                            <property role="3oM_SC" value="document," />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0tWbk" role="1PaTwD">
+                                            <property role="3oM_SC" value="then" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0tWbv" role="1PaTwD">
+                                            <property role="3oM_SC" value="we" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0tWbF" role="1PaTwD">
+                                            <property role="3oM_SC" value="collect" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0tXev" role="1PaTwD">
+                                            <property role="3oM_SC" value="all" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0tXeH" role="1PaTwD">
+                                            <property role="3oM_SC" value="referencable" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0uoJ6" role="1PaTwD">
+                                            <property role="3oM_SC" value="content" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0upWx" role="1PaTwD">
+                                            <property role="3oM_SC" value="" />
+                                          </node>
+                                        </node>
+                                        <node concept="1PaTwC" id="7U$sKL0u2H6" role="2lOMFJ">
+                                          <node concept="3oM_SD" id="7U$sKL0upWM" role="1PaTwD">
+                                            <property role="3oM_SC" value="(everything" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0uyPz" role="1PaTwD">
+                                            <property role="3oM_SC" value="extending" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0uFyO" role="1PaTwD">
+                                            <property role="3oM_SC" value="AbstractSection)" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0uXMU" role="1PaTwD">
+                                            <property role="3oM_SC" value="in" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0uYZ0" role="1PaTwD">
+                                            <property role="3oM_SC" value="the" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0uYZ7" role="1PaTwD">
+                                            <property role="3oM_SC" value="included" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0v3rF" role="1PaTwD">
+                                            <property role="3oM_SC" value="document" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0v6Jf" role="1PaTwD">
+                                            <property role="3oM_SC" value="as" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0v6Jp" role="1PaTwD">
+                                            <property role="3oM_SC" value="well" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0v6J$" role="1PaTwD">
+                                            <property role="3oM_SC" value="as" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0v7J7" role="1PaTwD">
+                                            <property role="3oM_SC" value="the" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0vb3R" role="1PaTwD">
+                                            <property role="3oM_SC" value="copy" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0vb45" role="1PaTwD">
+                                            <property role="3oM_SC" value="of" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0vb4k" role="1PaTwD">
+                                            <property role="3oM_SC" value="if." />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0uSC8" role="1PaTwD">
+                                            <property role="3oM_SC" value="" />
+                                          </node>
+                                        </node>
+                                        <node concept="1PaTwC" id="7U$sKL0vfzZ" role="2lOMFJ">
+                                          <node concept="3oM_SD" id="7U$sKL0vjUZ" role="1PaTwD">
+                                            <property role="3oM_SC" value="To" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0vjV1" role="1PaTwD">
+                                            <property role="3oM_SC" value="identify" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0vkN9" role="1PaTwD">
+                                            <property role="3oM_SC" value="if" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0vo6N" role="1PaTwD">
+                                            <property role="3oM_SC" value="a" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0vo6S" role="1PaTwD">
+                                            <property role="3oM_SC" value="reference" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0vpnS" role="1PaTwD">
+                                            <property role="3oM_SC" value="needs" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0vpnZ" role="1PaTwD">
+                                            <property role="3oM_SC" value="an" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0vrrL" role="1PaTwD">
+                                            <property role="3oM_SC" value="update" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0vrrU" role="1PaTwD">
+                                            <property role="3oM_SC" value="the" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0vrs4" role="1PaTwD">
+                                            <property role="3oM_SC" value="generator" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0vrsf" role="1PaTwD">
+                                            <property role="3oM_SC" value="trace" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0vvA$" role="1PaTwD">
+                                            <property role="3oM_SC" value="api" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0vvAL" role="1PaTwD">
+                                            <property role="3oM_SC" value="is" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0vAgT" role="1PaTwD">
+                                            <property role="3oM_SC" value="used." />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0vAh8" role="1PaTwD">
+                                            <property role="3oM_SC" value="If" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0vCnf" role="1PaTwD">
+                                            <property role="3oM_SC" value="a" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0vRXs" role="1PaTwD">
+                                            <property role="3oM_SC" value="in" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0vT7z" role="1PaTwD">
+                                            <property role="3oM_SC" value="the" />
+                                          </node>
+                                        </node>
+                                        <node concept="1PaTwC" id="7U$sKL0vTZO" role="2lOMFJ">
+                                          <node concept="3oM_SD" id="7U$sKL0w39N" role="1PaTwD">
+                                            <property role="3oM_SC" value="including" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0w4dU" role="1PaTwD">
+                                            <property role="3oM_SC" value="document" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0w4dX" role="1PaTwD">
+                                            <property role="3oM_SC" value="points" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0w6ls" role="1PaTwD">
+                                            <property role="3oM_SC" value="to" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0w6lx" role="1PaTwD">
+                                            <property role="3oM_SC" value="something" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0w8EP" role="1PaTwD">
+                                            <property role="3oM_SC" value="we" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0waAY" role="1PaTwD">
+                                            <property role="3oM_SC" value="included" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0weWI" role="1PaTwD">
+                                            <property role="3oM_SC" value="the" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0wh2I" role="1PaTwD">
+                                            <property role="3oM_SC" value="generator" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0wh2S" role="1PaTwD">
+                                            <property role="3oM_SC" value="trace" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0wh33" role="1PaTwD">
+                                            <property role="3oM_SC" value="api" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0wh3f" role="1PaTwD">
+                                            <property role="3oM_SC" value="is" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0wjdD" role="1PaTwD">
+                                            <property role="3oM_SC" value="used" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0wnrg" role="1PaTwD">
+                                            <property role="3oM_SC" value="to" />
+                                          </node>
+                                        </node>
+                                        <node concept="1PaTwC" id="7U$sKL0woJo" role="2lOMFJ">
+                                          <node concept="3oM_SD" id="7U$sKL0woJn" role="1PaTwD">
+                                            <property role="3oM_SC" value="identify" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0wqO8" role="1PaTwD">
+                                            <property role="3oM_SC" value="the" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0wqOb" role="1PaTwD">
+                                            <property role="3oM_SC" value="copy." />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0wu7E" role="1PaTwD">
+                                            <property role="3oM_SC" value="" />
+                                          </node>
+                                        </node>
+                                        <node concept="1PaTwC" id="7U$sKL0wEaY" role="2lOMFJ">
+                                          <node concept="3oM_SD" id="7U$sKL0wEaX" role="1PaTwD">
+                                            <property role="3oM_SC" value="The" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0wFnG" role="1PaTwD">
+                                            <property role="3oM_SC" value="copy" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0wFnJ" role="1PaTwD">
+                                            <property role="3oM_SC" value="is" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0wKSJ" role="1PaTwD">
+                                            <property role="3oM_SC" value="identified" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0wSrt" role="1PaTwD">
+                                            <property role="3oM_SC" value="as" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0wTlw" role="1PaTwD">
+                                            <property role="3oM_SC" value="such" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0wTlB" role="1PaTwD">
+                                            <property role="3oM_SC" value="when" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0x3Ze" role="1PaTwD">
+                                            <property role="3oM_SC" value="its" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0x66M" role="1PaTwD">
+                                            <property role="3oM_SC" value="original" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0xbuF" role="1PaTwD">
+                                            <property role="3oM_SC" value="node" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0xcC4" role="1PaTwD">
+                                            <property role="3oM_SC" value="(the" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0xeEq" role="1PaTwD">
+                                            <property role="3oM_SC" value="one" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0xeEB" role="1PaTwD">
+                                            <property role="3oM_SC" value="in" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0xeEP" role="1PaTwD">
+                                            <property role="3oM_SC" value="the" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0xeF4" role="1PaTwD">
+                                            <property role="3oM_SC" value="input" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0xgPx" role="1PaTwD">
+                                            <property role="3oM_SC" value="model)" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0xlir" role="1PaTwD">
+                                            <property role="3oM_SC" value="is" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0xliH" role="1PaTwD">
+                                            <property role="3oM_SC" value="the" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0xlj0" role="1PaTwD">
+                                            <property role="3oM_SC" value="same" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0xljk" role="1PaTwD">
+                                            <property role="3oM_SC" value="" />
+                                          </node>
+                                        </node>
+                                        <node concept="1PaTwC" id="7U$sKL0xniK" role="2lOMFJ">
+                                          <node concept="3oM_SD" id="7U$sKL0xniJ" role="1PaTwD">
+                                            <property role="3oM_SC" value="as" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0xnmP" role="1PaTwD">
+                                            <property role="3oM_SC" value="the" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0xnmS" role="1PaTwD">
+                                            <property role="3oM_SC" value="input" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0xpz1" role="1PaTwD">
+                                            <property role="3oM_SC" value="node" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0xrKp" role="1PaTwD">
+                                            <property role="3oM_SC" value="for" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0xtI$" role="1PaTwD">
+                                            <property role="3oM_SC" value="included" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0xuRT" role="1PaTwD">
+                                            <property role="3oM_SC" value="content." />
+                                          </node>
+                                        </node>
+                                        <node concept="1PaTwC" id="7U$sKL0x_yf" role="2lOMFJ">
+                                          <node concept="3oM_SD" id="7U$sKL0xBKo" role="1PaTwD">
+                                            <property role="3oM_SC" value="This" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0xCXA" role="1PaTwD">
+                                            <property role="3oM_SC" value="way" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0xCXD" role="1PaTwD">
+                                            <property role="3oM_SC" value="we" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0xCXH" role="1PaTwD">
+                                            <property role="3oM_SC" value="don't" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0xCXM" role="1PaTwD">
+                                            <property role="3oM_SC" value="depend" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0xF85" role="1PaTwD">
+                                            <property role="3oM_SC" value="on" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0xF8c" role="1PaTwD">
+                                            <property role="3oM_SC" value="any" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0xF8k" role="1PaTwD">
+                                            <property role="3oM_SC" value="naming" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0xIrS" role="1PaTwD">
+                                            <property role="3oM_SC" value="schema" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0xNKC" role="1PaTwD">
+                                            <property role="3oM_SC" value="or" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0xPLY" role="1PaTwD">
+                                            <property role="3oM_SC" value="scopes" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0xUeA" role="1PaTwD">
+                                            <property role="3oM_SC" value="from" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0xUeN" role="1PaTwD">
+                                            <property role="3oM_SC" value="the" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0y0tx" role="1PaTwD">
+                                            <property role="3oM_SC" value="language" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0y0tK" role="1PaTwD">
+                                            <property role="3oM_SC" value="itself." />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0y2xU" role="1PaTwD">
+                                            <property role="3oM_SC" value="" />
+                                          </node>
+                                        </node>
+                                        <node concept="1PaTwC" id="7U$sKL0y4Ej" role="2lOMFJ">
+                                          <node concept="3oM_SD" id="7U$sKL0y90H" role="1PaTwD">
+                                            <property role="3oM_SC" value="" />
+                                          </node>
+                                        </node>
+                                        <node concept="1PaTwC" id="7U$sKL0y90K" role="2lOMFJ">
+                                          <node concept="3oM_SD" id="7U$sKL0y90J" role="1PaTwD">
+                                            <property role="3oM_SC" value="The" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0yakH" role="1PaTwD">
+                                            <property role="3oM_SC" value="only" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0yakK" role="1PaTwD">
+                                            <property role="3oM_SC" value="limitation" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0ye83" role="1PaTwD">
+                                            <property role="3oM_SC" value="is" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0ye88" role="1PaTwD">
+                                            <property role="3oM_SC" value="that" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0yfjM" role="1PaTwD">
+                                            <property role="3oM_SC" value="if" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0yjKN" role="1PaTwD">
+                                            <property role="3oM_SC" value="one" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0yjKV" role="1PaTwD">
+                                            <property role="3oM_SC" value="document" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0yn4v" role="1PaTwD">
+                                            <property role="3oM_SC" value="is" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0yn4D" role="1PaTwD">
+                                            <property role="3oM_SC" value="included" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0ypfR" role="1PaTwD">
+                                            <property role="3oM_SC" value="twice" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0ysid" role="1PaTwD">
+                                            <property role="3oM_SC" value="into" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0ytrC" role="1PaTwD">
+                                            <property role="3oM_SC" value="an" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0yxSY" role="1PaTwD">
+                                            <property role="3oM_SC" value="including" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0yxTd" role="1PaTwD">
+                                            <property role="3oM_SC" value="document" />
+                                          </node>
+                                        </node>
+                                        <node concept="1PaTwC" id="7U$sKL0y_8Y" role="2lOMFJ">
+                                          <node concept="3oM_SD" id="7U$sKL0y_8X" role="1PaTwD">
+                                            <property role="3oM_SC" value="this" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0yAmR" role="1PaTwD">
+                                            <property role="3oM_SC" value="code" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0yAmU" role="1PaTwD">
+                                            <property role="3oM_SC" value="will" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0yAmY" role="1PaTwD">
+                                            <property role="3oM_SC" value="point" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0yCxg" role="1PaTwD">
+                                            <property role="3oM_SC" value="all" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0yCxm" role="1PaTwD">
+                                            <property role="3oM_SC" value="references" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0yCxt" role="1PaTwD">
+                                            <property role="3oM_SC" value="to" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0yD_E" role="1PaTwD">
+                                            <property role="3oM_SC" value="first" />
+                                          </node>
+                                          <node concept="3oM_SD" id="7U$sKL0yGH6" role="1PaTwD">
+                                            <property role="3oM_SC" value="include." />
+                                          </node>
+                                        </node>
+                                      </node>
+                                      <node concept="3clFbH" id="7U$sKL0r6om" role="3cqZAp" />
+                                      <node concept="3clFbH" id="7U$sKL0r5pE" role="3cqZAp" />
+                                      <node concept="3cpWs8" id="5FHtHFq09t7" role="3cqZAp">
+                                        <node concept="3cpWsn" id="5FHtHFq09t8" role="3cpWs9">
+                                          <property role="TrG5h" value="allReferencesIntoOtherDocs" />
+                                          <node concept="A3Dl8" id="5FHtHFq09jz" role="1tU5fm">
+                                            <node concept="2z4iKi" id="5FHtHFq09jA" role="A3Ik2" />
+                                          </node>
+                                          <node concept="2OqwBi" id="7U$sKL0zEXB" role="33vP2m">
+                                            <node concept="2OqwBi" id="5FHtHFq09t9" role="2Oq$k0">
+                                              <node concept="2OqwBi" id="5FHtHFq09ta" role="2Oq$k0">
+                                                <node concept="37vLTw" id="5FHtHFq09tb" role="2Oq$k0">
+                                                  <ref role="3cqZAo" node="3lxJBjikdRi" resolve="document" />
+                                                </node>
+                                                <node concept="2Rf3mk" id="5FHtHFq09tc" role="2OqNvi">
+                                                  <node concept="1xIGOp" id="5FHtHFq09td" role="1xVPHs" />
+                                                </node>
+                                              </node>
+                                              <node concept="3goQfb" id="5FHtHFq09te" role="2OqNvi">
+                                                <node concept="1bVj0M" id="5FHtHFq09tf" role="23t8la">
+                                                  <node concept="3clFbS" id="5FHtHFq09tg" role="1bW5cS">
+                                                    <node concept="3clFbF" id="5FHtHFq09th" role="3cqZAp">
+                                                      <node concept="2OqwBi" id="5FHtHFq09ti" role="3clFbG">
+                                                        <node concept="37vLTw" id="5FHtHFq09tj" role="2Oq$k0">
+                                                          <ref role="3cqZAo" node="5FHtHFq09tl" resolve="it" />
+                                                        </node>
+                                                        <node concept="2z74zc" id="5FHtHFq09tk" role="2OqNvi" />
+                                                      </node>
+                                                    </node>
+                                                  </node>
+                                                  <node concept="Rh6nW" id="5FHtHFq09tl" role="1bW2Oz">
+                                                    <property role="TrG5h" value="it" />
+                                                    <node concept="2jxLKc" id="5FHtHFq09tm" role="1tU5fm" />
+                                                  </node>
+                                                </node>
+                                              </node>
+                                            </node>
+                                            <node concept="3zZkjj" id="7U$sKL0zGeF" role="2OqNvi">
+                                              <node concept="1bVj0M" id="7U$sKL0zGeH" role="23t8la">
+                                                <node concept="3clFbS" id="7U$sKL0zGeI" role="1bW5cS">
+                                                  <node concept="3clFbF" id="7U$sKL0zIhs" role="3cqZAp">
+                                                    <node concept="17QLQc" id="7U$sKL0zPhy" role="3clFbG">
+                                                      <node concept="37vLTw" id="7U$sKL0zRjo" role="3uHU7w">
+                                                        <ref role="3cqZAo" node="3lxJBjikdRi" resolve="document" />
+                                                      </node>
+                                                      <node concept="2OqwBi" id="7U$sKL0zMLh" role="3uHU7B">
+                                                        <node concept="2OqwBi" id="7U$sKL0zJB2" role="2Oq$k0">
+                                                          <node concept="37vLTw" id="7U$sKL0zIhr" role="2Oq$k0">
+                                                            <ref role="3cqZAo" node="7U$sKL0zGeJ" resolve="it" />
+                                                          </node>
+                                                          <node concept="2ZHEkA" id="7U$sKL0zLF6" role="2OqNvi" />
+                                                        </node>
+                                                        <node concept="2Rxl7S" id="7U$sKL0zO5c" role="2OqNvi" />
+                                                      </node>
+                                                    </node>
+                                                  </node>
+                                                </node>
+                                                <node concept="Rh6nW" id="7U$sKL0zGeJ" role="1bW2Oz">
+                                                  <property role="TrG5h" value="it" />
+                                                  <node concept="2jxLKc" id="7U$sKL0zGeK" role="1tU5fm" />
+                                                </node>
+                                              </node>
+                                            </node>
+                                          </node>
+                                        </node>
+                                      </node>
+                                      <node concept="3clFbH" id="7U$sKL0$5Hr" role="3cqZAp" />
+                                      <node concept="3cpWs8" id="5FHtHFq414A" role="3cqZAp">
+                                        <node concept="3cpWsn" id="5FHtHFq414B" role="3cpWs9">
+                                          <property role="TrG5h" value="repository" />
+                                          <node concept="3uibUv" id="5FHtHFq40QF" role="1tU5fm">
+                                            <ref role="3uigEE" to="lui2:~SRepository" resolve="SRepository" />
+                                          </node>
+                                          <node concept="2OqwBi" id="5FHtHFq414C" role="33vP2m">
+                                            <node concept="2JrnkZ" id="5FHtHFq414D" role="2Oq$k0">
+                                              <node concept="2OqwBi" id="5FHtHFq414E" role="2JrQYb">
+                                                <node concept="1iwH7S" id="5FHtHFq414F" role="2Oq$k0" />
+                                                <node concept="1st3f0" id="5FHtHFq414G" role="2OqNvi" />
+                                              </node>
+                                            </node>
+                                            <node concept="liA8E" id="5FHtHFq414H" role="2OqNvi">
+                                              <ref role="37wK5l" to="mhbf:~SModel.getRepository()" resolve="getRepository" />
+                                            </node>
+                                          </node>
+                                        </node>
+                                      </node>
+                                      <node concept="3clFbH" id="5FHtHFq2WEk" role="3cqZAp" />
+                                      <node concept="3cpWs8" id="7U$sKL0zAr4" role="3cqZAp">
+                                        <node concept="3cpWsn" id="7U$sKL0zAr5" role="3cpWs9">
+                                          <property role="TrG5h" value="documentContentByOriginalNode" />
+                                          <node concept="3rvAFt" id="7U$sKL0zAr6" role="1tU5fm">
+                                            <node concept="3Tqbb2" id="7U$sKL0zAr7" role="3rvQeY" />
+                                            <node concept="3Tqbb2" id="7U$sKL0zAr8" role="3rvSg0" />
+                                          </node>
+                                          <node concept="2OqwBi" id="7U$sKL0zAr9" role="33vP2m">
+                                            <node concept="2OqwBi" id="7U$sKL0zAra" role="2Oq$k0">
+                                              <node concept="2OqwBi" id="7U$sKL0zArb" role="2Oq$k0">
+                                                <node concept="37vLTw" id="7U$sKL0zArc" role="2Oq$k0">
+                                                  <ref role="3cqZAo" node="3lxJBjikdRi" resolve="document" />
+                                                </node>
+                                                <node concept="2Rf3mk" id="7U$sKL0zArd" role="2OqNvi">
+                                                  <node concept="1xMEDy" id="7U$sKL0zAre" role="1xVPHs">
+                                                    <node concept="chp4Y" id="7U$sKL0zArf" role="ri$Ld">
+                                                      <ref role="cht4Q" to="2c95:2TZO3Dbv6Ju" resolve="AbstractSection" />
+                                                    </node>
+                                                  </node>
+                                                </node>
+                                              </node>
+                                              <node concept="liA8E" id="7U$sKL0zArg" role="2OqNvi">
+                                                <ref role="37wK5l" to="33ny:~Collection.stream()" resolve="stream" />
+                                              </node>
+                                            </node>
+                                            <node concept="liA8E" id="7U$sKL0zArh" role="2OqNvi">
+                                              <ref role="37wK5l" to="1ctc:~Stream.collect(java.util.stream.Collector)" resolve="collect" />
+                                              <node concept="2YIFZM" id="7U$sKL0zAri" role="37wK5m">
+                                                <ref role="1Pybhc" to="1ctc:~Collectors" resolve="Collectors" />
+                                                <ref role="37wK5l" to="1ctc:~Collectors.toMap(java.util.function.Function,java.util.function.Function)" resolve="toMap" />
+                                                <node concept="1bVj0M" id="7U$sKL0zArj" role="37wK5m">
+                                                  <node concept="37vLTG" id="7U$sKL0zArk" role="1bW2Oz">
+                                                    <property role="TrG5h" value="n" />
+                                                    <node concept="3Tqbb2" id="7U$sKL0zArl" role="1tU5fm" />
+                                                  </node>
+                                                  <node concept="3clFbS" id="7U$sKL0zArm" role="1bW5cS">
+                                                    <node concept="3clFbF" id="7U$sKL0zArn" role="3cqZAp">
+                                                      <node concept="1eOMI4" id="7U$sKL0zAro" role="3clFbG">
+                                                        <node concept="10QFUN" id="7U$sKL0zArp" role="1eOMHV">
+                                                          <node concept="2YIFZM" id="7U$sKL0zArq" role="10QFUP">
+                                                            <ref role="37wK5l" to="fwk:~TracingUtil.getInputNode(org.jetbrains.mps.openapi.model.SNode,org.jetbrains.mps.openapi.module.SRepository)" resolve="getInputNode" />
+                                                            <ref role="1Pybhc" to="fwk:~TracingUtil" resolve="TracingUtil" />
+                                                            <node concept="37vLTw" id="7U$sKL0zArr" role="37wK5m">
+                                                              <ref role="3cqZAo" node="7U$sKL0zArk" resolve="n" />
+                                                            </node>
+                                                            <node concept="37vLTw" id="7U$sKL0zArs" role="37wK5m">
+                                                              <ref role="3cqZAo" node="5FHtHFq414B" resolve="repository" />
+                                                            </node>
+                                                          </node>
+                                                          <node concept="3Tqbb2" id="7U$sKL0zArt" role="10QFUM" />
+                                                        </node>
+                                                      </node>
+                                                    </node>
+                                                  </node>
+                                                </node>
+                                                <node concept="2YIFZM" id="7U$sKL0zAru" role="37wK5m">
+                                                  <ref role="37wK5l" to="82uw:~Function.identity()" resolve="identity" />
+                                                  <ref role="1Pybhc" to="82uw:~Function" resolve="Function" />
+                                                  <node concept="3Tqbb2" id="7U$sKL0zArv" role="3PaCim" />
+                                                </node>
+                                                <node concept="3Tqbb2" id="7U$sKL0zArw" role="3PaCim" />
+                                                <node concept="3Tqbb2" id="7U$sKL0zArx" role="3PaCim" />
+                                                <node concept="3Tqbb2" id="7U$sKL0zAry" role="3PaCim" />
+                                              </node>
+                                            </node>
+                                          </node>
+                                        </node>
+                                      </node>
+                                      <node concept="3clFbH" id="7U$sKL0zArz" role="3cqZAp" />
+                                      <node concept="3clFbF" id="7U$sKL0zAr$" role="3cqZAp">
+                                        <node concept="2OqwBi" id="7U$sKL0zAr_" role="3clFbG">
+                                          <node concept="37vLTw" id="7U$sKL0zCMI" role="2Oq$k0">
+                                            <ref role="3cqZAo" node="5FHtHFq09t8" resolve="allReferencesIntoOtherDocs" />
+                                          </node>
+                                          <node concept="2es0OD" id="7U$sKL0zArB" role="2OqNvi">
+                                            <node concept="1bVj0M" id="7U$sKL0zArC" role="23t8la">
+                                              <node concept="3clFbS" id="7U$sKL0zArD" role="1bW5cS">
+                                                <node concept="3cpWs8" id="7U$sKL0zArE" role="3cqZAp">
+                                                  <node concept="3cpWsn" id="7U$sKL0zArF" role="3cpWs9">
+                                                    <property role="TrG5h" value="inputOfReference" />
+                                                    <node concept="3Tqbb2" id="7U$sKL0zArG" role="1tU5fm" />
+                                                    <node concept="2YIFZM" id="7U$sKL0zArH" role="33vP2m">
+                                                      <ref role="37wK5l" to="fwk:~TracingUtil.getInputNode(org.jetbrains.mps.openapi.model.SNode,org.jetbrains.mps.openapi.module.SRepository)" resolve="getInputNode" />
+                                                      <ref role="1Pybhc" to="fwk:~TracingUtil" resolve="TracingUtil" />
+                                                      <node concept="2OqwBi" id="7U$sKL0zArI" role="37wK5m">
+                                                        <node concept="37vLTw" id="7U$sKL0zArJ" role="2Oq$k0">
+                                                          <ref role="3cqZAo" node="7U$sKL0zAs7" resolve="reference" />
+                                                        </node>
+                                                        <node concept="2ZHEkA" id="7U$sKL0zArK" role="2OqNvi" />
+                                                      </node>
+                                                      <node concept="37vLTw" id="7U$sKL0zArL" role="37wK5m">
+                                                        <ref role="3cqZAo" node="5FHtHFq414B" resolve="repository" />
+                                                      </node>
+                                                    </node>
+                                                  </node>
+                                                </node>
+                                                <node concept="3cpWs8" id="7U$sKL0zArM" role="3cqZAp">
+                                                  <node concept="3cpWsn" id="7U$sKL0zArN" role="3cpWs9">
+                                                    <property role="TrG5h" value="copyInDoc" />
+                                                    <node concept="3Tqbb2" id="7U$sKL0zArO" role="1tU5fm" />
+                                                    <node concept="3EllGN" id="7U$sKL0zArP" role="33vP2m">
+                                                      <node concept="37vLTw" id="7U$sKL0zArQ" role="3ElVtu">
+                                                        <ref role="3cqZAo" node="7U$sKL0zArF" resolve="inputOfReference" />
+                                                      </node>
+                                                      <node concept="37vLTw" id="7U$sKL0zArR" role="3ElQJh">
+                                                        <ref role="3cqZAo" node="7U$sKL0zAr5" resolve="documentContentByOriginalNode" />
+                                                      </node>
+                                                    </node>
+                                                  </node>
+                                                </node>
+                                                <node concept="3clFbJ" id="7U$sKL0zArS" role="3cqZAp">
+                                                  <node concept="3clFbS" id="7U$sKL0zArT" role="3clFbx">
+                                                    <node concept="3clFbF" id="7U$sKL0zArU" role="3cqZAp">
+                                                      <node concept="2OqwBi" id="7U$sKL0zArV" role="3clFbG">
+                                                        <node concept="0kSF2" id="7U$sKL0zArW" role="2Oq$k0">
+                                                          <node concept="3uibUv" id="7U$sKL0zArX" role="0kSFW">
+                                                            <ref role="3uigEE" to="w1kc:~StaticReference" resolve="StaticReference" />
+                                                          </node>
+                                                          <node concept="37vLTw" id="7U$sKL0zArY" role="0kSFX">
+                                                            <ref role="3cqZAo" node="7U$sKL0zAs7" resolve="reference" />
+                                                          </node>
+                                                        </node>
+                                                        <node concept="liA8E" id="7U$sKL0zArZ" role="2OqNvi">
+                                                          <ref role="37wK5l" to="w1kc:~StaticReference.setTargetNodeId(org.jetbrains.mps.openapi.model.SNodeId)" resolve="setTargetNodeId" />
+                                                          <node concept="2OqwBi" id="7U$sKL0zAs0" role="37wK5m">
+                                                            <node concept="2JrnkZ" id="7U$sKL0zAs1" role="2Oq$k0">
+                                                              <node concept="37vLTw" id="7U$sKL0zAs2" role="2JrQYb">
+                                                                <ref role="3cqZAo" node="7U$sKL0zArN" resolve="copyInDoc" />
+                                                              </node>
+                                                            </node>
+                                                            <node concept="liA8E" id="7U$sKL0zAs3" role="2OqNvi">
+                                                              <ref role="37wK5l" to="mhbf:~SNode.getNodeId()" resolve="getNodeId" />
+                                                            </node>
+                                                          </node>
+                                                        </node>
+                                                      </node>
+                                                    </node>
+                                                  </node>
+                                                  <node concept="2OqwBi" id="7U$sKL0zAs4" role="3clFbw">
+                                                    <node concept="37vLTw" id="7U$sKL0zAs5" role="2Oq$k0">
+                                                      <ref role="3cqZAo" node="7U$sKL0zArN" resolve="copyInDoc" />
+                                                    </node>
+                                                    <node concept="3x8VRR" id="7U$sKL0zAs6" role="2OqNvi" />
+                                                  </node>
+                                                </node>
+                                              </node>
+                                              <node concept="Rh6nW" id="7U$sKL0zAs7" role="1bW2Oz">
+                                                <property role="TrG5h" value="reference" />
+                                                <node concept="2jxLKc" id="7U$sKL0zAs8" role="1tU5fm" />
+                                              </node>
+                                            </node>
+                                          </node>
+                                        </node>
+                                      </node>
+                                      <node concept="3clFbF" id="5FHtHFpZ$MM" role="3cqZAp">
+                                        <node concept="2OqwBi" id="5FHtHFpZ_as" role="3clFbG">
+                                          <node concept="37vLTw" id="5FHtHFpZ$MK" role="2Oq$k0">
+                                            <ref role="3cqZAo" node="3lxJBjiqwol" resolve="include" />
+                                          </node>
+                                          <node concept="3YRAZt" id="5FHtHFpZAlu" role="2OqNvi" />
+                                        </node>
+                                      </node>
+                                    </node>
+                                    <node concept="Rh6nW" id="3lxJBjiqwol" role="1bW2Oz">
+                                      <property role="TrG5h" value="include" />
+                                      <node concept="2jxLKc" id="3lxJBjiqwom" role="1tU5fm" />
+                                    </node>
                                   </node>
                                 </node>
                               </node>
                             </node>
-                            <node concept="1eOMI4" id="7NleypPGih3" role="3uHU7w">
-                              <node concept="17R0WA" id="7NleypPGih4" role="1eOMHV">
-                                <node concept="2OqwBi" id="7NleypPGih5" role="3uHU7B">
-                                  <node concept="37vLTw" id="7NleypPGih6" role="2Oq$k0">
-                                    <ref role="3cqZAo" node="7NleypPGih9" resolve="ref" />
+                          </node>
+                          <node concept="Rh6nW" id="3lxJBjikdRi" role="1bW2Oz">
+                            <property role="TrG5h" value="document" />
+                            <node concept="2jxLKc" id="3lxJBjikdRj" role="1tU5fm" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="Rh6nW" id="3lxJBjijK_k" role="1bW2Oz">
+                  <property role="TrG5h" value="export" />
+                  <node concept="2jxLKc" id="3lxJBjijK_l" role="1tU5fm" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="7U$sKL0$RtA" role="3cqZAp" />
+        <node concept="2lOVwT" id="7U$sKL0$RQv" role="3cqZAp">
+          <node concept="1PaTwC" id="7U$sKL0$RQw" role="2lOMFJ">
+            <node concept="3oM_SD" id="7U$sKL0$S6l" role="1PaTwD">
+              <property role="3oM_SC" value="Documents" />
+            </node>
+            <node concept="3oM_SD" id="7U$sKL0$S6v" role="1PaTwD">
+              <property role="3oM_SC" value="that" />
+            </node>
+            <node concept="3oM_SD" id="7U$sKL0$S6y" role="1PaTwD">
+              <property role="3oM_SC" value="aren't" />
+            </node>
+            <node concept="3oM_SD" id="7U$sKL0$S6A" role="1PaTwD">
+              <property role="3oM_SC" value="used" />
+            </node>
+            <node concept="3oM_SD" id="7U$sKL0$S6N" role="1PaTwD">
+              <property role="3oM_SC" value="in" />
+            </node>
+            <node concept="3oM_SD" id="7U$sKL0$S71" role="1PaTwD">
+              <property role="3oM_SC" value="any" />
+            </node>
+            <node concept="3oM_SD" id="7U$sKL0$S7g" role="1PaTwD">
+              <property role="3oM_SC" value="export" />
+            </node>
+            <node concept="3oM_SD" id="7U$sKL0$S7o" role="1PaTwD">
+              <property role="3oM_SC" value="are" />
+            </node>
+            <node concept="3oM_SD" id="7U$sKL0$S7D" role="1PaTwD">
+              <property role="3oM_SC" value="considered" />
+            </node>
+            <node concept="3oM_SD" id="7U$sKL0$S7V" role="1PaTwD">
+              <property role="3oM_SC" value="obsolete" />
+            </node>
+            <node concept="3oM_SD" id="7U$sKL0$S8u" role="1PaTwD">
+              <property role="3oM_SC" value="and" />
+            </node>
+            <node concept="3oM_SD" id="7U$sKL0$S8E" role="1PaTwD">
+              <property role="3oM_SC" value="deleted" />
+            </node>
+            <node concept="3oM_SD" id="7U$sKL0$S9f" role="1PaTwD">
+              <property role="3oM_SC" value="as" />
+            </node>
+            <node concept="3oM_SD" id="7U$sKL0$S9t" role="1PaTwD">
+              <property role="3oM_SC" value="well" />
+            </node>
+          </node>
+          <node concept="1PaTwC" id="7U$sKL0$S9P" role="2lOMFJ">
+            <node concept="3oM_SD" id="7U$sKL0$S9O" role="1PaTwD">
+              <property role="3oM_SC" value="as" />
+            </node>
+            <node concept="3oM_SD" id="7U$sKL0$Sau" role="1PaTwD">
+              <property role="3oM_SC" value="their" />
+            </node>
+            <node concept="3oM_SD" id="7U$sKL0$SaD" role="1PaTwD">
+              <property role="3oM_SC" value="depends" />
+            </node>
+            <node concept="3oM_SD" id="7U$sKL0$SaX" role="1PaTwD">
+              <property role="3oM_SC" value="on" />
+            </node>
+            <node concept="3oM_SD" id="7U$sKL0$SbJ" role="1PaTwD">
+              <property role="3oM_SC" value="references." />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7U$sKL0$xBc" role="3cqZAp">
+          <node concept="2OqwBi" id="7U$sKL0$KRS" role="3clFbG">
+            <node concept="2OqwBi" id="7U$sKL0$Bnv" role="2Oq$k0">
+              <node concept="2OqwBi" id="7U$sKL0$xXm" role="2Oq$k0">
+                <node concept="1Q6Npb" id="7U$sKL0$xBb" role="2Oq$k0" />
+                <node concept="2SmgA7" id="7U$sKL0$yZY" role="2OqNvi">
+                  <node concept="chp4Y" id="7U$sKL0$z0g" role="1dBWTz">
+                    <ref role="cht4Q" to="2c95:2TZO3DbuxwK" resolve="Document" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3zZkjj" id="7U$sKL0$FjN" role="2OqNvi">
+                <node concept="1bVj0M" id="7U$sKL0$FjP" role="23t8la">
+                  <node concept="3clFbS" id="7U$sKL0$FjQ" role="1bW5cS">
+                    <node concept="3clFbF" id="7U$sKL0$Fo3" role="3cqZAp">
+                      <node concept="3fqX7Q" id="7U$sKL0$Fo1" role="3clFbG">
+                        <node concept="2OqwBi" id="7U$sKL0$FSW" role="3fr31v">
+                          <node concept="2OqwBi" id="7U$sKL0$FAj" role="2Oq$k0">
+                            <node concept="1Q6Npb" id="7U$sKL0$Fr7" role="2Oq$k0" />
+                            <node concept="2SmgA7" id="7U$sKL0$FMx" role="2OqNvi">
+                              <node concept="chp4Y" id="7U$sKL0$FPE" role="1dBWTz">
+                                <ref role="cht4Q" to="2c95:5gTlpaky5gD" resolve="AbstractExport" />
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="2HwmR7" id="7U$sKL0$Ijt" role="2OqNvi">
+                            <node concept="1bVj0M" id="7U$sKL0$Ijv" role="23t8la">
+                              <node concept="3clFbS" id="7U$sKL0$Ijw" role="1bW5cS">
+                                <node concept="3clFbF" id="7U$sKL0$Iq8" role="3cqZAp">
+                                  <node concept="17R0WA" id="7U$sKL0$Kbj" role="3clFbG">
+                                    <node concept="37vLTw" id="7U$sKL0$K$U" role="3uHU7w">
+                                      <ref role="3cqZAo" node="7U$sKL0$FjR" resolve="document" />
+                                    </node>
+                                    <node concept="2OqwBi" id="7U$sKL0$Jlb" role="3uHU7B">
+                                      <node concept="2OqwBi" id="7U$sKL0$IFc" role="2Oq$k0">
+                                        <node concept="37vLTw" id="7U$sKL0$Iq7" role="2Oq$k0">
+                                          <ref role="3cqZAo" node="7U$sKL0$Ijx" resolve="export" />
+                                        </node>
+                                        <node concept="3TrEf2" id="7U$sKL0$J2b" role="2OqNvi">
+                                          <ref role="3Tt5mk" to="2c95:5gTlpaky6t1" resolve="root" />
+                                        </node>
+                                      </node>
+                                      <node concept="3TrEf2" id="7U$sKL0$JCy" role="2OqNvi">
+                                        <ref role="3Tt5mk" to="2c95:2TZO3DbvI5E" resolve="doc" />
+                                      </node>
+                                    </node>
                                   </node>
-                                  <node concept="2NL2c5" id="7NleypPGih7" role="2OqNvi" />
                                 </node>
-                                <node concept="359W_D" id="7NleypPGih8" role="3uHU7w">
-                                  <ref role="359W_E" to="2c95:5L$H31Kgq3f" resolve="IDocumentLike" />
-                                  <ref role="359W_F" to="2c95:7$DvC4gRxZ6" resolve="dependsOn" />
-                                </node>
+                              </node>
+                              <node concept="Rh6nW" id="7U$sKL0$Ijx" role="1bW2Oz">
+                                <property role="TrG5h" value="export" />
+                                <node concept="2jxLKc" id="7U$sKL0$Ijy" role="1tU5fm" />
                               </node>
                             </node>
                           </node>
                         </node>
                       </node>
-                      <node concept="Rh6nW" id="7NleypPGih9" role="1bW2Oz">
-                        <property role="TrG5h" value="ref" />
-                        <node concept="2jxLKc" id="7NleypPGiha" role="1tU5fm" />
-                      </node>
                     </node>
+                  </node>
+                  <node concept="Rh6nW" id="7U$sKL0$FjR" role="1bW2Oz">
+                    <property role="TrG5h" value="document" />
+                    <node concept="2jxLKc" id="7U$sKL0$FjS" role="1tU5fm" />
                   </node>
                 </node>
               </node>
             </node>
-            <node concept="3clFbF" id="7NleypLVORX" role="3cqZAp">
-              <node concept="2OqwBi" id="7NleypLW5sg" role="3clFbG">
-                <node concept="37vLTw" id="7NleypPGihb" role="2Oq$k0">
-                  <ref role="3cqZAo" node="7NleypPGigI" resolve="dependsRefs" />
-                </node>
-                <node concept="2es0OD" id="7NleypLW669" role="2OqNvi">
-                  <node concept="1bVj0M" id="7NleypLW66b" role="23t8la">
-                    <node concept="3clFbS" id="7NleypLW66c" role="1bW5cS">
-                      <node concept="3clFbF" id="7NleypLW68d" role="3cqZAp">
-                        <node concept="2OqwBi" id="7NleypLW6qf" role="3clFbG">
-                          <node concept="37vLTw" id="7NleypLW68c" role="2Oq$k0">
-                            <ref role="3cqZAo" node="7NleypLW66d" resolve="it" />
+            <node concept="2es0OD" id="7U$sKL0$LkH" role="2OqNvi">
+              <node concept="1bVj0M" id="7U$sKL0$LkJ" role="23t8la">
+                <node concept="3clFbS" id="7U$sKL0$LkK" role="1bW5cS">
+                  <node concept="3cpWs8" id="7U$sKL0$N4d" role="3cqZAp">
+                    <node concept="3cpWsn" id="7U$sKL0$N4e" role="3cpWs9">
+                      <property role="TrG5h" value="dependsRefs" />
+                      <node concept="A3Dl8" id="7U$sKL0$N4f" role="1tU5fm">
+                        <node concept="3Tqbb2" id="7U$sKL0$N4g" role="A3Ik2">
+                          <ref role="ehGHo" to="2c95:2TZO3DbvI5D" resolve="DocumentRef" />
+                        </node>
+                      </node>
+                      <node concept="2OqwBi" id="7U$sKL0$N4h" role="33vP2m">
+                        <node concept="2OqwBi" id="7U$sKL0$N4i" role="2Oq$k0">
+                          <node concept="1Q6Npb" id="7U$sKL0$N4j" role="2Oq$k0" />
+                          <node concept="2SmgA7" id="7U$sKL0$N4k" role="2OqNvi">
+                            <node concept="chp4Y" id="7U$sKL0$N4l" role="1dBWTz">
+                              <ref role="cht4Q" to="2c95:2TZO3DbvI5D" resolve="DocumentRef" />
+                            </node>
                           </node>
-                          <node concept="3YRAZt" id="7NleypLW7sm" role="2OqNvi" />
+                        </node>
+                        <node concept="3zZkjj" id="7U$sKL0$N4m" role="2OqNvi">
+                          <node concept="1bVj0M" id="7U$sKL0$N4n" role="23t8la">
+                            <property role="3yWfEV" value="true" />
+                            <node concept="3clFbS" id="7U$sKL0$N4o" role="1bW5cS">
+                              <node concept="3clFbF" id="7U$sKL0$N4p" role="3cqZAp">
+                                <node concept="1Wc70l" id="7U$sKL0$N4q" role="3clFbG">
+                                  <node concept="1eOMI4" id="7U$sKL0$N4r" role="3uHU7B">
+                                    <node concept="17R0WA" id="7U$sKL0$N4s" role="1eOMHV">
+                                      <node concept="37vLTw" id="7U$sKL0$ODT" role="3uHU7w">
+                                        <ref role="3cqZAo" node="7U$sKL0$LkL" resolve="document" />
+                                      </node>
+                                      <node concept="2OqwBi" id="7U$sKL0$N4y" role="3uHU7B">
+                                        <node concept="37vLTw" id="7U$sKL0$N4z" role="2Oq$k0">
+                                          <ref role="3cqZAo" node="7U$sKL0$N4F" resolve="ref" />
+                                        </node>
+                                        <node concept="3TrEf2" id="7U$sKL0$N4$" role="2OqNvi">
+                                          <ref role="3Tt5mk" to="2c95:2TZO3DbvI5E" resolve="doc" />
+                                        </node>
+                                      </node>
+                                    </node>
+                                  </node>
+                                  <node concept="1eOMI4" id="7U$sKL0$N4_" role="3uHU7w">
+                                    <node concept="17R0WA" id="7U$sKL0$N4A" role="1eOMHV">
+                                      <node concept="2OqwBi" id="7U$sKL0$N4B" role="3uHU7B">
+                                        <node concept="37vLTw" id="7U$sKL0$N4C" role="2Oq$k0">
+                                          <ref role="3cqZAo" node="7U$sKL0$N4F" resolve="ref" />
+                                        </node>
+                                        <node concept="2NL2c5" id="7U$sKL0$N4D" role="2OqNvi" />
+                                      </node>
+                                      <node concept="359W_D" id="7U$sKL0$N4E" role="3uHU7w">
+                                        <ref role="359W_E" to="2c95:5L$H31Kgq3f" resolve="IDocumentLike" />
+                                        <ref role="359W_F" to="2c95:7$DvC4gRxZ6" resolve="dependsOn" />
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="Rh6nW" id="7U$sKL0$N4F" role="1bW2Oz">
+                              <property role="TrG5h" value="ref" />
+                              <node concept="2jxLKc" id="7U$sKL0$N4G" role="1tU5fm" />
+                            </node>
+                          </node>
                         </node>
                       </node>
                     </node>
-                    <node concept="Rh6nW" id="7NleypLW66d" role="1bW2Oz">
-                      <property role="TrG5h" value="it" />
-                      <node concept="2jxLKc" id="7NleypLW66e" role="1tU5fm" />
+                  </node>
+                  <node concept="3clFbF" id="7U$sKL0$OOl" role="3cqZAp">
+                    <node concept="2OqwBi" id="7U$sKL0$Pf_" role="3clFbG">
+                      <node concept="37vLTw" id="7U$sKL0$OOj" role="2Oq$k0">
+                        <ref role="3cqZAo" node="7U$sKL0$N4e" resolve="dependsRefs" />
+                      </node>
+                      <node concept="2es0OD" id="7U$sKL0$P$e" role="2OqNvi">
+                        <node concept="1bVj0M" id="7U$sKL0$P$g" role="23t8la">
+                          <node concept="3clFbS" id="7U$sKL0$P$h" role="1bW5cS">
+                            <node concept="3clFbF" id="7U$sKL0$PPm" role="3cqZAp">
+                              <node concept="2OqwBi" id="7U$sKL0$Q5F" role="3clFbG">
+                                <node concept="37vLTw" id="7U$sKL0$PPl" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="7U$sKL0$P$i" resolve="ref" />
+                                </node>
+                                <node concept="3YRAZt" id="7U$sKL0$QlM" role="2OqNvi" />
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="Rh6nW" id="7U$sKL0$P$i" role="1bW2Oz">
+                            <property role="TrG5h" value="ref" />
+                            <node concept="2jxLKc" id="7U$sKL0$P$j" role="1tU5fm" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbF" id="7U$sKL0$LmK" role="3cqZAp">
+                    <node concept="2OqwBi" id="7U$sKL0$LDe" role="3clFbG">
+                      <node concept="37vLTw" id="7U$sKL0$LmJ" role="2Oq$k0">
+                        <ref role="3cqZAo" node="7U$sKL0$LkL" resolve="document" />
+                      </node>
+                      <node concept="3YRAZt" id="7U$sKL0$MOU" role="2OqNvi" />
                     </node>
                   </node>
                 </node>
-              </node>
-            </node>
-            <node concept="3clFbF" id="6NmtaR2_6ZI" role="3cqZAp">
-              <node concept="2OqwBi" id="6NmtaR2_8xs" role="3clFbG">
-                <node concept="3YRAZt" id="6NmtaR2_9uO" role="2OqNvi" />
-                <node concept="1eOMI4" id="7NleypLVMPx" role="2Oq$k0">
-                  <node concept="2OqwBi" id="6NmtaR2_7W3" role="1eOMHV">
-                    <node concept="2OqwBi" id="6NmtaR2_7by" role="2Oq$k0">
-                      <node concept="2GrUjf" id="6NmtaR2_6ZG" role="2Oq$k0">
-                        <ref role="2Gs0qQ" node="6NmtaR2$khD" resolve="inc" />
-                      </node>
-                      <node concept="3TrEf2" id="6NmtaR2_7za" role="2OqNvi">
-                        <ref role="3Tt5mk" to="2c95:5mf_X_Lbqjz" resolve="ref" />
-                      </node>
-                    </node>
-                    <node concept="3TrEf2" id="6NmtaR2_8dJ" role="2OqNvi">
-                      <ref role="3Tt5mk" to="2c95:2TZO3DbvI5E" resolve="doc" />
-                    </node>
-                  </node>
+                <node concept="Rh6nW" id="7U$sKL0$LkL" role="1bW2Oz">
+                  <property role="TrG5h" value="document" />
+                  <node concept="2jxLKc" id="7U$sKL0$LkM" role="1tU5fm" />
                 </node>
-              </node>
-            </node>
-            <node concept="3clFbF" id="6NmtaR2$Rr5" role="3cqZAp">
-              <node concept="2OqwBi" id="6NmtaR2$RA_" role="3clFbG">
-                <node concept="2GrUjf" id="6NmtaR2$Rr3" role="2Oq$k0">
-                  <ref role="2Gs0qQ" node="6NmtaR2$khD" resolve="inc" />
-                </node>
-                <node concept="3YRAZt" id="6NmtaR2$Sdr" role="2OqNvi" />
               </node>
             </node>
           </node>

--- a/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/languageModels/behavior.mps
+++ b/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/languageModels/behavior.mps
@@ -23,6 +23,7 @@
     <import index="tpcu" ref="r:00000000-0000-4000-0000-011c89590282(jetbrains.mps.lang.core.behavior)" />
     <import index="kwxp" ref="b4d28e19-7d2d-47e9-943e-3a41f97a0e52/r:4903509f-5416-46ff-9a8b-44b5a178b568(com.mbeddr.mpsutil.plantuml.node/com.mbeddr.mpsutil.plantuml.node.structure)" />
     <import index="48kf" ref="r:5f41c82d-84d1-4fb1-a1cf-6697d2365854(com.mbeddr.mpsutil.filepicker.behavior)" />
+    <import index="gtp9" ref="r:007d0985-20e2-4d70-80f1-d0de1aff1076(com.mbeddr.mpsutil.common.graph)" />
   </imports>
   <registry>
     <language id="af65afd8-f0dd-4942-87d9-63a55f2a9db1" name="jetbrains.mps.lang.behavior">
@@ -182,6 +183,7 @@
       <concept id="7812454656619025412" name="jetbrains.mps.baseLanguage.structure.LocalMethodCall" flags="nn" index="1rXfSq" />
       <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
         <reference id="1107535924139" name="classifier" index="3uigEE" />
+        <child id="1109201940907" name="parameter" index="11_B2D" />
       </concept>
       <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
         <child id="1081773367579" name="rightExpression" index="3uHU7w" />
@@ -262,6 +264,9 @@
       </concept>
       <concept id="1171407110247" name="jetbrains.mps.lang.smodel.structure.Node_GetAncestorOperation" flags="nn" index="2Xjw5R" />
       <concept id="1143511969223" name="jetbrains.mps.lang.smodel.structure.Node_GetPrevSiblingOperation" flags="nn" index="YBYNd" />
+      <concept id="3562215692195599741" name="jetbrains.mps.lang.smodel.structure.SLinkImplicitSelect" flags="nn" index="13MTOL">
+        <reference id="3562215692195600259" name="link" index="13MTZf" />
+      </concept>
       <concept id="2644386474300074836" name="jetbrains.mps.lang.smodel.structure.ConceptIdRefExpression" flags="nn" index="35c_gC">
         <reference id="2644386474300074837" name="conceptDeclaration" index="35c_gD" />
       </concept>
@@ -5091,6 +5096,75 @@
     </node>
     <node concept="13hLZK" id="Wvp8me3QAe" role="13h7CW">
       <node concept="3clFbS" id="Wvp8me3QAf" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="3lxJBjiiRgo" role="13h7CS">
+      <property role="TrG5h" value="getDependenciesRelevantForCycleDetection" />
+      <ref role="13i0hy" to="hwgx:59HbAIOYveX" resolve="getDependenciesRelevantForCycleDetection" />
+      <node concept="3Tm1VV" id="3lxJBjiiRgp" role="1B3o_S" />
+      <node concept="3clFbS" id="3lxJBjiiRgt" role="3clF47">
+        <node concept="3clFbF" id="7U$sKL0_s3$" role="3cqZAp">
+          <node concept="2OqwBi" id="7U$sKL0_zrm" role="3clFbG">
+            <node concept="2OqwBi" id="7U$sKL0_uQn" role="2Oq$k0">
+              <node concept="2OqwBi" id="7U$sKL0_s8B" role="2Oq$k0">
+                <node concept="13iPFW" id="7U$sKL0_s3t" role="2Oq$k0" />
+                <node concept="2Rf3mk" id="7U$sKL0_sps" role="2OqNvi">
+                  <node concept="1xMEDy" id="7U$sKL0_spu" role="1xVPHs">
+                    <node concept="chp4Y" id="7U$sKL0_syI" role="ri$Ld">
+                      <ref role="cht4Q" to="2c95:5mf_X_Lbqjw" resolve="DocumentInclude" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="13MTOL" id="7U$sKL0_x17" role="2OqNvi">
+                <ref role="13MTZf" to="2c95:5mf_X_Lbqjz" resolve="ref" />
+              </node>
+            </node>
+            <node concept="13MTOL" id="7U$sKL0_zBV" role="2OqNvi">
+              <ref role="13MTZf" to="2c95:2TZO3DbvI5E" resolve="doc" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="A3Dl8" id="3lxJBjiiRgu" role="3clF45">
+        <node concept="3Tqbb2" id="3lxJBjiiRgv" role="A3Ik2">
+          <ref role="ehGHo" to="vs0r:59HbAIOYkEn" resolve="IDetectCycle" />
+        </node>
+      </node>
+    </node>
+    <node concept="13i0hz" id="3lxJBjijN4E" role="13h7CS">
+      <property role="TrG5h" value="getTopologicalSortedDocuments" />
+      <node concept="3Tm1VV" id="3lxJBjijN4F" role="1B3o_S" />
+      <node concept="3clFbS" id="3lxJBjijN4H" role="3clF47">
+        <node concept="3cpWs8" id="3lxJBjik4Ue" role="3cqZAp">
+          <node concept="3cpWsn" id="3lxJBjik4Uf" role="3cpWs9">
+            <property role="TrG5h" value="dependencyGraph" />
+            <node concept="3uibUv" id="3lxJBjik4P1" role="1tU5fm">
+              <ref role="3uigEE" to="gtp9:9NO9Tq8VKe" resolve="Graph" />
+              <node concept="3Tqbb2" id="3lxJBjik4P4" role="11_B2D">
+                <ref role="ehGHo" to="vs0r:59HbAIOYkEn" resolve="IDetectCycle" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="3lxJBjik4Ug" role="33vP2m">
+              <node concept="13iPFW" id="3lxJBjik4Uh" role="2Oq$k0" />
+              <node concept="2qgKlT" id="3lxJBjik4Ui" role="2OqNvi">
+                <ref role="37wK5l" to="hwgx:17fjvcLC_kB" resolve="getDependencyGraph" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="3lxJBjik59d" role="3cqZAp">
+          <node concept="2YIFZM" id="3lxJBjik5Xa" role="3clFbG">
+            <ref role="37wK5l" to="gtp9:3FYfbA7e8OO" resolve="computeTopologicalSorting" />
+            <ref role="1Pybhc" to="gtp9:59VTJR_XXJb" resolve="GraphUtil" />
+            <node concept="37vLTw" id="3lxJBjik5Xb" role="37wK5m">
+              <ref role="3cqZAo" node="3lxJBjik4Uf" resolve="dependencyGraph" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="_YKpA" id="3lxJBjijSF2" role="3clF45">
+        <node concept="3Tqbb2" id="3lxJBjijSNr" role="_ZDj9" />
+      </node>
     </node>
   </node>
   <node concept="13h7C7" id="2U5fsQejoWj">

--- a/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/languageModels/structure.mps
+++ b/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/languageModels/structure.mps
@@ -1135,6 +1135,9 @@
     <node concept="PrWs8" id="4um$GA1L66q" role="PrDN$">
       <ref role="PrY4T" to="tpck:h0TrEE$" resolve="INamedConcept" />
     </node>
+    <node concept="PrWs8" id="3lxJBjiiNZg" role="PrDN$">
+      <ref role="PrY4T" to="vs0r:59HbAIOYkEn" resolve="IDetectCycle" />
+    </node>
   </node>
   <node concept="PlHQZ" id="2U5fsQei4zf">
     <property role="3GE5qa" value="config" />

--- a/code/languages/com.mbeddr.doc/solutions/com.mbeddr.doc.test.documents/models/com.mbeddr.doc.test.documents.transitiveIncludes.mps
+++ b/code/languages/com.mbeddr.doc/solutions/com.mbeddr.doc.test.documents/models/com.mbeddr.doc.test.documents.transitiveIncludes.mps
@@ -1,0 +1,270 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:8e880dfd-9c5b-4299-bcbf-6f33a31204bd(com.mbeddr.doc.test.documents.transitiveIncludes)">
+  <persistence version="9" />
+  <languages>
+    <use id="2dec0852-3a21-4c4e-a68c-b05236cc37f2" name="com.mbeddr.doc.gen_xhtml" version="1" />
+    <use id="92d2ea16-5a42-4fdf-a676-c7604efe3504" name="de.slisson.mps.richtext" version="0" />
+    <use id="d3a0fd26-445a-466c-900e-10444ddfed52" name="com.mbeddr.mpsutil.filepicker" version="0" />
+    <use id="d4280a54-f6df-4383-aa41-d1b2bffa7eb1" name="com.mbeddr.core.base" version="5" />
+    <use id="2374bc90-7e37-41f1-a9c4-c2e35194c36a" name="com.mbeddr.doc" version="3" />
+  </languages>
+  <imports />
+  <registry>
+    <language id="2dec0852-3a21-4c4e-a68c-b05236cc37f2" name="com.mbeddr.doc.gen_xhtml">
+      <concept id="3350625596580275037" name="com.mbeddr.doc.gen_xhtml.structure.HTMLRenderer" flags="ng" index="1_07dB" />
+      <concept id="3498379661306969557" name="com.mbeddr.doc.gen_xhtml.structure.HTMLDummyRenderer" flags="ng" index="1TaS0h" />
+    </language>
+    <language id="92d2ea16-5a42-4fdf-a676-c7604efe3504" name="de.slisson.mps.richtext">
+      <concept id="2557074442922380897" name="de.slisson.mps.richtext.structure.Text" flags="ng" index="19SGf9">
+        <child id="2557074442922392302" name="words" index="19SJt6" />
+      </concept>
+      <concept id="2557074442922438156" name="de.slisson.mps.richtext.structure.Word" flags="ng" index="19SUe$">
+        <property id="2557074442922438158" name="escapedValue" index="19SUeA" />
+      </concept>
+    </language>
+    <language id="2374bc90-7e37-41f1-a9c4-c2e35194c36a" name="com.mbeddr.doc">
+      <concept id="6165313375056012512" name="com.mbeddr.doc.structure.DocumentInclude" flags="ng" index="$CzcT">
+        <property id="324047639344492301" name="referenceOnly" index="1P4p2h" />
+        <child id="6165313375056012515" name="ref" index="$CzcU" />
+      </concept>
+      <concept id="6657644269295214799" name="com.mbeddr.doc.structure.IDocumentLike" flags="ng" index="G9hjZ">
+        <reference id="6657644269295214800" name="config" index="G9hjw" />
+        <child id="8730648445433290694" name="dependsOn" index="1DXQ57" />
+      </concept>
+      <concept id="6386504476136554612" name="com.mbeddr.doc.structure.PathMapping" flags="ng" index="2SbEIf">
+        <property id="6386504476136554614" name="mappedPath" index="2SbEId" />
+        <reference id="6386504476136554613" name="pathDef" index="2SbEIe" />
+      </concept>
+      <concept id="6386504476136472795" name="com.mbeddr.doc.structure.PathDefinition" flags="ng" index="2SbYGw">
+        <child id="2642765975824057986" name="pathPicker" index="9PVG_" />
+      </concept>
+      <concept id="6386504476136472782" name="com.mbeddr.doc.structure.DocumentConfig" flags="ng" index="2SbYGP">
+        <child id="3352153450711894224" name="configItems" index="2wNnkt" />
+        <child id="6617418817009206267" name="defaultImagePath" index="A10yx" />
+        <child id="5785245534401182264" name="defaultTempPath" index="Cbewh" />
+      </concept>
+      <concept id="6068976060904002601" name="com.mbeddr.doc.structure.AbstractExport" flags="ng" index="30Gg6V">
+        <child id="6068976060904007487" name="renderer" index="30GjaH" />
+        <child id="6068976060904007490" name="mappings" index="30Gjbg" />
+        <child id="6068976060904007489" name="root" index="30Gjbj" />
+      </concept>
+      <concept id="3350625596580256366" name="com.mbeddr.doc.structure.DocumentExport" flags="ng" index="1_08Dk">
+        <property id="126932837435324910" name="title" index="WqcPg" />
+      </concept>
+      <concept id="3350625596580225385" name="com.mbeddr.doc.structure.DocumentRef" flags="ng" index="1_0j5j">
+        <reference id="3350625596580225386" name="doc" index="1_0j5g" />
+      </concept>
+      <concept id="3350625596580108709" name="com.mbeddr.doc.structure.SectRefWord" flags="ng" index="1_0GAv">
+        <reference id="3350625596580108719" name="target" index="1_0GAl" />
+      </concept>
+      <concept id="3350625596580089586" name="com.mbeddr.doc.structure.TextParagraph" flags="ng" index="1_0LV8">
+        <child id="3350625596580089613" name="text" index="1_0LWR" />
+      </concept>
+      <concept id="3350625596580064249" name="com.mbeddr.doc.structure.IDocContentContainer" flags="ng" index="1_0VJ3">
+        <child id="3350625596580064250" name="contents" index="1_0VJ0" />
+      </concept>
+      <concept id="3350625596580064222" name="com.mbeddr.doc.structure.AbstractSection" flags="ng" index="1_0VJ$">
+        <property id="3350625596580064225" name="text" index="1_0VJr" />
+      </concept>
+      <concept id="3350625596580064455" name="com.mbeddr.doc.structure.Section" flags="ng" index="1_0VNX" />
+      <concept id="3350625596579911728" name="com.mbeddr.doc.structure.Document" flags="ng" index="1_1swa">
+        <property id="5572730672710143343" name="chapterStartIndex" index="yApLE" />
+      </concept>
+      <concept id="3350625596579911760" name="com.mbeddr.doc.structure.EmptyDocContent" flags="ng" index="1_1sxE" />
+    </language>
+    <language id="d3a0fd26-445a-466c-900e-10444ddfed52" name="com.mbeddr.mpsutil.filepicker">
+      <concept id="2642765975824060179" name="com.mbeddr.mpsutil.filepicker.structure.SolutionRelativeDirPicker" flags="ng" index="9PVaO" />
+      <concept id="6156524541422549000" name="com.mbeddr.mpsutil.filepicker.structure.AbstractPicker" flags="ng" index="3N1QpV">
+        <property id="9294901202237533" name="mayBeEmpty" index="3kgbRO" />
+        <property id="6156524541422553710" name="path" index="3N1Lgt" />
+        <property id="2711621784026951428" name="pointOnlyToExistingFile" index="1RwFax" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="2SbYGP" id="2khznRHyx6c">
+    <property role="TrG5h" value="Config" />
+    <node concept="1_07dB" id="2khznRHyx6d" role="2wNnkt" />
+    <node concept="2SbYGw" id="2khznRHyx6e" role="Cbewh">
+      <property role="TrG5h" value="main" />
+      <node concept="9PVaO" id="2khznRHyx6f" role="9PVG_">
+        <property role="1RwFax" value="true" />
+        <property role="3kgbRO" value="false" />
+      </node>
+    </node>
+    <node concept="2SbYGw" id="2B9KjOuvX9f" role="A10yx">
+      <property role="TrG5h" value="imgs" />
+      <node concept="9PVaO" id="2B9KjOuvX9e" role="9PVG_">
+        <property role="1RwFax" value="true" />
+        <property role="3kgbRO" value="false" />
+        <property role="3N1Lgt" value="imgs" />
+      </node>
+    </node>
+  </node>
+  <node concept="1_08Dk" id="2khznRHyx68">
+    <property role="TrG5h" value="Export" />
+    <property role="WqcPg" value="My strange export config" />
+    <node concept="2SbEIf" id="4eRbT2iEycg" role="30Gjbg">
+      <property role="2SbEId" value="/Users/kdummann/source/mbeddr/mbeddr.core/" />
+      <ref role="2SbEIe" node="2khznRHyx6e" resolve="main" />
+    </node>
+    <node concept="1_0j5j" id="2khznRHyx6i" role="30Gjbj">
+      <ref role="1_0j5g" node="2khznRHyx5W" resolve="main_document_including_other_docs" />
+    </node>
+    <node concept="1TaS0h" id="2khznRHyx6b" role="30GjaH" />
+  </node>
+  <node concept="1_1swa" id="2khznRHyx5W">
+    <property role="yApLE" value="1" />
+    <property role="TrG5h" value="main_document_including_other_docs" />
+    <ref role="G9hjw" node="2khznRHyx6c" resolve="Config" />
+    <node concept="1_0VNX" id="2khznRHyx5X" role="1_0VJ0">
+      <property role="TrG5h" value="firstsection" />
+      <property role="1_0VJr" value="This the first section" />
+      <node concept="1_0LV8" id="2khznRHyx5Y" role="1_0VJ0">
+        <node concept="19SGf9" id="2khznRHyx5Z" role="1_0LWR">
+          <node concept="19SUe$" id="2khznRHyx60" role="19SJt6">
+            <property role="19SUeA" value="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce egestas, purus non commodo efficitur, quam odio fermentum mi, ut tincidunt dolor neque non lacus. Vestibulum sit amet aliquam leo, mollis iaculis velit. Donec rhoncus, diam sed rutrum porttitor, mauris risus faucibus dui, at mattis nisi eros in ligula. Nunc mauris quam, aliquam quis mauris iaculis, luctus viverra leo. Sed pharetra sodales diam. Duis luctus velit in justo volutpat sagittis. Suspendisse et eleifend dolor.&#10;&#10;" />
+          </node>
+          <node concept="1_0GAv" id="2khznRHyCug" role="19SJt6">
+            <ref role="1_0GAl" node="2khznRHyCtE" resolve="second_section_from_first_document" />
+          </node>
+          <node concept="19SUe$" id="2khznRHyCuh" role="19SJt6">
+            <property role="19SUeA" value="&#10;" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1_1sxE" id="2khznRHyCs1" role="1_0VJ0">
+      <property role="TrG5h" value="empty_-1" />
+    </node>
+    <node concept="1_0VNX" id="2khznRHyCtE" role="1_0VJ0">
+      <property role="TrG5h" value="second_section_from_first_document" />
+      <property role="1_0VJr" value="Second section from first document" />
+    </node>
+    <node concept="1_1sxE" id="2khznRHyCt5" role="1_0VJ0">
+      <property role="TrG5h" value="empty_-1" />
+    </node>
+    <node concept="$CzcT" id="5FHtHFpWRqT" role="1_0VJ0">
+      <property role="1P4p2h" value="true" />
+      <node concept="1_0j5j" id="5FHtHFpWRrp" role="$CzcU">
+        <ref role="1_0j5g" node="7VyEbceXaad" resolve="document_including_other" />
+      </node>
+    </node>
+    <node concept="$CzcT" id="5FHtHFpWRrD" role="1_0VJ0">
+      <property role="1P4p2h" value="true" />
+      <node concept="1_0j5j" id="5FHtHFpWRrU" role="$CzcU">
+        <ref role="1_0j5g" node="7VyEbceXac_" resolve="including_document_that_includes" />
+      </node>
+    </node>
+    <node concept="1_0j5j" id="5FHtHFpWRrd" role="1DXQ57">
+      <ref role="1_0j5g" node="7VyEbceXac_" resolve="including_document_that_includes" />
+    </node>
+    <node concept="1_0j5j" id="5FHtHFpWRrl" role="1DXQ57">
+      <ref role="1_0j5g" node="7VyEbceXaad" resolve="document_including_other" />
+    </node>
+  </node>
+  <node concept="1_1swa" id="7VyEbceXaad">
+    <property role="yApLE" value="1" />
+    <property role="TrG5h" value="document_including_other" />
+    <ref role="G9hjw" node="2khznRHyx6c" resolve="Config" />
+    <node concept="1_0VNX" id="7VyEbceXaba" role="1_0VJ0">
+      <property role="TrG5h" value="document_including_other_section" />
+      <property role="1_0VJr" value="I do include" />
+      <node concept="1_0LV8" id="7VyEbceXabh" role="1_0VJ0">
+        <node concept="19SGf9" id="7VyEbceXabi" role="1_0LWR">
+          <node concept="19SUe$" id="7VyEbceXabj" role="19SJt6">
+            <property role="19SUeA" value="I do be including stuff " />
+          </node>
+          <node concept="1_0GAv" id="7VyEbceXabo" role="19SJt6">
+            <ref role="1_0GAl" node="7VyEbceXaaG" resolve="leaf_section" />
+          </node>
+          <node concept="19SUe$" id="7VyEbceXabp" role="19SJt6" />
+        </node>
+      </node>
+    </node>
+    <node concept="$CzcT" id="7VyEbceXaaV" role="1_0VJ0">
+      <node concept="1_0j5j" id="7VyEbceXab1" role="$CzcU">
+        <ref role="1_0j5g" node="7VyEbceXaau" resolve="leaf_document" />
+      </node>
+    </node>
+    <node concept="1_0j5j" id="7VyEbceXaaZ" role="1DXQ57">
+      <ref role="1_0j5g" node="7VyEbceXaau" resolve="leaf_document" />
+    </node>
+  </node>
+  <node concept="1_1swa" id="7VyEbceXaau">
+    <property role="yApLE" value="1" />
+    <property role="TrG5h" value="leaf_document" />
+    <ref role="G9hjw" node="2khznRHyx6c" resolve="Config" />
+    <node concept="1_0VNX" id="7VyEbceXaaG" role="1_0VJ0">
+      <property role="TrG5h" value="leaf_section" />
+      <property role="1_0VJr" value="Leaf" />
+      <node concept="1_0LV8" id="7VyEbceXaaK" role="1_0VJ0">
+        <node concept="19SGf9" id="7VyEbceXaaL" role="1_0LWR">
+          <node concept="19SUe$" id="7VyEbceXaaM" role="19SJt6">
+            <property role="19SUeA" value="&#10;Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed scelerisque velit a molestie feugiat. Interdum et malesuada fames ac ante ipsum primis in faucibus. Maecenas porta dolor ut justo fermentum blandit. Fusce rutrum consectetur arcu, id rhoncus lacus vehicula elementum. Fusce dictum mollis orci, nec aliquam metus tempor eu. Vestibulum ac tortor vitae quam porttitor malesuada sed sed ligula. Vestibulum sed enim euismod, finibus lectus sit amet, varius neque. Praesent iaculis, dui non interdum tempus, purus eros lacinia arcu, a venenatis leo odio quis orci. Fusce convallis massa elit, et pulvinar velit ultrices eget. Ut sem felis, laoreet non arcu in, gravida accumsan lacus.&#10;&#10;Mauris sagittis enim at nisi sodales, id rutrum nibh pretium. Cras eu commodo enim. Nullam eget nulla odio. Nulla suscipit semper tortor, at scelerisque nunc elementum vitae. Quisque commodo aliquam malesuada. Morbi commodo velit nec vulputate convallis. Integer accumsan odio et dictum lobortis. Phasellus ultrices ex urna, ac sagittis nisi lacinia eu. Phasellus sit amet diam purus.&#10;&#10;Morbi magna erat, congue ac erat quis, viverra ornare ante. Proin et pretium lorem. Donec efficitur nulla eu dolor vulputate consequat. Cras ac ornare sem. Suspendisse convallis eleifend tincidunt. Cras elit risus, blandit ultricies malesuada eget, lacinia sed leo. Nullam et placerat magna. Nulla tempus eros vel est molestie, nec ullamcorper turpis tincidunt. Sed eget mauris sed eros pharetra dapibus eget ut urna. Suspendisse tincidunt ac mi ac consequat. Nam non mollis tellus. Phasellus vel neque pretium, vestibulum urna a, dapibus erat. Donec fringilla lectus volutpat arcu ullamcorper euismod a eget massa. " />
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="1_1swa" id="7VyEbceXabH">
+    <property role="yApLE" value="1" />
+    <property role="TrG5h" value="another_document_including_stuff" />
+    <ref role="G9hjw" node="2khznRHyx6c" resolve="Config" />
+    <node concept="1_0j5j" id="7VyEbceXabI" role="1DXQ57">
+      <ref role="1_0j5g" node="7VyEbceXaau" resolve="leaf_document" />
+    </node>
+    <node concept="1_0VNX" id="7VyEbceXabV" role="1_0VJ0">
+      <property role="TrG5h" value="another_document_including_stuff_section" />
+      <property role="1_0VJr" value="An other document including" />
+      <node concept="1_1sxE" id="7VyEbceXac0" role="1_0VJ0">
+        <property role="TrG5h" value="empty_-1" />
+      </node>
+      <node concept="1_0LV8" id="7VyEbceXac5" role="1_0VJ0">
+        <node concept="19SGf9" id="7VyEbceXac6" role="1_0LWR">
+          <node concept="19SUe$" id="7VyEbceXac7" role="19SJt6">
+            <property role="19SUeA" value="yep I'm another document including the leaf one. But I don't have a reference" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="$CzcT" id="7VyEbceXabK" role="1_0VJ0">
+      <node concept="1_0j5j" id="7VyEbceXabO" role="$CzcU">
+        <ref role="1_0j5g" node="7VyEbceXaau" resolve="leaf_document" />
+      </node>
+    </node>
+  </node>
+  <node concept="1_1swa" id="7VyEbceXac_">
+    <property role="yApLE" value="1" />
+    <property role="TrG5h" value="including_document_that_includes" />
+    <ref role="G9hjw" node="2khznRHyx6c" resolve="Config" />
+    <node concept="1_0j5j" id="7VyEbceXacA" role="1DXQ57">
+      <ref role="1_0j5g" node="7VyEbceXabH" resolve="another_document_including_stuff" />
+    </node>
+    <node concept="1_0VNX" id="7VyEbceXacN" role="1_0VJ0">
+      <property role="TrG5h" value="including_document_that_includes_section" />
+      <property role="1_0VJr" value="sdfjkslkfjsf" />
+      <node concept="1_0LV8" id="7VyEbceXacW" role="1_0VJ0">
+        <node concept="19SGf9" id="7VyEbceXacX" role="1_0LWR">
+          <node concept="19SUe$" id="7VyEbceXacY" role="19SJt6">
+            <property role="19SUeA" value="include and includer and ref stuff from included include: " />
+          </node>
+          <node concept="1_0GAv" id="7VyEbceXad3" role="19SJt6">
+            <ref role="1_0GAl" node="7VyEbceXaaG" resolve="leaf_section" />
+          </node>
+          <node concept="19SUe$" id="7VyEbceXad4" role="19SJt6" />
+        </node>
+      </node>
+    </node>
+    <node concept="$CzcT" id="7VyEbceXacC" role="1_0VJ0">
+      <node concept="1_0j5j" id="7VyEbceXacG" role="$CzcU">
+        <ref role="1_0j5g" node="7VyEbceXabH" resolve="another_document_including_stuff" />
+      </node>
+    </node>
+  </node>
+</model>
+


### PR DESCRIPTION
Remove the limitation that a document could only get included once. It
is now possible to include a document in as many places as desired. The
resolving of transient imports is supported and includes are resolved in
inverse topological order (from the leaf to the root). The generator
automatically restores references within the including document to
content that is included if required.

The reference resolving logic is limited to resolve references to
included content only to the first include. This means including the
same document twice in one document will not yield the desired result.

Please see the code comments for much more details on the design. 