### PR TITLE
build: additional publishing to github packages

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -113,7 +113,7 @@ subprojects {
                 ext.mbeddrBuildCounter = GitBasedVersioning.getGitCommitCount()
             }
             if(mbeddrBuild == "stable" || mbeddrBuild.startsWith("maintenance-")) {
-                mbeddrBuild = "master"
+                ext.mbeddrBuild = "master"
             }
             ext.mbeddrBuildNumber = GitBasedVersioning.getVersion(mbeddrBuild, mbeddrMajor, mbeddrMinor, mbeddrBuildCounter as int)
         } else {

--- a/build/com.mbeddr/build.gradle
+++ b/build/com.mbeddr/build.gradle
@@ -62,7 +62,7 @@ String minorVersion = '-Dminor.version=' + ext.mbeddrMinor
 ext.mbeddr_home = ['-Dmbeddr.github.core.home=' + file(rootProject.projectDir.absolutePath).getAbsolutePath(), minorVersion, majorVersion, buildVersion]
 ext.slall_home = ['-Dsl-all.home=' + file(artifactsDir.absolutePath + '/de.itemis.mps.extensions').getAbsolutePath(), minorVersion, majorVersion, buildVersion]
 ext.dependsOnMPS_scriptArgs = [mps_home, build_dir, artifacts_root]
-ext["itemis.mps.gradle.ant.defaultScriptArgs"] = ext.dependsOnMbeddr_scriptArgs = [*dependsOnMPS_scriptArgs, *mbeddr_home, *slall_home]
+ext["itemis.mps.gradle.ant.defaultScriptArgs"] = ext.dependsOnMbeddr_scriptArgs = [*dependsOnMPS_scriptArgs, *mbeddr_home, *slall_home, "-D'mps.generator.skipUnmodifiedModels=true"]
 
 // path locations
 ext.mbeddrScripts_basePath = file(ant.properties['mbeddr.github.core.home'] + "/build").getAbsolutePath()
@@ -115,6 +115,24 @@ private static void configureRepositories(Project project) {
                     }
                 }
             }
+
+            //mbeddr build is "master" also for maintenance branches
+            //using the clouse to delay evaluate from configuration to execution phase is important because the
+            //mbeddrBuild property is created by a "subproject" block which is executed after this script is configured.
+            //if no closure is used the build script won't compile.
+            if({project.mbeddrBuild}() == "master") {
+                maven {
+                    name = "GitHubPackages"
+                    url = "https://maven.pkg.github.com/mbeddr/mbeddr.core"
+                    if (project.hasProperty("gpr.token")) {
+                        credentials {
+                            username = project.findProperty("gpr.user")
+                            password = project.findProperty("gpr.token")
+                        }
+                    }
+                }
+            }
+
         }
     }
     project.repositories {
@@ -133,6 +151,7 @@ private static void configureRepositories(Project project) {
         mavenCentral()
     }
 }
+
 
 task printVersions {
     doLast {

--- a/build/com.mbeddr/build.gradle
+++ b/build/com.mbeddr/build.gradle
@@ -117,7 +117,7 @@ private static void configureRepositories(Project project) {
             }
 
             //mbeddr build is "master" also for maintenance branches
-            //using the clouse to delay evaluate from configuration to execution phase is important because the
+            //using the closure to delay evaluate from configuration to execution phase is important because the
             //mbeddrBuild property is created by a "subproject" block which is executed after this script is configured.
             //if no closure is used the build script won't compile.
             if({project.mbeddrBuild}() == "master") {

--- a/build/com.mbeddr/build.gradle
+++ b/build/com.mbeddr/build.gradle
@@ -62,7 +62,7 @@ String minorVersion = '-Dminor.version=' + ext.mbeddrMinor
 ext.mbeddr_home = ['-Dmbeddr.github.core.home=' + file(rootProject.projectDir.absolutePath).getAbsolutePath(), minorVersion, majorVersion, buildVersion]
 ext.slall_home = ['-Dsl-all.home=' + file(artifactsDir.absolutePath + '/de.itemis.mps.extensions').getAbsolutePath(), minorVersion, majorVersion, buildVersion]
 ext.dependsOnMPS_scriptArgs = [mps_home, build_dir, artifacts_root]
-ext["itemis.mps.gradle.ant.defaultScriptArgs"] = ext.dependsOnMbeddr_scriptArgs = [*dependsOnMPS_scriptArgs, *mbeddr_home, *slall_home, "-D'mps.generator.skipUnmodifiedModels=true"]
+ext["itemis.mps.gradle.ant.defaultScriptArgs"] = ext.dependsOnMbeddr_scriptArgs = [*dependsOnMPS_scriptArgs, *mbeddr_home, *slall_home, "-Dmps.generator.skipUnmodifiedModels=true"]
 
 // path locations
 ext.mbeddrScripts_basePath = file(ant.properties['mbeddr.github.core.home'] + "/build").getAbsolutePath()

--- a/build/com.mbeddr/languages/build.gradle
+++ b/build/com.mbeddr/languages/build.gradle
@@ -217,4 +217,18 @@ publishing {
 task publishMbeddrToLocal (dependsOn: ['publishMbeddrPublicationToMavenLocal',
 ':build:com.mbeddr:platform:publishMbeddrPlatformToLocal']) {}
 
+//mbeddr build is "master" also for maintenance branches
+//using the clouse to delay evaluate from configuration to execution phase is important because the
+//mbeddrBuild property is created by a "subproject" block which is executed after this script is configured.
+//if no closure is used the build script won't compile.
+if({project.mbeddrBuild}() == "master") {
+    /* this is pretty much a workaround so we don't need to change anything in Teamcity. Teamcity calls the  publishMbeddrPlatformPublicationToMavenRepository
+       tasks but since we have a new publishing target we would need to change the teamcity config to also include publishMbeddrPlatformPublicationToGitHubPackagesRepository
+       If we change the Teamcity configuration this would break older maintenance and feature branches and we would loose the ablilty to
+       rebuild the exact same source code. There for this workaround is present that adds a dependency between the itemis maven repo
+       and github packages when we are on master or a maintenance branch.
+       */
+    tasks.findByName("publishMbeddrPublicationToMavenRepository").dependsOn("publishMbeddrPublicationToGitHubPackagesRepository")
+}
+
 check.dependsOn test_mbeddr

--- a/build/com.mbeddr/languages/build.gradle
+++ b/build/com.mbeddr/languages/build.gradle
@@ -218,7 +218,7 @@ task publishMbeddrToLocal (dependsOn: ['publishMbeddrPublicationToMavenLocal',
 ':build:com.mbeddr:platform:publishMbeddrPlatformToLocal']) {}
 
 //mbeddr build is "master" also for maintenance branches
-//using the clouse to delay evaluate from configuration to execution phase is important because the
+//using the closure to delay evaluate from configuration to execution phase is important because the
 //mbeddrBuild property is created by a "subproject" block which is executed after this script is configured.
 //if no closure is used the build script won't compile.
 if({project.mbeddrBuild}() == "master") {

--- a/build/com.mbeddr/platform/build.gradle
+++ b/build/com.mbeddr/platform/build.gradle
@@ -163,3 +163,17 @@ publishing {
         }
     }
 }
+
+//mbeddr build is "master" also for maintenance branches
+//using the clouse to delay evaluate from configuration to execution phase is important because the
+//mbeddrBuild property is created by a "subproject" block which is executed after this script is configured.
+//if no closure is used the build script won't compile.
+if({project.mbeddrBuild}() == "master") {
+    /* this is pretty much a workaround so we don't need to change anything in Teamcity. Teamcity calls the  publishMbeddrPlatformPublicationToMavenRepository
+       tasks but since we have a new publishing target we would need to change the teamcity config to also include publishMbeddrPlatformPublicationToGitHubPackagesRepository
+       If we change the Teamcity configuration this would break older maintenance and feature branches and we would loose the ablilty to
+       rebuild the exact same source code. There for this workaround is present that adds a dependency between the itemis maven repo
+       and github packages when we are on master or a maintenance branch.
+       */
+    tasks.findByName("publishMbeddrPlatformPublicationToMavenRepository").dependsOn("publishMbeddrPlatformPublicationToGitHubPackagesRepository")
+}

--- a/build/com.mbeddr/platform/build.gradle
+++ b/build/com.mbeddr/platform/build.gradle
@@ -165,7 +165,7 @@ publishing {
 }
 
 //mbeddr build is "master" also for maintenance branches
-//using the clouse to delay evaluate from configuration to execution phase is important because the
+//using the closure to delay evaluate from configuration to execution phase is important because the
 //mbeddrBuild property is created by a "subproject" block which is executed after this script is configured.
 //if no closure is used the build script won't compile.
 if({project.mbeddrBuild}() == "master") {


### PR DESCRIPTION
The build now publishes the master and maintenance/* branches to github
packages in addition to the normal itemis maven repository. The changes
are backwards compatible and don't require any changes on teamcity,
apart from providing the github logins data.

Read the inline comments carefully because some changes are none obvious
without. Mostly caused by the fact that we configure our subproject from
a parent project was tricky to get right.