### PR TITLE
[2020.1 backport] doc: fix code removal in screenshots

### DIFF
--- a/code/languages/com.mbeddr.build/solutions/com.mbeddr.platform/models/com/mbeddr/platform/build.mps
+++ b/code/languages/com.mbeddr.build/solutions/com.mbeddr.platform/models/com/mbeddr/platform/build.mps
@@ -629,15 +629,15 @@
       <node concept="m$_yC" id="6rBfBe1Wuqz" role="m$_yJ">
         <ref role="m$_y1" node="5fGcQI94fMR" resolve="com.mbeddr.mpsutil.common" />
       </node>
-      <node concept="m$_yC" id="7odnKbxM7aM" role="m$_yJ">
-        <ref role="m$_y1" node="$bJ0jguQdg" resolve="com.mbeddr.platform" />
-      </node>
       <node concept="m$f5U" id="6rBfBe1WpV0" role="m$_yh">
         <ref role="m$f5T" node="3quoVcnN1e0" resolve="group.interpreter" />
       </node>
       <node concept="2iUeEo" id="7yAshxDtplR" role="2iVFfd">
         <property role="2iUeEt" value="mbedrr" />
         <property role="2iUeEu" value="http://mbeddr.com" />
+      </node>
+      <node concept="m$_yC" id="7odnKbxM7aM" role="m$_yJ">
+        <ref role="m$_y1" node="$bJ0jguQdg" resolve="com.mbeddr.platform" />
       </node>
     </node>
     <node concept="m$_wf" id="6rBfBe1WRMd" role="3989C9">
@@ -18462,6 +18462,11 @@
             </node>
           </node>
         </node>
+        <node concept="1SiIV0" id="1aCwgFOnMPO" role="3bR37C">
+          <node concept="3bR9La" id="1aCwgFOnMPP" role="1SiIV1">
+            <ref role="3bR37D" to="90a9:5vQ_hAOOn52" resolve="de.slisson.mps.conditionalEditor.hints" />
+          </node>
+        </node>
       </node>
       <node concept="1E1JtD" id="$bJ0jguQfr" role="2G$12L">
         <property role="BnDLt" value="true" />
@@ -25691,6 +25696,11 @@
             <node concept="3qWCbU" id="$Kq8MetF6v" role="3LXTna">
               <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
             </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="1aCwgFOnNvZ" role="3bR37C">
+          <node concept="3bR9La" id="1aCwgFOnNw0" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:7Kfy9QB6KYb" resolve="jetbrains.mps.baseLanguage" />
           </node>
         </node>
       </node>

--- a/code/languages/com.mbeddr.core/languages/com.mbeddr.core.base/solutions/pluginSolution/models/com/mbeddr/core/base/pluginSolution/plugin.mps
+++ b/code/languages/com.mbeddr.core/languages/com.mbeddr.core.base/solutions/pluginSolution/models/com/mbeddr/core/base/pluginSolution/plugin.mps
@@ -2,29 +2,29 @@
 <model ref="r:0a882e21-5553-485b-8777-3b0ace5a0d84(com.mbeddr.core.base.pluginSolution.plugin)">
   <persistence version="9" />
   <languages>
-    <use id="28f9e497-3b42-4291-aeba-0a1039153ab1" name="jetbrains.mps.lang.plugin" version="4" />
+    <use id="28f9e497-3b42-4291-aeba-0a1039153ab1" name="jetbrains.mps.lang.plugin" version="-1" />
     <use id="443f4c36-fcf5-4eb6-9500-8d06ed259e3e" name="jetbrains.mps.baseLanguage.classifiers" version="-1" />
     <use id="982eb8df-2c96-4bd7-9963-11712ea622e5" name="jetbrains.mps.lang.resources" version="-1" />
     <use id="ef7bf5ac-d06c-4342-b11d-e42104eb9343" name="jetbrains.mps.lang.plugin.standalone" version="-1" />
     <use id="1fc20ffe-f35b-4791-a0b7-d706bad5c49a" name="com.mbeddr.mpsutil.refactoring" version="-1" />
-    <use id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections" version="1" />
+    <use id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections" version="-1" />
     <use id="63650c59-16c8-498a-99c8-005c7ee9515d" name="jetbrains.mps.lang.access" version="-1" />
     <use id="63e0e566-5131-447e-90e3-12ea330e1a00" name="com.mbeddr.mpsutil.blutil" version="-1" />
     <use id="c3bfea76-7bba-4f0e-b5a2-ff4e7a8d7cf1" name="com.mbeddr.mpsutil.spreferences" version="-1" />
-    <use id="fe9d76d7-5809-45c9-ae28-a40915b4d6ff" name="jetbrains.mps.lang.checkedName" version="1" />
+    <use id="fe9d76d7-5809-45c9-ae28-a40915b4d6ff" name="jetbrains.mps.lang.checkedName" version="-1" />
     <use id="760a0a8c-eabb-4521-8bfd-65db761a9ba3" name="jetbrains.mps.baseLanguage.logging" version="-1" />
     <use id="58e731a3-6aaa-444a-bf40-801b91c15878" name="com.mbeddr.mpsutil.lang.plugin.extensions" version="-1" />
     <use id="aee9cad2-acd4-4608-aef2-0004f6a1cdbd" name="jetbrains.mps.lang.actions" version="-1" />
-    <use id="c38abce1-4c09-44cb-9ebf-2a764e824bb5" name="com.mbeddr.mpsutil.actionsfilter" version="-1" />
     <use id="13744753-c81f-424a-9c1b-cf8943bf4e86" name="jetbrains.mps.lang.sharedConcepts" version="-1" />
     <use id="ed6d7656-532c-4bc2-81d1-af945aeb8280" name="jetbrains.mps.baseLanguage.blTypes" version="-1" />
     <use id="9ded098b-ad6a-4657-bfd9-48636cfe8bc3" name="jetbrains.mps.lang.traceable" version="-1" />
-    <use id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core" version="2" />
-    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="17" />
-    <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="11" />
-    <use id="c72da2b9-7cce-4447-8389-f407dc1158b7" name="jetbrains.mps.lang.structure" version="9" />
+    <use id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core" version="-1" />
+    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="-1" />
+    <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="-1" />
+    <use id="c72da2b9-7cce-4447-8389-f407dc1158b7" name="jetbrains.mps.lang.structure" version="-1" />
     <use id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc" version="-1" />
-    <use id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor" version="14" />
+    <use id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor" version="-1" />
+    <use id="c38abce1-4c09-44cb-9ebf-2a764e824bb5" name="com.mbeddr.mpsutil.actionsfilter" version="-1" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
@@ -115,6 +115,7 @@
     <import index="lwvz" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.selection(MPS.Editor/)" />
     <import index="b8lf" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor.selection(MPS.Editor/)" />
     <import index="xr52" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.ide.ui.tree.smodel(MPS.Platform/)" />
+    <import index="461n" ref="r:3b46a963-6deb-4d82-bdc0-36b5d9297fcf(de.slisson.mps.conditionalEditor.hints.editor)" />
   </imports>
   <registry>
     <language id="982eb8df-2c96-4bd7-9963-11712ea622e5" name="jetbrains.mps.lang.resources">
@@ -221,6 +222,9 @@
       </concept>
     </language>
     <language id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor">
+      <concept id="4820515453818318288" name="jetbrains.mps.lang.editor.structure.ConceptEditorHintDeclarationReferenceExpression" flags="ng" index="2pYGij">
+        <reference id="4820515453818318891" name="hint" index="2pYH_C" />
+      </concept>
       <concept id="3547227755871693971" name="jetbrains.mps.lang.editor.structure.PredefinedSelector" flags="ng" index="2B6iha">
         <property id="2162403111523065396" name="cellId" index="1lyBwo" />
       </concept>
@@ -558,6 +562,9 @@
       </concept>
     </language>
     <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
+      <concept id="1200830824066" name="jetbrains.mps.baseLanguage.closures.structure.YieldStatement" flags="nn" index="2n63Yl">
+        <child id="1200830928149" name="expression" index="2n6tg2" />
+      </concept>
       <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
         <child id="1199569906740" name="parameter" index="1bW2Oz" />
         <child id="1199569916463" name="body" index="1bW5cS" />
@@ -708,6 +715,9 @@
       <concept id="1204796164442" name="jetbrains.mps.baseLanguage.collections.structure.InternalSequenceOperation" flags="nn" index="23sCx2">
         <child id="1204796294226" name="closure" index="23t8la" />
       </concept>
+      <concept id="1176906603202" name="jetbrains.mps.baseLanguage.collections.structure.BinaryOperation" flags="nn" index="56pJg">
+        <child id="1176906787974" name="rightExpression" index="576Qk" />
+      </concept>
       <concept id="540871147943773365" name="jetbrains.mps.baseLanguage.collections.structure.SingleArgumentSequenceOperation" flags="nn" index="25WWJ4">
         <child id="540871147943773366" name="argument" index="25WWJ7" />
       </concept>
@@ -716,6 +726,10 @@
         <child id="1226511765987" name="elementType" index="2hN53Y" />
       </concept>
       <concept id="1226516258405" name="jetbrains.mps.baseLanguage.collections.structure.HashSetCreator" flags="nn" index="2i4dXS" />
+      <concept id="1224414427926" name="jetbrains.mps.baseLanguage.collections.structure.SequenceCreator" flags="nn" index="kMnCb">
+        <child id="1224414456414" name="elementType" index="kMuH3" />
+        <child id="1224414466839" name="initializer" index="kMx8a" />
+      </concept>
       <concept id="1151688443754" name="jetbrains.mps.baseLanguage.collections.structure.ListType" flags="in" index="_YKpA">
         <child id="1151688676805" name="elementType" index="_ZDj9" />
       </concept>
@@ -761,6 +775,7 @@
       <concept id="1184963466173" name="jetbrains.mps.baseLanguage.collections.structure.ToArrayOperation" flags="nn" index="3_kTaI" />
       <concept id="1176501494711" name="jetbrains.mps.baseLanguage.collections.structure.IsNotEmptyOperation" flags="nn" index="3GX2aA" />
       <concept id="1172254888721" name="jetbrains.mps.baseLanguage.collections.structure.ContainsOperation" flags="nn" index="3JPx81" />
+      <concept id="1180964022718" name="jetbrains.mps.baseLanguage.collections.structure.ConcatOperation" flags="nn" index="3QWeyG" />
       <concept id="1178894719932" name="jetbrains.mps.baseLanguage.collections.structure.DistinctOperation" flags="nn" index="1VAtEI" />
     </language>
   </registry>
@@ -11142,12 +11157,12 @@
                     <node concept="3cpWs6" id="7o1blyu$2OD" role="3cqZAp">
                       <node concept="2OqwBi" id="7o1blyu$2OE" role="3cqZAk">
                         <node concept="2OqwBi" id="7o1blyu$2OF" role="2Oq$k0">
+                          <node concept="liA8E" id="7o1blyu$2OH" role="2OqNvi">
+                            <ref role="37wK5l" to="w1kc:~MPSModuleRepository.getModules()" resolve="getModules" />
+                          </node>
                           <node concept="2YIFZM" id="7o1blyu$hnJ" role="2Oq$k0">
                             <ref role="1Pybhc" to="w1kc:~MPSModuleRepository" resolve="MPSModuleRepository" />
                             <ref role="37wK5l" to="w1kc:~MPSModuleRepository.getInstance()" resolve="getInstance" />
-                          </node>
-                          <node concept="liA8E" id="7o1blyu$2OH" role="2OqNvi">
-                            <ref role="37wK5l" to="w1kc:~MPSModuleRepository.getModules()" resolve="getModules" />
                           </node>
                         </node>
                         <node concept="liA8E" id="7o1blyu$2OI" role="2OqNvi">
@@ -13656,12 +13671,12 @@
               </node>
             </node>
             <node concept="2OqwBi" id="79AXByxOrmb" role="33vP2m">
+              <node concept="liA8E" id="79AXByxOrmd" role="2OqNvi">
+                <ref role="37wK5l" to="ends:~ModelFactoryService.getFactories()" resolve="getFactories" />
+              </node>
               <node concept="2YIFZM" id="79AXByxOrmr" role="2Oq$k0">
                 <ref role="37wK5l" to="ends:~ModelFactoryService.getInstance()" resolve="getInstance" />
                 <ref role="1Pybhc" to="ends:~ModelFactoryService" resolve="ModelFactoryService" />
-              </node>
-              <node concept="liA8E" id="79AXByxOrmd" role="2OqNvi">
-                <ref role="37wK5l" to="ends:~ModelFactoryService.getFactories()" resolve="getFactories" />
               </node>
             </node>
           </node>
@@ -21950,10 +21965,7 @@
                                       <node concept="37vLTI" id="2cjkfC8_XO3" role="3clFbG">
                                         <node concept="2ShNRf" id="5Pb2U$k6TNH" role="37vLTx">
                                           <node concept="1pGfFk" id="5Pb2U$k6TNI" role="2ShVmc">
-                                            <ref role="37wK5l" to="7a0s:2qx2hw9gxhG" resolve="HeadlessEditorComponent" />
-                                            <node concept="37vLTw" id="5Pb2U$k6TNJ" role="37wK5m">
-                                              <ref role="3cqZAo" node="1yFmGPnLcLw" resolve="n" />
-                                            </node>
+                                            <ref role="37wK5l" to="7a0s:2iNJDZP2RE6" resolve="HeadlessEditorComponent" />
                                             <node concept="2OqwBi" id="5Pb2U$k6TNK" role="37wK5m">
                                               <node concept="2OqwBi" id="5Pb2U$k6TNL" role="2Oq$k0">
                                                 <node concept="2JrnkZ" id="5Pb2U$k6TNM" role="2Oq$k0">
@@ -21976,7 +21988,19 @@
                                         </node>
                                       </node>
                                     </node>
-                                    <node concept="3clFbH" id="1vW6hmyXWQb" role="3cqZAp" />
+                                    <node concept="3clFbF" id="1aCwgFOlo9I" role="3cqZAp">
+                                      <node concept="2OqwBi" id="1aCwgFOlpFW" role="3clFbG">
+                                        <node concept="37vLTw" id="1aCwgFOlo9G" role="2Oq$k0">
+                                          <ref role="3cqZAo" node="5Pb2U$k6TNF" resolve="editorComp" />
+                                        </node>
+                                        <node concept="liA8E" id="1aCwgFOlrrE" role="2OqNvi">
+                                          <ref role="37wK5l" to="exr9:~EditorComponent.editNode(org.jetbrains.mps.openapi.model.SNode)" resolve="editNode" />
+                                          <node concept="37vLTw" id="1aCwgFOlsdP" role="37wK5m">
+                                            <ref role="3cqZAo" node="1yFmGPnLcLw" resolve="n" />
+                                          </node>
+                                        </node>
+                                      </node>
+                                    </node>
                                     <node concept="3clFbJ" id="1vW6hmyYxSy" role="3cqZAp">
                                       <node concept="3clFbS" id="1vW6hmyYxS$" role="3clFbx">
                                         <node concept="3cpWs8" id="1vW6hmyYLOA" role="3cqZAp">
@@ -21995,6 +22019,126 @@
                                             </node>
                                           </node>
                                         </node>
+                                        <node concept="3SKdUt" id="1aCwgFOntFq" role="3cqZAp">
+                                          <node concept="1PaTwC" id="1aCwgFOntFr" role="1aUNEU">
+                                            <node concept="3oM_SD" id="1aCwgFOntFs" role="1PaTwD">
+                                              <property role="3oM_SC" value="enable" />
+                                            </node>
+                                            <node concept="3oM_SD" id="1aCwgFOnu_U" role="1PaTwD">
+                                              <property role="3oM_SC" value="conditional" />
+                                            </node>
+                                            <node concept="3oM_SD" id="1aCwgFOnv1H" role="1PaTwD">
+                                              <property role="3oM_SC" value="editors" />
+                                            </node>
+                                            <node concept="3oM_SD" id="1aCwgFOnv1L" role="1PaTwD">
+                                              <property role="3oM_SC" value="by" />
+                                            </node>
+                                            <node concept="3oM_SD" id="1aCwgFOnva5" role="1PaTwD">
+                                              <property role="3oM_SC" value="setting" />
+                                            </node>
+                                            <node concept="3oM_SD" id="1aCwgFOnwn6" role="1PaTwD">
+                                              <property role="3oM_SC" value="the" />
+                                            </node>
+                                            <node concept="3oM_SD" id="1aCwgFOnwnd" role="1PaTwD">
+                                              <property role="3oM_SC" value="required" />
+                                            </node>
+                                            <node concept="3oM_SD" id="1aCwgFOnxES" role="1PaTwD">
+                                              <property role="3oM_SC" value="hints." />
+                                            </node>
+                                            <node concept="3oM_SD" id="1aCwgFOny_b" role="1PaTwD">
+                                              <property role="3oM_SC" value="Otherwise" />
+                                            </node>
+                                            <node concept="3oM_SD" id="1aCwgFOny_l" role="1PaTwD">
+                                              <property role="3oM_SC" value="no" />
+                                            </node>
+                                            <node concept="3oM_SD" id="1aCwgFOnz1g" role="1PaTwD">
+                                              <property role="3oM_SC" value="conditional" />
+                                            </node>
+                                            <node concept="3oM_SD" id="1aCwgFOnztc" role="1PaTwD">
+                                              <property role="3oM_SC" value="" />
+                                            </node>
+                                          </node>
+                                        </node>
+                                        <node concept="3SKdUt" id="1aCwgFOn$J3" role="3cqZAp">
+                                          <node concept="1PaTwC" id="1aCwgFOn$J4" role="1aUNEU">
+                                            <node concept="3oM_SD" id="1aCwgFOn$J5" role="1PaTwD">
+                                              <property role="3oM_SC" value="editors" />
+                                            </node>
+                                            <node concept="3oM_SD" id="1aCwgFOn_e1" role="1PaTwD">
+                                              <property role="3oM_SC" value="are" />
+                                            </node>
+                                            <node concept="3oM_SD" id="1aCwgFOn_e4" role="1PaTwD">
+                                              <property role="3oM_SC" value="considered" />
+                                            </node>
+                                            <node concept="3oM_SD" id="1aCwgFOn_DS" role="1PaTwD">
+                                              <property role="3oM_SC" value="and" />
+                                            </node>
+                                            <node concept="3oM_SD" id="1aCwgFOn_DX" role="1PaTwD">
+                                              <property role="3oM_SC" value="for" />
+                                            </node>
+                                            <node concept="3oM_SD" id="1aCwgFOnA5N" role="1PaTwD">
+                                              <property role="3oM_SC" value="instance" />
+                                            </node>
+                                            <node concept="3oM_SD" id="1aCwgFOnA5U" role="1PaTwD">
+                                              <property role="3oM_SC" value="code" />
+                                            </node>
+                                            <node concept="3oM_SD" id="1aCwgFOnA$0" role="1PaTwD">
+                                              <property role="3oM_SC" value="paragraphs" />
+                                            </node>
+                                            <node concept="3oM_SD" id="1aCwgFOnBRp" role="1PaTwD">
+                                              <property role="3oM_SC" value="would" />
+                                            </node>
+                                            <node concept="3oM_SD" id="1aCwgFOnCaD" role="1PaTwD">
+                                              <property role="3oM_SC" value="not" />
+                                            </node>
+                                            <node concept="3oM_SD" id="1aCwgFOnCaO" role="1PaTwD">
+                                              <property role="3oM_SC" value="render" />
+                                            </node>
+                                            <node concept="3oM_SD" id="1aCwgFOnCb0" role="1PaTwD">
+                                              <property role="3oM_SC" value="correctly" />
+                                            </node>
+                                          </node>
+                                        </node>
+                                        <node concept="3cpWs8" id="1aCwgFOmFaM" role="3cqZAp">
+                                          <node concept="3cpWsn" id="1aCwgFOmFaN" role="3cpWs9">
+                                            <property role="TrG5h" value="hintsWithConditionalEditor" />
+                                            <node concept="10Q1$e" id="1aCwgFOmEN9" role="1tU5fm">
+                                              <node concept="17QB3L" id="1aCwgFOmENc" role="10Q1$1" />
+                                            </node>
+                                            <node concept="2OqwBi" id="1aCwgFOmFaO" role="33vP2m">
+                                              <node concept="2OqwBi" id="1aCwgFOmFaP" role="2Oq$k0">
+                                                <node concept="2OqwBi" id="1aCwgFOmFaQ" role="2Oq$k0">
+                                                  <node concept="37vLTw" id="1aCwgFOmFaR" role="2Oq$k0">
+                                                    <ref role="3cqZAo" node="54ozzUwnA$t" resolve="hints" />
+                                                  </node>
+                                                  <node concept="39bAoz" id="1aCwgFOmFaS" role="2OqNvi" />
+                                                </node>
+                                                <node concept="3QWeyG" id="1aCwgFOmFaT" role="2OqNvi">
+                                                  <node concept="2ShNRf" id="1aCwgFOmFaU" role="576Qk">
+                                                    <node concept="kMnCb" id="1aCwgFOmFaV" role="2ShVmc">
+                                                      <node concept="17QB3L" id="1aCwgFOmFaW" role="kMuH3" />
+                                                      <node concept="1bVj0M" id="1aCwgFOmFaX" role="kMx8a">
+                                                        <node concept="3clFbS" id="1aCwgFOmFaY" role="1bW5cS">
+                                                          <node concept="2n63Yl" id="1aCwgFOmFaZ" role="3cqZAp">
+                                                            <node concept="2pYGij" id="1aCwgFOmFb0" role="2n6tg2">
+                                                              <ref role="2pYH_C" to="461n:2kbUaNP7dpe" resolve="conditionalEditor" />
+                                                            </node>
+                                                          </node>
+                                                          <node concept="2n63Yl" id="1aCwgFOmFb1" role="3cqZAp">
+                                                            <node concept="2pYGij" id="1aCwgFOmFb2" role="2n6tg2">
+                                                              <ref role="2pYH_C" to="461n:2kbUaNP7dpg" resolve="conditionalEditor_doNotUseThisHint" />
+                                                            </node>
+                                                          </node>
+                                                        </node>
+                                                      </node>
+                                                    </node>
+                                                  </node>
+                                                </node>
+                                              </node>
+                                              <node concept="3_kTaI" id="1aCwgFOmFb3" role="2OqNvi" />
+                                            </node>
+                                          </node>
+                                        </node>
                                         <node concept="3clFbF" id="PgCWzngEmo" role="3cqZAp">
                                           <node concept="2OqwBi" id="5Pb2U$k6TNW" role="3clFbG">
                                             <node concept="37vLTw" id="1vW6hmyYLOF" role="2Oq$k0">
@@ -22002,8 +22146,8 @@
                                             </node>
                                             <node concept="liA8E" id="5Pb2U$k6TO0" role="2OqNvi">
                                               <ref role="37wK5l" to="22ra:~Updater.setInitialEditorHints(java.lang.String[])" resolve="setInitialEditorHints" />
-                                              <node concept="37vLTw" id="5Pb2U$k6TO1" role="37wK5m">
-                                                <ref role="3cqZAo" node="54ozzUwnA$t" resolve="hints" />
+                                              <node concept="37vLTw" id="1aCwgFOmIAC" role="37wK5m">
+                                                <ref role="3cqZAo" node="1aCwgFOmFaN" resolve="hintsWithConditionalEditor" />
                                               </node>
                                             </node>
                                           </node>

--- a/code/languages/com.mbeddr.core/languages/com.mbeddr.core.base/solutions/pluginSolution/pluginSolution.msd
+++ b/code/languages/com.mbeddr.core/languages/com.mbeddr.core.base/solutions/pluginSolution/pluginSolution.msd
@@ -27,6 +27,7 @@
     <dependency reexport="true">8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)</dependency>
     <dependency reexport="false">25092e07-e655-497c-92fb-558a8e3080ed(jetbrains.mps.ide.ui)</dependency>
     <dependency reexport="false">34e84b8f-afa8-4364-abcd-a279fddddbe7(jetbrains.mps.editor.runtime)</dependency>
+    <dependency reexport="false">5474e4cd-6621-4b33-a39a-75552543ba57(de.slisson.mps.conditionalEditor.hints)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:c38abce1-4c09-44cb-9ebf-2a764e824bb5:com.mbeddr.mpsutil.actionsfilter" version="0" />

--- a/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/generator/template/com/mbeddr/doc/generator/template/main@generator.mps
+++ b/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/generator/template/com/mbeddr/doc/generator/template/main@generator.mps
@@ -10,7 +10,7 @@
     <use id="2374bc90-7e37-41f1-a9c4-c2e35194c36a" name="com.mbeddr.doc" version="-1" />
     <use id="d4280a54-f6df-4383-aa41-d1b2bffa7eb1" name="com.mbeddr.core.base" version="-1" />
     <use id="d3a0fd26-445a-466c-900e-10444ddfed52" name="com.mbeddr.mpsutil.filepicker" version="-1" />
-    <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="11" />
+    <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="-1" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
@@ -31,6 +31,7 @@
     <import index="znf5" ref="r:07597124-beb3-41b7-beb1-a882af3ded40(com.mbeddr.doc.plugin)" />
     <import index="rqen" ref="r:4fc6545d-39fa-4c9a-b98d-9868767dc0c0(com.mbeddr.doc.generator.template.utils)" />
     <import index="68mc" ref="r:2a10821d-612f-4a73-b7b0-ed6b57106321(com.mbeddr.mpsutil.filepicker.structure)" />
+    <import index="z726" ref="r:6b7eb85f-64d8-4de6-8906-0e18804729df(com.mbeddr.doc.editor)" />
     <import index="tpcb" ref="r:00000000-0000-4000-0000-011c89590297(jetbrains.mps.lang.editor.behavior)" implicit="true" />
   </imports>
   <registry>
@@ -443,6 +444,9 @@
       <concept id="1204796164442" name="jetbrains.mps.baseLanguage.collections.structure.InternalSequenceOperation" flags="nn" index="23sCx2">
         <child id="1204796294226" name="closure" index="23t8la" />
       </concept>
+      <concept id="1176906603202" name="jetbrains.mps.baseLanguage.collections.structure.BinaryOperation" flags="nn" index="56pJg">
+        <child id="1176906787974" name="rightExpression" index="576Qk" />
+      </concept>
       <concept id="540871147943773365" name="jetbrains.mps.baseLanguage.collections.structure.SingleArgumentSequenceOperation" flags="nn" index="25WWJ4">
         <child id="540871147943773366" name="argument" index="25WWJ7" />
       </concept>
@@ -468,6 +472,7 @@
       <concept id="1202128969694" name="jetbrains.mps.baseLanguage.collections.structure.SelectOperation" flags="nn" index="3$u5V9" />
       <concept id="1184963466173" name="jetbrains.mps.baseLanguage.collections.structure.ToArrayOperation" flags="nn" index="3_kTaI" />
       <concept id="1172254888721" name="jetbrains.mps.baseLanguage.collections.structure.ContainsOperation" flags="nn" index="3JPx81" />
+      <concept id="1180964022718" name="jetbrains.mps.baseLanguage.collections.structure.ConcatOperation" flags="nn" index="3QWeyG" />
     </language>
   </registry>
   <node concept="bUwia" id="3RseghId8Of">
@@ -1843,6 +1848,214 @@
                     </node>
                   </node>
                 </node>
+                <node concept="3cpWs8" id="1aCwgFOd_I8" role="3cqZAp">
+                  <node concept="3cpWsn" id="1aCwgFOd_I9" role="3cpWs9">
+                    <property role="TrG5h" value="hints" />
+                    <node concept="A3Dl8" id="1aCwgFOd_r2" role="1tU5fm">
+                      <node concept="17QB3L" id="1aCwgFOd_r5" role="A3Ik2" />
+                    </node>
+                    <node concept="2OqwBi" id="1aCwgFOd_Ia" role="33vP2m">
+                      <node concept="2OqwBi" id="1aCwgFOd_Ib" role="2Oq$k0">
+                        <node concept="2GrUjf" id="1aCwgFOd_Ic" role="2Oq$k0">
+                          <ref role="2Gs0qQ" node="5$bT90ZdhP_" resolve="cc" />
+                        </node>
+                        <node concept="3Tsc0h" id="1aCwgFOdJyW" role="2OqNvi">
+                          <ref role="3TtcxE" to="2c95:54ozzUwjhw1" resolve="hints" />
+                        </node>
+                      </node>
+                      <node concept="3$u5V9" id="1aCwgFOd_Ie" role="2OqNvi">
+                        <node concept="1bVj0M" id="1aCwgFOd_If" role="23t8la">
+                          <node concept="3clFbS" id="1aCwgFOd_Ig" role="1bW5cS">
+                            <node concept="3clFbF" id="1aCwgFOd_Ih" role="3cqZAp">
+                              <node concept="2OqwBi" id="1aCwgFOd_Ii" role="3clFbG">
+                                <node concept="2OqwBi" id="1aCwgFOd_Ij" role="2Oq$k0">
+                                  <node concept="37vLTw" id="1aCwgFOd_Ik" role="2Oq$k0">
+                                    <ref role="3cqZAo" node="1aCwgFOd_In" resolve="it" />
+                                  </node>
+                                  <node concept="3TrEf2" id="1aCwgFOd_Il" role="2OqNvi">
+                                    <ref role="3Tt5mk" to="tpc2:59ZEGVQrrtd" resolve="hint" />
+                                  </node>
+                                </node>
+                                <node concept="2qgKlT" id="1aCwgFOd_Im" role="2OqNvi">
+                                  <ref role="37wK5l" to="tpcb:59ZEGVRaGvv" resolve="getQualifiedName" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="Rh6nW" id="1aCwgFOd_In" role="1bW2Oz">
+                            <property role="TrG5h" value="it" />
+                            <node concept="2jxLKc" id="1aCwgFOd_Io" role="1tU5fm" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3SKdUt" id="1aCwgFOnfhM" role="3cqZAp">
+                  <node concept="1PaTwC" id="1aCwgFOnfhN" role="1aUNEU">
+                    <node concept="3oM_SD" id="1aCwgFOnfhO" role="1PaTwD">
+                      <property role="3oM_SC" value="adding" />
+                    </node>
+                    <node concept="3oM_SD" id="1aCwgFOnf$4" role="1PaTwD">
+                      <property role="3oM_SC" value="code" />
+                    </node>
+                    <node concept="3oM_SD" id="1aCwgFOnf$f" role="1PaTwD">
+                      <property role="3oM_SC" value="paragraph" />
+                    </node>
+                    <node concept="3oM_SD" id="1aCwgFOnf$N" role="1PaTwD">
+                      <property role="3oM_SC" value="decider" />
+                    </node>
+                    <node concept="3oM_SD" id="1aCwgFOnf_g" role="1PaTwD">
+                      <property role="3oM_SC" value="for" />
+                    </node>
+                    <node concept="3oM_SD" id="1aCwgFOnf_m" role="1PaTwD">
+                      <property role="3oM_SC" value="the" />
+                    </node>
+                    <node concept="3oM_SD" id="1aCwgFOnf_t" role="1PaTwD">
+                      <property role="3oM_SC" value="node" />
+                    </node>
+                    <node concept="3oM_SD" id="1aCwgFOnfA0" role="1PaTwD">
+                      <property role="3oM_SC" value="of" />
+                    </node>
+                    <node concept="3oM_SD" id="1aCwgFOnfAh" role="1PaTwD">
+                      <property role="3oM_SC" value="the" />
+                    </node>
+                    <node concept="3oM_SD" id="1aCwgFOnfAr" role="1PaTwD">
+                      <property role="3oM_SC" value="transient" />
+                    </node>
+                    <node concept="3oM_SD" id="1aCwgFOnfAI" role="1PaTwD">
+                      <property role="3oM_SC" value="model" />
+                    </node>
+                    <node concept="3oM_SD" id="1aCwgFOnfAU" role="1PaTwD">
+                      <property role="3oM_SC" value="and" />
+                    </node>
+                    <node concept="3oM_SD" id="1aCwgFOnfBf" role="1PaTwD">
+                      <property role="3oM_SC" value="pass" />
+                    </node>
+                    <node concept="3oM_SD" id="1aCwgFOnfBt" role="1PaTwD">
+                      <property role="3oM_SC" value="the" />
+                    </node>
+                    <node concept="3oM_SD" id="1aCwgFOnfDP" role="1PaTwD">
+                      <property role="3oM_SC" value="resulting" />
+                    </node>
+                    <node concept="3oM_SD" id="1aCwgFOnfEd" role="1PaTwD">
+                      <property role="3oM_SC" value="hints" />
+                    </node>
+                    <node concept="3oM_SD" id="1aCwgFOnfEI" role="1PaTwD">
+                      <property role="3oM_SC" value="" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3SKdUt" id="1aCwgFOngHQ" role="3cqZAp">
+                  <node concept="1PaTwC" id="1aCwgFOngHR" role="1aUNEU">
+                    <node concept="3oM_SD" id="1aCwgFOngHS" role="1PaTwD">
+                      <property role="3oM_SC" value="down" />
+                    </node>
+                    <node concept="3oM_SD" id="1aCwgFOnh0N" role="1PaTwD">
+                      <property role="3oM_SC" value="into" />
+                    </node>
+                    <node concept="3oM_SD" id="1aCwgFOnh0Y" role="1PaTwD">
+                      <property role="3oM_SC" value="the" />
+                    </node>
+                    <node concept="3oM_SD" id="1aCwgFOnh12" role="1PaTwD">
+                      <property role="3oM_SC" value="screenshooter." />
+                    </node>
+                    <node concept="3oM_SD" id="1aCwgFOnh1f" role="1PaTwD">
+                      <property role="3oM_SC" value="The" />
+                    </node>
+                    <node concept="3oM_SD" id="1aCwgFOnh1_" role="1PaTwD">
+                      <property role="3oM_SC" value="code" />
+                    </node>
+                    <node concept="3oM_SD" id="1aCwgFOnire" role="1PaTwD">
+                      <property role="3oM_SC" value="CodeParagraphManager" />
+                    </node>
+                    <node concept="3oM_SD" id="1aCwgFOniru" role="1PaTwD">
+                      <property role="3oM_SC" value="uses" />
+                    </node>
+                    <node concept="3oM_SD" id="1aCwgFOnis$" role="1PaTwD">
+                      <property role="3oM_SC" value="dynamically" />
+                    </node>
+                    <node concept="3oM_SD" id="1aCwgFOnisQ" role="1PaTwD">
+                      <property role="3oM_SC" value="constructed" />
+                    </node>
+                    <node concept="3oM_SD" id="1aCwgFOnitT" role="1PaTwD">
+                      <property role="3oM_SC" value="hint" />
+                    </node>
+                    <node concept="3oM_SD" id="1aCwgFOniud" role="1PaTwD">
+                      <property role="3oM_SC" value="that" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3SKdUt" id="1aCwgFOnjxA" role="3cqZAp">
+                  <node concept="1PaTwC" id="1aCwgFOnjxB" role="1aUNEU">
+                    <node concept="3oM_SD" id="1aCwgFOnjxC" role="1PaTwD">
+                      <property role="3oM_SC" value="contain" />
+                    </node>
+                    <node concept="3oM_SD" id="1aCwgFOnjOp" role="1PaTwD">
+                      <property role="3oM_SC" value="the" />
+                    </node>
+                    <node concept="3oM_SD" id="1aCwgFOnjOs" role="1PaTwD">
+                      <property role="3oM_SC" value="node" />
+                    </node>
+                    <node concept="3oM_SD" id="1aCwgFOnjOK" role="1PaTwD">
+                      <property role="3oM_SC" value="id" />
+                    </node>
+                    <node concept="3oM_SD" id="1aCwgFOnjOX" role="1PaTwD">
+                      <property role="3oM_SC" value="of" />
+                    </node>
+                    <node concept="3oM_SD" id="1aCwgFOnjPj" role="1PaTwD">
+                      <property role="3oM_SC" value="the" />
+                    </node>
+                    <node concept="3oM_SD" id="1aCwgFOnjQm" role="1PaTwD">
+                      <property role="3oM_SC" value="nodes" />
+                    </node>
+                    <node concept="3oM_SD" id="1aCwgFOnjQI" role="1PaTwD">
+                      <property role="3oM_SC" value="it" />
+                    </node>
+                    <node concept="3oM_SD" id="1aCwgFOnjQR" role="1PaTwD">
+                      <property role="3oM_SC" value="should" />
+                    </node>
+                    <node concept="3oM_SD" id="1aCwgFOnjR1" role="1PaTwD">
+                      <property role="3oM_SC" value="operate" />
+                    </node>
+                    <node concept="3oM_SD" id="1aCwgFOnjRc" role="1PaTwD">
+                      <property role="3oM_SC" value="on." />
+                    </node>
+                    <node concept="3oM_SD" id="1aCwgFOnjRC" role="1PaTwD">
+                      <property role="3oM_SC" value="See" />
+                    </node>
+                    <node concept="3oM_SD" id="1aCwgFOnmCO" role="1PaTwD">
+                      <property role="3oM_SC" value="CodeParagraphManager.concatHint" />
+                    </node>
+                    <node concept="3oM_SD" id="1aCwgFOnmCq" role="1PaTwD">
+                      <property role="3oM_SC" value="" />
+                    </node>
+                    <node concept="3oM_SD" id="1aCwgFOnlrU" role="1PaTwD">
+                      <property role="3oM_SC" value="" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbF" id="1aCwgFOd_Tm" role="3cqZAp">
+                  <node concept="37vLTI" id="1aCwgFOdGl4" role="3clFbG">
+                    <node concept="37vLTw" id="1aCwgFOdGnL" role="37vLTJ">
+                      <ref role="3cqZAo" node="1aCwgFOd_I9" resolve="hints" />
+                    </node>
+                    <node concept="2OqwBi" id="1aCwgFOdAbb" role="37vLTx">
+                      <node concept="37vLTw" id="1aCwgFOd_Tk" role="2Oq$k0">
+                        <ref role="3cqZAo" node="1aCwgFOd_I9" resolve="hints" />
+                      </node>
+                      <node concept="3QWeyG" id="1aCwgFOdAEw" role="2OqNvi">
+                        <node concept="2YIFZM" id="1aCwgFOgxSa" role="576Qk">
+                          <ref role="37wK5l" to="z726:1aCwgFOgrFU" resolve="getCodeParagraphHints" />
+                          <ref role="1Pybhc" to="z726:3_8b99743FU" resolve="CodeParagraphHelper" />
+                          <node concept="2GrUjf" id="1aCwgFOgxTL" role="37wK5m">
+                            <ref role="2Gs0qQ" node="5$bT90ZdhP_" resolve="cc" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
                 <node concept="3clFbF" id="7$DvC4gQTRT" role="3cqZAp">
                   <node concept="2YIFZM" id="7$DvC4gQTRV" role="3clFbG">
                     <ref role="1Pybhc" to="d244:1yFmGPnLcL9" resolve="CellEditorScreenshooter" />
@@ -1859,42 +2072,10 @@
                       </node>
                     </node>
                     <node concept="2OqwBi" id="54ozzUwo46J" role="37wK5m">
-                      <node concept="2OqwBi" id="54ozzUwnSsH" role="2Oq$k0">
-                        <node concept="2OqwBi" id="54ozzUwnR15" role="2Oq$k0">
-                          <node concept="2GrUjf" id="54ozzUwnQTt" role="2Oq$k0">
-                            <ref role="2Gs0qQ" node="5$bT90ZdhP_" resolve="cc" />
-                          </node>
-                          <node concept="3Tsc0h" id="54ozzUwnRBY" role="2OqNvi">
-                            <ref role="3TtcxE" to="2c95:54ozzUwjhw1" resolve="hints" />
-                          </node>
-                        </node>
-                        <node concept="3$u5V9" id="54ozzUwnUpG" role="2OqNvi">
-                          <node concept="1bVj0M" id="54ozzUwnUpI" role="23t8la">
-                            <node concept="3clFbS" id="54ozzUwnUpJ" role="1bW5cS">
-                              <node concept="3clFbF" id="54ozzUwnUzz" role="3cqZAp">
-                                <node concept="2OqwBi" id="54ozzUwo3at" role="3clFbG">
-                                  <node concept="2OqwBi" id="54ozzUwnUDw" role="2Oq$k0">
-                                    <node concept="37vLTw" id="54ozzUwnUzy" role="2Oq$k0">
-                                      <ref role="3cqZAo" node="54ozzUwnUpK" resolve="it" />
-                                    </node>
-                                    <node concept="3TrEf2" id="54ozzUwnUQA" role="2OqNvi">
-                                      <ref role="3Tt5mk" to="tpc2:59ZEGVQrrtd" resolve="hint" />
-                                    </node>
-                                  </node>
-                                  <node concept="2qgKlT" id="54ozzUwo3ps" role="2OqNvi">
-                                    <ref role="37wK5l" to="tpcb:59ZEGVRaGvv" resolve="getQualifiedName" />
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                            <node concept="Rh6nW" id="54ozzUwnUpK" role="1bW2Oz">
-                              <property role="TrG5h" value="it" />
-                              <node concept="2jxLKc" id="54ozzUwnUpL" role="1tU5fm" />
-                            </node>
-                          </node>
-                        </node>
-                      </node>
                       <node concept="3_kTaI" id="54ozzUwo4pL" role="2OqNvi" />
+                      <node concept="37vLTw" id="1aCwgFOdJPA" role="2Oq$k0">
+                        <ref role="3cqZAo" node="1aCwgFOd_I9" resolve="hints" />
+                      </node>
                     </node>
                   </node>
                 </node>

--- a/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/languageModels/editor.mps
+++ b/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/languageModels/editor.mps
@@ -12,8 +12,9 @@
     <use id="b8bb702e-43ed-4090-a902-d180d3e5f292" name="de.slisson.mps.conditionalEditor" version="-1" />
     <use id="52733268-be24-4f5f-ab84-a73b7c0c03b0" name="de.slisson.mps.richtext.customcell" version="-1" />
     <use id="a247e09e-2435-45ba-b8d2-07e93feba96a" name="jetbrains.mps.baseLanguage.tuples" version="-1" />
-    <use id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor" version="14" />
-    <use id="b1ab8c10-c118-4755-bf2a-cebab35cf533" name="jetbrains.mps.lang.editor.tooltips" version="0" />
+    <use id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor" version="-1" />
+    <use id="b1ab8c10-c118-4755-bf2a-cebab35cf533" name="jetbrains.mps.lang.editor.tooltips" version="-1" />
+    <use id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc" version="-1" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
@@ -585,6 +586,33 @@
         <child id="1199569916463" name="body" index="1bW5cS" />
       </concept>
     </language>
+    <language id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc">
+      <concept id="5858074156537516430" name="jetbrains.mps.baseLanguage.javadoc.structure.ReturnBlockDocTag" flags="ng" index="x79VA">
+        <property id="5858074156537516431" name="text" index="x79VB" />
+      </concept>
+      <concept id="6832197706140518104" name="jetbrains.mps.baseLanguage.javadoc.structure.DocMethodParameterReference" flags="ng" index="zr_55" />
+      <concept id="6832197706140518103" name="jetbrains.mps.baseLanguage.javadoc.structure.BaseParameterReference" flags="ng" index="zr_5a">
+        <reference id="6832197706140518108" name="param" index="zr_51" />
+      </concept>
+      <concept id="5349172909345501395" name="jetbrains.mps.baseLanguage.javadoc.structure.BaseDocComment" flags="ng" index="P$AiS">
+        <child id="8465538089690331502" name="body" index="TZ5H$" />
+        <child id="5383422241790532083" name="tags" index="3nqlJM" />
+      </concept>
+      <concept id="5349172909345532724" name="jetbrains.mps.baseLanguage.javadoc.structure.MethodDocComment" flags="ng" index="P$JXv" />
+      <concept id="8465538089690881930" name="jetbrains.mps.baseLanguage.javadoc.structure.ParameterBlockDocTag" flags="ng" index="TUZQ0">
+        <property id="8465538089690881934" name="text" index="TUZQ4" />
+        <child id="6832197706140518123" name="parameter" index="zr_5Q" />
+      </concept>
+      <concept id="8465538089690331500" name="jetbrains.mps.baseLanguage.javadoc.structure.CommentLine" flags="ng" index="TZ5HA">
+        <child id="8970989240999019149" name="part" index="1dT_Ay" />
+      </concept>
+      <concept id="8465538089690331492" name="jetbrains.mps.baseLanguage.javadoc.structure.DeprecatedBlockDocTag" flags="ng" index="TZ5HI">
+        <child id="2667874559098216723" name="text" index="3HnX3l" />
+      </concept>
+      <concept id="8970989240999019143" name="jetbrains.mps.baseLanguage.javadoc.structure.TextCommentLinePart" flags="ng" index="1dT_AC">
+        <property id="8970989240999019144" name="text" index="1dT_AB" />
+      </concept>
+    </language>
     <language id="52733268-be24-4f5f-ab84-a73b7c0c03b0" name="de.slisson.mps.richtext.customcell">
       <concept id="1161622981231" name="de.slisson.mps.richtext.customcell.structure.ConceptFunctionParameter_cell" flags="nn" index="1Q80Hy" />
       <concept id="1176749715029" name="de.slisson.mps.richtext.customcell.structure.QueryFunction_Cell" flags="in" index="3VJUX5" />
@@ -648,6 +676,12 @@
     </language>
     <language id="f89904fb-9486-43a1-865e-5ad0375a8a88" name="de.itemis.mps.editor.bool">
       <concept id="4900677560559655527" name="de.itemis.mps.editor.bool.structure.CellModel_Checkbox" flags="sg" stub="416014060004381438" index="27S6Sx" />
+    </language>
+    <language id="760a0a8c-eabb-4521-8bfd-65db761a9ba3" name="jetbrains.mps.baseLanguage.logging">
+      <concept id="2034914114981261497" name="jetbrains.mps.baseLanguage.logging.structure.LogLowLevelStatement" flags="ng" index="RRSsy">
+        <property id="2034914114981261751" name="severity" index="RRSoG" />
+        <child id="2034914114981261753" name="message" index="RRSoy" />
+      </concept>
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
       <concept id="1204851882688" name="jetbrains.mps.lang.smodel.structure.LinkRefQualifier" flags="ng" index="26LbJo">
@@ -729,6 +763,7 @@
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
         <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
       </concept>
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
@@ -8079,9 +8114,8 @@
             <node concept="3clFbS" id="26B0wrFVhDA" role="2VODD2">
               <node concept="3clFbF" id="3_8b9974u5A" role="3cqZAp">
                 <node concept="2YIFZM" id="3_8b9974uaP" role="3clFbG">
-                  <ref role="37wK5l" node="3_8b9974scU" resolve="getCodeParagraphHints" />
                   <ref role="1Pybhc" node="3_8b99743FU" resolve="CodeParagraphHelper" />
-                  <node concept="1Q80Hx" id="3_8b9974ulN" role="37wK5m" />
+                  <ref role="37wK5l" node="1aCwgFOgrFU" resolve="getCodeParagraphHints" />
                   <node concept="pncrf" id="3_8b9974uvj" role="37wK5m" />
                 </node>
               </node>
@@ -8386,8 +8420,7 @@
             <node concept="3clFbF" id="3_8b9974v3D" role="3cqZAp">
               <node concept="2YIFZM" id="3_8b9974v3E" role="3clFbG">
                 <ref role="1Pybhc" node="3_8b99743FU" resolve="CodeParagraphHelper" />
-                <ref role="37wK5l" node="3_8b9974scU" resolve="getCodeParagraphHints" />
-                <node concept="1Q80Hx" id="3_8b9974v3F" role="37wK5m" />
+                <ref role="37wK5l" node="1aCwgFOgrFU" resolve="getCodeParagraphHints" />
                 <node concept="pncrf" id="3_8b9974v3G" role="37wK5m" />
               </node>
             </node>
@@ -8562,8 +8595,7 @@
                   <node concept="2OqwBi" id="54ozzUwpA_H" role="3clFbG">
                     <node concept="2YIFZM" id="3_8b9974wVO" role="2Oq$k0">
                       <ref role="1Pybhc" node="3_8b99743FU" resolve="CodeParagraphHelper" />
-                      <ref role="37wK5l" node="3_8b9974scU" resolve="getCodeParagraphHints" />
-                      <node concept="1Q80Hx" id="3_8b9974wVP" role="37wK5m" />
+                      <ref role="37wK5l" node="1aCwgFOgrFU" resolve="getCodeParagraphHints" />
                       <node concept="pncrf" id="3_8b9974wVQ" role="37wK5m" />
                     </node>
                     <node concept="3QWeyG" id="54ozzUwpAJU" role="2OqNvi">
@@ -8761,8 +8793,7 @@
                   <node concept="2OqwBi" id="54ozzUwp67k" role="3clFbG">
                     <node concept="2YIFZM" id="3_8b9974w4q" role="2Oq$k0">
                       <ref role="1Pybhc" node="3_8b99743FU" resolve="CodeParagraphHelper" />
-                      <ref role="37wK5l" node="3_8b9974scU" resolve="getCodeParagraphHints" />
-                      <node concept="1Q80Hx" id="3_8b9974w4r" role="37wK5m" />
+                      <ref role="37wK5l" node="1aCwgFOgrFU" resolve="getCodeParagraphHints" />
                       <node concept="pncrf" id="3_8b9974w4s" role="37wK5m" />
                     </node>
                     <node concept="3QWeyG" id="54ozzUwp6jl" role="2OqNvi">
@@ -10452,6 +10483,17 @@
                     </node>
                   </node>
                 </node>
+                <node concept="RRSsy" id="1aCwgFOk2dd" role="3cqZAp">
+                  <property role="RRSoG" value="gZ5fksE/warn" />
+                  <node concept="3cpWs3" id="1aCwgFOnqCM" role="RRSoy">
+                    <node concept="37vLTw" id="1aCwgFOnqOk" role="3uHU7w">
+                      <ref role="3cqZAo" node="1U2fVW5yh8d" resolve="hintPostfix" />
+                    </node>
+                    <node concept="Xl_RD" id="1aCwgFOk2df" role="3uHU7B">
+                      <property role="Xl_RC" value="did not find decider for node id: " />
+                    </node>
+                  </node>
+                </node>
               </node>
               <node concept="2OqwBi" id="1U2fVW5yfKr" role="3clFbw">
                 <node concept="2GrUjf" id="1U2fVW5yfAd" role="2Oq$k0">
@@ -10840,116 +10882,12 @@
       <property role="DiZV1" value="false" />
       <property role="2aFKle" value="false" />
       <node concept="3clFbS" id="3_8b9974scX" role="3clF47">
-        <node concept="3cpWs8" id="3_8b9974sHv" role="3cqZAp">
-          <node concept="3cpWsn" id="3_8b9974sHw" role="3cpWs9">
-            <property role="TrG5h" value="result" />
-            <node concept="_YKpA" id="3_8b9974sHx" role="1tU5fm">
-              <node concept="17QB3L" id="3_8b9974sHy" role="_ZDj9" />
+        <node concept="3cpWs6" id="1aCwgFOgt_z" role="3cqZAp">
+          <node concept="1rXfSq" id="1aCwgFOgt__" role="3cqZAk">
+            <ref role="37wK5l" node="1aCwgFOgrFU" resolve="getCodeParagraphHints" />
+            <node concept="37vLTw" id="1aCwgFOgt_A" role="37wK5m">
+              <ref role="3cqZAo" node="3_8b9974sd8" resolve="codeParagraph" />
             </node>
-            <node concept="2ShNRf" id="3_8b9974sHz" role="33vP2m">
-              <node concept="Tc6Ow" id="3_8b9974sH$" role="2ShVmc">
-                <node concept="17QB3L" id="3_8b9974sH_" role="HW$YZ" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbH" id="3_8b9974sHA" role="3cqZAp" />
-        <node concept="3clFbF" id="3_8b9974sHG" role="3cqZAp">
-          <node concept="2OqwBi" id="3_8b9974sHH" role="3clFbG">
-            <node concept="37vLTw" id="3_8b9974sHI" role="2Oq$k0">
-              <ref role="3cqZAo" node="3_8b9974sHw" resolve="result" />
-            </node>
-            <node concept="TSZUe" id="3_8b9974sHJ" role="2OqNvi">
-              <node concept="2OqwBi" id="3_8b9974sHK" role="25WWJ7">
-                <node concept="2OqwBi" id="3_8b9974sHL" role="2Oq$k0">
-                  <node concept="2OqwBi" id="3_8b9974sHM" role="2Oq$k0">
-                    <node concept="3B5_sB" id="3_8b9974sHN" role="2Oq$k0">
-                      <ref role="3B5MYn" node="6yKlfSOYShZ" resolve="CodeHint" />
-                    </node>
-                    <node concept="3Tsc0h" id="3_8b9974sHO" role="2OqNvi">
-                      <ref role="3TtcxE" to="tpc2:59ZEGVOSRBV" resolve="hints" />
-                    </node>
-                  </node>
-                  <node concept="1uHKPH" id="3_8b9974sHP" role="2OqNvi" />
-                </node>
-                <node concept="2qgKlT" id="3_8b9974sHQ" role="2OqNvi">
-                  <ref role="37wK5l" to="tpcb:59ZEGVRaGvv" resolve="getQualifiedName" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="3_8b9974sHR" role="3cqZAp">
-          <node concept="2OqwBi" id="3_8b9974sHS" role="3clFbG">
-            <node concept="37vLTw" id="3_8b9974sHT" role="2Oq$k0">
-              <ref role="3cqZAo" node="3_8b9974sHw" resolve="result" />
-            </node>
-            <node concept="TSZUe" id="3_8b9974sHU" role="2OqNvi">
-              <node concept="2YIFZM" id="3_8b9974sHV" role="25WWJ7">
-                <ref role="1Pybhc" node="1U2fVW5vyXu" resolve="CodeParagraphManager" />
-                <ref role="37wK5l" node="1U2fVW5xdag" resolve="concatHint" />
-                <node concept="37vLTw" id="3_8b9974tcL" role="37wK5m">
-                  <ref role="3cqZAo" node="3_8b9974sd8" resolve="codeParagraph" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbH" id="3_8b9974sHX" role="3cqZAp" />
-        <node concept="3clFbF" id="3_8b9974sHY" role="3cqZAp">
-          <node concept="2OqwBi" id="3_8b9974sHZ" role="3clFbG">
-            <node concept="2YIFZM" id="3_8b9974sI0" role="2Oq$k0">
-              <ref role="1Pybhc" node="1U2fVW5vyXu" resolve="CodeParagraphManager" />
-              <ref role="37wK5l" node="1U2fVW5w4SO" resolve="getInstance" />
-            </node>
-            <node concept="liA8E" id="3_8b9974sI1" role="2OqNvi">
-              <ref role="37wK5l" node="1U2fVW5xnA2" resolve="registerDecider" />
-              <node concept="37vLTw" id="3_8b9974tcK" role="37wK5m">
-                <ref role="3cqZAo" node="3_8b9974sd8" resolve="codeParagraph" />
-              </node>
-              <node concept="2ShNRf" id="3_8b9974sI3" role="37wK5m">
-                <node concept="YeOm9" id="3_8b9974sI4" role="2ShVmc">
-                  <node concept="1Y3b0j" id="3_8b9974sI5" role="YeSDq">
-                    <property role="2bfB8j" value="true" />
-                    <ref role="1Y3XeK" node="1U2fVW5wrEr" resolve="ICodeParagraphDecider" />
-                    <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
-                    <node concept="3Tm1VV" id="3_8b9974sI6" role="1B3o_S" />
-                    <node concept="3clFb_" id="3_8b9974sI7" role="jymVt">
-                      <property role="1EzhhJ" value="false" />
-                      <property role="2aFKle" value="false" />
-                      <property role="TrG5h" value="shouldBeRemoved" />
-                      <node concept="3Tm1VV" id="3_8b9974sI8" role="1B3o_S" />
-                      <node concept="10P_77" id="3_8b9974sI9" role="3clF45" />
-                      <node concept="37vLTG" id="3_8b9974sIa" role="3clF46">
-                        <property role="TrG5h" value="candidate" />
-                        <node concept="3Tqbb2" id="3_8b9974sIb" role="1tU5fm" />
-                      </node>
-                      <node concept="3clFbS" id="3_8b9974sIc" role="3clF47">
-                        <node concept="3clFbF" id="3_8b9974sId" role="3cqZAp">
-                          <node concept="2OqwBi" id="3_8b9974sIe" role="3clFbG">
-                            <node concept="37vLTw" id="3_8b9974tcM" role="2Oq$k0">
-                              <ref role="3cqZAo" node="3_8b9974sd8" resolve="codeParagraph" />
-                            </node>
-                            <node concept="2qgKlT" id="3_8b9974sIg" role="2OqNvi">
-                              <ref role="37wK5l" to="4gky:6TjoDcE6uBZ" resolve="shouldBeRemoved" />
-                              <node concept="37vLTw" id="3_8b9974sIh" role="37wK5m">
-                                <ref role="3cqZAo" node="3_8b9974sIa" resolve="candidate" />
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbH" id="3_8b9974sIi" role="3cqZAp" />
-        <node concept="3cpWs6" id="3_8b9974sIj" role="3cqZAp">
-          <node concept="37vLTw" id="3_8b9974sIk" role="3cqZAk">
-            <ref role="3cqZAo" node="3_8b9974sHw" resolve="result" />
           </node>
         </node>
       </node>
@@ -10963,12 +10901,174 @@
         <node concept="3uibUv" id="3_8b9974sdw" role="1tU5fm">
           <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
         </node>
+        <node concept="2AHcQZ" id="1aCwgFOgsGH" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
+        </node>
       </node>
       <node concept="37vLTG" id="3_8b9974sd8" role="3clF46">
         <property role="TrG5h" value="codeParagraph" />
         <property role="3TUv4t" value="true" />
         <node concept="3Tqbb2" id="3_8b9974sd7" role="1tU5fm">
           <ref role="ehGHo" to="2c95:627_yy34G14" resolve="AbstractModelContentParagraph" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="1aCwgFOgs_S" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
+      </node>
+      <node concept="P$JXv" id="1aCwgFOgs_P" role="lGtFl">
+        <node concept="TZ5HI" id="1aCwgFOgs_Q" role="3nqlJM">
+          <node concept="TZ5HA" id="1aCwgFOgs_R" role="3HnX3l">
+            <node concept="1dT_AC" id="1aCwgFOgsGD" role="1dT_Ay">
+              <property role="1dT_AB" value="Use the method that doesn't take a EditorConctext because it is no longer needed." />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2YIFZL" id="1aCwgFOgrFU" role="jymVt">
+      <property role="TrG5h" value="getCodeParagraphHints" />
+      <property role="od$2w" value="false" />
+      <property role="DiZV1" value="false" />
+      <property role="2aFKle" value="false" />
+      <node concept="3clFbS" id="1aCwgFOgrFV" role="3clF47">
+        <node concept="3cpWs8" id="1aCwgFOgrFW" role="3cqZAp">
+          <node concept="3cpWsn" id="1aCwgFOgrFX" role="3cpWs9">
+            <property role="TrG5h" value="result" />
+            <node concept="_YKpA" id="1aCwgFOgrFY" role="1tU5fm">
+              <node concept="17QB3L" id="1aCwgFOgrFZ" role="_ZDj9" />
+            </node>
+            <node concept="2ShNRf" id="1aCwgFOgrG0" role="33vP2m">
+              <node concept="Tc6Ow" id="1aCwgFOgrG1" role="2ShVmc">
+                <node concept="17QB3L" id="1aCwgFOgrG2" role="HW$YZ" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="1aCwgFOgrG3" role="3cqZAp" />
+        <node concept="3clFbF" id="1aCwgFOgrG4" role="3cqZAp">
+          <node concept="2OqwBi" id="1aCwgFOgrG5" role="3clFbG">
+            <node concept="37vLTw" id="1aCwgFOgrG6" role="2Oq$k0">
+              <ref role="3cqZAo" node="1aCwgFOgrFX" resolve="result" />
+            </node>
+            <node concept="TSZUe" id="1aCwgFOgrG7" role="2OqNvi">
+              <node concept="2OqwBi" id="1aCwgFOgrG8" role="25WWJ7">
+                <node concept="2OqwBi" id="1aCwgFOgrG9" role="2Oq$k0">
+                  <node concept="2OqwBi" id="1aCwgFOgrGa" role="2Oq$k0">
+                    <node concept="3B5_sB" id="1aCwgFOgrGb" role="2Oq$k0">
+                      <ref role="3B5MYn" node="6yKlfSOYShZ" resolve="CodeHint" />
+                    </node>
+                    <node concept="3Tsc0h" id="1aCwgFOgrGc" role="2OqNvi">
+                      <ref role="3TtcxE" to="tpc2:59ZEGVOSRBV" resolve="hints" />
+                    </node>
+                  </node>
+                  <node concept="1uHKPH" id="1aCwgFOgrGd" role="2OqNvi" />
+                </node>
+                <node concept="2qgKlT" id="1aCwgFOgrGe" role="2OqNvi">
+                  <ref role="37wK5l" to="tpcb:59ZEGVRaGvv" resolve="getQualifiedName" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="1aCwgFOgrGf" role="3cqZAp">
+          <node concept="2OqwBi" id="1aCwgFOgrGg" role="3clFbG">
+            <node concept="37vLTw" id="1aCwgFOgrGh" role="2Oq$k0">
+              <ref role="3cqZAo" node="1aCwgFOgrFX" resolve="result" />
+            </node>
+            <node concept="TSZUe" id="1aCwgFOgrGi" role="2OqNvi">
+              <node concept="2YIFZM" id="1aCwgFOgrGj" role="25WWJ7">
+                <ref role="1Pybhc" node="1U2fVW5vyXu" resolve="CodeParagraphManager" />
+                <ref role="37wK5l" node="1U2fVW5xdag" resolve="concatHint" />
+                <node concept="37vLTw" id="1aCwgFOgrGk" role="37wK5m">
+                  <ref role="3cqZAo" node="1aCwgFOgrGM" resolve="codeParagraph" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="1aCwgFOgrGl" role="3cqZAp" />
+        <node concept="3clFbF" id="1aCwgFOgrGm" role="3cqZAp">
+          <node concept="2OqwBi" id="1aCwgFOgrGn" role="3clFbG">
+            <node concept="2YIFZM" id="1aCwgFOgrGo" role="2Oq$k0">
+              <ref role="1Pybhc" node="1U2fVW5vyXu" resolve="CodeParagraphManager" />
+              <ref role="37wK5l" node="1U2fVW5w4SO" resolve="getInstance" />
+            </node>
+            <node concept="liA8E" id="1aCwgFOgrGp" role="2OqNvi">
+              <ref role="37wK5l" node="1U2fVW5xnA2" resolve="registerDecider" />
+              <node concept="37vLTw" id="1aCwgFOgrGq" role="37wK5m">
+                <ref role="3cqZAo" node="1aCwgFOgrGM" resolve="codeParagraph" />
+              </node>
+              <node concept="2ShNRf" id="1aCwgFOgrGr" role="37wK5m">
+                <node concept="YeOm9" id="1aCwgFOgrGs" role="2ShVmc">
+                  <node concept="1Y3b0j" id="1aCwgFOgrGt" role="YeSDq">
+                    <property role="2bfB8j" value="true" />
+                    <ref role="1Y3XeK" node="1U2fVW5wrEr" resolve="ICodeParagraphDecider" />
+                    <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
+                    <node concept="3Tm1VV" id="1aCwgFOgrGu" role="1B3o_S" />
+                    <node concept="3clFb_" id="1aCwgFOgrGv" role="jymVt">
+                      <property role="1EzhhJ" value="false" />
+                      <property role="2aFKle" value="false" />
+                      <property role="TrG5h" value="shouldBeRemoved" />
+                      <node concept="3Tm1VV" id="1aCwgFOgrGw" role="1B3o_S" />
+                      <node concept="10P_77" id="1aCwgFOgrGx" role="3clF45" />
+                      <node concept="37vLTG" id="1aCwgFOgrGy" role="3clF46">
+                        <property role="TrG5h" value="candidate" />
+                        <node concept="3Tqbb2" id="1aCwgFOgrGz" role="1tU5fm" />
+                      </node>
+                      <node concept="3clFbS" id="1aCwgFOgrG$" role="3clF47">
+                        <node concept="3clFbF" id="1aCwgFOgrG_" role="3cqZAp">
+                          <node concept="2OqwBi" id="1aCwgFOgrGA" role="3clFbG">
+                            <node concept="37vLTw" id="1aCwgFOgrGB" role="2Oq$k0">
+                              <ref role="3cqZAo" node="1aCwgFOgrGM" resolve="codeParagraph" />
+                            </node>
+                            <node concept="2qgKlT" id="1aCwgFOgrGC" role="2OqNvi">
+                              <ref role="37wK5l" to="4gky:6TjoDcE6uBZ" resolve="shouldBeRemoved" />
+                              <node concept="37vLTw" id="1aCwgFOgrGD" role="37wK5m">
+                                <ref role="3cqZAo" node="1aCwgFOgrGy" resolve="candidate" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="1aCwgFOgrGE" role="3cqZAp" />
+        <node concept="3cpWs6" id="1aCwgFOgrGF" role="3cqZAp">
+          <node concept="37vLTw" id="1aCwgFOgrGG" role="3cqZAk">
+            <ref role="3cqZAo" node="1aCwgFOgrFX" resolve="result" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="1aCwgFOgrGH" role="1B3o_S" />
+      <node concept="A3Dl8" id="1aCwgFOgrGI" role="3clF45">
+        <node concept="17QB3L" id="1aCwgFOgrGJ" role="A3Ik2" />
+      </node>
+      <node concept="37vLTG" id="1aCwgFOgrGM" role="3clF46">
+        <property role="TrG5h" value="codeParagraph" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3Tqbb2" id="1aCwgFOgrGN" role="1tU5fm">
+          <ref role="ehGHo" to="2c95:627_yy34G14" resolve="AbstractModelContentParagraph" />
+        </node>
+      </node>
+      <node concept="P$JXv" id="1aCwgFOnrhN" role="lGtFl">
+        <node concept="TZ5HA" id="1aCwgFOnrhO" role="TZ5H$">
+          <node concept="1dT_AC" id="1aCwgFOnrhP" role="1dT_Ay">
+            <property role="1dT_AB" value="Gets the node specific editor hints for the code paragraph and registers the required replacer for the paragraph." />
+          </node>
+        </node>
+        <node concept="TUZQ0" id="1aCwgFOnrhQ" role="3nqlJM">
+          <property role="TUZQ4" value="code paragraph that should have code replacement enabeled" />
+          <node concept="zr_55" id="1aCwgFOnrhS" role="zr_5Q">
+            <ref role="zr_51" node="1aCwgFOgrGM" resolve="codeParagraph" />
+          </node>
+        </node>
+        <node concept="x79VA" id="1aCwgFOnrhT" role="3nqlJM">
+          <property role="x79VB" value="the list of hints specific to this codeParagraph" />
         </node>
       </node>
     </node>

--- a/code/languages/com.mbeddr.doc/solutions/com.mbeddr.doc.test.documents/com.mbeddr.doc.test.documents.msd
+++ b/code/languages/com.mbeddr.doc/solutions/com.mbeddr.doc.test.documents/com.mbeddr.doc.test.documents.msd
@@ -11,6 +11,9 @@
     </facet>
   </facets>
   <sourcePath />
+  <dependencies>
+    <dependency reexport="false">f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)</dependency>
+  </dependencies>
   <languageVersions>
     <language slang="l:d4280a54-f6df-4383-aa41-d1b2bffa7eb1:com.mbeddr.core.base" version="5" />
     <language slang="l:2374bc90-7e37-41f1-a9c4-c2e35194c36a:com.mbeddr.doc" version="3" />
@@ -35,7 +38,17 @@
     <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
   </languageVersions>
   <dependencyVersions>
+    <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
+    <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
+    <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
+    <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
     <module reference="4078ebaa-02fd-430a-ab03-975592a2372c(com.mbeddr.doc.test.documents)" version="0" />
+    <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
+    <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
+    <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
+    <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
+    <module reference="9e98f4e2-decf-4e97-bf80-9109e8b759aa(jetbrains.mps.lang.feedback.context)" version="0" />
+    <module reference="9ded098b-ad6a-4657-bfd9-48636cfe8bc3(jetbrains.mps.lang.traceable)" version="0" />
   </dependencyVersions>
 </solution>
 

--- a/code/languages/com.mbeddr.doc/solutions/com.mbeddr.doc.test.documents/models/doc1.mps
+++ b/code/languages/com.mbeddr.doc/solutions/com.mbeddr.doc.test.documents/models/doc1.mps
@@ -7,6 +7,7 @@
   </languages>
   <imports>
     <import index="u9wj" ref="r:5de29430-c053-484a-9826-87e7556eee3e(com.mbeddr.doc.test.documents.code)" />
+    <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" />
   </imports>
   <registry>
     <language id="2dec0852-3a21-4c4e-a68c-b05236cc37f2" name="com.mbeddr.doc.gen_xhtml">
@@ -23,6 +24,9 @@
     </language>
     <language id="2374bc90-7e37-41f1-a9c4-c2e35194c36a" name="com.mbeddr.doc">
       <concept id="4317007310193476045" name="com.mbeddr.doc.structure.ScaleDownNotUp100" flags="ng" index="2bctqb" />
+      <concept id="2179458690439382890" name="com.mbeddr.doc.structure.ConceptModelContentRemoval" flags="ng" index="2Cuv_b">
+        <reference id="2179458690439403347" name="conceptDecl" index="2Cuq_M" />
+      </concept>
       <concept id="6657644269295214799" name="com.mbeddr.doc.structure.IDocumentLike" flags="ng" index="G9hjZ">
         <reference id="6657644269295214800" name="config" index="G9hjw" />
       </concept>
@@ -63,6 +67,8 @@
         <child id="6955693250238922833" name="sizeSpec" index="3z_lpT" />
       </concept>
       <concept id="6955693250238922820" name="com.mbeddr.doc.structure.AbstractModelContentParagraph" flags="ng" index="3z_lpG">
+        <property id="6955693250238922823" name="showContents" index="3z_lpJ" />
+        <child id="6955693250238922821" name="removals" index="3z_lpH" />
         <child id="6955693250238922822" name="codeptr" index="3z_lpI" />
       </concept>
       <concept id="3350625596580256366" name="com.mbeddr.doc.structure.DocumentExport" flags="ng" index="1_08Dk">
@@ -122,6 +128,7 @@
     </node>
     <node concept="3z_lpz" id="4pIcGABsAbh" role="1_0VJ0">
       <property role="TrG5h" value="class" />
+      <property role="3z_lpJ" value="true" />
       <node concept="OjmMv" id="4pIcGABsAbj" role="3z_lpS">
         <node concept="19SGf9" id="4pIcGABsAbk" role="OjmMu">
           <node concept="19SUe$" id="4pIcGABsAbl" role="19SJt6">
@@ -134,6 +141,9 @@
         <node concept="2NCMab" id="4pIcGABsMkr" role="2NCMaf">
           <ref role="2NCMaa" to="u9wj:4pIcGABsAbC" resolve="myClass" />
         </node>
+      </node>
+      <node concept="2Cuv_b" id="1aCwgFOglh4" role="3z_lpH">
+        <ref role="2Cuq_M" to="tpee:fzcpWvY" resolve="ReturnStatement" />
       </node>
     </node>
   </node>


### PR DESCRIPTION
This PR backports #2162 to MPS 2020.1

Screenshots didn't respect the content removal specified in the
ModelContentAsScreenShotParagraph since we migrated to the logic
that takes screenshots from the intermediate model and not from
the original model.

This changes sets the editors hints for the intermediate model
correctly in the docs languages to allow the remove to work.

Only setting the hints wasn't enough because conditional editors
were disabled in the screenshooter code since the editor hints
for conditional editors were not set. The screenshooter now
always sets the conditional editor hint so that conditional