### PR TITLE
build: additional publishing to github packages (maintenance/MPS20203)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -113,7 +113,7 @@ subprojects {
                 ext.mbeddrBuildCounter = GitBasedVersioning.getGitCommitCount()
             }
             if(mbeddrBuild == "stable" || mbeddrBuild.startsWith("maintenance-")) {
-                mbeddrBuild = "master"
+                ext.mbeddrBuild = "master"
             }
             ext.mbeddrBuildNumber = GitBasedVersioning.getVersion(mbeddrBuild, mbeddrMajor, mbeddrMinor, mbeddrBuildCounter as int)
         } else {
@@ -122,12 +122,12 @@ subprojects {
 
         // Enable mbeddr to be assigned a different version number than mbeddr platform,
         // as well as mbeddr to be built against a specified existing mbeddr platform version
-		ext.mbeddrPlatformBuildNumber = findNonEmptyProperty('mbeddrPlatformVersion') ?: mbeddrBuildNumber
+        ext.mbeddrPlatformBuildNumber = findNonEmptyProperty('mbeddrPlatformVersion') ?: mbeddrBuildNumber
 
         if (ciBuild) {
-			// Coerce TeamCity build number to mbeddrBuildNumber by default
-			// (see https://octopus.com/blog/teamcity-version-numbers-based-on-branches for details)
-			println "##teamcity[buildNumber '${mbeddrBuildNumber}']"
+            // Coerce TeamCity build number to mbeddrBuildNumber by default
+            // (see https://octopus.com/blog/teamcity-version-numbers-based-on-branches for details)
+            println "##teamcity[buildNumber '${mbeddrBuildNumber}']"
         } else {
             println "Local build detected. mbeddr version $ext.mbeddrBuildNumber, mbeddr platform version $ext.mbeddrPlatformBuildNumber"
         }

--- a/build/com.mbeddr/build.gradle
+++ b/build/com.mbeddr/build.gradle
@@ -62,7 +62,7 @@ String minorVersion = '-Dminor.version=' + ext.mbeddrMinor
 ext.mbeddr_home = ['-Dmbeddr.github.core.home=' + file(rootProject.projectDir.absolutePath).getAbsolutePath(), minorVersion, majorVersion, buildVersion]
 ext.slall_home = ['-Dsl-all.home=' + file(artifactsDir.absolutePath + '/de.itemis.mps.extensions').getAbsolutePath(), minorVersion, majorVersion, buildVersion]
 ext.dependsOnMPS_scriptArgs = [mps_home, build_dir, artifacts_root]
-ext["itemis.mps.gradle.ant.defaultScriptArgs"] = ext.dependsOnMbeddr_scriptArgs = [*dependsOnMPS_scriptArgs, *mbeddr_home, *slall_home]
+ext["itemis.mps.gradle.ant.defaultScriptArgs"] = ext.dependsOnMbeddr_scriptArgs = [*dependsOnMPS_scriptArgs, *mbeddr_home, *slall_home, "-Dmps.generator.skipUnmodifiedModels=true"]
 
 // path locations
 ext.mbeddrScripts_basePath = file(ant.properties['mbeddr.github.core.home'] + "/build").getAbsolutePath()
@@ -115,6 +115,22 @@ private static void configureRepositories(Project project) {
                     }
                 }
             }
+             //mbeddr build is "master" also for maintenance branches
+            //using the closure to delay evaluate from configuration to execution phase is important because the
+            //mbeddrBuild property is created by a "subproject" block which is executed after this script is configured.
+            //if no closure is used the build script won't compile.
+            if({project.mbeddrBuild}() == "master") {
+                maven {
+                    name = "GitHubPackages"
+                    url = "https://maven.pkg.github.com/mbeddr/mbeddr.core"
+                    if (project.hasProperty("gpr.token")) {
+                        credentials {
+                            username = project.findProperty("gpr.user")
+                            password = project.findProperty("gpr.token")
+                        }
+                    }
+                }
+            }
         }
     }
     project.repositories {
@@ -137,7 +153,7 @@ private static void configureRepositories(Project project) {
 task printVersions {
     doLast {
         println "mbeddrBuildNumber: $project.mbeddrBuildNumber"
-		println "mbeddrPlatformBuildNumber: $project.mbeddrPlatformBuildNumber"
+        println "mbeddrPlatformBuildNumber: $project.mbeddrPlatformBuildNumber"
     }
 }
 

--- a/build/com.mbeddr/build.gradle
+++ b/build/com.mbeddr/build.gradle
@@ -62,7 +62,7 @@ String minorVersion = '-Dminor.version=' + ext.mbeddrMinor
 ext.mbeddr_home = ['-Dmbeddr.github.core.home=' + file(rootProject.projectDir.absolutePath).getAbsolutePath(), minorVersion, majorVersion, buildVersion]
 ext.slall_home = ['-Dsl-all.home=' + file(artifactsDir.absolutePath + '/de.itemis.mps.extensions').getAbsolutePath(), minorVersion, majorVersion, buildVersion]
 ext.dependsOnMPS_scriptArgs = [mps_home, build_dir, artifacts_root]
-ext["itemis.mps.gradle.ant.defaultScriptArgs"] = ext.dependsOnMbeddr_scriptArgs = [*dependsOnMPS_scriptArgs, *mbeddr_home, *slall_home, "-Dmps.generator.skipUnmodifiedModels=true"]
+ext["itemis.mps.gradle.ant.defaultScriptArgs"] = ext.dependsOnMbeddr_scriptArgs = [*dependsOnMPS_scriptArgs, *mbeddr_home, *slall_home]
 
 // path locations
 ext.mbeddrScripts_basePath = file(ant.properties['mbeddr.github.core.home'] + "/build").getAbsolutePath()

--- a/build/com.mbeddr/languages/build.gradle
+++ b/build/com.mbeddr/languages/build.gradle
@@ -217,4 +217,18 @@ publishing {
 task publishMbeddrToLocal (dependsOn: ['publishMbeddrPublicationToMavenLocal',
 ':build:com.mbeddr:platform:publishMbeddrPlatformToLocal']) {}
 
+//mbeddr build is "master" also for maintenance branches
+//using the closure to delay evaluate from configuration to execution phase is important because the
+//mbeddrBuild property is created by a "subproject" block which is executed after this script is configured.
+//if no closure is used the build script won't compile.
+if({project.mbeddrBuild}() == "master") {
+    /* this is pretty much a workaround so we don't need to change anything in Teamcity. Teamcity calls the  publishMbeddrPlatformPublicationToMavenRepository
+       tasks but since we have a new publishing target we would need to change the teamcity config to also include publishMbeddrPlatformPublicationToGitHubPackagesRepository
+       If we change the Teamcity configuration this would break older maintenance and feature branches and we would loose the ablilty to
+       rebuild the exact same source code. There for this workaround is present that adds a dependency between the itemis maven repo
+       and github packages when we are on master or a maintenance branch.
+       */
+    tasks.findByName("publishMbeddrPublicationToMavenRepository").dependsOn("publishMbeddrPublicationToGitHubPackagesRepository")
+}
+
 check.dependsOn test_mbeddr

--- a/build/com.mbeddr/platform/build.gradle
+++ b/build/com.mbeddr/platform/build.gradle
@@ -36,13 +36,13 @@ if (project.hasProperty('mpsExtensionsZip')) {
 }
 
 task build_allScripts(type: BuildLanguages, dependsOn: [resolve_mps, resolve_mps_extensions]) {
-	doFirst {
-		if (ciBuild) {
-			// Coerce TeamCity build number to mbeddrPlatformBuildNumber
-			// (see https://octopus.com/blog/teamcity-version-numbers-based-on-branches for details)
-			println "##teamcity[buildNumber '${mbeddrPlatformBuildNumber}']"
-		}
-	}
+    doFirst {
+        if (ciBuild) {
+            // Coerce TeamCity build number to mbeddrPlatformBuildNumber
+            // (see https://octopus.com/blog/teamcity-version-numbers-based-on-branches for details)
+            println "##teamcity[buildNumber '${mbeddrPlatformBuildNumber}']"
+        }
+    }
     script rootProject.file('build/com.mbeddr.allScripts/build.xml')
 }
 
@@ -162,4 +162,18 @@ publishing {
             }
         }
     }
+}
+
+//mbeddr build is "master" also for maintenance branches
+//using the closure to delay evaluate from configuration to execution phase is important because the
+//mbeddrBuild property is created by a "subproject" block which is executed after this script is configured.
+//if no closure is used the build script won't compile.
+if({project.mbeddrBuild}() == "master") {
+    /* this is pretty much a workaround so we don't need to change anything in Teamcity. Teamcity calls the  publishMbeddrPlatformPublicationToMavenRepository
+       tasks but since we have a new publishing target we would need to change the teamcity config to also include publishMbeddrPlatformPublicationToGitHubPackagesRepository
+       If we change the Teamcity configuration this would break older maintenance and feature branches and we would loose the ablilty to
+       rebuild the exact same source code. There for this workaround is present that adds a dependency between the itemis maven repo
+       and github packages when we are on master or a maintenance branch.
+       */
+    tasks.findByName("publishMbeddrPlatformPublicationToMavenRepository").dependsOn("publishMbeddrPlatformPublicationToGitHubPackagesRepository")
 }


### PR DESCRIPTION
Applies identical changes as in PR #2180 to the MPS20203 maintenance branch so that this older version is also published to github packages.

See also: 2c585c7c815884659d360a548df9edea8dd5db67