### PR TITLE
mbeddr.doc: Fix ToC link clashes and image file name clashes

### DIFF
--- a/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/generator/template/com/mbeddr/doc/generator/template/main@generator.mps
+++ b/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/generator/template/com/mbeddr/doc/generator/template/main@generator.mps
@@ -967,9 +967,6 @@
         </node>
       </node>
     </node>
-    <node concept="1puMqW" id="6jiGbW_aM$5" role="1puA0r">
-      <ref role="1puQsG" node="6jiGbW_aM4A" resolve="putStableIds" />
-    </node>
     <node concept="3aamgX" id="2CRkjeiosub" role="3acgRq">
       <ref role="30HIoZ" to="2c95:5mf_X_Lbqjw" resolve="DocumentInclude" />
       <node concept="gft3U" id="2CRkjeiouEH" role="1lVwrX">
@@ -1062,6 +1059,9 @@
     </node>
     <node concept="1puMqW" id="6NmtaR2ruMf" role="1pvy6N">
       <ref role="1puQsG" node="6NmtaR2qzDb" resolve="resolveRemainingIncludes" />
+    </node>
+    <node concept="1puMqW" id="73FPRWNVhPt" role="1pvy6N">
+      <ref role="1puQsG" node="6jiGbW_aM4A" resolve="putStableIds" />
     </node>
   </node>
   <node concept="1pmfR0" id="2fGuOSYbJJ$">
@@ -2190,7 +2190,6 @@
   </node>
   <node concept="1pmfR0" id="6jiGbW_aM4A">
     <property role="TrG5h" value="putStableIds" />
-    <property role="1v3f2W" value="hpv1Zf2/pre_processing" />
     <node concept="1pplIY" id="6jiGbW_aM4B" role="1pqMTA">
       <node concept="3clFbS" id="6jiGbW_aM4C" role="2VODD2">
         <node concept="3clFbF" id="6jiGbW_aMAz" role="3cqZAp">
@@ -2209,13 +2208,13 @@
                       <ref role="37wK5l" to="4gky:6jiGbW_zIRh" resolve="setStableId" />
                       <ref role="1Pybhc" to="4gky:6jiGbW_zIPK" resolve="StableIdHelper" />
                       <node concept="37vLTw" id="6jiGbW_zLuL" role="37wK5m">
-                        <ref role="3cqZAo" node="6jiGbW_aSUm" resolve="section" />
+                        <ref role="3cqZAo" node="6jiGbW_aSUm" resolve="it" />
                       </node>
                     </node>
                   </node>
                 </node>
                 <node concept="Rh6nW" id="6jiGbW_aSUm" role="1bW2Oz">
-                  <property role="TrG5h" value="section" />
+                  <property role="TrG5h" value="it" />
                   <node concept="2jxLKc" id="6jiGbW_aSUn" role="1tU5fm" />
                 </node>
               </node>

--- a/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/languageModels/behavior.mps
+++ b/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/languageModels/behavior.mps
@@ -7813,30 +7813,79 @@
           </node>
           <node concept="9aQIb" id="6jiGbW_aKR7" role="9aQIa">
             <node concept="3clFbS" id="6jiGbW_aKR8" role="9aQI4">
-              <node concept="3cpWs6" id="6jiGbW_zIrR" role="3cqZAp">
-                <node concept="3cpWs3" id="6jiGbW_JB$y" role="3cqZAk">
-                  <node concept="37vLTw" id="6jiGbW_JBC_" role="3uHU7B">
-                    <ref role="3cqZAo" node="6jiGbW_JBxg" resolve="STABLE_ID_PREFIX" />
+              <node concept="3SKdUt" id="73FPRWNYFiD" role="3cqZAp">
+                <node concept="1PaTwC" id="73FPRWNYFiE" role="1aUNEU">
+                  <node concept="3oM_SD" id="73FPRWNYFiF" role="1PaTwD">
+                    <property role="3oM_SC" value="create" />
                   </node>
-                  <node concept="2YIFZM" id="6jiGbW_zIrT" role="3uHU7w">
-                    <ref role="1Pybhc" to="btm1:~StringUtils" resolve="StringUtils" />
-                    <ref role="37wK5l" to="btm1:~StringUtils.deleteWhitespace(java.lang.String)" resolve="deleteWhitespace" />
-                    <node concept="2OqwBi" id="6jiGbW_zIrU" role="37wK5m">
-                      <node concept="2OqwBi" id="6jiGbW_zIrV" role="2Oq$k0">
-                        <node concept="2JrnkZ" id="6jiGbW_zIrW" role="2Oq$k0">
-                          <node concept="37vLTw" id="6jiGbW_zJws" role="2JrQYb">
-                            <ref role="3cqZAo" node="6jiGbW_zIQs" resolve="n" />
-                          </node>
-                        </node>
-                        <node concept="liA8E" id="6jiGbW_zIrY" role="2OqNvi">
-                          <ref role="37wK5l" to="mhbf:~SNode.getNodeId()" resolve="getNodeId" />
-                        </node>
-                      </node>
-                      <node concept="liA8E" id="6jiGbW_zIrZ" role="2OqNvi">
-                        <ref role="37wK5l" to="wyt6:~Object.toString()" resolve="toString" />
+                  <node concept="3oM_SD" id="73FPRWNYFm6" role="1PaTwD">
+                    <property role="3oM_SC" value="a" />
+                  </node>
+                  <node concept="3oM_SD" id="73FPRWNYFnb" role="1PaTwD">
+                    <property role="3oM_SC" value="stableId" />
+                  </node>
+                  <node concept="3oM_SD" id="73FPRWNYFnq" role="1PaTwD">
+                    <property role="3oM_SC" value="on" />
+                  </node>
+                  <node concept="3oM_SD" id="73FPRWNYFnF" role="1PaTwD">
+                    <property role="3oM_SC" value="demand" />
+                  </node>
+                  <node concept="3oM_SD" id="73FPRWNYFnY" role="1PaTwD">
+                    <property role="3oM_SC" value="and" />
+                  </node>
+                  <node concept="3oM_SD" id="73FPRWNYFoj" role="1PaTwD">
+                    <property role="3oM_SC" value="store" />
+                  </node>
+                  <node concept="3oM_SD" id="73FPRWNYFoE" role="1PaTwD">
+                    <property role="3oM_SC" value="it" />
+                  </node>
+                  <node concept="3oM_SD" id="73FPRWNYFoV" role="1PaTwD">
+                    <property role="3oM_SC" value="for" />
+                  </node>
+                  <node concept="3oM_SD" id="73FPRWNYFpe" role="1PaTwD">
+                    <property role="3oM_SC" value="next" />
+                  </node>
+                  <node concept="3oM_SD" id="73FPRWNYFpz" role="1PaTwD">
+                    <property role="3oM_SC" value="time" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3cpWs8" id="73FPRWNYESw" role="3cqZAp">
+                <node concept="3cpWsn" id="73FPRWNYESx" role="3cpWs9">
+                  <property role="TrG5h" value="newStableId" />
+                  <node concept="17QB3L" id="73FPRWNYEFN" role="1tU5fm" />
+                  <node concept="1rXfSq" id="73FPRWNYESy" role="33vP2m">
+                    <ref role="37wK5l" node="73FPRWNYEdD" resolve="computeStableId" />
+                    <node concept="37vLTw" id="73FPRWNYESz" role="37wK5m">
+                      <ref role="3cqZAo" node="6jiGbW_zIQs" resolve="n" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbF" id="73FPRWNYFqb" role="3cqZAp">
+                <node concept="2OqwBi" id="73FPRWNYFqc" role="3clFbG">
+                  <node concept="2JrnkZ" id="73FPRWNYFqd" role="2Oq$k0">
+                    <node concept="37vLTw" id="73FPRWNYFqe" role="2JrQYb">
+                      <ref role="3cqZAo" node="6jiGbW_zIQs" resolve="n" />
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="73FPRWNYFqf" role="2OqNvi">
+                    <ref role="37wK5l" to="mhbf:~SNode.putUserObject(java.lang.Object,java.lang.Object)" resolve="putUserObject" />
+                    <node concept="37vLTw" id="73FPRWNYFqn" role="37wK5m">
+                      <ref role="3cqZAo" node="6jiGbW_zIT$" resolve="USER_OBJECT_KEY" />
+                    </node>
+                    <node concept="1rXfSq" id="73FPRWNYFqg" role="37wK5m">
+                      <ref role="37wK5l" node="73FPRWNYEdD" resolve="computeStableId" />
+                      <node concept="37vLTw" id="73FPRWNYFqh" role="37wK5m">
+                        <ref role="3cqZAo" node="6jiGbW_zIQs" resolve="n" />
                       </node>
                     </node>
                   </node>
+                </node>
+              </node>
+              <node concept="3cpWs6" id="6jiGbW_zIrR" role="3cqZAp">
+                <node concept="37vLTw" id="73FPRWNYES$" role="3cqZAk">
+                  <ref role="3cqZAo" node="73FPRWNYESx" resolve="newStableId" />
                 </node>
               </node>
             </node>
@@ -7850,6 +7899,7 @@
         <node concept="3Tqbb2" id="6jiGbW_zIQr" role="1tU5fm" />
       </node>
     </node>
+    <node concept="2tJIrI" id="73FPRWNYEj7" role="jymVt" />
     <node concept="2YIFZL" id="6jiGbW_zIRh" role="jymVt">
       <property role="TrG5h" value="setStableId" />
       <property role="od$2w" value="false" />
@@ -7868,9 +7918,9 @@
               <node concept="37vLTw" id="6jiGbW_zK6c" role="37wK5m">
                 <ref role="3cqZAo" node="6jiGbW_zIT$" resolve="USER_OBJECT_KEY" />
               </node>
-              <node concept="1rXfSq" id="6jiGbW_zK8p" role="37wK5m">
-                <ref role="37wK5l" node="6jiGbW_zIQb" resolve="getStableId" />
-                <node concept="37vLTw" id="6jiGbW_zK9H" role="37wK5m">
+              <node concept="1rXfSq" id="73FPRWNYELD" role="37wK5m">
+                <ref role="37wK5l" node="73FPRWNYEdD" resolve="computeStableId" />
+                <node concept="37vLTw" id="73FPRWNYEOx" role="37wK5m">
                   <ref role="3cqZAo" node="6jiGbW_zIRI" resolve="n" />
                 </node>
               </node>
@@ -7883,6 +7933,44 @@
       <node concept="37vLTG" id="6jiGbW_zIRI" role="3clF46">
         <property role="TrG5h" value="n" />
         <node concept="3Tqbb2" id="6jiGbW_zIRH" role="1tU5fm" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="73FPRWNYE3w" role="jymVt" />
+    <node concept="2YIFZL" id="73FPRWNYEdD" role="jymVt">
+      <property role="TrG5h" value="computeStableId" />
+      <node concept="3clFbS" id="73FPRWNYEdG" role="3clF47">
+        <node concept="3clFbF" id="73FPRWNYEmv" role="3cqZAp">
+          <node concept="3cpWs3" id="73FPRWNYEmx" role="3clFbG">
+            <node concept="37vLTw" id="73FPRWNYEmI" role="3uHU7B">
+              <ref role="3cqZAo" node="6jiGbW_JBxg" resolve="STABLE_ID_PREFIX" />
+            </node>
+            <node concept="2YIFZM" id="73FPRWNYEmy" role="3uHU7w">
+              <ref role="37wK5l" to="btm1:~StringUtils.deleteWhitespace(java.lang.String)" resolve="deleteWhitespace" />
+              <ref role="1Pybhc" to="btm1:~StringUtils" resolve="StringUtils" />
+              <node concept="2OqwBi" id="73FPRWNYEmz" role="37wK5m">
+                <node concept="2OqwBi" id="73FPRWNYEm$" role="2Oq$k0">
+                  <node concept="2JrnkZ" id="73FPRWNYEm_" role="2Oq$k0">
+                    <node concept="37vLTw" id="73FPRWNYEmA" role="2JrQYb">
+                      <ref role="3cqZAo" node="73FPRWNYEgX" resolve="n" />
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="73FPRWNYEmB" role="2OqNvi">
+                    <ref role="37wK5l" to="mhbf:~SNode.getNodeId()" resolve="getNodeId" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="73FPRWNYEmC" role="2OqNvi">
+                  <ref role="37wK5l" to="wyt6:~Object.toString()" resolve="toString" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm6S6" id="73FPRWNYE96" role="1B3o_S" />
+      <node concept="17QB3L" id="73FPRWNYEcT" role="3clF45" />
+      <node concept="37vLTG" id="73FPRWNYEgX" role="3clF46">
+        <property role="TrG5h" value="n" />
+        <node concept="3Tqbb2" id="73FPRWNYEgW" role="1tU5fm" />
       </node>
     </node>
     <node concept="3Tm1VV" id="6jiGbW_zIPL" role="1B3o_S" />

--- a/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/languageModels/behavior.mps
+++ b/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/languageModels/behavior.mps
@@ -6747,31 +6747,41 @@
       <node concept="17QB3L" id="627_yy34GmO" role="3clF45" />
       <node concept="3clFbS" id="627_yy34GmP" role="3clF47">
         <node concept="3clFbF" id="627_yy34GmQ" role="3cqZAp">
-          <node concept="3cpWs3" id="627_yy34GmR" role="3clFbG">
-            <node concept="3cpWs3" id="627_yy34GmS" role="3uHU7B">
-              <node concept="Xl_RD" id="627_yy34GmT" role="3uHU7w">
-                <property role="Xl_RC" value="_" />
-              </node>
-              <node concept="2OqwBi" id="627_yy34GmU" role="3uHU7B">
-                <node concept="2OqwBi" id="627_yy34GmV" role="2Oq$k0">
-                  <node concept="13iPFW" id="627_yy34GmW" role="2Oq$k0" />
-                  <node concept="2Xjw5R" id="627_yy34GmX" role="2OqNvi">
-                    <node concept="1xMEDy" id="627_yy34GmY" role="1xVPHs">
-                      <node concept="chp4Y" id="627_yy34GmZ" role="ri$Ld">
-                        <ref role="cht4Q" to="2c95:2TZO3DbuxwK" resolve="Document" />
+          <node concept="3cpWs3" id="73FPRWNSUCx" role="3clFbG">
+            <node concept="BsUDl" id="73FPRWNTqA8" role="3uHU7w">
+              <ref role="37wK5l" node="6jiGbW_aIil" resolve="stableId" />
+            </node>
+            <node concept="3cpWs3" id="73FPRWNSUqa" role="3uHU7B">
+              <node concept="3cpWs3" id="627_yy34GmR" role="3uHU7B">
+                <node concept="3cpWs3" id="627_yy34GmS" role="3uHU7B">
+                  <node concept="Xl_RD" id="627_yy34GmT" role="3uHU7w">
+                    <property role="Xl_RC" value="_" />
+                  </node>
+                  <node concept="2OqwBi" id="627_yy34GmU" role="3uHU7B">
+                    <node concept="2OqwBi" id="627_yy34GmV" role="2Oq$k0">
+                      <node concept="13iPFW" id="627_yy34GmW" role="2Oq$k0" />
+                      <node concept="2Xjw5R" id="627_yy34GmX" role="2OqNvi">
+                        <node concept="1xMEDy" id="627_yy34GmY" role="1xVPHs">
+                          <node concept="chp4Y" id="627_yy34GmZ" role="ri$Ld">
+                            <ref role="cht4Q" to="2c95:2TZO3DbuxwK" resolve="Document" />
+                          </node>
+                        </node>
                       </node>
+                    </node>
+                    <node concept="3TrcHB" id="627_yy34Gn0" role="2OqNvi">
+                      <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
                     </node>
                   </node>
                 </node>
-                <node concept="3TrcHB" id="627_yy34Gn0" role="2OqNvi">
-                  <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                <node concept="2OqwBi" id="627_yy34Gn1" role="3uHU7w">
+                  <node concept="13iPFW" id="627_yy34Gn2" role="2Oq$k0" />
+                  <node concept="3TrcHB" id="627_yy34Gn3" role="2OqNvi">
+                    <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                  </node>
                 </node>
               </node>
-            </node>
-            <node concept="2OqwBi" id="627_yy34Gn1" role="3uHU7w">
-              <node concept="13iPFW" id="627_yy34Gn2" role="2Oq$k0" />
-              <node concept="3TrcHB" id="627_yy34Gn3" role="2OqNvi">
-                <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+              <node concept="Xl_RD" id="73FPRWNSUqd" role="3uHU7w">
+                <property role="Xl_RC" value="_" />
               </node>
             </node>
           </node>


### PR DESCRIPTION
Due to problems with stable-id computations (see issue #2191), duplicate stable-ids have been generated for different link targets. This is solved by this PR. Additionally, image file names could be not unique if two or more `ModelContentAsImageParagraph` nodes have the same name (issue #2190). This is also fixed by this PR.

This PR closes #2190 and #2191. 