### PR TITLE
mpsutil: fix ActionsFilter IDE error

### DIFF
--- a/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.actionsfilter.runtime/models/com/mbeddr/mpsutil/actionsfilter/runtime.mps
+++ b/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.actionsfilter.runtime/models/com/mbeddr/mpsutil/actionsfilter/runtime.mps
@@ -12716,14 +12716,24 @@
             </node>
           </node>
         </node>
-        <node concept="3clFbF" id="5vQUrnx8Uek" role="3cqZAp">
-          <node concept="1rXfSq" id="5vQUrnx8Uel" role="3clFbG">
-            <ref role="37wK5l" node="5vQUrnx98p1" resolve="applyFilter" />
-          </node>
-        </node>
-        <node concept="3clFbF" id="49MflvORFPV" role="3cqZAp">
-          <node concept="1rXfSq" id="49MflvORFPT" role="3clFbG">
-            <ref role="37wK5l" node="49MflvOR_Li" resolve="applyToolbar" />
+        <node concept="3clFbF" id="24qwin8x0Ns" role="3cqZAp">
+          <node concept="2YIFZM" id="24qwin8x0Rd" role="3clFbG">
+            <ref role="37wK5l" to="dxuu:~SwingUtilities.invokeLater(java.lang.Runnable)" resolve="invokeLater" />
+            <ref role="1Pybhc" to="dxuu:~SwingUtilities" resolve="SwingUtilities" />
+            <node concept="1bVj0M" id="24qwin8x6Nl" role="37wK5m">
+              <node concept="3clFbS" id="24qwin8x6Nm" role="1bW5cS">
+                <node concept="3clFbF" id="24qwin8x7pu" role="3cqZAp">
+                  <node concept="1rXfSq" id="24qwin8x7pt" role="3clFbG">
+                    <ref role="37wK5l" node="5vQUrnx98p1" resolve="applyFilter" />
+                  </node>
+                </node>
+                <node concept="3clFbF" id="24qwin8x8lu" role="3cqZAp">
+                  <node concept="1rXfSq" id="24qwin8x8ls" role="3clFbG">
+                    <ref role="37wK5l" node="49MflvOR_Li" resolve="applyToolbar" />
+                  </node>
+                </node>
+              </node>
+            </node>
           </node>
         </node>
       </node>


### PR DESCRIPTION
Premature use of ActionsFilter during startup causes an "IDE Fatal Error"

```
Should be called at least in the state COMPONENTS_LOADED, the current state is: CONFIGURATION_STORE_INITIALIZED

Current violators count: 1
java.lang.Throwable
	at com.intellij.diagnostic.LoadingState.logStateError(LoadingState.java:63)
	at com.intellij.diagnostic.LoadingState.checkOccurred(LoadingState.java:59)
	at com.intellij.openapi.actionSystem.impl.ActionManagerImpl.<init>(ActionManagerImpl.java:169)
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:490)
	at com.intellij.serviceContainer.ConstructorInjectionKt.instantiateUsingPicoContainer(constructorInjection.kt:47)
	at com.intellij.serviceContainer.ComponentManagerImpl.instantiateClassWithConstructorInjection(ComponentManagerImpl.kt:733)
	at com.intellij.serviceContainer.ServiceComponentAdapter.createAndInitialize(ServiceComponentAdapter.kt:49)
	at com.intellij.serviceContainer.ServiceComponentAdapter.access$createAndInitialize(ServiceComponentAdapter.kt:13)
	at com.intellij.serviceContainer.ServiceComponentAdapter$doCreateInstance$1.run(ServiceComponentAdapter.kt:43)
	at com.intellij.openapi.progress.impl.CoreProgressManager.registerIndicatorAndRun(CoreProgressManager.java:658)
	at com.intellij.openapi.progress.impl.CoreProgressManager.executeProcessUnderProgress(CoreProgressManager.java:610)
	at com.intellij.openapi.progress.impl.ProgressManagerImpl.executeProcessUnderProgress(ProgressManagerImpl.java:65)
	at com.intellij.openapi.progress.impl.CoreProgressManager.executeNonCancelableSection(CoreProgressManager.java:218)
	at com.intellij.serviceContainer.ServiceComponentAdapter.doCreateInstance(ServiceComponentAdapter.kt:42)
	at com.intellij.serviceContainer.BaseComponentAdapter.getInstanceUncached(BaseComponentAdapter.kt:113)
	at com.intellij.serviceContainer.BaseComponentAdapter.getInstance(BaseComponentAdapter.kt:67)
	at com.intellij.serviceContainer.ComponentManagerImpl.doGetService(ComponentManagerImpl.kt:457)
	at com.intellij.serviceContainer.ComponentManagerImpl.getService(ComponentManagerImpl.kt:440)
	at com.intellij.openapi.actionSystem.ActionManager.getInstance(ActionManager.java:29)
	at com.mbeddr.mpsutil.actionsfilter.runtime.ActionFilter.applyFilters(ActionFilter.java:139)
	at com.mbeddr.mpsutil.actionsfilter.runtime.ActionFilter.addFilters(ActionFilter.java:97)
	at com.mbeddr.mpsutil.actionsfilter.runtime.ActionFilter.setFilters(ActionFilter.java:128)
	at com.mbeddr.mpsutil.actionsfilter.runtime.ActionFilter.setFilters(ActionFilter.java:132)
	at com.mbeddr.mpsutil.actionsfilter.runtime.ActionsApplicationComponent.applyFilter(ActionsApplicationComponent.java:61)
	at com.mbeddr.mpsutil.actionsfilter.runtime.ActionsApplicationComponent.loadState(ActionsApplicationComponent.java:44)
	at com.mbeddr.mpsutil.actionsfilter.runtime.ActionsApplicationComponent.loadState(ActionsApplicationComponent.java:14)
	at com.intellij.configurationStore.ComponentStoreImpl.doInitComponent(ComponentStoreImpl.kt:445)
        [...]
```

Fixed by delaying filter and toolbar application.