### PR TITLE
Permit any JSON value as root of a JsonFile instead of only JSON Objects

### DIFF
--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.json/models/com.mbeddr.mpsutil.json.structure.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.json/models/com.mbeddr.mpsutil.json.structure.mps
@@ -161,7 +161,7 @@
       <property role="20kJfa" value="object" />
       <property role="20lbJX" value="fLJekj4/_1" />
       <property role="IQ2ns" value="4342692121161094142" />
-      <ref role="20lvS9" node="3L4lRB2GdlQ" resolve="JSONObject" />
+      <ref role="20lvS9" node="3L4lRB2GdnB" resolve="IValue" />
     </node>
     <node concept="PrWs8" id="6Cwq1JbSPoF" role="PzmwI">
       <ref role="PrY4T" to="tpck:h0TrEE$" resolve="INamedConcept" />


### PR DESCRIPTION
The previous implementation enforces that a JsonFile contains a JsonObject as the root node of the contained JSON text.
This is not in accordance with the JSON Standard, which allows _any_ JSON value (such as arrays or a numbers in addition to objects) to be the root of a JSON text.
Refer to [https://www.ecma-international.org/publications-and-standards/standards/ecma-404/](https://www.ecma-international.org/publications-and-standards/standards/ecma-404/), Section 4.

Since a JSON object is a JSON value, this change does not break existing models.