### PR TITLE
mbeddr.doc: Show ToC in presentation mode

### DIFF
--- a/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/languageModels/behavior.mps
+++ b/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/languageModels/behavior.mps
@@ -140,6 +140,7 @@
         <child id="1082485599094" name="ifFalseStatement" index="9aQIa" />
         <child id="1068580123160" name="condition" index="3clFbw" />
         <child id="1068580123161" name="ifTrue" index="3clFbx" />
+        <child id="1206060520071" name="elsifClauses" index="3eNLev" />
       </concept>
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
@@ -159,6 +160,10 @@
       </concept>
       <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
       <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
+      <concept id="1206060495898" name="jetbrains.mps.baseLanguage.structure.ElsifClause" flags="ng" index="3eNFk2">
+        <child id="1206060619838" name="condition" index="3eO9$A" />
+        <child id="1206060644605" name="statementList" index="3eOfB_" />
+      </concept>
       <concept id="1079359253375" name="jetbrains.mps.baseLanguage.structure.ParenthesizedExpression" flags="nn" index="1eOMI4">
         <child id="1079359253376" name="expression" index="1eOMHV" />
       </concept>
@@ -287,7 +292,9 @@
       <concept id="1180636770613" name="jetbrains.mps.lang.smodel.structure.SNodeCreator" flags="nn" index="3zrR0B">
         <child id="1180636770616" name="createdType" index="3zrR0E" />
       </concept>
-      <concept id="1140137987495" name="jetbrains.mps.lang.smodel.structure.SNodeTypeCastExpression" flags="nn" index="1PxgMI" />
+      <concept id="1140137987495" name="jetbrains.mps.lang.smodel.structure.SNodeTypeCastExpression" flags="nn" index="1PxgMI">
+        <property id="1238684351431" name="asCast" index="1BlNFB" />
+      </concept>
       <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
         <reference id="1138405853777" name="concept" index="ehGHo" />
       </concept>
@@ -333,6 +340,9 @@
         <child id="1226511765987" name="elementType" index="2hN53Y" />
       </concept>
       <concept id="1226516258405" name="jetbrains.mps.baseLanguage.collections.structure.HashSetCreator" flags="nn" index="2i4dXS" />
+      <concept id="1224414427926" name="jetbrains.mps.baseLanguage.collections.structure.SequenceCreator" flags="nn" index="kMnCb">
+        <child id="1224414456414" name="elementType" index="kMuH3" />
+      </concept>
       <concept id="1151688443754" name="jetbrains.mps.baseLanguage.collections.structure.ListType" flags="in" index="_YKpA">
         <child id="1151688676805" name="elementType" index="_ZDj9" />
       </concept>
@@ -7735,8 +7745,10 @@
         <node concept="3cpWs8" id="73FPRWNpgXG" role="3cqZAp">
           <node concept="3cpWsn" id="73FPRWNpgXH" role="3cpWs9">
             <property role="TrG5h" value="contents" />
-            <node concept="2I9FWS" id="73FPRWNpgUT" role="1tU5fm">
-              <ref role="2I9WkF" to="2c95:2TZO3DbuxwP" resolve="IDocumentContent" />
+            <node concept="A3Dl8" id="lY5Enm5Ni5" role="1tU5fm">
+              <node concept="3Tqbb2" id="lY5Enm5NNP" role="A3Ik2">
+                <ref role="ehGHo" to="2c95:2TZO3DbuxwP" resolve="IDocumentContent" />
+              </node>
             </node>
             <node concept="2OqwBi" id="73FPRWNpgXI" role="33vP2m">
               <node concept="2OqwBi" id="73FPRWNpgXJ" role="2Oq$k0">
@@ -7774,100 +7786,160 @@
         </node>
       </node>
       <node concept="3clFbS" id="73FPRWNpfC9" role="3clF47">
-        <node concept="3cpWs8" id="73FPRWNpiwB" role="3cqZAp">
-          <node concept="3cpWsn" id="73FPRWNpiwC" role="3cpWs9">
-            <property role="TrG5h" value="entries" />
-            <node concept="A3Dl8" id="73FPRWNpioU" role="1tU5fm">
-              <node concept="3Tqbb2" id="73FPRWNpioX" role="A3Ik2">
-                <ref role="ehGHo" to="2c95:2TZO3Dbv6Ju" resolve="AbstractSection" />
-              </node>
+        <node concept="3clFbF" id="2yDAfHErxfo" role="3cqZAp">
+          <node concept="2OqwBi" id="2yDAfHErxuN" role="3clFbG">
+            <node concept="37vLTw" id="2yDAfHErxfm" role="2Oq$k0">
+              <ref role="3cqZAo" node="73FPRWNpfDH" resolve="contents" />
             </node>
-            <node concept="2OqwBi" id="73FPRWNpiwD" role="33vP2m">
-              <node concept="2OqwBi" id="73FPRWNpiwE" role="2Oq$k0">
-                <node concept="37vLTw" id="73FPRWNpiwF" role="2Oq$k0">
-                  <ref role="3cqZAo" node="73FPRWNpfDH" resolve="contents" />
-                </node>
-                <node concept="v3k3i" id="73FPRWNpiwG" role="2OqNvi">
-                  <node concept="chp4Y" id="73FPRWNpiwH" role="v3oSu">
-                    <ref role="cht4Q" to="2c95:2TZO3Dbv6Ju" resolve="AbstractSection" />
-                  </node>
-                </node>
-              </node>
-              <node concept="3zZkjj" id="73FPRWNpiwI" role="2OqNvi">
-                <node concept="1bVj0M" id="73FPRWNpiwJ" role="23t8la">
-                  <node concept="3clFbS" id="73FPRWNpiwK" role="1bW5cS">
-                    <node concept="3clFbF" id="73FPRWNpiwL" role="3cqZAp">
-                      <node concept="2OqwBi" id="73FPRWNpiwM" role="3clFbG">
-                        <node concept="37vLTw" id="73FPRWNpiwN" role="2Oq$k0">
-                          <ref role="3cqZAo" node="73FPRWNpiwP" resolve="it" />
-                        </node>
-                        <node concept="2qgKlT" id="73FPRWNpiwO" role="2OqNvi">
-                          <ref role="37wK5l" node="QRmqzHsFzm" resolve="isInIndex" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="Rh6nW" id="73FPRWNpiwP" role="1bW2Oz">
-                    <property role="TrG5h" value="it" />
-                    <node concept="2jxLKc" id="73FPRWNpiwQ" role="1tU5fm" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="73FPRWNph36" role="3cqZAp">
-          <node concept="2OqwBi" id="73FPRWNpiSJ" role="3clFbG">
-            <node concept="37vLTw" id="73FPRWNpiwR" role="2Oq$k0">
-              <ref role="3cqZAo" node="73FPRWNpiwC" resolve="entries" />
-            </node>
-            <node concept="3goQfb" id="73FPRWNpj4s" role="2OqNvi">
-              <node concept="1bVj0M" id="73FPRWNpj4u" role="23t8la">
-                <node concept="3clFbS" id="73FPRWNpj4v" role="1bW5cS">
-                  <node concept="3cpWs8" id="73FPRWNppDA" role="3cqZAp">
-                    <node concept="3cpWsn" id="73FPRWNppDB" role="3cpWs9">
-                      <property role="TrG5h" value="self" />
-                      <node concept="A3Dl8" id="73FPRWNppRL" role="1tU5fm">
-                        <node concept="3Tqbb2" id="73FPRWNppRN" role="A3Ik2">
-                          <ref role="ehGHo" to="2c95:2TZO3Dbv6Ju" resolve="AbstractSection" />
-                        </node>
-                      </node>
-                      <node concept="2ShNRf" id="73FPRWNppDC" role="33vP2m">
-                        <node concept="Tc6Ow" id="73FPRWNppDD" role="2ShVmc">
-                          <node concept="3Tqbb2" id="73FPRWNppDE" role="HW$YZ">
-                            <ref role="ehGHo" to="2c95:2TZO3Dbv6Ju" resolve="AbstractSection" />
-                          </node>
-                          <node concept="37vLTw" id="73FPRWNppDF" role="HW$Y0">
-                            <ref role="3cqZAo" node="73FPRWNpj4w" resolve="it" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="3clFbF" id="73FPRWNpkXS" role="3cqZAp">
-                    <node concept="2OqwBi" id="73FPRWNpqeq" role="3clFbG">
-                      <node concept="37vLTw" id="73FPRWNppDG" role="2Oq$k0">
-                        <ref role="3cqZAo" node="73FPRWNppDB" resolve="self" />
-                      </node>
-                      <node concept="3QWeyG" id="73FPRWNpqv3" role="2OqNvi">
-                        <node concept="BsUDl" id="73FPRWNpjYR" role="576Qk">
+            <node concept="3goQfb" id="2yDAfHErxE_" role="2OqNvi">
+              <node concept="1bVj0M" id="2yDAfHErxEB" role="23t8la">
+                <node concept="3clFbS" id="2yDAfHErxEC" role="1bW5cS">
+                  <node concept="3clFbJ" id="2yDAfHErxWM" role="3cqZAp">
+                    <node concept="3clFbS" id="2yDAfHErxWO" role="3clFbx">
+                      <node concept="3cpWs6" id="2yDAfHEr_eA" role="3cqZAp">
+                        <node concept="BsUDl" id="2yDAfHEr_vi" role="3cqZAk">
                           <ref role="37wK5l" node="73FPRWNpfC6" resolve="getEntriesRec" />
-                          <node concept="2OqwBi" id="73FPRWNpk8w" role="37wK5m">
-                            <node concept="37vLTw" id="73FPRWNpk24" role="2Oq$k0">
-                              <ref role="3cqZAo" node="73FPRWNpj4w" resolve="it" />
+                          <node concept="2OqwBi" id="2yDAfHErBPJ" role="37wK5m">
+                            <node concept="2OqwBi" id="2yDAfHErBho" role="2Oq$k0">
+                              <node concept="2OqwBi" id="2yDAfHErApl" role="2Oq$k0">
+                                <node concept="1PxgMI" id="2yDAfHEr_T8" role="2Oq$k0">
+                                  <node concept="chp4Y" id="2yDAfHErA2M" role="3oSUPX">
+                                    <ref role="cht4Q" to="2c95:5mf_X_Lbqjw" resolve="DocumentInclude" />
+                                  </node>
+                                  <node concept="37vLTw" id="2yDAfHEr_CN" role="1m5AlR">
+                                    <ref role="3cqZAo" node="2yDAfHErxED" resolve="it" />
+                                  </node>
+                                </node>
+                                <node concept="3TrEf2" id="2yDAfHErAJu" role="2OqNvi">
+                                  <ref role="3Tt5mk" to="2c95:5mf_X_Lbqjz" resolve="ref" />
+                                </node>
+                              </node>
+                              <node concept="3TrEf2" id="2yDAfHErB$0" role="2OqNvi">
+                                <ref role="3Tt5mk" to="2c95:2TZO3DbvI5E" resolve="doc" />
+                              </node>
                             </node>
-                            <node concept="3Tsc0h" id="73FPRWNpke0" role="2OqNvi">
+                            <node concept="3Tsc0h" id="2yDAfHErCjY" role="2OqNvi">
                               <ref role="3TtcxE" to="2c95:2TZO3Dbv6JU" resolve="contents" />
                             </node>
                           </node>
                         </node>
                       </node>
                     </node>
+                    <node concept="1Wc70l" id="2yDAfHErzfn" role="3clFbw">
+                      <node concept="3fqX7Q" id="2yDAfHErzpl" role="3uHU7w">
+                        <node concept="2OqwBi" id="2yDAfHEr$AX" role="3fr31v">
+                          <node concept="1PxgMI" id="2yDAfHErzZf" role="2Oq$k0">
+                            <node concept="chp4Y" id="2yDAfHEr$fB" role="3oSUPX">
+                              <ref role="cht4Q" to="2c95:5mf_X_Lbqjw" resolve="DocumentInclude" />
+                            </node>
+                            <node concept="37vLTw" id="2yDAfHErzpr" role="1m5AlR">
+                              <ref role="3cqZAo" node="2yDAfHErxED" resolve="it" />
+                            </node>
+                          </node>
+                          <node concept="3TrcHB" id="2yDAfHEr_24" role="2OqNvi">
+                            <ref role="3TsBF5" to="2c95:hZfTLLrEWd" resolve="referenceOnly" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="2OqwBi" id="2yDAfHErylq" role="3uHU7B">
+                        <node concept="37vLTw" id="2yDAfHEry32" role="2Oq$k0">
+                          <ref role="3cqZAo" node="2yDAfHErxED" resolve="it" />
+                        </node>
+                        <node concept="1mIQ4w" id="2yDAfHEryFe" role="2OqNvi">
+                          <node concept="chp4Y" id="2yDAfHEryNU" role="cj9EA">
+                            <ref role="cht4Q" to="2c95:5mf_X_Lbqjw" resolve="DocumentInclude" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3eNFk2" id="2yDAfHErCEd" role="3eNLev">
+                      <node concept="2OqwBi" id="2yDAfHErF8K" role="3eO9$A">
+                        <node concept="1PxgMI" id="2yDAfHErErb" role="2Oq$k0">
+                          <property role="1BlNFB" value="true" />
+                          <node concept="chp4Y" id="2yDAfHErEJK" role="3oSUPX">
+                            <ref role="cht4Q" to="2c95:2TZO3Dbv6Ju" resolve="AbstractSection" />
+                          </node>
+                          <node concept="37vLTw" id="2yDAfHErE0d" role="1m5AlR">
+                            <ref role="3cqZAo" node="2yDAfHErxED" resolve="it" />
+                          </node>
+                        </node>
+                        <node concept="2qgKlT" id="2yDAfHErFON" role="2OqNvi">
+                          <ref role="37wK5l" node="QRmqzHsFzm" resolve="isInIndex" />
+                        </node>
+                      </node>
+                      <node concept="3clFbS" id="2yDAfHErCEf" role="3eOfB_">
+                        <node concept="3cpWs8" id="2yDAfHErJtp" role="3cqZAp">
+                          <node concept="3cpWsn" id="2yDAfHErJtq" role="3cpWs9">
+                            <property role="TrG5h" value="section" />
+                            <node concept="3Tqbb2" id="2yDAfHErJso" role="1tU5fm">
+                              <ref role="ehGHo" to="2c95:2TZO3Dbv6Ju" resolve="AbstractSection" />
+                            </node>
+                            <node concept="1PxgMI" id="2yDAfHErJtr" role="33vP2m">
+                              <node concept="chp4Y" id="2yDAfHErJts" role="3oSUPX">
+                                <ref role="cht4Q" to="2c95:2TZO3Dbv6Ju" resolve="AbstractSection" />
+                              </node>
+                              <node concept="37vLTw" id="2yDAfHErJtt" role="1m5AlR">
+                                <ref role="3cqZAo" node="2yDAfHErxED" resolve="it" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3cpWs8" id="2yDAfHErFZL" role="3cqZAp">
+                          <node concept="3cpWsn" id="2yDAfHErFZM" role="3cpWs9">
+                            <property role="TrG5h" value="self" />
+                            <node concept="A3Dl8" id="2yDAfHErFZN" role="1tU5fm">
+                              <node concept="3Tqbb2" id="2yDAfHErFZO" role="A3Ik2">
+                                <ref role="ehGHo" to="2c95:2TZO3Dbv6Ju" resolve="AbstractSection" />
+                              </node>
+                            </node>
+                            <node concept="2ShNRf" id="2yDAfHErFZP" role="33vP2m">
+                              <node concept="Tc6Ow" id="2yDAfHErFZQ" role="2ShVmc">
+                                <node concept="3Tqbb2" id="2yDAfHErFZR" role="HW$YZ">
+                                  <ref role="ehGHo" to="2c95:2TZO3Dbv6Ju" resolve="AbstractSection" />
+                                </node>
+                                <node concept="37vLTw" id="2yDAfHErJtu" role="HW$Y0">
+                                  <ref role="3cqZAo" node="2yDAfHErJtq" resolve="section" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3cpWs6" id="2yDAfHErIno" role="3cqZAp">
+                          <node concept="2OqwBi" id="2yDAfHErInq" role="3cqZAk">
+                            <node concept="37vLTw" id="2yDAfHErInr" role="2Oq$k0">
+                              <ref role="3cqZAo" node="2yDAfHErFZM" resolve="self" />
+                            </node>
+                            <node concept="3QWeyG" id="2yDAfHErIns" role="2OqNvi">
+                              <node concept="BsUDl" id="2yDAfHErInt" role="576Qk">
+                                <ref role="37wK5l" node="73FPRWNpfC6" resolve="getEntriesRec" />
+                                <node concept="2OqwBi" id="2yDAfHErInu" role="37wK5m">
+                                  <node concept="37vLTw" id="2yDAfHErJtv" role="2Oq$k0">
+                                    <ref role="3cqZAo" node="2yDAfHErJtq" resolve="section" />
+                                  </node>
+                                  <node concept="3Tsc0h" id="2yDAfHErIny" role="2OqNvi">
+                                    <ref role="3TtcxE" to="2c95:2TZO3Dbv6JU" resolve="contents" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3cpWs6" id="2yDAfHEu$O$" role="3cqZAp">
+                    <node concept="2ShNRf" id="2yDAfHEu__4" role="3cqZAk">
+                      <node concept="kMnCb" id="2yDAfHEuBhO" role="2ShVmc">
+                        <node concept="3Tqbb2" id="2yDAfHEuBEl" role="kMuH3">
+                          <ref role="ehGHo" to="2c95:2TZO3Dbv6Ju" resolve="AbstractSection" />
+                        </node>
+                      </node>
+                    </node>
                   </node>
                 </node>
-                <node concept="Rh6nW" id="73FPRWNpj4w" role="1bW2Oz">
+                <node concept="Rh6nW" id="2yDAfHErxED" role="1bW2Oz">
                   <property role="TrG5h" value="it" />
-                  <node concept="2jxLKc" id="73FPRWNpj4x" role="1tU5fm" />
+                  <node concept="2jxLKc" id="2yDAfHErxEE" role="1tU5fm" />
                 </node>
               </node>
             </node>

--- a/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/languageModels/behavior.mps
+++ b/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/languageModels/behavior.mps
@@ -351,6 +351,7 @@
       <concept id="1235566554328" name="jetbrains.mps.baseLanguage.collections.structure.AnyOperation" flags="nn" index="2HwmR7" />
       <concept id="1235566831861" name="jetbrains.mps.baseLanguage.collections.structure.AllOperation" flags="nn" index="2HxqBE" />
       <concept id="1237721394592" name="jetbrains.mps.baseLanguage.collections.structure.AbstractContainerCreator" flags="nn" index="HWqM0">
+        <child id="1237721435808" name="initValue" index="HW$Y0" />
         <child id="1237721435807" name="elementType" index="HW$YZ" />
       </concept>
       <concept id="1227008614712" name="jetbrains.mps.baseLanguage.collections.structure.LinkedListCreator" flags="nn" index="2Jqq0_" />
@@ -358,6 +359,7 @@
       <concept id="1227022210526" name="jetbrains.mps.baseLanguage.collections.structure.ClearAllElementsOperation" flags="nn" index="2Kehj3" />
       <concept id="1227026082377" name="jetbrains.mps.baseLanguage.collections.structure.RemoveFirstElementOperation" flags="nn" index="2Kt2Hk" />
       <concept id="1203518072036" name="jetbrains.mps.baseLanguage.collections.structure.SmartClosureParameterDeclaration" flags="ig" index="Rh6nW" />
+      <concept id="1160600644654" name="jetbrains.mps.baseLanguage.collections.structure.ListCreatorWithInit" flags="nn" index="Tc6Ow" />
       <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="nn" index="TSZUe" />
       <concept id="1171391069720" name="jetbrains.mps.baseLanguage.collections.structure.GetIndexOfOperation" flags="nn" index="2WmjW8" />
       <concept id="1160666733551" name="jetbrains.mps.baseLanguage.collections.structure.AddAllElementsOperation" flags="nn" index="X8dFx" />
@@ -379,6 +381,7 @@
         <child id="5686963296372573084" name="elementType" index="3O5elw" />
       </concept>
       <concept id="5686963296372475025" name="jetbrains.mps.baseLanguage.collections.structure.QueueType" flags="in" index="3O6Q9H" />
+      <concept id="1180964022718" name="jetbrains.mps.baseLanguage.collections.structure.ConcatOperation" flags="nn" index="3QWeyG" />
       <concept id="1178894719932" name="jetbrains.mps.baseLanguage.collections.structure.DistinctOperation" flags="nn" index="1VAtEI" />
     </language>
   </registry>
@@ -7719,6 +7722,166 @@
         </node>
       </node>
       <node concept="10P_77" id="QRmqzGVOVR" role="3clF45" />
+    </node>
+    <node concept="13i0hz" id="73FPRWNpfg_" role="13h7CS">
+      <property role="TrG5h" value="getEntriesFlat" />
+      <node concept="3Tm1VV" id="73FPRWNpfgA" role="1B3o_S" />
+      <node concept="A3Dl8" id="73FPRWNpfgV" role="3clF45">
+        <node concept="3Tqbb2" id="73FPRWNpfh8" role="A3Ik2">
+          <ref role="ehGHo" to="2c95:2TZO3Dbv6Ju" resolve="AbstractSection" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="73FPRWNpfgC" role="3clF47">
+        <node concept="3cpWs8" id="73FPRWNpgXG" role="3cqZAp">
+          <node concept="3cpWsn" id="73FPRWNpgXH" role="3cpWs9">
+            <property role="TrG5h" value="contents" />
+            <node concept="2I9FWS" id="73FPRWNpgUT" role="1tU5fm">
+              <ref role="2I9WkF" to="2c95:2TZO3DbuxwP" resolve="IDocumentContent" />
+            </node>
+            <node concept="2OqwBi" id="73FPRWNpgXI" role="33vP2m">
+              <node concept="2OqwBi" id="73FPRWNpgXJ" role="2Oq$k0">
+                <node concept="13iPFW" id="73FPRWNpgXK" role="2Oq$k0" />
+                <node concept="2Xjw5R" id="73FPRWNpgXL" role="2OqNvi">
+                  <node concept="1xMEDy" id="73FPRWNpgXM" role="1xVPHs">
+                    <node concept="chp4Y" id="73FPRWNpgXN" role="ri$Ld">
+                      <ref role="cht4Q" to="2c95:5L$H31Kgq3f" resolve="IDocumentLike" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3Tsc0h" id="73FPRWNpgXO" role="2OqNvi">
+                <ref role="3TtcxE" to="2c95:2TZO3Dbv6JU" resolve="contents" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="73FPRWNpfEB" role="3cqZAp">
+          <node concept="BsUDl" id="73FPRWNprvU" role="3clFbG">
+            <ref role="37wK5l" node="73FPRWNpfC6" resolve="getEntriesRec" />
+            <node concept="37vLTw" id="73FPRWNprwT" role="37wK5m">
+              <ref role="3cqZAo" node="73FPRWNpgXH" resolve="contents" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="13i0hz" id="73FPRWNpfC6" role="13h7CS">
+      <property role="TrG5h" value="getEntriesRec" />
+      <node concept="3Tm6S6" id="73FPRWNpfCx" role="1B3o_S" />
+      <node concept="A3Dl8" id="73FPRWNpfCG" role="3clF45">
+        <node concept="3Tqbb2" id="73FPRWNpfCT" role="A3Ik2">
+          <ref role="ehGHo" to="2c95:2TZO3Dbv6Ju" resolve="AbstractSection" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="73FPRWNpfC9" role="3clF47">
+        <node concept="3cpWs8" id="73FPRWNpiwB" role="3cqZAp">
+          <node concept="3cpWsn" id="73FPRWNpiwC" role="3cpWs9">
+            <property role="TrG5h" value="entries" />
+            <node concept="A3Dl8" id="73FPRWNpioU" role="1tU5fm">
+              <node concept="3Tqbb2" id="73FPRWNpioX" role="A3Ik2">
+                <ref role="ehGHo" to="2c95:2TZO3Dbv6Ju" resolve="AbstractSection" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="73FPRWNpiwD" role="33vP2m">
+              <node concept="2OqwBi" id="73FPRWNpiwE" role="2Oq$k0">
+                <node concept="37vLTw" id="73FPRWNpiwF" role="2Oq$k0">
+                  <ref role="3cqZAo" node="73FPRWNpfDH" resolve="contents" />
+                </node>
+                <node concept="v3k3i" id="73FPRWNpiwG" role="2OqNvi">
+                  <node concept="chp4Y" id="73FPRWNpiwH" role="v3oSu">
+                    <ref role="cht4Q" to="2c95:2TZO3Dbv6Ju" resolve="AbstractSection" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3zZkjj" id="73FPRWNpiwI" role="2OqNvi">
+                <node concept="1bVj0M" id="73FPRWNpiwJ" role="23t8la">
+                  <node concept="3clFbS" id="73FPRWNpiwK" role="1bW5cS">
+                    <node concept="3clFbF" id="73FPRWNpiwL" role="3cqZAp">
+                      <node concept="2OqwBi" id="73FPRWNpiwM" role="3clFbG">
+                        <node concept="37vLTw" id="73FPRWNpiwN" role="2Oq$k0">
+                          <ref role="3cqZAo" node="73FPRWNpiwP" resolve="it" />
+                        </node>
+                        <node concept="2qgKlT" id="73FPRWNpiwO" role="2OqNvi">
+                          <ref role="37wK5l" node="QRmqzHsFzm" resolve="isInIndex" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="Rh6nW" id="73FPRWNpiwP" role="1bW2Oz">
+                    <property role="TrG5h" value="it" />
+                    <node concept="2jxLKc" id="73FPRWNpiwQ" role="1tU5fm" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="73FPRWNph36" role="3cqZAp">
+          <node concept="2OqwBi" id="73FPRWNpiSJ" role="3clFbG">
+            <node concept="37vLTw" id="73FPRWNpiwR" role="2Oq$k0">
+              <ref role="3cqZAo" node="73FPRWNpiwC" resolve="entries" />
+            </node>
+            <node concept="3goQfb" id="73FPRWNpj4s" role="2OqNvi">
+              <node concept="1bVj0M" id="73FPRWNpj4u" role="23t8la">
+                <node concept="3clFbS" id="73FPRWNpj4v" role="1bW5cS">
+                  <node concept="3cpWs8" id="73FPRWNppDA" role="3cqZAp">
+                    <node concept="3cpWsn" id="73FPRWNppDB" role="3cpWs9">
+                      <property role="TrG5h" value="self" />
+                      <node concept="A3Dl8" id="73FPRWNppRL" role="1tU5fm">
+                        <node concept="3Tqbb2" id="73FPRWNppRN" role="A3Ik2">
+                          <ref role="ehGHo" to="2c95:2TZO3Dbv6Ju" resolve="AbstractSection" />
+                        </node>
+                      </node>
+                      <node concept="2ShNRf" id="73FPRWNppDC" role="33vP2m">
+                        <node concept="Tc6Ow" id="73FPRWNppDD" role="2ShVmc">
+                          <node concept="3Tqbb2" id="73FPRWNppDE" role="HW$YZ">
+                            <ref role="ehGHo" to="2c95:2TZO3Dbv6Ju" resolve="AbstractSection" />
+                          </node>
+                          <node concept="37vLTw" id="73FPRWNppDF" role="HW$Y0">
+                            <ref role="3cqZAo" node="73FPRWNpj4w" resolve="it" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbF" id="73FPRWNpkXS" role="3cqZAp">
+                    <node concept="2OqwBi" id="73FPRWNpqeq" role="3clFbG">
+                      <node concept="37vLTw" id="73FPRWNppDG" role="2Oq$k0">
+                        <ref role="3cqZAo" node="73FPRWNppDB" resolve="self" />
+                      </node>
+                      <node concept="3QWeyG" id="73FPRWNpqv3" role="2OqNvi">
+                        <node concept="BsUDl" id="73FPRWNpjYR" role="576Qk">
+                          <ref role="37wK5l" node="73FPRWNpfC6" resolve="getEntriesRec" />
+                          <node concept="2OqwBi" id="73FPRWNpk8w" role="37wK5m">
+                            <node concept="37vLTw" id="73FPRWNpk24" role="2Oq$k0">
+                              <ref role="3cqZAo" node="73FPRWNpj4w" resolve="it" />
+                            </node>
+                            <node concept="3Tsc0h" id="73FPRWNpke0" role="2OqNvi">
+                              <ref role="3TtcxE" to="2c95:2TZO3Dbv6JU" resolve="contents" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="Rh6nW" id="73FPRWNpj4w" role="1bW2Oz">
+                  <property role="TrG5h" value="it" />
+                  <node concept="2jxLKc" id="73FPRWNpj4x" role="1tU5fm" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="73FPRWNpfDH" role="3clF46">
+        <property role="TrG5h" value="contents" />
+        <node concept="A3Dl8" id="73FPRWNpfE7" role="1tU5fm">
+          <node concept="3Tqbb2" id="73FPRWNpfE8" role="A3Ik2">
+            <ref role="ehGHo" to="2c95:2TZO3DbuxwP" resolve="IDocumentContent" />
+          </node>
+        </node>
+      </node>
     </node>
   </node>
   <node concept="13h7C7" id="QRmqzHsCHv">

--- a/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/languageModels/editor.mps
+++ b/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/languageModels/editor.mps
@@ -12519,5 +12519,146 @@
     <ref role="aqKnT" to="2c95:5mf_X_LbOnj" resolve="CodeParagraph" />
     <node concept="22hDWj" id="27yO7ubx4ln" role="22hAXT" />
   </node>
+  <node concept="24kQdi" id="73FPRWNmwwH">
+    <property role="3GE5qa" value="structure" />
+    <ref role="1XX52x" to="2c95:QRmqzGVqHp" resolve="TableOfContents" />
+    <node concept="3EZMnI" id="73FPRWNmxIj" role="2wV5jI">
+      <node concept="3F0ifn" id="73FPRWNmxIl" role="3EZMnx">
+        <property role="3F0ifm" value="Table of Contents" />
+      </node>
+      <node concept="gc7cB" id="73FPRWNydVq" role="3EZMnx">
+        <node concept="3VJUX4" id="73FPRWNydVr" role="3YsKMw">
+          <node concept="3clFbS" id="73FPRWNydVs" role="2VODD2">
+            <node concept="3clFbF" id="73FPRWNydVR" role="3cqZAp">
+              <node concept="2ShNRf" id="73FPRWNydVS" role="3clFbG">
+                <node concept="1pGfFk" id="73FPRWNydVT" role="2ShVmc">
+                  <ref role="37wK5l" to="r4b4:3Dgh5aYiKso" resolve="HorizLineCell" />
+                  <node concept="pncrf" id="73FPRWNydVU" role="37wK5m" />
+                  <node concept="10M0yZ" id="73FPRWNydVV" role="37wK5m">
+                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                    <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
+                  </node>
+                  <node concept="3cmrfG" id="73FPRWNydVW" role="37wK5m">
+                    <property role="3cmrfH" value="2" />
+                  </node>
+                  <node concept="3cmrfG" id="73FPRWNyebA" role="37wK5m">
+                    <property role="3cmrfH" value="2" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2iRkQZ" id="73FPRWNmxIm" role="2iSdaV" />
+      <node concept="s8t4o" id="73FPRWNmxIt" role="3EZMnx">
+        <property role="28Zw97" value="true" />
+        <ref role="28F8cf" to="2c95:2TZO3Dbv6Ju" resolve="AbstractSection" />
+        <node concept="xShMh" id="73FPRWNmxIv" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+        <node concept="s8sZD" id="73FPRWNmxIw" role="sbcd9">
+          <node concept="3clFbS" id="73FPRWNmxIx" role="2VODD2">
+            <node concept="3clFbF" id="73FPRWNprUY" role="3cqZAp">
+              <node concept="2OqwBi" id="73FPRWNpsdD" role="3clFbG">
+                <node concept="pncrf" id="73FPRWNprUX" role="2Oq$k0" />
+                <node concept="2qgKlT" id="73FPRWNpsI7" role="2OqNvi">
+                  <ref role="37wK5l" to="4gky:73FPRWNpfg_" resolve="getEntriesFlat" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1yz3lS" id="73FPRWNmAdK" role="1yzFaX">
+          <node concept="3EZMnI" id="73FPRWNmAtB" role="2wV5jI">
+            <node concept="1HlG4h" id="73FPRWNs$UK" role="3EZMnx">
+              <node concept="1HfYo3" id="73FPRWNs$UM" role="1HlULh">
+                <node concept="3TQlhw" id="73FPRWNs$UO" role="1Hhtcw">
+                  <node concept="3clFbS" id="73FPRWNs$UQ" role="2VODD2">
+                    <node concept="3clFbF" id="73FPRWNs$VU" role="3cqZAp">
+                      <node concept="2OqwBi" id="73FPRWNs_3Q" role="3clFbG">
+                        <node concept="pncrf" id="73FPRWNs$VT" role="2Oq$k0" />
+                        <node concept="2qgKlT" id="73FPRWNs_9K" role="2OqNvi">
+                          <ref role="37wK5l" to="4gky:4vQSg$Aq5vD" resolve="nestingIndex" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3tD6jV" id="73FPRWNzplR" role="3F10Kt">
+                <ref role="3tD7wE" to="z0fb:vtaHb5XosV" resolve="_margin-left" />
+                <node concept="3sjG9q" id="73FPRWNzplS" role="3tD6jU">
+                  <node concept="3clFbS" id="73FPRWNzplT" role="2VODD2">
+                    <node concept="3clFbF" id="73FPRWNzpEB" role="3cqZAp">
+                      <node concept="17qRlL" id="73FPRWNzrBl" role="3clFbG">
+                        <node concept="3cmrfG" id="73FPRWNzrBo" role="3uHU7w">
+                          <property role="3cmrfH" value="20" />
+                        </node>
+                        <node concept="2OqwBi" id="73FPRWNzq70" role="3uHU7B">
+                          <node concept="pncrf" id="73FPRWNzpEA" role="2Oq$k0" />
+                          <node concept="2qgKlT" id="73FPRWNzqO0" role="2OqNvi">
+                            <ref role="37wK5l" to="4gky:4vQSg$AqJMN" resolve="nestingLevel" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="1HlG4h" id="73FPRWNmAtK" role="3EZMnx">
+              <node concept="1HfYo3" id="73FPRWNmAtM" role="1HlULh">
+                <node concept="3TQlhw" id="73FPRWNmAtO" role="1Hhtcw">
+                  <node concept="3clFbS" id="73FPRWNmAtQ" role="2VODD2">
+                    <node concept="3clFbF" id="73FPRWNmAyt" role="3cqZAp">
+                      <node concept="2OqwBi" id="73FPRWNmAR5" role="3clFbG">
+                        <node concept="pncrf" id="73FPRWNmAys" role="2Oq$k0" />
+                        <node concept="3TrcHB" id="73FPRWNpea0" role="2OqNvi">
+                          <ref role="3TsBF5" to="2c95:2TZO3Dbv6Jx" resolve="text" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="2iRfu4" id="73FPRWNmAtE" role="2iSdaV" />
+            <node concept="VPM3Z" id="73FPRWNmAtF" role="3F10Kt" />
+            <node concept="3tD6jV" id="73FPRWNwjgc" role="3F10Kt">
+              <ref role="3tD7wE" to="tj7y:ojedFZ7Qi6" resolve="hyperlink-node" />
+              <node concept="3sjG9q" id="73FPRWNwjge" role="3tD6jU">
+                <node concept="3clFbS" id="73FPRWNwjgf" role="2VODD2">
+                  <node concept="3clFbF" id="73FPRWNwjgg" role="3cqZAp">
+                    <node concept="pncrf" id="73FPRWNwjgh" role="3clFbG" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2iRkQZ" id="73FPRWNrBKv" role="2czzBy" />
+      </node>
+      <node concept="3F0ifn" id="73FPRWNz96q" role="3EZMnx" />
+    </node>
+    <node concept="3EZMnI" id="73FPRWNmwwJ" role="6VMZX">
+      <node concept="2iRkQZ" id="73FPRWNmwwK" role="2iSdaV" />
+      <node concept="3EZMnI" id="73FPRWNmwwL" role="3EZMnx">
+        <node concept="2iRfu4" id="73FPRWNmwwM" role="2iSdaV" />
+        <node concept="VPM3Z" id="73FPRWNmwwN" role="3F10Kt">
+          <property role="VOm3f" value="false" />
+        </node>
+        <node concept="3F0ifn" id="73FPRWNmwwO" role="3EZMnx">
+          <property role="3F0ifm" value="name:" />
+        </node>
+        <node concept="3F0A7n" id="73FPRWNmwwP" role="3EZMnx">
+          <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
+        </node>
+      </node>
+    </node>
+    <node concept="2aJ2om" id="73FPRWNmwwS" role="CpUAK">
+      <ref role="2$4xQ3" to="r4b4:7xesQBpJXuT" resolve="presentationMode" />
+    </node>
+  </node>
 </model>
 

--- a/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/languageModels/editor.mps
+++ b/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/languageModels/editor.mps
@@ -64,6 +64,7 @@
     <import index="emqf" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor.cellProviders(MPS.Editor/)" />
     <import index="18ew" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.util(MPS.Core/)" />
     <import index="22ra" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.update(MPS.Editor/)" implicit="true" />
+    <import index="lwvz" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.selection(MPS.Editor/)" implicit="true" />
   </imports>
   <registry>
     <language id="a247e09e-2435-45ba-b8d2-07e93feba96a" name="jetbrains.mps.baseLanguage.tuples">
@@ -441,6 +442,7 @@
       <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
       <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
       <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
+      <concept id="1225271283259" name="jetbrains.mps.baseLanguage.structure.NPEEqualsExpression" flags="nn" index="17R0WA" />
       <concept id="1225271408483" name="jetbrains.mps.baseLanguage.structure.IsNotEmptyOperation" flags="nn" index="17RvpY" />
       <concept id="1225271546410" name="jetbrains.mps.baseLanguage.structure.TrimOperation" flags="nn" index="17S1cR">
         <property id="1225271546413" name="trimKind" index="17S1cK" />
@@ -5592,169 +5594,6 @@
         </node>
       </node>
       <node concept="3EZMnI" id="4E5hYf5ZYOF" role="3EZMnx">
-        <node concept="3EZMnI" id="2QDtwSqD_bC" role="3EZMnx">
-          <node concept="2iRfu4" id="2QDtwSqD_bD" role="2iSdaV" />
-          <node concept="1HlG4h" id="4E5hYf5ZYOJ" role="3EZMnx">
-            <node concept="1HfYo3" id="4E5hYf5ZYOK" role="1HlULh">
-              <node concept="3TQlhw" id="4E5hYf5ZYOL" role="1Hhtcw">
-                <node concept="3clFbS" id="4E5hYf5ZYOM" role="2VODD2">
-                  <node concept="3clFbF" id="4E5hYf5ZYON" role="3cqZAp">
-                    <node concept="2OqwBi" id="4E5hYf5ZYOO" role="3clFbG">
-                      <node concept="pncrf" id="4E5hYf5ZYOP" role="2Oq$k0" />
-                      <node concept="2qgKlT" id="4E5hYf5ZYOQ" role="2OqNvi">
-                        <ref role="37wK5l" to="4gky:4vQSg$Aq5vD" resolve="nestingIndex" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="VPM3Z" id="4E5hYf5ZYOS" role="3F10Kt">
-              <property role="VOm3f" value="false" />
-            </node>
-            <node concept="VPxyj" id="4E5hYf5ZYOT" role="3F10Kt">
-              <property role="VOm3f" value="false" />
-            </node>
-            <node concept="Vb9p2" id="4E5hYf66U$5" role="3F10Kt">
-              <property role="Vbekb" value="g1_k_vY/BOLD" />
-            </node>
-            <node concept="VSNWy" id="4E5hYf66U$6" role="3F10Kt">
-              <node concept="1cFabM" id="4E5hYf66U$7" role="1d8cEk">
-                <node concept="3clFbS" id="4E5hYf66U$8" role="2VODD2">
-                  <node concept="3cpWs8" id="4E5hYf66U$9" role="3cqZAp">
-                    <node concept="3cpWsn" id="4E5hYf66U$a" role="3cpWs9">
-                      <property role="TrG5h" value="factor" />
-                      <node concept="10P55v" id="4E5hYf66U$b" role="1tU5fm" />
-                      <node concept="3cmrfG" id="4E5hYf66U$c" role="33vP2m">
-                        <property role="3cmrfH" value="1" />
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="3KaCP$" id="4E5hYf66U$d" role="3cqZAp">
-                    <node concept="3clFbS" id="4E5hYf66U$e" role="3Kb1Dw" />
-                    <node concept="2OqwBi" id="4E5hYf66U$f" role="3KbGdf">
-                      <node concept="pncrf" id="4E5hYf66U$g" role="2Oq$k0" />
-                      <node concept="2qgKlT" id="4E5hYf66U$h" role="2OqNvi">
-                        <ref role="37wK5l" to="4gky:4vQSg$AqJMN" resolve="nestingLevel" />
-                      </node>
-                    </node>
-                    <node concept="3KbdKl" id="4E5hYf66U$i" role="3KbHQx">
-                      <node concept="3cmrfG" id="4E5hYf66U$j" role="3Kbmr1">
-                        <property role="3cmrfH" value="0" />
-                      </node>
-                      <node concept="3clFbS" id="4E5hYf66U$k" role="3Kbo56">
-                        <node concept="3clFbF" id="4E5hYf66U$l" role="3cqZAp">
-                          <node concept="37vLTI" id="4E5hYf66U$m" role="3clFbG">
-                            <node concept="3b6qkQ" id="4E5hYf6i9Hl" role="37vLTx">
-                              <property role="$nhwW" value="1.6" />
-                            </node>
-                            <node concept="37vLTw" id="4E5hYf66U$o" role="37vLTJ">
-                              <ref role="3cqZAo" node="4E5hYf66U$a" resolve="factor" />
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="3zACq4" id="4E5hYf66U$p" role="3cqZAp" />
-                      </node>
-                    </node>
-                    <node concept="3KbdKl" id="4E5hYf66U$q" role="3KbHQx">
-                      <node concept="3cmrfG" id="4E5hYf66U$r" role="3Kbmr1">
-                        <property role="3cmrfH" value="1" />
-                      </node>
-                      <node concept="3clFbS" id="4E5hYf66U$s" role="3Kbo56">
-                        <node concept="3clFbF" id="4E5hYf66U$t" role="3cqZAp">
-                          <node concept="37vLTI" id="4E5hYf66U$u" role="3clFbG">
-                            <node concept="3b6qkQ" id="4E5hYf66U$v" role="37vLTx">
-                              <property role="$nhwW" value="1.4" />
-                            </node>
-                            <node concept="37vLTw" id="4E5hYf66U$w" role="37vLTJ">
-                              <ref role="3cqZAo" node="4E5hYf66U$a" resolve="factor" />
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="3zACq4" id="4E5hYf66U$x" role="3cqZAp" />
-                      </node>
-                    </node>
-                    <node concept="3KbdKl" id="4E5hYf66U$y" role="3KbHQx">
-                      <node concept="3cmrfG" id="4E5hYf66U$z" role="3Kbmr1">
-                        <property role="3cmrfH" value="2" />
-                      </node>
-                      <node concept="3clFbS" id="4E5hYf66U$$" role="3Kbo56">
-                        <node concept="3clFbF" id="4E5hYf66U$_" role="3cqZAp">
-                          <node concept="37vLTI" id="4E5hYf66U$A" role="3clFbG">
-                            <node concept="3b6qkQ" id="4E5hYf66U$B" role="37vLTx">
-                              <property role="$nhwW" value="1.2" />
-                            </node>
-                            <node concept="37vLTw" id="4E5hYf66U$C" role="37vLTJ">
-                              <ref role="3cqZAo" node="4E5hYf66U$a" resolve="factor" />
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="3zACq4" id="4E5hYf66U$D" role="3cqZAp" />
-                      </node>
-                    </node>
-                    <node concept="3KbdKl" id="4E5hYf66U$E" role="3KbHQx">
-                      <node concept="3cmrfG" id="4E5hYf66U$F" role="3Kbmr1">
-                        <property role="3cmrfH" value="3" />
-                      </node>
-                      <node concept="3clFbS" id="4E5hYf66U$G" role="3Kbo56">
-                        <node concept="3clFbF" id="4E5hYf66U$H" role="3cqZAp">
-                          <node concept="37vLTI" id="4E5hYf66U$I" role="3clFbG">
-                            <node concept="3b6qkQ" id="4E5hYf66U$J" role="37vLTx">
-                              <property role="$nhwW" value="1.2" />
-                            </node>
-                            <node concept="37vLTw" id="4E5hYf66U$K" role="37vLTJ">
-                              <ref role="3cqZAo" node="4E5hYf66U$a" resolve="factor" />
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="3zACq4" id="4E5hYf66U$L" role="3cqZAp" />
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="3clFbF" id="4E5hYf66U$M" role="3cqZAp">
-                    <node concept="1eOMI4" id="4E5hYf66U$N" role="3clFbG">
-                      <node concept="10QFUN" id="4E5hYf66U$O" role="1eOMHV">
-                        <node concept="1eOMI4" id="4E5hYf66U$P" role="10QFUP">
-                          <node concept="17qRlL" id="4E5hYf66U$Q" role="1eOMHV">
-                            <node concept="37vLTw" id="4E5hYf66U$R" role="3uHU7w">
-                              <ref role="3cqZAo" node="4E5hYf66U$a" resolve="factor" />
-                            </node>
-                            <node concept="2OqwBi" id="4E5hYf66U$S" role="3uHU7B">
-                              <node concept="2YIFZM" id="4E5hYf66U$T" role="2Oq$k0">
-                                <ref role="1Pybhc" to="exr9:~EditorSettings" resolve="EditorSettings" />
-                                <ref role="37wK5l" to="exr9:~EditorSettings.getInstance()" resolve="getInstance" />
-                              </node>
-                              <node concept="liA8E" id="4E5hYf66U$U" role="2OqNvi">
-                                <ref role="37wK5l" to="exr9:~EditorSettings.getFontSize()" resolve="getFontSize" />
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="10Oyi0" id="4E5hYf66U$V" role="10QFUM" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="3XFhqQ" id="4E5hYf68T4f" role="3EZMnx" />
-          <node concept="pkWqt" id="2QDtwSqDA5V" role="pqm2j">
-            <node concept="3clFbS" id="2QDtwSqDA5W" role="2VODD2">
-              <node concept="3clFbF" id="2QDtwSqDAcc" role="3cqZAp">
-                <node concept="2OqwBi" id="2QDtwSqDAkU" role="3clFbG">
-                  <node concept="2OqwBi" id="2QDtwSqDAcd" role="2Oq$k0">
-                    <node concept="pncrf" id="2QDtwSqDAce" role="2Oq$k0" />
-                    <node concept="2qgKlT" id="2QDtwSqDAcf" role="2OqNvi">
-                      <ref role="37wK5l" to="4gky:4vQSg$Aq5vD" resolve="nestingIndex" />
-                    </node>
-                  </node>
-                  <node concept="17RvpY" id="2QDtwSqDAyG" role="2OqNvi" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
         <node concept="l2Vlx" id="4E5hYf5ZYOG" role="2iSdaV" />
         <node concept="3F0A7n" id="4E5hYf5ZYOZ" role="3EZMnx">
           <ref role="1NtTu8" to="2c95:2TZO3Dbv6Jx" resolve="text" />
@@ -12570,35 +12409,151 @@
           </node>
         </node>
         <node concept="1yz3lS" id="73FPRWNmAdK" role="1yzFaX">
-          <node concept="3EZMnI" id="73FPRWNmAtB" role="2wV5jI">
-            <node concept="1HlG4h" id="73FPRWNs$UK" role="3EZMnx">
-              <node concept="1HfYo3" id="73FPRWNs$UM" role="1HlULh">
-                <node concept="3TQlhw" id="73FPRWNs$UO" role="1Hhtcw">
-                  <node concept="3clFbS" id="73FPRWNs$UQ" role="2VODD2">
-                    <node concept="3clFbF" id="73FPRWNs$VU" role="3cqZAp">
-                      <node concept="2OqwBi" id="73FPRWNs_3Q" role="3clFbG">
-                        <node concept="pncrf" id="73FPRWNs$VT" role="2Oq$k0" />
-                        <node concept="2qgKlT" id="73FPRWNs_9K" role="2OqNvi">
-                          <ref role="37wK5l" to="4gky:4vQSg$Aq5vD" resolve="nestingIndex" />
+          <node concept="gc7cB" id="4RNNpFeNiYC" role="2wV5jI">
+            <node concept="3tD6jV" id="73FPRWNzplR" role="3F10Kt">
+              <ref role="3tD7wE" to="z0fb:vtaHb5XosV" resolve="_margin-left" />
+              <node concept="3sjG9q" id="73FPRWNzplS" role="3tD6jU">
+                <node concept="3clFbS" id="73FPRWNzplT" role="2VODD2">
+                  <node concept="3clFbF" id="73FPRWNzpEB" role="3cqZAp">
+                    <node concept="17qRlL" id="73FPRWNzrBl" role="3clFbG">
+                      <node concept="3cmrfG" id="73FPRWNzrBo" role="3uHU7w">
+                        <property role="3cmrfH" value="20" />
+                      </node>
+                      <node concept="2OqwBi" id="73FPRWNzq70" role="3uHU7B">
+                        <node concept="pncrf" id="73FPRWNzpEA" role="2Oq$k0" />
+                        <node concept="2qgKlT" id="73FPRWNzqO0" role="2OqNvi">
+                          <ref role="37wK5l" to="4gky:4vQSg$AqJMN" resolve="nestingLevel" />
                         </node>
                       </node>
                     </node>
                   </node>
                 </node>
               </node>
-              <node concept="3tD6jV" id="73FPRWNzplR" role="3F10Kt">
-                <ref role="3tD7wE" to="z0fb:vtaHb5XosV" resolve="_margin-left" />
-                <node concept="3sjG9q" id="73FPRWNzplS" role="3tD6jU">
-                  <node concept="3clFbS" id="73FPRWNzplT" role="2VODD2">
-                    <node concept="3clFbF" id="73FPRWNzpEB" role="3cqZAp">
-                      <node concept="17qRlL" id="73FPRWNzrBl" role="3clFbG">
-                        <node concept="3cmrfG" id="73FPRWNzrBo" role="3uHU7w">
-                          <property role="3cmrfH" value="20" />
-                        </node>
-                        <node concept="2OqwBi" id="73FPRWNzq70" role="3uHU7B">
-                          <node concept="pncrf" id="73FPRWNzpEA" role="2Oq$k0" />
-                          <node concept="2qgKlT" id="73FPRWNzqO0" role="2OqNvi">
-                            <ref role="37wK5l" to="4gky:4vQSg$AqJMN" resolve="nestingLevel" />
+            </node>
+            <node concept="Vb9p2" id="4RNNpFf1GsM" role="3F10Kt" />
+            <node concept="VPM3Z" id="4RNNpFf4yJY" role="3F10Kt" />
+            <node concept="xShMh" id="4RNNpFf4zUk" role="3F10Kt">
+              <property role="VOm3f" value="true" />
+            </node>
+            <node concept="3tD6jV" id="4RNNpFe8FYO" role="3F10Kt">
+              <ref role="3tD7wE" to="tj7y:5A_Zlt6qyoK" resolve="hyperlink-handler" />
+              <node concept="3sjG9q" id="4RNNpFe8FYQ" role="3tD6jU">
+                <node concept="3clFbS" id="4RNNpFe8FYR" role="2VODD2">
+                  <node concept="3clFbF" id="4RNNpFe8Gmk" role="3cqZAp">
+                    <node concept="2ShNRf" id="4RNNpFe8Gme" role="3clFbG">
+                      <node concept="YeOm9" id="4RNNpFe8Hfk" role="2ShVmc">
+                        <node concept="1Y3b0j" id="4RNNpFe8Hfn" role="YeSDq">
+                          <property role="2bfB8j" value="true" />
+                          <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
+                          <ref role="1Y3XeK" to="ag3p:5A_Zlt6xR6d" resolve="HyperlinkHandler" />
+                          <node concept="3Tm1VV" id="4RNNpFe8Hfo" role="1B3o_S" />
+                          <node concept="3clFb_" id="4RNNpFe8Hft" role="jymVt">
+                            <property role="TrG5h" value="open" />
+                            <node concept="3cqZAl" id="4RNNpFe8Hfu" role="3clF45" />
+                            <node concept="3Tm1VV" id="4RNNpFe8Hfv" role="1B3o_S" />
+                            <node concept="37vLTG" id="4RNNpFe8Hfx" role="3clF46">
+                              <property role="TrG5h" value="util" />
+                              <node concept="3uibUv" id="4RNNpFe8Hfy" role="1tU5fm">
+                                <ref role="3uigEE" to="ag3p:5A_Zlt6xR7j" resolve="HyperlinkUtil" />
+                              </node>
+                            </node>
+                            <node concept="3clFbS" id="4RNNpFe8Hfz" role="3clF47">
+                              <node concept="3cpWs8" id="4RNNpFe8MAM" role="3cqZAp">
+                                <node concept="3cpWsn" id="4RNNpFe8MAN" role="3cpWs9">
+                                  <property role="TrG5h" value="root" />
+                                  <node concept="3uibUv" id="4RNNpFe8M_M" role="1tU5fm">
+                                    <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
+                                  </node>
+                                  <node concept="2OqwBi" id="4RNNpFe8MAO" role="33vP2m">
+                                    <node concept="2OqwBi" id="4RNNpFe8MAP" role="2Oq$k0">
+                                      <node concept="1Q80Hx" id="4RNNpFe8MAQ" role="2Oq$k0" />
+                                      <node concept="liA8E" id="4RNNpFe8MAR" role="2OqNvi">
+                                        <ref role="37wK5l" to="cj4x:~EditorContext.getEditorComponent()" resolve="getEditorComponent" />
+                                      </node>
+                                    </node>
+                                    <node concept="liA8E" id="4RNNpFe8MAS" role="2OqNvi">
+                                      <ref role="37wK5l" to="cj4x:~EditorComponent.getRootCell()" resolve="getRootCell" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                              <node concept="3cpWs8" id="4RNNpFe9oDy" role="3cqZAp">
+                                <node concept="3cpWsn" id="4RNNpFe9oDz" role="3cpWs9">
+                                  <property role="TrG5h" value="toSelect" />
+                                  <node concept="3uibUv" id="4RNNpFe9o_L" role="1tU5fm">
+                                    <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
+                                  </node>
+                                  <node concept="2YIFZM" id="4RNNpFe9oD$" role="33vP2m">
+                                    <ref role="37wK5l" to="g51k:~CellFinderUtil.findChildByCondition(jetbrains.mps.openapi.editor.cells.EditorCell,org.jetbrains.mps.util.Condition,boolean)" resolve="findChildByCondition" />
+                                    <ref role="1Pybhc" to="g51k:~CellFinderUtil" resolve="CellFinderUtil" />
+                                    <node concept="37vLTw" id="4RNNpFe9oD_" role="37wK5m">
+                                      <ref role="3cqZAo" node="4RNNpFe8MAN" resolve="root" />
+                                    </node>
+                                    <node concept="1bVj0M" id="4RNNpFe9oDA" role="37wK5m">
+                                      <node concept="3clFbS" id="4RNNpFe9oDB" role="1bW5cS">
+                                        <node concept="3cpWs6" id="4RNNpFe9oDC" role="3cqZAp">
+                                          <node concept="17R0WA" id="4RNNpFe9oDD" role="3cqZAk">
+                                            <node concept="2OqwBi" id="4RNNpFe9oDF" role="3uHU7B">
+                                              <node concept="37vLTw" id="4RNNpFe9oDG" role="2Oq$k0">
+                                                <ref role="3cqZAo" node="4RNNpFe9oDI" resolve="cell" />
+                                              </node>
+                                              <node concept="liA8E" id="4RNNpFe9oDH" role="2OqNvi">
+                                                <ref role="37wK5l" to="f4zo:~EditorCell.getSNode()" resolve="getSNode" />
+                                              </node>
+                                            </node>
+                                            <node concept="pncrf" id="4RNNpFeykLb" role="3uHU7w" />
+                                          </node>
+                                        </node>
+                                      </node>
+                                      <node concept="37vLTG" id="4RNNpFe9oDI" role="1bW2Oz">
+                                        <property role="TrG5h" value="cell" />
+                                        <node concept="3uibUv" id="4RNNpFe9oDJ" role="1tU5fm">
+                                          <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
+                                        </node>
+                                      </node>
+                                    </node>
+                                    <node concept="3clFbT" id="4RNNpFe9oDK" role="37wK5m">
+                                      <property role="3clFbU" value="true" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                              <node concept="3clFbF" id="4RNNpFe9pMo" role="3cqZAp">
+                                <node concept="2OqwBi" id="4RNNpFe9qsX" role="3clFbG">
+                                  <node concept="2OqwBi" id="4RNNpFe9q9$" role="2Oq$k0">
+                                    <node concept="1Q80Hx" id="4RNNpFe9pMn" role="2Oq$k0" />
+                                    <node concept="liA8E" id="4RNNpFe9qnf" role="2OqNvi">
+                                      <ref role="37wK5l" to="cj4x:~EditorContext.getSelectionManager()" resolve="getSelectionManager" />
+                                    </node>
+                                  </node>
+                                  <node concept="liA8E" id="4RNNpFe9qE1" role="2OqNvi">
+                                    <ref role="37wK5l" to="lwvz:~SelectionManager.setSelection(jetbrains.mps.openapi.editor.cells.EditorCell)" resolve="setSelection" />
+                                    <node concept="37vLTw" id="4RNNpFe9qPw" role="37wK5m">
+                                      <ref role="3cqZAo" node="4RNNpFe9oDz" resolve="toSelect" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                              <node concept="3clFbF" id="4RNNpFeYSMz" role="3cqZAp">
+                                <node concept="2OqwBi" id="4RNNpFeYW8S" role="3clFbG">
+                                  <node concept="2OqwBi" id="4RNNpFeYTtz" role="2Oq$k0">
+                                    <node concept="1Q80Hx" id="4RNNpFeYSMA" role="2Oq$k0" />
+                                    <node concept="liA8E" id="4RNNpFeYW3a" role="2OqNvi">
+                                      <ref role="37wK5l" to="cj4x:~EditorContext.getEditorComponent()" resolve="getEditorComponent" />
+                                    </node>
+                                  </node>
+                                  <node concept="liA8E" id="4RNNpFeYWnO" role="2OqNvi">
+                                    <ref role="37wK5l" to="cj4x:~EditorComponent.scrollToCell(jetbrains.mps.openapi.editor.cells.EditorCell)" resolve="scrollToCell" />
+                                    <node concept="37vLTw" id="4RNNpFeYWIL" role="37wK5m">
+                                      <ref role="3cqZAo" node="4RNNpFe9oDz" resolve="toSelect" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="2AHcQZ" id="4RNNpFe8Hf_" role="2AJF6D">
+                              <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                            </node>
                           </node>
                         </node>
                       </node>
@@ -12607,30 +12562,87 @@
                 </node>
               </node>
             </node>
-            <node concept="1HlG4h" id="73FPRWNmAtK" role="3EZMnx">
-              <node concept="1HfYo3" id="73FPRWNmAtM" role="1HlULh">
-                <node concept="3TQlhw" id="73FPRWNmAtO" role="1Hhtcw">
-                  <node concept="3clFbS" id="73FPRWNmAtQ" role="2VODD2">
-                    <node concept="3clFbF" id="73FPRWNmAyt" role="3cqZAp">
-                      <node concept="2OqwBi" id="73FPRWNmAR5" role="3clFbG">
-                        <node concept="pncrf" id="73FPRWNmAys" role="2Oq$k0" />
-                        <node concept="3TrcHB" id="73FPRWNpea0" role="2OqNvi">
-                          <ref role="3TsBF5" to="2c95:2TZO3Dbv6Jx" resolve="text" />
+            <node concept="3VJUX4" id="4RNNpFeNiYE" role="3YsKMw">
+              <node concept="3clFbS" id="4RNNpFeNiYG" role="2VODD2">
+                <node concept="3clFbF" id="4RNNpFeQyJ6" role="3cqZAp">
+                  <node concept="2ShNRf" id="4RNNpFeQyJ2" role="3clFbG">
+                    <node concept="YeOm9" id="4RNNpFeQzBW" role="2ShVmc">
+                      <node concept="1Y3b0j" id="4RNNpFeQzBZ" role="YeSDq">
+                        <property role="2bfB8j" value="true" />
+                        <ref role="37wK5l" to="exr9:~AbstractCellProvider.&lt;init&gt;(org.jetbrains.mps.openapi.model.SNode)" resolve="AbstractCellProvider" />
+                        <ref role="1Y3XeK" to="exr9:~AbstractCellProvider" resolve="AbstractCellProvider" />
+                        <node concept="3Tm1VV" id="4RNNpFeQzC0" role="1B3o_S" />
+                        <node concept="3clFb_" id="4RNNpFeQzC3" role="jymVt">
+                          <property role="TrG5h" value="createEditorCell" />
+                          <node concept="3Tm1VV" id="4RNNpFeQzC4" role="1B3o_S" />
+                          <node concept="3uibUv" id="4RNNpFeQzC6" role="3clF45">
+                            <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
+                          </node>
+                          <node concept="37vLTG" id="4RNNpFeQzC7" role="3clF46">
+                            <property role="TrG5h" value="p1" />
+                            <node concept="3uibUv" id="4RNNpFeQzC8" role="1tU5fm">
+                              <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
+                            </node>
+                          </node>
+                          <node concept="3clFbS" id="4RNNpFeQzC9" role="3clF47">
+                            <node concept="3cpWs8" id="4RNNpFeTkRR" role="3cqZAp">
+                              <node concept="3cpWsn" id="4RNNpFeTkRS" role="3cpWs9">
+                                <property role="TrG5h" value="text" />
+                                <node concept="17QB3L" id="4RNNpFeTkn2" role="1tU5fm" />
+                                <node concept="3cpWs3" id="4RNNpFeTl7B" role="33vP2m">
+                                  <node concept="Xl_RD" id="4RNNpFeTmB6" role="3uHU7B">
+                                    <property role="Xl_RC" value="• " />
+                                  </node>
+                                  <node concept="2OqwBi" id="4RNNpFeTkRT" role="3uHU7w">
+                                    <node concept="pncrf" id="4RNNpFeTkRU" role="2Oq$k0" />
+                                    <node concept="3TrcHB" id="4RNNpFeTkRV" role="2OqNvi">
+                                      <ref role="3TsBF5" to="2c95:2TZO3Dbv6Jx" resolve="text" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="3clFbF" id="4RNNpFeNk8w" role="3cqZAp">
+                              <node concept="2ShNRf" id="4RNNpFeNk8u" role="3clFbG">
+                                <node concept="YeOm9" id="4RNNpFeW81B" role="2ShVmc">
+                                  <node concept="1Y3b0j" id="4RNNpFeW81E" role="YeSDq">
+                                    <property role="2bfB8j" value="true" />
+                                    <ref role="37wK5l" to="g51k:~EditorCell_Constant.&lt;init&gt;(jetbrains.mps.openapi.editor.EditorContext,org.jetbrains.mps.openapi.model.SNode,java.lang.String,boolean)" resolve="EditorCell_Constant" />
+                                    <ref role="1Y3XeK" to="g51k:~EditorCell_Constant" resolve="EditorCell_Constant" />
+                                    <node concept="3Tm1VV" id="4RNNpFeW81F" role="1B3o_S" />
+                                    <node concept="1Q80Hx" id="4RNNpFeQwzh" role="37wK5m" />
+                                    <node concept="pncrf" id="4RNNpFeQxAu" role="37wK5m" />
+                                    <node concept="37vLTw" id="4RNNpFeTkRW" role="37wK5m">
+                                      <ref role="3cqZAo" node="4RNNpFeTkRS" resolve="text" />
+                                    </node>
+                                    <node concept="3clFbT" id="4RNNpFeQyw4" role="37wK5m" />
+                                    <node concept="3clFb_" id="4RNNpFeW8eI" role="jymVt">
+                                      <property role="TrG5h" value="getSNode" />
+                                      <node concept="3Tm1VV" id="4RNNpFeW8eJ" role="1B3o_S" />
+                                      <node concept="3uibUv" id="4RNNpFeW8eL" role="3clF45">
+                                        <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
+                                      </node>
+                                      <node concept="3clFbS" id="4RNNpFeW8eT" role="3clF47">
+                                        <node concept="3cpWs6" id="4RNNpFeW9Av" role="3cqZAp">
+                                          <node concept="10Nm6u" id="4RNNpFeW9Ax" role="3cqZAk" />
+                                        </node>
+                                      </node>
+                                      <node concept="2AHcQZ" id="4RNNpFeW8eU" role="2AJF6D">
+                                        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="2AHcQZ" id="4RNNpFeQzCb" role="2AJF6D">
+                            <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                          </node>
                         </node>
+                        <node concept="pncrf" id="4RNNpFeQ$Jt" role="37wK5m" />
                       </node>
                     </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="2iRfu4" id="73FPRWNmAtE" role="2iSdaV" />
-            <node concept="VPM3Z" id="73FPRWNmAtF" role="3F10Kt" />
-            <node concept="3tD6jV" id="73FPRWNwjgc" role="3F10Kt">
-              <ref role="3tD7wE" to="tj7y:ojedFZ7Qi6" resolve="hyperlink-node" />
-              <node concept="3sjG9q" id="73FPRWNwjge" role="3tD6jU">
-                <node concept="3clFbS" id="73FPRWNwjgf" role="2VODD2">
-                  <node concept="3clFbF" id="73FPRWNwjgg" role="3cqZAp">
-                    <node concept="pncrf" id="73FPRWNwjgh" role="3clFbG" />
                   </node>
                 </node>
               </node>


### PR DESCRIPTION
In presentation mode, a table-of-contents in an mbeddr.doc document is just a constant string "table of contents". With this PR, it is an actual table of contents list, with clickable links.

Example ([node URL](http://127.0.0.1:63320/node?ref=r%3Ae178f830-5ea3-43a6-9d0d-4469b64bfbe8%28com.mbeddr.doc.markdown.sandbox.doc2markdown%29%2F603951059624405033)):
<img width="669" alt="image" src="https://user-images.githubusercontent.com/1193045/133066094-192e4cd3-17a9-4476-bb47-4c3e4a114446.png">

This closes issue #2187.