### PR TITLE
doc.gen: allow referencing documents from different models

### DIFF
--- a/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc.gen_xhtml/languageAccessories/com/mbeddr/doc/gen_xhtml/defaults.mps
+++ b/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc.gen_xhtml/languageAccessories/com/mbeddr/doc/gen_xhtml/defaults.mps
@@ -115,7 +115,7 @@
     <node concept="3zOSV2" id="QRmqzIt6CL" role="3zO_yG">
       <node concept="3zO__7" id="QRmqzIt6DZ" role="3zO_yy">
         <property role="3zO_yR" value="margin-left" />
-        <property role="3zO_ya" value="1em" />
+        <property role="3zO_ya" value="2em" />
       </node>
       <node concept="3zO__Y" id="QRmqzIt6DW" role="3zO_yJ">
         <property role="3zO_yB" value=".tocSection" />

--- a/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/generator/template/com/mbeddr/doc/generator/template/main@generator.mps
+++ b/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/generator/template/com/mbeddr/doc/generator/template/main@generator.mps
@@ -330,6 +330,10 @@
       <concept id="1217026863835" name="jetbrains.mps.lang.generator.generationContext.structure.GenerationContextOp_GetOriginalInputModel" flags="nn" index="1st3f0" />
     </language>
     <language id="3a13115c-633c-4c5c-bbcc-75c4219e9555" name="jetbrains.mps.lang.quotation">
+      <concept id="5455284157994012186" name="jetbrains.mps.lang.quotation.structure.NodeBuilderInitLink" flags="ng" index="2pIpSj">
+        <reference id="5455284157994012188" name="link" index="2pIpSl" />
+        <child id="1595412875168045827" name="initValue" index="28nt2d" />
+      </concept>
       <concept id="5455284157993911077" name="jetbrains.mps.lang.quotation.structure.NodeBuilderInitProperty" flags="ng" index="2pJxcG">
         <reference id="5455284157993911078" name="property" index="2pJxcJ" />
         <child id="1595412875168045201" name="initValue" index="28ntcv" />
@@ -343,6 +347,9 @@
       </concept>
       <concept id="6985522012210254362" name="jetbrains.mps.lang.quotation.structure.NodeBuilderPropertyExpression" flags="nn" index="WxPPo">
         <child id="6985522012210254363" name="expression" index="WxPPp" />
+      </concept>
+      <concept id="8182547171709752110" name="jetbrains.mps.lang.quotation.structure.NodeBuilderExpression" flags="nn" index="36biLy">
+        <child id="8182547171709752112" name="expression" index="36biLW" />
       </concept>
     </language>
     <language id="d3a0fd26-445a-466c-900e-10444ddfed52" name="com.mbeddr.mpsutil.filepicker">
@@ -474,6 +481,10 @@
         <child id="540871147943773366" name="argument" index="25WWJ7" />
       </concept>
       <concept id="1204980550705" name="jetbrains.mps.baseLanguage.collections.structure.VisitAllOperation" flags="nn" index="2es0OD" />
+      <concept id="1226511727824" name="jetbrains.mps.baseLanguage.collections.structure.SetType" flags="in" index="2hMVRd">
+        <child id="1226511765987" name="elementType" index="2hN53Y" />
+      </concept>
+      <concept id="1226516258405" name="jetbrains.mps.baseLanguage.collections.structure.HashSetCreator" flags="nn" index="2i4dXS" />
       <concept id="1151688443754" name="jetbrains.mps.baseLanguage.collections.structure.ListType" flags="in" index="_YKpA">
         <child id="1151688676805" name="elementType" index="_ZDj9" />
       </concept>
@@ -490,6 +501,9 @@
         <reference id="1153944258490" name="variable" index="2Gs0qQ" />
       </concept>
       <concept id="1235566554328" name="jetbrains.mps.baseLanguage.collections.structure.AnyOperation" flags="nn" index="2HwmR7" />
+      <concept id="1237721394592" name="jetbrains.mps.baseLanguage.collections.structure.AbstractContainerCreator" flags="nn" index="HWqM0">
+        <child id="1237721435807" name="elementType" index="HW$YZ" />
+      </concept>
       <concept id="1203518072036" name="jetbrains.mps.baseLanguage.collections.structure.SmartClosureParameterDeclaration" flags="ig" index="Rh6nW" />
       <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="nn" index="TSZUe" />
       <concept id="1162934736510" name="jetbrains.mps.baseLanguage.collections.structure.GetElementOperation" flags="nn" index="34jXtK" />
@@ -2729,6 +2743,323 @@
             </node>
           </node>
         </node>
+        <node concept="3clFbH" id="8QSRajGjZW" role="3cqZAp" />
+        <node concept="3SKdUt" id="8QSRajGkqB" role="3cqZAp">
+          <node concept="1PaTwC" id="8QSRajGkqC" role="1aUNEU">
+            <node concept="3oM_SD" id="8QSRajGkqD" role="1PaTwD">
+              <property role="3oM_SC" value="fix" />
+            </node>
+            <node concept="3oM_SD" id="8QSRajGktL" role="1PaTwD">
+              <property role="3oM_SC" value="references" />
+            </node>
+            <node concept="3oM_SD" id="8QSRajGkAL" role="1PaTwD">
+              <property role="3oM_SC" value="to" />
+            </node>
+            <node concept="3oM_SD" id="8QSRajGkAP" role="1PaTwD">
+              <property role="3oM_SC" value="docs" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="8QSRajP0Vg" role="3cqZAp">
+          <node concept="3cpWsn" id="8QSRajP0Vj" role="3cpWs9">
+            <property role="TrG5h" value="docs" />
+            <node concept="2hMVRd" id="8QSRajP_DT" role="1tU5fm">
+              <node concept="3Tqbb2" id="8QSRajPCYA" role="2hN53Y">
+                <ref role="ehGHo" to="2c95:2TZO3DbuxwK" resolve="Document" />
+              </node>
+            </node>
+            <node concept="2ShNRf" id="8QSRajP12d" role="33vP2m">
+              <node concept="2i4dXS" id="8QSRajPFFr" role="2ShVmc">
+                <node concept="3Tqbb2" id="8QSRajPG79" role="HW$YZ">
+                  <ref role="ehGHo" to="2c95:2TZO3DbuxwK" resolve="Document" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2Gpval" id="8QSRajGkBi" role="3cqZAp">
+          <node concept="2GrKxI" id="8QSRajGkBj" role="2Gsz3X">
+            <property role="TrG5h" value="sr" />
+          </node>
+          <node concept="3clFbS" id="8QSRajGkBk" role="2LFqv$">
+            <node concept="3clFbJ" id="8QSRajGkBl" role="3cqZAp">
+              <node concept="3clFbS" id="8QSRajGkBm" role="3clFbx">
+                <node concept="3clFbF" id="8QSRajGkCm" role="3cqZAp">
+                  <node concept="37vLTI" id="8QSRajGkCn" role="3clFbG">
+                    <node concept="2OqwBi" id="8QSRajGkCp" role="37vLTJ">
+                      <node concept="2GrUjf" id="8QSRajGngb" role="2Oq$k0">
+                        <ref role="2Gs0qQ" node="8QSRajGkBj" resolve="sr" />
+                      </node>
+                      <node concept="3TrEf2" id="8QSRajGnQt" role="2OqNvi">
+                        <ref role="3Tt5mk" to="2c95:2T4ELtZGU9" resolve="target" />
+                      </node>
+                    </node>
+                    <node concept="2OqwBi" id="8QSRajGkBI" role="37vLTx">
+                      <node concept="2OqwBi" id="8QSRajGkBJ" role="2Oq$k0">
+                        <node concept="1Q6Npb" id="8QSRajGkBK" role="2Oq$k0" />
+                        <node concept="2RRcyG" id="8QSRajGkBL" role="2OqNvi">
+                          <ref role="2RRcyH" to="2c95:2TZO3DbuxwK" resolve="Document" />
+                        </node>
+                      </node>
+                      <node concept="1z4cxt" id="8QSRajGkBM" role="2OqNvi">
+                        <node concept="1bVj0M" id="8QSRajGkBN" role="23t8la">
+                          <node concept="3clFbS" id="8QSRajGkBO" role="1bW5cS">
+                            <node concept="3clFbF" id="8QSRajGkBP" role="3cqZAp">
+                              <node concept="2OqwBi" id="8QSRajGkBQ" role="3clFbG">
+                                <node concept="2OqwBi" id="8QSRajGkBR" role="2Oq$k0">
+                                  <node concept="37vLTw" id="8QSRajGkBS" role="2Oq$k0">
+                                    <ref role="3cqZAo" node="8QSRajGkBW" resolve="it" />
+                                  </node>
+                                  <node concept="3TrcHB" id="8QSRajGkBT" role="2OqNvi">
+                                    <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                                  </node>
+                                </node>
+                                <node concept="liA8E" id="8QSRajGkBU" role="2OqNvi">
+                                  <ref role="37wK5l" to="wyt6:~String.equals(java.lang.Object)" resolve="equals" />
+                                  <node concept="2OqwBi" id="8QSRajGkBy" role="37wK5m">
+                                    <node concept="2OqwBi" id="8QSRajGkB$" role="2Oq$k0">
+                                      <node concept="2GrUjf" id="8QSRajGkB_" role="2Oq$k0">
+                                        <ref role="2Gs0qQ" node="8QSRajGkBj" resolve="sr" />
+                                      </node>
+                                      <node concept="3TrEf2" id="8QSRajGn2M" role="2OqNvi">
+                                        <ref role="3Tt5mk" to="2c95:2T4ELtZGU9" resolve="target" />
+                                      </node>
+                                    </node>
+                                    <node concept="3TrcHB" id="8QSRajGkBE" role="2OqNvi">
+                                      <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="Rh6nW" id="8QSRajGkBW" role="1bW2Oz">
+                            <property role="TrG5h" value="it" />
+                            <node concept="2jxLKc" id="8QSRajGkBX" role="1tU5fm" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbF" id="8QSRajPu4z" role="3cqZAp">
+                  <node concept="2OqwBi" id="8QSRajPxII" role="3clFbG">
+                    <node concept="37vLTw" id="8QSRajPu4x" role="2Oq$k0">
+                      <ref role="3cqZAo" node="8QSRajP0Vj" resolve="docs" />
+                    </node>
+                    <node concept="TSZUe" id="8QSRajPHge" role="2OqNvi">
+                      <node concept="2OqwBi" id="8QSRajPHUH" role="25WWJ7">
+                        <node concept="2GrUjf" id="8QSRajPHDp" role="2Oq$k0">
+                          <ref role="2Gs0qQ" node="8QSRajGkBj" resolve="sr" />
+                        </node>
+                        <node concept="3TrEf2" id="8QSRajPIQ7" role="2OqNvi">
+                          <ref role="3Tt5mk" to="2c95:2T4ELtZGU9" resolve="target" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="17QLQc" id="8QSRajGkCs" role="3clFbw">
+                <node concept="1Q6Npb" id="8QSRajGkCt" role="3uHU7w" />
+                <node concept="2OqwBi" id="8QSRajGkCu" role="3uHU7B">
+                  <node concept="2OqwBi" id="8QSRajGkCv" role="2Oq$k0">
+                    <node concept="2GrUjf" id="8QSRajGkCw" role="2Oq$k0">
+                      <ref role="2Gs0qQ" node="8QSRajGkBj" resolve="sr" />
+                    </node>
+                    <node concept="3TrEf2" id="8QSRajGnHC" role="2OqNvi">
+                      <ref role="3Tt5mk" to="2c95:2T4ELtZGU9" resolve="target" />
+                    </node>
+                  </node>
+                  <node concept="I4A8Y" id="8QSRajGkCy" role="2OqNvi" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="8QSRajGkCz" role="2GsD0m">
+            <node concept="1Q6Npb" id="8QSRajGkC$" role="2Oq$k0" />
+            <node concept="2SmgA7" id="8QSRajGkC_" role="2OqNvi">
+              <node concept="chp4Y" id="8QSRajGlSb" role="1dBWTz">
+                <ref role="cht4Q" to="2c95:2T4ELtZGU8" resolve="DocRefWord" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2Gpval" id="8QSRajPaml" role="3cqZAp">
+          <node concept="2GrKxI" id="8QSRajPamn" role="2Gsz3X">
+            <property role="TrG5h" value="doc" />
+          </node>
+          <node concept="37vLTw" id="8QSRajPatD" role="2GsD0m">
+            <ref role="3cqZAo" node="8QSRajP0Vj" resolve="docs" />
+          </node>
+          <node concept="3clFbS" id="8QSRajPamr" role="2LFqv$">
+            <node concept="3clFbJ" id="8QSRajPavc" role="3cqZAp">
+              <node concept="3fqX7Q" id="8QSRajPi7h" role="3clFbw">
+                <node concept="2OqwBi" id="8QSRajPi7j" role="3fr31v">
+                  <node concept="2OqwBi" id="8QSRajPi7k" role="2Oq$k0">
+                    <node concept="1Q6Npb" id="8QSRajPi7l" role="2Oq$k0" />
+                    <node concept="2RRcyG" id="8QSRajPi7m" role="2OqNvi">
+                      <ref role="2RRcyH" to="2c95:5gTlpaky5gD" resolve="AbstractExport" />
+                    </node>
+                  </node>
+                  <node concept="2HwmR7" id="8QSRajPi7n" role="2OqNvi">
+                    <node concept="1bVj0M" id="8QSRajPi7o" role="23t8la">
+                      <node concept="3clFbS" id="8QSRajPi7p" role="1bW5cS">
+                        <node concept="3clFbF" id="8QSRajPi7q" role="3cqZAp">
+                          <node concept="17R0WA" id="8QSRajPi7r" role="3clFbG">
+                            <node concept="2GrUjf" id="8QSRajPi7s" role="3uHU7w">
+                              <ref role="2Gs0qQ" node="8QSRajPamn" resolve="doc" />
+                            </node>
+                            <node concept="2OqwBi" id="8QSRajPi7t" role="3uHU7B">
+                              <node concept="2OqwBi" id="8QSRajPi7u" role="2Oq$k0">
+                                <node concept="37vLTw" id="8QSRajPi7v" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="8QSRajPi7y" resolve="it" />
+                                </node>
+                                <node concept="3TrEf2" id="8QSRajPi7w" role="2OqNvi">
+                                  <ref role="3Tt5mk" to="2c95:5gTlpaky6t1" resolve="root" />
+                                </node>
+                              </node>
+                              <node concept="3TrEf2" id="8QSRajPi7x" role="2OqNvi">
+                                <ref role="3Tt5mk" to="2c95:2TZO3DbvI5E" resolve="doc" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="Rh6nW" id="8QSRajPi7y" role="1bW2Oz">
+                        <property role="TrG5h" value="it" />
+                        <node concept="2jxLKc" id="8QSRajPi7z" role="1tU5fm" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbS" id="8QSRajPave" role="3clFbx">
+                <node concept="3cpWs8" id="8QSRajPjq_" role="3cqZAp">
+                  <node concept="3cpWsn" id="8QSRajPjqA" role="3cpWs9">
+                    <property role="TrG5h" value="ie" />
+                    <node concept="3Tqbb2" id="8QSRajPjk6" role="1tU5fm">
+                      <ref role="ehGHo" to="2c95:5gTlpaky6t5" resolve="IncludableExport" />
+                    </node>
+                    <node concept="2pJPEk" id="8QSRajPjqB" role="33vP2m">
+                      <node concept="2pJPED" id="8QSRajPjqC" role="2pJPEn">
+                        <ref role="2pJxaS" to="2c95:5gTlpaky6t5" resolve="IncludableExport" />
+                        <node concept="2pJxcG" id="8QSRajPjHX" role="2pJxcM">
+                          <ref role="2pJxcJ" to="tpck:h0TrG11" resolve="name" />
+                          <node concept="WxPPo" id="8QSRajPjJ4" role="28ntcv">
+                            <node concept="2OqwBi" id="8QSRajPjZ_" role="WxPPp">
+                              <node concept="2GrUjf" id="8QSRajPjJ2" role="2Oq$k0">
+                                <ref role="2Gs0qQ" node="8QSRajPamn" resolve="doc" />
+                              </node>
+                              <node concept="3TrcHB" id="8QSRajPkEJ" role="2OqNvi">
+                                <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="2pIpSj" id="8QSRajPp16" role="2pJxcM">
+                          <ref role="2pIpSl" to="2c95:5gTlpaky6t1" resolve="root" />
+                          <node concept="2pJPED" id="8QSRajPpEd" role="28nt2d">
+                            <ref role="2pJxaS" to="2c95:2TZO3DbvI5D" resolve="DocumentRef" />
+                            <node concept="2pIpSj" id="8QSRajPpIC" role="2pJxcM">
+                              <ref role="2pIpSl" to="2c95:2TZO3DbvI5E" resolve="doc" />
+                              <node concept="36biLy" id="8QSRajPpIU" role="28nt2d">
+                                <node concept="2GrUjf" id="8QSRajPpJd" role="36biLW">
+                                  <ref role="2Gs0qQ" node="8QSRajPamn" resolve="doc" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="2pIpSj" id="8QSRajPkYi" role="2pJxcM">
+                          <ref role="2pIpSl" to="2c95:5gTlpaky6sZ" resolve="renderer" />
+                          <node concept="36biLy" id="8QSRajPl35" role="28nt2d">
+                            <node concept="2OqwBi" id="8QSRajPoIr" role="36biLW">
+                              <node concept="2OqwBi" id="8QSRajPoc2" role="2Oq$k0">
+                                <node concept="2OqwBi" id="8QSRajPl3o" role="2Oq$k0">
+                                  <node concept="2OqwBi" id="8QSRajPl3p" role="2Oq$k0">
+                                    <node concept="2OqwBi" id="8QSRajPl3q" role="2Oq$k0">
+                                      <node concept="1iwH7S" id="8QSRajPl3r" role="2Oq$k0" />
+                                      <node concept="1r8y6K" id="8QSRajPl3s" role="2OqNvi" />
+                                    </node>
+                                    <node concept="2SmgA7" id="8QSRajPl3t" role="2OqNvi">
+                                      <node concept="chp4Y" id="8QSRajPl3u" role="1dBWTz">
+                                        <ref role="cht4Q" to="2c95:2TZO3DbvPDI" resolve="DocumentExport" />
+                                      </node>
+                                    </node>
+                                  </node>
+                                  <node concept="1uHKPH" id="8QSRajPl3v" role="2OqNvi" />
+                                </node>
+                                <node concept="3TrEf2" id="8QSRajPo$K" role="2OqNvi">
+                                  <ref role="3Tt5mk" to="2c95:5gTlpaky6sZ" resolve="renderer" />
+                                </node>
+                              </node>
+                              <node concept="1$rogu" id="8QSRajPoZw" role="2OqNvi" />
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="2pIpSj" id="8QSRajPpSJ" role="2pJxcM">
+                          <ref role="2pIpSl" to="2c95:5gTlpaky6t2" resolve="mappings" />
+                          <node concept="36biLy" id="8QSRajPpU7" role="28nt2d">
+                            <node concept="2OqwBi" id="8QSRajPrQH" role="36biLW">
+                              <node concept="2OqwBi" id="8QSRajPpUr" role="2Oq$k0">
+                                <node concept="2OqwBi" id="8QSRajPpUs" role="2Oq$k0">
+                                  <node concept="2OqwBi" id="8QSRajPpUt" role="2Oq$k0">
+                                    <node concept="2OqwBi" id="8QSRajPpUu" role="2Oq$k0">
+                                      <node concept="1iwH7S" id="8QSRajPpUv" role="2Oq$k0" />
+                                      <node concept="1r8y6K" id="8QSRajPpUw" role="2OqNvi" />
+                                    </node>
+                                    <node concept="2SmgA7" id="8QSRajPpUx" role="2OqNvi">
+                                      <node concept="chp4Y" id="8QSRajPpUy" role="1dBWTz">
+                                        <ref role="cht4Q" to="2c95:2TZO3DbvPDI" resolve="DocumentExport" />
+                                      </node>
+                                    </node>
+                                  </node>
+                                  <node concept="1uHKPH" id="8QSRajPpUz" role="2OqNvi" />
+                                </node>
+                                <node concept="3Tsc0h" id="8QSRajPqsy" role="2OqNvi">
+                                  <ref role="3TtcxE" to="2c95:5gTlpaky6t2" resolve="mappings" />
+                                </node>
+                              </node>
+                              <node concept="3$u5V9" id="8QSRajPtu0" role="2OqNvi">
+                                <node concept="1bVj0M" id="8QSRajPtu2" role="23t8la">
+                                  <node concept="3clFbS" id="8QSRajPtu3" role="1bW5cS">
+                                    <node concept="3clFbF" id="8QSRajPt_5" role="3cqZAp">
+                                      <node concept="2OqwBi" id="8QSRajPtIO" role="3clFbG">
+                                        <node concept="37vLTw" id="8QSRajPt_4" role="2Oq$k0">
+                                          <ref role="3cqZAo" node="8QSRajPtu4" resolve="it" />
+                                        </node>
+                                        <node concept="1$rogu" id="8QSRajPtXK" role="2OqNvi" />
+                                      </node>
+                                    </node>
+                                  </node>
+                                  <node concept="Rh6nW" id="8QSRajPtu4" role="1bW2Oz">
+                                    <property role="TrG5h" value="it" />
+                                    <node concept="2jxLKc" id="8QSRajPtu5" role="1tU5fm" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbF" id="8QSRajPjrI" role="3cqZAp">
+                  <node concept="2OqwBi" id="8QSRajPjyR" role="3clFbG">
+                    <node concept="1Q6Npb" id="8QSRajPjrH" role="2Oq$k0" />
+                    <node concept="3BYIHo" id="8QSRajPjD7" role="2OqNvi">
+                      <node concept="37vLTw" id="8QSRajPjDw" role="3BYIHq">
+                        <ref role="3cqZAo" node="8QSRajPjqA" resolve="ie" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
         <node concept="3clFbH" id="mQGf9iJKf6" role="3cqZAp" />
         <node concept="3SKdUt" id="mQGf9iK75W" role="3cqZAp">
           <node concept="1PaTwC" id="6JXsDxqZW0E" role="1aUNEU">
@@ -3978,18 +4309,36 @@
                                               <node concept="1bVj0M" id="7U$sKL0zGeH" role="23t8la">
                                                 <node concept="3clFbS" id="7U$sKL0zGeI" role="1bW5cS">
                                                   <node concept="3clFbF" id="7U$sKL0zIhs" role="3cqZAp">
-                                                    <node concept="17QLQc" id="7U$sKL0zPhy" role="3clFbG">
-                                                      <node concept="37vLTw" id="7U$sKL0zRjo" role="3uHU7w">
-                                                        <ref role="3cqZAo" node="3lxJBjikdRi" resolve="document" />
-                                                      </node>
-                                                      <node concept="2OqwBi" id="7U$sKL0zMLh" role="3uHU7B">
-                                                        <node concept="2OqwBi" id="7U$sKL0zJB2" role="2Oq$k0">
-                                                          <node concept="37vLTw" id="7U$sKL0zIhr" role="2Oq$k0">
-                                                            <ref role="3cqZAo" node="7U$sKL0zGeJ" resolve="it" />
+                                                    <node concept="1Wc70l" id="8QSRajxk7M" role="3clFbG">
+                                                      <node concept="2OqwBi" id="8QSRajxqOc" role="3uHU7B">
+                                                        <node concept="2OqwBi" id="8QSRajxoz0" role="2Oq$k0">
+                                                          <node concept="2OqwBi" id="8QSRajxmhq" role="2Oq$k0">
+                                                            <node concept="37vLTw" id="8QSRajxlvP" role="2Oq$k0">
+                                                              <ref role="3cqZAo" node="7U$sKL0zGeJ" resolve="it" />
+                                                            </node>
+                                                            <node concept="2ZHEkA" id="8QSRajxnzo" role="2OqNvi" />
                                                           </node>
-                                                          <node concept="2ZHEkA" id="7U$sKL0zLF6" role="2OqNvi" />
+                                                          <node concept="2Rxl7S" id="8QSRajxphw" role="2OqNvi" />
                                                         </node>
-                                                        <node concept="2Rxl7S" id="7U$sKL0zO5c" role="2OqNvi" />
+                                                        <node concept="1mIQ4w" id="8QSRajxsjR" role="2OqNvi">
+                                                          <node concept="chp4Y" id="8QSRajxsUe" role="cj9EA">
+                                                            <ref role="cht4Q" to="2c95:2TZO3DbuxwK" resolve="Document" />
+                                                          </node>
+                                                        </node>
+                                                      </node>
+                                                      <node concept="17QLQc" id="7U$sKL0zPhy" role="3uHU7w">
+                                                        <node concept="37vLTw" id="7U$sKL0zRjo" role="3uHU7w">
+                                                          <ref role="3cqZAo" node="3lxJBjikdRi" resolve="document" />
+                                                        </node>
+                                                        <node concept="2OqwBi" id="8QSRaj6X6g" role="3uHU7B">
+                                                          <node concept="2OqwBi" id="8QSRaj6X6h" role="2Oq$k0">
+                                                            <node concept="37vLTw" id="8QSRaj6X6i" role="2Oq$k0">
+                                                              <ref role="3cqZAo" node="7U$sKL0zGeJ" resolve="it" />
+                                                            </node>
+                                                            <node concept="2ZHEkA" id="8QSRaj6X6j" role="2OqNvi" />
+                                                          </node>
+                                                          <node concept="2Rxl7S" id="8QSRaj6X6k" role="2OqNvi" />
+                                                        </node>
                                                       </node>
                                                     </node>
                                                   </node>
@@ -4092,7 +4441,6 @@
                                           </node>
                                         </node>
                                       </node>
-                                      <node concept="3clFbH" id="7U$sKL0zArz" role="3cqZAp" />
                                       <node concept="3clFbF" id="7U$sKL0zAr$" role="3cqZAp">
                                         <node concept="2OqwBi" id="7U$sKL0zAr_" role="3clFbG">
                                           <node concept="37vLTw" id="7U$sKL0zCMI" role="2Oq$k0">

--- a/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/languageModels/behavior.mps
+++ b/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/languageModels/behavior.mps
@@ -1649,6 +1649,22 @@
         </node>
       </node>
     </node>
+    <node concept="13i0hz" id="3DLpMp_rMFu" role="13h7CS">
+      <property role="TrG5h" value="tocText" />
+      <ref role="13i0hy" node="3DLpMp_rLlJ" resolve="tocText" />
+      <node concept="3Tm1VV" id="3DLpMp_rMFv" role="1B3o_S" />
+      <node concept="3clFbS" id="3DLpMp_rMFy" role="3clF47">
+        <node concept="3clFbF" id="3DLpMp_rNre" role="3cqZAp">
+          <node concept="2OqwBi" id="3DLpMp_rNGk" role="3clFbG">
+            <node concept="13iPFW" id="3DLpMp_rNrb" role="2Oq$k0" />
+            <node concept="3TrcHB" id="3DLpMp_rOan" role="2OqNvi">
+              <ref role="3TsBF5" to="2c95:2TZO3Dbv6Jx" resolve="text" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="3DLpMp_rMFz" role="3clF45" />
+    </node>
     <node concept="13i0hz" id="QRmqzHsFzm" role="13h7CS">
       <property role="TrG5h" value="isInIndex" />
       <property role="13i0it" value="true" />
@@ -7748,7 +7764,7 @@
       <node concept="3Tm1VV" id="73FPRWNpfgA" role="1B3o_S" />
       <node concept="A3Dl8" id="73FPRWNpfgV" role="3clF45">
         <node concept="3Tqbb2" id="73FPRWNpfh8" role="A3Ik2">
-          <ref role="ehGHo" to="2c95:2TZO3Dbv6Ju" resolve="AbstractSection" />
+          <ref role="ehGHo" to="2c95:3DLpMp_rLlz" resolve="ITocEntry" />
         </node>
       </node>
       <node concept="3clFbS" id="73FPRWNpfgC" role="3clF47">
@@ -7792,7 +7808,7 @@
       <node concept="3Tm6S6" id="73FPRWNpfCx" role="1B3o_S" />
       <node concept="A3Dl8" id="73FPRWNpfCG" role="3clF45">
         <node concept="3Tqbb2" id="73FPRWNpfCT" role="A3Ik2">
-          <ref role="ehGHo" to="2c95:2TZO3Dbv6Ju" resolve="AbstractSection" />
+          <ref role="ehGHo" to="2c95:3DLpMp_rLlz" resolve="ITocEntry" />
         </node>
       </node>
       <node concept="3clFbS" id="73FPRWNpfC9" role="3clF47">
@@ -7806,59 +7822,83 @@
                 <node concept="3clFbS" id="2yDAfHErxEC" role="1bW5cS">
                   <node concept="3clFbJ" id="2yDAfHErxWM" role="3cqZAp">
                     <node concept="3clFbS" id="2yDAfHErxWO" role="3clFbx">
-                      <node concept="3cpWs6" id="2yDAfHEr_eA" role="3cqZAp">
-                        <node concept="BsUDl" id="2yDAfHEr_vi" role="3cqZAk">
-                          <ref role="37wK5l" node="73FPRWNpfC6" resolve="getEntriesRec" />
-                          <node concept="2OqwBi" id="2yDAfHErBPJ" role="37wK5m">
-                            <node concept="2OqwBi" id="2yDAfHErBho" role="2Oq$k0">
-                              <node concept="2OqwBi" id="2yDAfHErApl" role="2Oq$k0">
-                                <node concept="1PxgMI" id="2yDAfHEr_T8" role="2Oq$k0">
-                                  <node concept="chp4Y" id="2yDAfHErA2M" role="3oSUPX">
-                                    <ref role="cht4Q" to="2c95:5mf_X_Lbqjw" resolve="DocumentInclude" />
+                      <node concept="3cpWs8" id="3DLpMp_s3ME" role="3cqZAp">
+                        <node concept="3cpWsn" id="3DLpMp_s3MF" role="3cpWs9">
+                          <property role="TrG5h" value="include" />
+                          <node concept="3Tqbb2" id="3DLpMp_s3Jy" role="1tU5fm">
+                            <ref role="ehGHo" to="2c95:5mf_X_Lbqjw" resolve="DocumentInclude" />
+                          </node>
+                          <node concept="1PxgMI" id="3DLpMp_s3MG" role="33vP2m">
+                            <node concept="chp4Y" id="3DLpMp_s3MH" role="3oSUPX">
+                              <ref role="cht4Q" to="2c95:5mf_X_Lbqjw" resolve="DocumentInclude" />
+                            </node>
+                            <node concept="37vLTw" id="3DLpMp_s3MI" role="1m5AlR">
+                              <ref role="3cqZAo" node="2yDAfHErxED" resolve="it" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbJ" id="3DLpMp_s0i7" role="3cqZAp">
+                        <node concept="3clFbS" id="3DLpMp_s0i9" role="3clFbx">
+                          <node concept="3cpWs6" id="2yDAfHEr_eA" role="3cqZAp">
+                            <node concept="BsUDl" id="2yDAfHEr_vi" role="3cqZAk">
+                              <ref role="37wK5l" node="73FPRWNpfC6" resolve="getEntriesRec" />
+                              <node concept="2OqwBi" id="2yDAfHErBPJ" role="37wK5m">
+                                <node concept="2OqwBi" id="2yDAfHErBho" role="2Oq$k0">
+                                  <node concept="2OqwBi" id="2yDAfHErApl" role="2Oq$k0">
+                                    <node concept="37vLTw" id="3DLpMp_s3MK" role="2Oq$k0">
+                                      <ref role="3cqZAo" node="3DLpMp_s3MF" resolve="include" />
+                                    </node>
+                                    <node concept="3TrEf2" id="2yDAfHErAJu" role="2OqNvi">
+                                      <ref role="3Tt5mk" to="2c95:5mf_X_Lbqjz" resolve="ref" />
+                                    </node>
                                   </node>
-                                  <node concept="37vLTw" id="2yDAfHEr_CN" role="1m5AlR">
-                                    <ref role="3cqZAo" node="2yDAfHErxED" resolve="it" />
+                                  <node concept="3TrEf2" id="2yDAfHErB$0" role="2OqNvi">
+                                    <ref role="3Tt5mk" to="2c95:2TZO3DbvI5E" resolve="doc" />
                                   </node>
                                 </node>
-                                <node concept="3TrEf2" id="2yDAfHErAJu" role="2OqNvi">
-                                  <ref role="3Tt5mk" to="2c95:5mf_X_Lbqjz" resolve="ref" />
+                                <node concept="3Tsc0h" id="2yDAfHErCjY" role="2OqNvi">
+                                  <ref role="3TtcxE" to="2c95:2TZO3Dbv6JU" resolve="contents" />
                                 </node>
-                              </node>
-                              <node concept="3TrEf2" id="2yDAfHErB$0" role="2OqNvi">
-                                <ref role="3Tt5mk" to="2c95:2TZO3DbvI5E" resolve="doc" />
                               </node>
                             </node>
-                            <node concept="3Tsc0h" id="2yDAfHErCjY" role="2OqNvi">
-                              <ref role="3TtcxE" to="2c95:2TZO3Dbv6JU" resolve="contents" />
+                          </node>
+                        </node>
+                        <node concept="3fqX7Q" id="2yDAfHErzpl" role="3clFbw">
+                          <node concept="2OqwBi" id="2yDAfHEr$AX" role="3fr31v">
+                            <node concept="37vLTw" id="3DLpMp_s3MJ" role="2Oq$k0">
+                              <ref role="3cqZAo" node="3DLpMp_s3MF" resolve="include" />
+                            </node>
+                            <node concept="3TrcHB" id="2yDAfHEr_24" role="2OqNvi">
+                              <ref role="3TsBF5" to="2c95:hZfTLLrEWd" resolve="referenceOnly" />
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="9aQIb" id="3DLpMp_s1e7" role="9aQIa">
+                          <node concept="3clFbS" id="3DLpMp_s1e8" role="9aQI4">
+                            <node concept="3cpWs6" id="3DLpMp_ymm3" role="3cqZAp">
+                              <node concept="2ShNRf" id="3DLpMp_ymm5" role="3cqZAk">
+                                <node concept="Tc6Ow" id="3DLpMp_ymm6" role="2ShVmc">
+                                  <node concept="3Tqbb2" id="3DLpMp_ymm7" role="HW$YZ">
+                                    <ref role="ehGHo" to="2c95:3DLpMp_rLlz" resolve="ITocEntry" />
+                                  </node>
+                                  <node concept="37vLTw" id="3DLpMp_ymm8" role="HW$Y0">
+                                    <ref role="3cqZAo" node="3DLpMp_s3MF" resolve="include" />
+                                  </node>
+                                </node>
+                              </node>
                             </node>
                           </node>
                         </node>
                       </node>
                     </node>
-                    <node concept="1Wc70l" id="2yDAfHErzfn" role="3clFbw">
-                      <node concept="3fqX7Q" id="2yDAfHErzpl" role="3uHU7w">
-                        <node concept="2OqwBi" id="2yDAfHEr$AX" role="3fr31v">
-                          <node concept="1PxgMI" id="2yDAfHErzZf" role="2Oq$k0">
-                            <node concept="chp4Y" id="2yDAfHEr$fB" role="3oSUPX">
-                              <ref role="cht4Q" to="2c95:5mf_X_Lbqjw" resolve="DocumentInclude" />
-                            </node>
-                            <node concept="37vLTw" id="2yDAfHErzpr" role="1m5AlR">
-                              <ref role="3cqZAo" node="2yDAfHErxED" resolve="it" />
-                            </node>
-                          </node>
-                          <node concept="3TrcHB" id="2yDAfHEr_24" role="2OqNvi">
-                            <ref role="3TsBF5" to="2c95:hZfTLLrEWd" resolve="referenceOnly" />
-                          </node>
-                        </node>
+                    <node concept="2OqwBi" id="2yDAfHErylq" role="3clFbw">
+                      <node concept="37vLTw" id="2yDAfHEry32" role="2Oq$k0">
+                        <ref role="3cqZAo" node="2yDAfHErxED" resolve="it" />
                       </node>
-                      <node concept="2OqwBi" id="2yDAfHErylq" role="3uHU7B">
-                        <node concept="37vLTw" id="2yDAfHEry32" role="2Oq$k0">
-                          <ref role="3cqZAo" node="2yDAfHErxED" resolve="it" />
-                        </node>
-                        <node concept="1mIQ4w" id="2yDAfHEryFe" role="2OqNvi">
-                          <node concept="chp4Y" id="2yDAfHEryNU" role="cj9EA">
-                            <ref role="cht4Q" to="2c95:5mf_X_Lbqjw" resolve="DocumentInclude" />
-                          </node>
+                      <node concept="1mIQ4w" id="3DLpMp_rZig" role="2OqNvi">
+                        <node concept="chp4Y" id="3DLpMp_rZoE" role="cj9EA">
+                          <ref role="cht4Q" to="2c95:5mf_X_Lbqjw" resolve="DocumentInclude" />
                         </node>
                       </node>
                     </node>
@@ -8769,6 +8809,81 @@
           </node>
         </node>
       </node>
+    </node>
+  </node>
+  <node concept="13h7C7" id="3DLpMp_rLl$">
+    <ref role="13h7C2" to="2c95:3DLpMp_rLlz" resolve="ITocEntry" />
+    <node concept="13i0hz" id="3DLpMp_rLlJ" role="13h7CS">
+      <property role="13i0iv" value="true" />
+      <property role="13i0it" value="true" />
+      <property role="TrG5h" value="tocText" />
+      <node concept="3Tm1VV" id="3DLpMp_rLlK" role="1B3o_S" />
+      <node concept="17QB3L" id="3DLpMp_rLlZ" role="3clF45" />
+      <node concept="3clFbS" id="3DLpMp_rLlM" role="3clF47" />
+    </node>
+    <node concept="13i0hz" id="3DLpMp_rLmy" role="13h7CS">
+      <property role="13i0it" value="true" />
+      <property role="TrG5h" value="addToTOC" />
+      <node concept="3Tm1VV" id="3DLpMp_rLmz" role="1B3o_S" />
+      <node concept="10P_77" id="3DLpMp_rLmQ" role="3clF45" />
+      <node concept="3clFbS" id="3DLpMp_rLm_" role="3clF47">
+        <node concept="3cpWs6" id="3DLpMp_rLnh" role="3cqZAp">
+          <node concept="3clFbT" id="3DLpMp_rLn$" role="3cqZAk">
+            <property role="3clFbU" value="true" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="13hLZK" id="3DLpMp_rLl_" role="13h7CW">
+      <node concept="3clFbS" id="3DLpMp_rLlA" role="2VODD2" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="3DLpMp_rOzx">
+    <ref role="13h7C2" to="2c95:5mf_X_Lbqjw" resolve="DocumentInclude" />
+    <node concept="13hLZK" id="3DLpMp_rOzy" role="13h7CW">
+      <node concept="3clFbS" id="3DLpMp_rOzz" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="3DLpMp_rOzG" role="13h7CS">
+      <property role="TrG5h" value="tocText" />
+      <ref role="13i0hy" node="3DLpMp_rLlJ" resolve="tocText" />
+      <node concept="3Tm1VV" id="3DLpMp_rOzH" role="1B3o_S" />
+      <node concept="3clFbS" id="3DLpMp_rOzK" role="3clF47">
+        <node concept="3cpWs6" id="3DLpMp_rRcU" role="3cqZAp">
+          <node concept="2OqwBi" id="3DLpMp_rRcW" role="3cqZAk">
+            <node concept="2OqwBi" id="3DLpMp_rRcX" role="2Oq$k0">
+              <node concept="2OqwBi" id="3DLpMp_rRcY" role="2Oq$k0">
+                <node concept="13iPFW" id="3DLpMp_rRcZ" role="2Oq$k0" />
+                <node concept="3TrEf2" id="3DLpMp_rRd0" role="2OqNvi">
+                  <ref role="3Tt5mk" to="2c95:5mf_X_Lbqjz" resolve="ref" />
+                </node>
+              </node>
+              <node concept="3TrEf2" id="3DLpMp_rRd1" role="2OqNvi">
+                <ref role="3Tt5mk" to="2c95:2TZO3DbvI5E" resolve="doc" />
+              </node>
+            </node>
+            <node concept="3TrcHB" id="3DLpMp_rRd2" role="2OqNvi">
+              <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="3DLpMp_rOzL" role="3clF45" />
+    </node>
+    <node concept="13i0hz" id="3DLpMp_rQeX" role="13h7CS">
+      <property role="TrG5h" value="addToTOC" />
+      <ref role="13i0hy" node="3DLpMp_rLmy" resolve="addToTOC" />
+      <node concept="3Tm1VV" id="3DLpMp_rQeY" role="1B3o_S" />
+      <node concept="3clFbS" id="3DLpMp_rQf3" role="3clF47">
+        <node concept="3cpWs6" id="3DLpMp_rR9w" role="3cqZAp">
+          <node concept="2OqwBi" id="3DLpMp_rR9y" role="3cqZAk">
+            <node concept="13iPFW" id="3DLpMp_rR9z" role="2Oq$k0" />
+            <node concept="3TrcHB" id="3DLpMp_rR9$" role="2OqNvi">
+              <ref role="3TsBF5" to="2c95:hZfTLLrEWd" resolve="referenceOnly" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="10P_77" id="3DLpMp_rQf4" role="3clF45" />
     </node>
   </node>
 </model>

--- a/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/languageModels/editor.mps
+++ b/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/languageModels/editor.mps
@@ -15,6 +15,7 @@
     <use id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor" version="14" />
     <use id="b1ab8c10-c118-4755-bf2a-cebab35cf533" name="jetbrains.mps.lang.editor.tooltips" version="0" />
     <use id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc" version="2" />
+    <use id="af65afd8-f0dd-4942-87d9-63a55f2a9db1" name="jetbrains.mps.lang.behavior" version="2" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
@@ -135,6 +136,9 @@
       <concept id="1142886221719" name="jetbrains.mps.lang.editor.structure.QueryFunction_NodeCondition" flags="in" index="pkWqt" />
       <concept id="1142886811589" name="jetbrains.mps.lang.editor.structure.ConceptFunctionParameter_node" flags="nn" index="pncrf" />
       <concept id="1237385578942" name="jetbrains.mps.lang.editor.structure.IndentLayoutOnNewLineStyleClassItem" flags="ln" index="pVoyu" />
+      <concept id="4820515453818318288" name="jetbrains.mps.lang.editor.structure.ConceptEditorHintDeclarationReferenceExpression" flags="ng" index="2pYGij">
+        <reference id="4820515453818318891" name="hint" index="2pYH_C" />
+      </concept>
       <concept id="1233148810477" name="jetbrains.mps.lang.editor.structure.InlineStyleDeclaration" flags="ng" index="tppnM" />
       <concept id="1177327274449" name="jetbrains.mps.lang.editor.structure.QueryFunctionParameter_pattern" flags="nn" index="ub8z3" />
       <concept id="1177327570013" name="jetbrains.mps.lang.editor.structure.QueryFunction_SubstituteMenu_Substitute" flags="in" index="ucgPf" />
@@ -147,6 +151,9 @@
       <concept id="8478191136882577348" name="jetbrains.mps.lang.editor.structure.QueryFunctionParameter_SubstituteMenu_CreatedNode" flags="ng" index="uqdCJ" />
       <concept id="8478191136882577194" name="jetbrains.mps.lang.editor.structure.QueryFunction_SubstituteMenu_Select" flags="in" index="uqdF1" />
       <concept id="1177335944525" name="jetbrains.mps.lang.editor.structure.QueryFunction_SubstituteMenu_SubstituteString" flags="in" index="uGdhv" />
+      <concept id="4242538589859161874" name="jetbrains.mps.lang.editor.structure.ExplicitHintsSpecification" flags="ng" index="2w$q5c">
+        <child id="4242538589859162459" name="hints" index="2w$qW5" />
+      </concept>
       <concept id="1080736578640" name="jetbrains.mps.lang.editor.structure.BaseEditorComponent" flags="ig" index="2wURMF">
         <child id="1080736633877" name="cellModel" index="2wV5jI" />
       </concept>
@@ -160,7 +167,6 @@
       <concept id="5944657839003601246" name="jetbrains.mps.lang.editor.structure.ConceptEditorHintDeclaration" flags="ig" index="2BsEeg">
         <property id="168363875802087287" name="showInUI" index="2gpH_U" />
       </concept>
-      <concept id="1239814640496" name="jetbrains.mps.lang.editor.structure.CellLayout_VerticalGrid" flags="nn" index="2EHx9g" />
       <concept id="6150987479542522273" name="jetbrains.mps.lang.editor.structure.QueryHintsSpecification" flags="ig" index="2Hnlc$" />
       <concept id="1160493135005" name="jetbrains.mps.lang.editor.structure.CellMenuPart_PropertyValues_GetValues" flags="in" index="MLZmj" />
       <concept id="1164824717996" name="jetbrains.mps.lang.editor.structure.CellMenuDescriptor" flags="ng" index="OXEIz">
@@ -472,7 +478,6 @@
         <child id="1082485599094" name="ifFalseStatement" index="9aQIa" />
         <child id="1068580123160" name="condition" index="3clFbw" />
         <child id="1068580123161" name="ifTrue" index="3clFbx" />
-        <child id="1206060520071" name="elsifClauses" index="3eNLev" />
       </concept>
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
@@ -494,10 +499,6 @@
       <concept id="1068581242869" name="jetbrains.mps.baseLanguage.structure.MinusExpression" flags="nn" index="3cpWsd" />
       <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
       <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
-      <concept id="1206060495898" name="jetbrains.mps.baseLanguage.structure.ElsifClause" flags="ng" index="3eNFk2">
-        <child id="1206060619838" name="condition" index="3eO9$A" />
-        <child id="1206060644605" name="statementList" index="3eOfB_" />
-      </concept>
       <concept id="1079359253375" name="jetbrains.mps.baseLanguage.structure.ParenthesizedExpression" flags="nn" index="1eOMI4">
         <child id="1079359253376" name="expression" index="1eOMHV" />
       </concept>
@@ -632,14 +633,11 @@
       <concept id="6202678563380238499" name="com.mbeddr.mpsutil.editor.querylist.structure.Function_GetElements" flags="ig" index="s8sZD" />
       <concept id="6202678563380233810" name="com.mbeddr.mpsutil.editor.querylist.structure.CellModel_QueryList" flags="ng" index="s8t4o">
         <property id="730823979356023502" name="duplicatesSafe" index="28Zw97" />
-        <property id="1160590307797" name="usesFolding" index="S$F3s" />
         <reference id="730823979350682502" name="elementsConcept" index="28F8cf" />
         <child id="1140524464360" name="cellLayout" index="2czzBy" />
         <child id="1140524464359" name="emptyCellModel" index="2czzBJ" />
         <child id="6202678563380433923" name="query" index="sbcd9" />
-        <child id="7238779735251877228" name="editorComponent" index="1yzFaX" />
       </concept>
-      <concept id="7238779735251712681" name="com.mbeddr.mpsutil.editor.querylist.structure.QueryListInlineEditorComponent" flags="ig" index="1yz3lS" />
     </language>
     <language id="aee9cad2-acd4-4608-aef2-0004f6a1cdbd" name="jetbrains.mps.lang.actions">
       <concept id="5979988948250981289" name="jetbrains.mps.lang.actions.structure.SNodeCreatorAndInitializer" flags="nn" index="2fJWfE" />
@@ -696,11 +694,9 @@
         <child id="1144104376918" name="parameter" index="1xVPHs" />
       </concept>
       <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
-      <concept id="4693937538533521280" name="jetbrains.mps.lang.smodel.structure.OfConceptOperation" flags="ng" index="v3k3i">
-        <child id="4693937538533538124" name="requestedConcept" index="v3oSu" />
-      </concept>
       <concept id="7453996997717780434" name="jetbrains.mps.lang.smodel.structure.Node_GetSConceptOperation" flags="nn" index="2yIwOk" />
       <concept id="1138757581985" name="jetbrains.mps.lang.smodel.structure.Link_SetNewChildOperation" flags="nn" index="zfrQC" />
+      <concept id="1173122760281" name="jetbrains.mps.lang.smodel.structure.Node_GetAncestorsOperation" flags="nn" index="z$bX8" />
       <concept id="2396822768958367367" name="jetbrains.mps.lang.smodel.structure.AbstractTypeCastExpression" flags="nn" index="$5XWr">
         <child id="6733348108486823193" name="leftExpression" index="1m5AlR" />
         <child id="3906496115198199033" name="conceptArgument" index="3oSUPX" />
@@ -713,9 +709,7 @@
       <concept id="1143235216708" name="jetbrains.mps.lang.smodel.structure.Model_CreateNewNodeOperation" flags="nn" index="I8ghe">
         <reference id="1143235391024" name="concept" index="I8UWU" />
       </concept>
-      <concept id="1145383075378" name="jetbrains.mps.lang.smodel.structure.SNodeListType" flags="in" index="2I9FWS">
-        <reference id="1145383142433" name="elementConcept" index="2I9WkF" />
-      </concept>
+      <concept id="1145383075378" name="jetbrains.mps.lang.smodel.structure.SNodeListType" flags="in" index="2I9FWS" />
       <concept id="1145404486709" name="jetbrains.mps.lang.smodel.structure.SemanticDowncastExpression" flags="nn" index="2JrnkZ">
         <child id="1145404616321" name="leftExpression" index="2JrQYb" />
       </concept>
@@ -724,7 +718,6 @@
       </concept>
       <concept id="1171407110247" name="jetbrains.mps.lang.smodel.structure.Node_GetAncestorOperation" flags="nn" index="2Xjw5R" />
       <concept id="1143511969223" name="jetbrains.mps.lang.smodel.structure.Node_GetPrevSiblingOperation" flags="nn" index="YBYNd" />
-      <concept id="1171500988903" name="jetbrains.mps.lang.smodel.structure.Node_GetChildrenOperation" flags="nn" index="32TBzR" />
       <concept id="5168775467716640652" name="jetbrains.mps.lang.smodel.structure.OperationParm_LinkQualifier" flags="ng" index="1aIX9F">
         <child id="5168775467716640653" name="linkQualifier" index="1aIX9E" />
       </concept>
@@ -808,7 +801,6 @@
       <concept id="1203518072036" name="jetbrains.mps.baseLanguage.collections.structure.SmartClosureParameterDeclaration" flags="ig" index="Rh6nW" />
       <concept id="1160600644654" name="jetbrains.mps.baseLanguage.collections.structure.ListCreatorWithInit" flags="nn" index="Tc6Ow" />
       <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="nn" index="TSZUe" />
-      <concept id="1160666733551" name="jetbrains.mps.baseLanguage.collections.structure.AddAllElementsOperation" flags="nn" index="X8dFx" />
       <concept id="1240216724530" name="jetbrains.mps.baseLanguage.collections.structure.LinkedHashMapCreator" flags="nn" index="32Fmki" />
       <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="nn" index="34oBXx" />
       <concept id="1240325842691" name="jetbrains.mps.baseLanguage.collections.structure.AsSequenceOperation" flags="nn" index="39bAoz" />
@@ -825,6 +817,7 @@
         <child id="1225711182005" name="list" index="1y566C" />
         <child id="1225711191269" name="index" index="1y58nS" />
       </concept>
+      <concept id="1202120902084" name="jetbrains.mps.baseLanguage.collections.structure.WhereOperation" flags="nn" index="3zZkjj" />
       <concept id="1202128969694" name="jetbrains.mps.baseLanguage.collections.structure.SelectOperation" flags="nn" index="3$u5V9" />
       <concept id="1197932370469" name="jetbrains.mps.baseLanguage.collections.structure.MapElement" flags="nn" index="3EllGN">
         <child id="1197932505799" name="map" index="3ElQJh" />
@@ -1001,10 +994,7 @@
         <node concept="2iRfu4" id="5nb$pd3dK38" role="2iSdaV" />
         <node concept="PMmxH" id="5HxjapwcezQ" role="3EZMnx">
           <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
-          <ref role="1k5W1q" node="2TZO3DbviIs" resolve="structure" />
-          <node concept="VPxyj" id="5HxjapwcezR" role="3F10Kt">
-            <property role="VOm3f" value="false" />
-          </node>
+          <ref role="1k5W1q" node="1Y3rEQ3k8Vi" resolve="readOnlyStructure" />
         </node>
         <node concept="1HlG4h" id="4vQSg$AqbVs" role="3EZMnx">
           <node concept="1HfYo3" id="4vQSg$AqbVt" role="1HlULh">
@@ -1433,9 +1423,6 @@
       </node>
       <node concept="VPxyj" id="1Y3rEQ3k8Vy" role="3F10Kt">
         <property role="VOm3f" value="false" />
-      </node>
-      <node concept="xShMh" id="1Y3rEQ3k8VG" role="3F10Kt">
-        <property role="VOm3f" value="true" />
       </node>
       <node concept="Vb9p2" id="1Y3rEQ3k8VS" role="3F10Kt">
         <property role="Vbekb" value="g1_kEg4/ITALIC" />
@@ -7114,454 +7101,6 @@
           </node>
         </node>
       </node>
-      <node concept="3EZMnI" id="hZfTLLs_2I" role="3EZMnx">
-        <node concept="2iRkQZ" id="hZfTLLs_2J" role="2iSdaV" />
-        <node concept="s8t4o" id="hZfTLLs_2Q" role="3EZMnx">
-          <property role="28Zw97" value="true" />
-          <property role="S$F3s" value="false" />
-          <ref role="28F8cf" to="2c95:2TZO3Dbv6Ju" resolve="AbstractSection" />
-          <node concept="xShMh" id="hZfTLLs_2R" role="3F10Kt">
-            <property role="VOm3f" value="true" />
-          </node>
-          <node concept="s8sZD" id="hZfTLLs_2S" role="sbcd9">
-            <node concept="3clFbS" id="hZfTLLs_2T" role="2VODD2">
-              <node concept="3clFbF" id="hZfTLLsA9V" role="3cqZAp">
-                <node concept="2OqwBi" id="hZfTLLvHoE" role="3clFbG">
-                  <node concept="2OqwBi" id="hZfTLLvFV6" role="2Oq$k0">
-                    <node concept="2OqwBi" id="hZfTLLs_34" role="2Oq$k0">
-                      <node concept="2OqwBi" id="hZfTLLs_35" role="2Oq$k0">
-                        <node concept="pncrf" id="hZfTLLs_36" role="2Oq$k0" />
-                        <node concept="3TrEf2" id="hZfTLLs_37" role="2OqNvi">
-                          <ref role="3Tt5mk" to="2c95:5mf_X_Lbqjz" resolve="ref" />
-                        </node>
-                      </node>
-                      <node concept="3TrEf2" id="hZfTLLs_38" role="2OqNvi">
-                        <ref role="3Tt5mk" to="2c95:2TZO3DbvI5E" resolve="doc" />
-                      </node>
-                    </node>
-                    <node concept="3Tsc0h" id="hZfTLLvGrr" role="2OqNvi">
-                      <ref role="3TtcxE" to="2c95:2TZO3Dbv6JU" resolve="contents" />
-                    </node>
-                  </node>
-                  <node concept="v3k3i" id="hZfTLLvKNb" role="2OqNvi">
-                    <node concept="chp4Y" id="hZfTLLvKQZ" role="v3oSu">
-                      <ref role="cht4Q" to="2c95:2TZO3Dbv6Ju" resolve="AbstractSection" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="1yz3lS" id="hZfTLLsAoi" role="1yzFaX">
-            <node concept="3EZMnI" id="hZfTLLvL7R" role="2wV5jI">
-              <node concept="3F0ifn" id="hZfTLLvL9M" role="3EZMnx">
-                <node concept="VPxyj" id="hZfTLLvLcI" role="3F10Kt">
-                  <property role="VOm3f" value="false" />
-                </node>
-                <node concept="VPM3Z" id="hZfTLLvLfl" role="3F10Kt">
-                  <property role="VOm3f" value="false" />
-                </node>
-              </node>
-              <node concept="3F0A7n" id="hZfTLLvL8o" role="3EZMnx">
-                <ref role="1NtTu8" to="2c95:2TZO3Dbv6Jx" resolve="text" />
-                <node concept="Vb9p2" id="hZfTLLyQn0" role="3F10Kt">
-                  <property role="Vbekb" value="g1_k_vY/BOLD" />
-                </node>
-                <node concept="3k4GqR" id="hZfTLLyQpF" role="3F10Kt">
-                  <node concept="3k4GqP" id="hZfTLLyQpH" role="3k4GqO">
-                    <node concept="3clFbS" id="hZfTLLyQpJ" role="2VODD2">
-                      <node concept="3clFbF" id="hZfTLLyQr6" role="3cqZAp">
-                        <node concept="2OqwBi" id="hZfTLL__RL" role="3clFbG">
-                          <node concept="2OqwBi" id="hZfTLL_$6o" role="2Oq$k0">
-                            <node concept="pncrf" id="hZfTLLyQr5" role="2Oq$k0" />
-                            <node concept="32TBzR" id="hZfTLL_$Wd" role="2OqNvi" />
-                          </node>
-                          <node concept="1uHKPH" id="hZfTLL_Ckj" role="2OqNvi" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="3tD6jV" id="2rKfGsW1NHV" role="3F10Kt">
-                  <ref role="3tD7wE" to="tj7y:80_psBRB9K" resolve="hyperlink-reference" />
-                  <node concept="3sjG9q" id="2rKfGsW1NHX" role="3tD6jU">
-                    <node concept="3clFbS" id="2rKfGsW1NHZ" role="2VODD2">
-                      <node concept="3clFbF" id="2rKfGsW1NVw" role="3cqZAp">
-                        <node concept="3clFbT" id="2rKfGsW1NVv" role="3clFbG">
-                          <property role="3clFbU" value="true" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="VSNWy" id="3QtXdiPo5vT" role="3F10Kt">
-                  <node concept="1cFabM" id="3QtXdiPo5Kb" role="1d8cEk">
-                    <node concept="3clFbS" id="3QtXdiPo5Kc" role="2VODD2">
-                      <node concept="3clFbF" id="3QtXdiPo65d" role="3cqZAp">
-                        <node concept="1eOMI4" id="3QtXdiPo8PC" role="3clFbG">
-                          <node concept="10QFUN" id="3QtXdiPo8PD" role="1eOMHV">
-                            <node concept="1eOMI4" id="3QtXdiPo8PE" role="10QFUP">
-                              <node concept="17qRlL" id="3QtXdiPo8Pz" role="1eOMHV">
-                                <node concept="3b6qkQ" id="3QtXdiPo8P$" role="3uHU7w">
-                                  <property role="$nhwW" value="1.2" />
-                                </node>
-                                <node concept="2OqwBi" id="3QtXdiPo8P_" role="3uHU7B">
-                                  <node concept="2YIFZM" id="3QtXdiPo8PA" role="2Oq$k0">
-                                    <ref role="1Pybhc" to="exr9:~EditorSettings" resolve="EditorSettings" />
-                                    <ref role="37wK5l" to="exr9:~EditorSettings.getInstance()" resolve="getInstance" />
-                                  </node>
-                                  <node concept="liA8E" id="3QtXdiPo8PB" role="2OqNvi">
-                                    <ref role="37wK5l" to="exr9:~EditorSettings.getFontSize()" resolve="getFontSize" />
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                            <node concept="10Oyi0" id="3QtXdiPo9kP" role="10QFUM" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="2iRkQZ" id="hZfTLLvL7U" role="2iSdaV" />
-              <node concept="VPM3Z" id="hZfTLLvL7V" role="3F10Kt">
-                <property role="VOm3f" value="false" />
-              </node>
-              <node concept="gc7cB" id="hZfTLLvL8Q" role="3EZMnx">
-                <node concept="3VJUX4" id="hZfTLLvL8S" role="3YsKMw">
-                  <node concept="3clFbS" id="hZfTLLvL8U" role="2VODD2">
-                    <node concept="3clFbF" id="hZfTLLvLfx" role="3cqZAp">
-                      <node concept="2ShNRf" id="hZfTLLvLfv" role="3clFbG">
-                        <node concept="1pGfFk" id="hZfTLLw2Hs" role="2ShVmc">
-                          <ref role="37wK5l" to="r4b4:5$bT90ZdOUF" resolve="HorizLineCell" />
-                          <node concept="pncrf" id="hZfTLLw2IG" role="37wK5m" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="gc7cB" id="7p0Z5lBz0_3" role="3EZMnx">
-                <node concept="3VJUX4" id="7p0Z5lBz0_4" role="3YsKMw">
-                  <node concept="3clFbS" id="7p0Z5lBz0_5" role="2VODD2">
-                    <node concept="3clFbF" id="7p0Z5lBz0_6" role="3cqZAp">
-                      <node concept="2ShNRf" id="7p0Z5lBz0_7" role="3clFbG">
-                        <node concept="1pGfFk" id="7p0Z5lBz0_8" role="2ShVmc">
-                          <ref role="37wK5l" to="r4b4:5$bT90Zfi_h" resolve="VerticalWhitespaceCell" />
-                          <node concept="pncrf" id="7p0Z5lBz0_9" role="37wK5m" />
-                          <node concept="3cmrfG" id="7p0Z5lBz0_a" role="37wK5m">
-                            <property role="3cmrfH" value="8" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="s8t4o" id="hZfTLLw2Nq" role="3EZMnx">
-                <property role="28Zw97" value="true" />
-                <property role="S$F3s" value="true" />
-                <ref role="28F8cf" to="2c95:2TZO3Dbv6Ju" resolve="AbstractSection" />
-                <node concept="xShMh" id="hZfTLLw2Ns" role="3F10Kt">
-                  <property role="VOm3f" value="true" />
-                </node>
-                <node concept="s8sZD" id="hZfTLLw2Nt" role="sbcd9">
-                  <node concept="3clFbS" id="hZfTLLw2Nu" role="2VODD2">
-                    <node concept="3cpWs8" id="hZfTLLF5i4" role="3cqZAp">
-                      <node concept="3cpWsn" id="hZfTLLF5i7" role="3cpWs9">
-                        <property role="TrG5h" value="res" />
-                        <node concept="2I9FWS" id="hZfTLLF5i2" role="1tU5fm">
-                          <ref role="2I9WkF" to="2c95:2TZO3Dbv6Ju" resolve="AbstractSection" />
-                        </node>
-                        <node concept="2ShNRf" id="hZfTLLF5BY" role="33vP2m">
-                          <node concept="2T8Vx0" id="hZfTLLF6ku" role="2ShVmc">
-                            <node concept="2I9FWS" id="hZfTLLF6kw" role="2T96Bj">
-                              <ref role="2I9WkF" to="2c95:2TZO3Dbv6Ju" resolve="AbstractSection" />
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="3clFbF" id="hZfTLLw2Nv" role="3cqZAp">
-                      <node concept="2OqwBi" id="hZfTLLF866" role="3clFbG">
-                        <node concept="2OqwBi" id="hZfTLLw30b" role="2Oq$k0">
-                          <node concept="pncrf" id="hZfTLLw2Uo" role="2Oq$k0" />
-                          <node concept="3Tsc0h" id="hZfTLLw3PV" role="2OqNvi">
-                            <ref role="3TtcxE" to="2c95:2TZO3Dbv6JU" resolve="contents" />
-                          </node>
-                        </node>
-                        <node concept="2es0OD" id="hZfTLLF9Me" role="2OqNvi">
-                          <node concept="1bVj0M" id="hZfTLLF9Mg" role="23t8la">
-                            <node concept="3clFbS" id="hZfTLLF9Mh" role="1bW5cS">
-                              <node concept="3clFbJ" id="hZfTLLF9X$" role="3cqZAp">
-                                <node concept="3clFbS" id="hZfTLLF9X_" role="3clFbx">
-                                  <node concept="3clFbF" id="hZfTLLFbfX" role="3cqZAp">
-                                    <node concept="2OqwBi" id="hZfTLLFbXw" role="3clFbG">
-                                      <node concept="37vLTw" id="hZfTLLFbfW" role="2Oq$k0">
-                                        <ref role="3cqZAo" node="hZfTLLF5i7" resolve="res" />
-                                      </node>
-                                      <node concept="X8dFx" id="hZfTLLFh99" role="2OqNvi">
-                                        <node concept="2OqwBi" id="hZfTLLMSNC" role="25WWJ7">
-                                          <node concept="2OqwBi" id="hZfTLLFsh5" role="2Oq$k0">
-                                            <node concept="2OqwBi" id="hZfTLLFpMc" role="2Oq$k0">
-                                              <node concept="2OqwBi" id="hZfTLLFmfa" role="2Oq$k0">
-                                                <node concept="1PxgMI" id="hZfTLLFkbh" role="2Oq$k0">
-                                                  <node concept="37vLTw" id="hZfTLLFitp" role="1m5AlR">
-                                                    <ref role="3cqZAo" node="hZfTLLF9Mi" resolve="it" />
-                                                  </node>
-                                                  <node concept="chp4Y" id="79i$vAXZAyc" role="3oSUPX">
-                                                    <ref role="cht4Q" to="2c95:5mf_X_Lbqjw" resolve="DocumentInclude" />
-                                                  </node>
-                                                </node>
-                                                <node concept="3TrEf2" id="hZfTLLFoFn" role="2OqNvi">
-                                                  <ref role="3Tt5mk" to="2c95:5mf_X_Lbqjz" resolve="ref" />
-                                                </node>
-                                              </node>
-                                              <node concept="3TrEf2" id="hZfTLLFrB5" role="2OqNvi">
-                                                <ref role="3Tt5mk" to="2c95:2TZO3DbvI5E" resolve="doc" />
-                                              </node>
-                                            </node>
-                                            <node concept="3Tsc0h" id="hZfTLLFvj1" role="2OqNvi">
-                                              <ref role="3TtcxE" to="2c95:2TZO3Dbv6JU" resolve="contents" />
-                                            </node>
-                                          </node>
-                                          <node concept="v3k3i" id="hZfTLLMXoz" role="2OqNvi">
-                                            <node concept="chp4Y" id="hZfTLLMZda" role="v3oSu">
-                                              <ref role="cht4Q" to="2c95:2TZO3Dbv6Ju" resolve="AbstractSection" />
-                                            </node>
-                                          </node>
-                                        </node>
-                                      </node>
-                                    </node>
-                                  </node>
-                                </node>
-                                <node concept="2OqwBi" id="hZfTLLFa8M" role="3clFbw">
-                                  <node concept="37vLTw" id="hZfTLLFa2Y" role="2Oq$k0">
-                                    <ref role="3cqZAo" node="hZfTLLF9Mi" resolve="it" />
-                                  </node>
-                                  <node concept="1mIQ4w" id="hZfTLLFaQ6" role="2OqNvi">
-                                    <node concept="chp4Y" id="hZfTLLFb2P" role="cj9EA">
-                                      <ref role="cht4Q" to="2c95:5mf_X_Lbqjw" resolve="DocumentInclude" />
-                                    </node>
-                                  </node>
-                                </node>
-                                <node concept="3eNFk2" id="hZfTLLN7I5" role="3eNLev">
-                                  <node concept="2OqwBi" id="hZfTLLNdlE" role="3eO9$A">
-                                    <node concept="37vLTw" id="hZfTLLNbGs" role="2Oq$k0">
-                                      <ref role="3cqZAo" node="hZfTLLF9Mi" resolve="it" />
-                                    </node>
-                                    <node concept="1mIQ4w" id="hZfTLLNf9o" role="2OqNvi">
-                                      <node concept="chp4Y" id="hZfTLLNh6N" role="cj9EA">
-                                        <ref role="cht4Q" to="2c95:2TZO3Dbv6Ju" resolve="AbstractSection" />
-                                      </node>
-                                    </node>
-                                  </node>
-                                  <node concept="3clFbS" id="hZfTLLN7I7" role="3eOfB_">
-                                    <node concept="3clFbF" id="hZfTLLNiol" role="3cqZAp">
-                                      <node concept="2OqwBi" id="hZfTLLNlqK" role="3clFbG">
-                                        <node concept="37vLTw" id="hZfTLLNiok" role="2Oq$k0">
-                                          <ref role="3cqZAo" node="hZfTLLF5i7" resolve="res" />
-                                        </node>
-                                        <node concept="TSZUe" id="hZfTLLNwyN" role="2OqNvi">
-                                          <node concept="1PxgMI" id="hZfTLLNA1h" role="25WWJ7">
-                                            <node concept="37vLTw" id="hZfTLLN$CC" role="1m5AlR">
-                                              <ref role="3cqZAo" node="hZfTLLF9Mi" resolve="it" />
-                                            </node>
-                                            <node concept="chp4Y" id="79i$vAXZAyh" role="3oSUPX">
-                                              <ref role="cht4Q" to="2c95:2TZO3Dbv6Ju" resolve="AbstractSection" />
-                                            </node>
-                                          </node>
-                                        </node>
-                                      </node>
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                            <node concept="Rh6nW" id="hZfTLLF9Mi" role="1bW2Oz">
-                              <property role="TrG5h" value="it" />
-                              <node concept="2jxLKc" id="hZfTLLF9Mj" role="1tU5fm" />
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="3clFbF" id="hZfTLLF6T8" role="3cqZAp">
-                      <node concept="37vLTw" id="hZfTLLF6T6" role="3clFbG">
-                        <ref role="3cqZAo" node="hZfTLLF5i7" resolve="res" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="1yz3lS" id="hZfTLLw8_L" role="1yzFaX">
-                  <node concept="3EZMnI" id="hZfTLLw8Ih" role="2wV5jI">
-                    <node concept="2iRkQZ" id="7p0Z5lBok6j" role="2iSdaV" />
-                    <node concept="VPM3Z" id="hZfTLLw8Il" role="3F10Kt">
-                      <property role="VOm3f" value="false" />
-                    </node>
-                    <node concept="3F0A7n" id="7p0Z5lBdCcC" role="3EZMnx">
-                      <ref role="1NtTu8" to="2c95:2TZO3Dbv6Jx" resolve="text" />
-                      <node concept="Vb9p2" id="7p0Z5lBgkyC" role="3F10Kt">
-                        <property role="Vbekb" value="g1_k_vY/BOLD" />
-                      </node>
-                      <node concept="3k4GqR" id="4Rhu9QGCU0E" role="3F10Kt">
-                        <node concept="3k4GqP" id="4Rhu9QGCU0G" role="3k4GqO">
-                          <node concept="3clFbS" id="4Rhu9QGCU0I" role="2VODD2">
-                            <node concept="3clFbF" id="4Rhu9QGCU8S" role="3cqZAp">
-                              <node concept="2OqwBi" id="4Rhu9QGCWaP" role="3clFbG">
-                                <node concept="2OqwBi" id="4Rhu9QGCUeE" role="2Oq$k0">
-                                  <node concept="pncrf" id="4Rhu9QGCU8R" role="2Oq$k0" />
-                                  <node concept="32TBzR" id="4Rhu9QGCVml" role="2OqNvi" />
-                                </node>
-                                <node concept="1uHKPH" id="4Rhu9QGCYA5" role="2OqNvi" />
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="3tD6jV" id="4Rhu9QGCYK_" role="3F10Kt">
-                        <ref role="3tD7wE" to="tj7y:80_psBRB9K" resolve="hyperlink-reference" />
-                        <node concept="3sjG9q" id="4Rhu9QGCYKB" role="3tD6jU">
-                          <node concept="3clFbS" id="4Rhu9QGCYKD" role="2VODD2">
-                            <node concept="3clFbF" id="4Rhu9QGCYYI" role="3cqZAp">
-                              <node concept="3clFbT" id="4Rhu9QGCYYH" role="3clFbG">
-                                <property role="3clFbU" value="true" />
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="s8t4o" id="4KbglN_l2ZW" role="3EZMnx">
-                      <property role="28Zw97" value="true" />
-                      <ref role="28F8cf" to="2c95:2TZO3Dbv6Ju" resolve="AbstractSection" />
-                      <node concept="s8sZD" id="4KbglN_l30J" role="sbcd9">
-                        <node concept="3clFbS" id="4KbglN_l30K" role="2VODD2">
-                          <node concept="3clFbF" id="4KbglN_l30L" role="3cqZAp">
-                            <node concept="2OqwBi" id="4KbglN_l5mf" role="3clFbG">
-                              <node concept="2OqwBi" id="4KbglN_l3eG" role="2Oq$k0">
-                                <node concept="pncrf" id="4KbglN_l38L" role="2Oq$k0" />
-                                <node concept="3Tsc0h" id="4KbglN_l4f8" role="2OqNvi">
-                                  <ref role="3TtcxE" to="2c95:2TZO3Dbv6JU" resolve="contents" />
-                                </node>
-                              </node>
-                              <node concept="v3k3i" id="4KbglN_l8FZ" role="2OqNvi">
-                                <node concept="chp4Y" id="4KbglN_l8La" role="v3oSu">
-                                  <ref role="cht4Q" to="2c95:2TZO3Dbv6Ju" resolve="AbstractSection" />
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="1yz3lS" id="4KbglN_l93M" role="1yzFaX">
-                        <node concept="3EZMnI" id="7p0Z5lBokNO" role="2wV5jI">
-                          <node concept="2iRfu4" id="7p0Z5lBokNP" role="2iSdaV" />
-                          <node concept="3XFhqQ" id="7p0Z5lBol7V" role="3EZMnx" />
-                          <node concept="3F0A7n" id="4KbglN_l9cC" role="3EZMnx">
-                            <ref role="1NtTu8" to="2c95:2TZO3Dbv6Jx" resolve="text" />
-                            <node concept="3k4GqR" id="7p0Z5lBlwTp" role="3F10Kt">
-                              <node concept="3k4GqP" id="7p0Z5lBlwTq" role="3k4GqO">
-                                <node concept="3clFbS" id="7p0Z5lBlwTr" role="2VODD2">
-                                  <node concept="3clFbF" id="7p0Z5lBlwUJ" role="3cqZAp">
-                                    <node concept="2OqwBi" id="7p0Z5lBlyWx" role="3clFbG">
-                                      <node concept="2OqwBi" id="7p0Z5lBlx0x" role="2Oq$k0">
-                                        <node concept="pncrf" id="7p0Z5lBlwUI" role="2Oq$k0" />
-                                        <node concept="32TBzR" id="7p0Z5lBly16" role="2OqNvi" />
-                                      </node>
-                                      <node concept="1uHKPH" id="7p0Z5lBl_od" role="2OqNvi" />
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                            <node concept="3tD6jV" id="7p0Z5lBlAcW" role="3F10Kt">
-                              <ref role="3tD7wE" to="tj7y:80_psBRB9K" resolve="hyperlink-reference" />
-                              <node concept="3sjG9q" id="7p0Z5lBlAcY" role="3tD6jU">
-                                <node concept="3clFbS" id="7p0Z5lBlAd0" role="2VODD2">
-                                  <node concept="3clFbF" id="7p0Z5lBlAkx" role="3cqZAp">
-                                    <node concept="3clFbT" id="7p0Z5lBlAkw" role="3clFbG">
-                                      <property role="3clFbU" value="true" />
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="2iRkQZ" id="7p0Z5lBqVlf" role="2czzBy" />
-                      <node concept="pkWqt" id="4KbglN_sKzR" role="pqm2j">
-                        <node concept="3clFbS" id="4KbglN_sKzS" role="2VODD2">
-                          <node concept="3clFbF" id="4KbglN_sKIv" role="3cqZAp">
-                            <node concept="2OqwBi" id="4KbglN_sPWV" role="3clFbG">
-                              <node concept="2OqwBi" id="4KbglN_sNlJ" role="2Oq$k0">
-                                <node concept="2OqwBi" id="4KbglN_sKQV" role="2Oq$k0">
-                                  <node concept="pncrf" id="4KbglN_sKIu" role="2Oq$k0" />
-                                  <node concept="3Tsc0h" id="4KbglN_sLKC" role="2OqNvi">
-                                    <ref role="3TtcxE" to="2c95:2TZO3Dbv6JU" resolve="contents" />
-                                  </node>
-                                </node>
-                                <node concept="v3k3i" id="4KbglN_sPcy" role="2OqNvi">
-                                  <node concept="chp4Y" id="4KbglN_sPr0" role="v3oSu">
-                                    <ref role="cht4Q" to="2c95:2TZO3Dbv6Ju" resolve="AbstractSection" />
-                                  </node>
-                                </node>
-                              </node>
-                              <node concept="3GX2aA" id="4KbglN_sQDf" role="2OqNvi" />
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="gc7cB" id="7p0Z5lBw3pl" role="3EZMnx">
-                      <node concept="3VJUX4" id="7p0Z5lBw3pn" role="3YsKMw">
-                        <node concept="3clFbS" id="7p0Z5lBw3pp" role="2VODD2">
-                          <node concept="3clFbF" id="7p0Z5lBw3Lr" role="3cqZAp">
-                            <node concept="2ShNRf" id="7p0Z5lBw3Lp" role="3clFbG">
-                              <node concept="1pGfFk" id="7p0Z5lBwlzG" role="2ShVmc">
-                                <ref role="37wK5l" to="r4b4:5$bT90Zfi_h" resolve="VerticalWhitespaceCell" />
-                                <node concept="pncrf" id="7p0Z5lBwl_k" role="37wK5m" />
-                                <node concept="3cmrfG" id="7p0Z5lBwlIC" role="37wK5m">
-                                  <property role="3cmrfH" value="8" />
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="2EHx9g" id="7p0Z5lBiUYh" role="2czzBy" />
-                <node concept="3F0ifn" id="5IsbCt$uIiW" role="2czzBJ">
-                  <node concept="xShMh" id="5IsbCt$uNzy" role="3F10Kt">
-                    <property role="VOm3f" value="true" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="3F0ifn" id="5IsbCt$vm6v" role="2czzBJ">
-            <node concept="xShMh" id="5IsbCt$vmKs" role="3F10Kt">
-              <property role="VOm3f" value="true" />
-            </node>
-          </node>
-        </node>
-        <node concept="pkWqt" id="hZfTLLs_3b" role="pqm2j">
-          <node concept="3clFbS" id="hZfTLLs_3c" role="2VODD2">
-            <node concept="3clFbF" id="hZfTLLs_3d" role="3cqZAp">
-              <node concept="2OqwBi" id="hZfTLLs_3f" role="3clFbG">
-                <node concept="pncrf" id="hZfTLLs_3g" role="2Oq$k0" />
-                <node concept="3TrcHB" id="hZfTLLs_3h" role="2OqNvi">
-                  <ref role="3TsBF5" to="2c95:hZfTLLrEWd" resolve="referenceOnly" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
     </node>
     <node concept="2aJ2om" id="39jEAIlmBpD" role="CpUAK">
       <ref role="2$4xQ3" to="r4b4:7xesQBpJXuT" resolve="presentationMode" />
@@ -12390,268 +11929,32 @@
         </node>
       </node>
       <node concept="2iRkQZ" id="73FPRWNmxIm" role="2iSdaV" />
-      <node concept="s8t4o" id="73FPRWNmxIt" role="3EZMnx">
+      <node concept="s8t4o" id="3DLpMpAbzJ2" role="3EZMnx">
         <property role="28Zw97" value="true" />
-        <ref role="28F8cf" to="2c95:2TZO3Dbv6Ju" resolve="AbstractSection" />
-        <node concept="xShMh" id="73FPRWNmxIv" role="3F10Kt">
+        <ref role="28F8cf" to="2c95:3DLpMp_rLlz" resolve="ITocEntry" />
+        <node concept="xShMh" id="3DLpMpAbzJ3" role="3F10Kt">
           <property role="VOm3f" value="true" />
         </node>
-        <node concept="s8sZD" id="73FPRWNmxIw" role="sbcd9">
-          <node concept="3clFbS" id="73FPRWNmxIx" role="2VODD2">
-            <node concept="3clFbF" id="73FPRWNprUY" role="3cqZAp">
-              <node concept="2OqwBi" id="73FPRWNpsdD" role="3clFbG">
-                <node concept="pncrf" id="73FPRWNprUX" role="2Oq$k0" />
-                <node concept="2qgKlT" id="73FPRWNpsI7" role="2OqNvi">
+        <node concept="s8sZD" id="3DLpMpAbzJ4" role="sbcd9">
+          <node concept="3clFbS" id="3DLpMpAbzJ5" role="2VODD2">
+            <node concept="3clFbF" id="3DLpMpAbzJ6" role="3cqZAp">
+              <node concept="2OqwBi" id="3DLpMpAbzJ7" role="3clFbG">
+                <node concept="pncrf" id="3DLpMpAbzJ8" role="2Oq$k0" />
+                <node concept="2qgKlT" id="3DLpMpAbzJ9" role="2OqNvi">
                   <ref role="37wK5l" to="4gky:73FPRWNpfg_" resolve="getEntriesFlat" />
                 </node>
               </node>
             </node>
           </node>
         </node>
-        <node concept="1yz3lS" id="73FPRWNmAdK" role="1yzFaX">
-          <node concept="gc7cB" id="4RNNpFeNiYC" role="2wV5jI">
-            <node concept="3tD6jV" id="73FPRWNzplR" role="3F10Kt">
-              <ref role="3tD7wE" to="z0fb:vtaHb5XosV" resolve="_margin-left" />
-              <node concept="3sjG9q" id="73FPRWNzplS" role="3tD6jU">
-                <node concept="3clFbS" id="73FPRWNzplT" role="2VODD2">
-                  <node concept="3clFbF" id="73FPRWNzpEB" role="3cqZAp">
-                    <node concept="17qRlL" id="73FPRWNzrBl" role="3clFbG">
-                      <node concept="3cmrfG" id="73FPRWNzrBo" role="3uHU7w">
-                        <property role="3cmrfH" value="20" />
-                      </node>
-                      <node concept="2OqwBi" id="73FPRWNzq70" role="3uHU7B">
-                        <node concept="pncrf" id="73FPRWNzpEA" role="2Oq$k0" />
-                        <node concept="2qgKlT" id="73FPRWNzqO0" role="2OqNvi">
-                          <ref role="37wK5l" to="4gky:4vQSg$AqJMN" resolve="nestingLevel" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="Vb9p2" id="4RNNpFf1GsM" role="3F10Kt" />
-            <node concept="VPM3Z" id="4RNNpFf4yJY" role="3F10Kt" />
-            <node concept="xShMh" id="4RNNpFf4zUk" role="3F10Kt">
-              <property role="VOm3f" value="true" />
-            </node>
-            <node concept="3tD6jV" id="4RNNpFe8FYO" role="3F10Kt">
-              <ref role="3tD7wE" to="tj7y:5A_Zlt6qyoK" resolve="hyperlink-handler" />
-              <node concept="3sjG9q" id="4RNNpFe8FYQ" role="3tD6jU">
-                <node concept="3clFbS" id="4RNNpFe8FYR" role="2VODD2">
-                  <node concept="3clFbF" id="4RNNpFe8Gmk" role="3cqZAp">
-                    <node concept="2ShNRf" id="4RNNpFe8Gme" role="3clFbG">
-                      <node concept="YeOm9" id="4RNNpFe8Hfk" role="2ShVmc">
-                        <node concept="1Y3b0j" id="4RNNpFe8Hfn" role="YeSDq">
-                          <property role="2bfB8j" value="true" />
-                          <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
-                          <ref role="1Y3XeK" to="ag3p:5A_Zlt6xR6d" resolve="HyperlinkHandler" />
-                          <node concept="3Tm1VV" id="4RNNpFe8Hfo" role="1B3o_S" />
-                          <node concept="3clFb_" id="4RNNpFe8Hft" role="jymVt">
-                            <property role="TrG5h" value="open" />
-                            <node concept="3cqZAl" id="4RNNpFe8Hfu" role="3clF45" />
-                            <node concept="3Tm1VV" id="4RNNpFe8Hfv" role="1B3o_S" />
-                            <node concept="37vLTG" id="4RNNpFe8Hfx" role="3clF46">
-                              <property role="TrG5h" value="util" />
-                              <node concept="3uibUv" id="4RNNpFe8Hfy" role="1tU5fm">
-                                <ref role="3uigEE" to="ag3p:5A_Zlt6xR7j" resolve="HyperlinkUtil" />
-                              </node>
-                            </node>
-                            <node concept="3clFbS" id="4RNNpFe8Hfz" role="3clF47">
-                              <node concept="3cpWs8" id="4RNNpFe8MAM" role="3cqZAp">
-                                <node concept="3cpWsn" id="4RNNpFe8MAN" role="3cpWs9">
-                                  <property role="TrG5h" value="root" />
-                                  <node concept="3uibUv" id="4RNNpFe8M_M" role="1tU5fm">
-                                    <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
-                                  </node>
-                                  <node concept="2OqwBi" id="4RNNpFe8MAO" role="33vP2m">
-                                    <node concept="2OqwBi" id="4RNNpFe8MAP" role="2Oq$k0">
-                                      <node concept="1Q80Hx" id="4RNNpFe8MAQ" role="2Oq$k0" />
-                                      <node concept="liA8E" id="4RNNpFe8MAR" role="2OqNvi">
-                                        <ref role="37wK5l" to="cj4x:~EditorContext.getEditorComponent()" resolve="getEditorComponent" />
-                                      </node>
-                                    </node>
-                                    <node concept="liA8E" id="4RNNpFe8MAS" role="2OqNvi">
-                                      <ref role="37wK5l" to="cj4x:~EditorComponent.getRootCell()" resolve="getRootCell" />
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                              <node concept="3cpWs8" id="4RNNpFe9oDy" role="3cqZAp">
-                                <node concept="3cpWsn" id="4RNNpFe9oDz" role="3cpWs9">
-                                  <property role="TrG5h" value="toSelect" />
-                                  <node concept="3uibUv" id="4RNNpFe9o_L" role="1tU5fm">
-                                    <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
-                                  </node>
-                                  <node concept="2YIFZM" id="4RNNpFe9oD$" role="33vP2m">
-                                    <ref role="37wK5l" to="g51k:~CellFinderUtil.findChildByCondition(jetbrains.mps.openapi.editor.cells.EditorCell,org.jetbrains.mps.util.Condition,boolean)" resolve="findChildByCondition" />
-                                    <ref role="1Pybhc" to="g51k:~CellFinderUtil" resolve="CellFinderUtil" />
-                                    <node concept="37vLTw" id="4RNNpFe9oD_" role="37wK5m">
-                                      <ref role="3cqZAo" node="4RNNpFe8MAN" resolve="root" />
-                                    </node>
-                                    <node concept="1bVj0M" id="4RNNpFe9oDA" role="37wK5m">
-                                      <node concept="3clFbS" id="4RNNpFe9oDB" role="1bW5cS">
-                                        <node concept="3cpWs6" id="4RNNpFe9oDC" role="3cqZAp">
-                                          <node concept="17R0WA" id="4RNNpFe9oDD" role="3cqZAk">
-                                            <node concept="2OqwBi" id="4RNNpFe9oDF" role="3uHU7B">
-                                              <node concept="37vLTw" id="4RNNpFe9oDG" role="2Oq$k0">
-                                                <ref role="3cqZAo" node="4RNNpFe9oDI" resolve="cell" />
-                                              </node>
-                                              <node concept="liA8E" id="4RNNpFe9oDH" role="2OqNvi">
-                                                <ref role="37wK5l" to="f4zo:~EditorCell.getSNode()" resolve="getSNode" />
-                                              </node>
-                                            </node>
-                                            <node concept="pncrf" id="4RNNpFeykLb" role="3uHU7w" />
-                                          </node>
-                                        </node>
-                                      </node>
-                                      <node concept="37vLTG" id="4RNNpFe9oDI" role="1bW2Oz">
-                                        <property role="TrG5h" value="cell" />
-                                        <node concept="3uibUv" id="4RNNpFe9oDJ" role="1tU5fm">
-                                          <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
-                                        </node>
-                                      </node>
-                                    </node>
-                                    <node concept="3clFbT" id="4RNNpFe9oDK" role="37wK5m">
-                                      <property role="3clFbU" value="true" />
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                              <node concept="3clFbF" id="4RNNpFe9pMo" role="3cqZAp">
-                                <node concept="2OqwBi" id="4RNNpFe9qsX" role="3clFbG">
-                                  <node concept="2OqwBi" id="4RNNpFe9q9$" role="2Oq$k0">
-                                    <node concept="1Q80Hx" id="4RNNpFe9pMn" role="2Oq$k0" />
-                                    <node concept="liA8E" id="4RNNpFe9qnf" role="2OqNvi">
-                                      <ref role="37wK5l" to="cj4x:~EditorContext.getSelectionManager()" resolve="getSelectionManager" />
-                                    </node>
-                                  </node>
-                                  <node concept="liA8E" id="4RNNpFe9qE1" role="2OqNvi">
-                                    <ref role="37wK5l" to="lwvz:~SelectionManager.setSelection(jetbrains.mps.openapi.editor.cells.EditorCell)" resolve="setSelection" />
-                                    <node concept="37vLTw" id="4RNNpFe9qPw" role="37wK5m">
-                                      <ref role="3cqZAo" node="4RNNpFe9oDz" resolve="toSelect" />
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                              <node concept="3clFbF" id="4RNNpFeYSMz" role="3cqZAp">
-                                <node concept="2OqwBi" id="4RNNpFeYW8S" role="3clFbG">
-                                  <node concept="2OqwBi" id="4RNNpFeYTtz" role="2Oq$k0">
-                                    <node concept="1Q80Hx" id="4RNNpFeYSMA" role="2Oq$k0" />
-                                    <node concept="liA8E" id="4RNNpFeYW3a" role="2OqNvi">
-                                      <ref role="37wK5l" to="cj4x:~EditorContext.getEditorComponent()" resolve="getEditorComponent" />
-                                    </node>
-                                  </node>
-                                  <node concept="liA8E" id="4RNNpFeYWnO" role="2OqNvi">
-                                    <ref role="37wK5l" to="cj4x:~EditorComponent.scrollToCell(jetbrains.mps.openapi.editor.cells.EditorCell)" resolve="scrollToCell" />
-                                    <node concept="37vLTw" id="4RNNpFeYWIL" role="37wK5m">
-                                      <ref role="3cqZAo" node="4RNNpFe9oDz" resolve="toSelect" />
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                            <node concept="2AHcQZ" id="4RNNpFe8Hf_" role="2AJF6D">
-                              <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3VJUX4" id="4RNNpFeNiYE" role="3YsKMw">
-              <node concept="3clFbS" id="4RNNpFeNiYG" role="2VODD2">
-                <node concept="3clFbF" id="4RNNpFeQyJ6" role="3cqZAp">
-                  <node concept="2ShNRf" id="4RNNpFeQyJ2" role="3clFbG">
-                    <node concept="YeOm9" id="4RNNpFeQzBW" role="2ShVmc">
-                      <node concept="1Y3b0j" id="4RNNpFeQzBZ" role="YeSDq">
-                        <property role="2bfB8j" value="true" />
-                        <ref role="37wK5l" to="exr9:~AbstractCellProvider.&lt;init&gt;(org.jetbrains.mps.openapi.model.SNode)" resolve="AbstractCellProvider" />
-                        <ref role="1Y3XeK" to="exr9:~AbstractCellProvider" resolve="AbstractCellProvider" />
-                        <node concept="3Tm1VV" id="4RNNpFeQzC0" role="1B3o_S" />
-                        <node concept="3clFb_" id="4RNNpFeQzC3" role="jymVt">
-                          <property role="TrG5h" value="createEditorCell" />
-                          <node concept="3Tm1VV" id="4RNNpFeQzC4" role="1B3o_S" />
-                          <node concept="3uibUv" id="4RNNpFeQzC6" role="3clF45">
-                            <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
-                          </node>
-                          <node concept="37vLTG" id="4RNNpFeQzC7" role="3clF46">
-                            <property role="TrG5h" value="p1" />
-                            <node concept="3uibUv" id="4RNNpFeQzC8" role="1tU5fm">
-                              <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
-                            </node>
-                          </node>
-                          <node concept="3clFbS" id="4RNNpFeQzC9" role="3clF47">
-                            <node concept="3cpWs8" id="4RNNpFeTkRR" role="3cqZAp">
-                              <node concept="3cpWsn" id="4RNNpFeTkRS" role="3cpWs9">
-                                <property role="TrG5h" value="text" />
-                                <node concept="17QB3L" id="4RNNpFeTkn2" role="1tU5fm" />
-                                <node concept="3cpWs3" id="4RNNpFeTl7B" role="33vP2m">
-                                  <node concept="Xl_RD" id="4RNNpFeTmB6" role="3uHU7B">
-                                    <property role="Xl_RC" value="• " />
-                                  </node>
-                                  <node concept="2OqwBi" id="4RNNpFeTkRT" role="3uHU7w">
-                                    <node concept="pncrf" id="4RNNpFeTkRU" role="2Oq$k0" />
-                                    <node concept="3TrcHB" id="4RNNpFeTkRV" role="2OqNvi">
-                                      <ref role="3TsBF5" to="2c95:2TZO3Dbv6Jx" resolve="text" />
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                            <node concept="3clFbF" id="4RNNpFeNk8w" role="3cqZAp">
-                              <node concept="2ShNRf" id="4RNNpFeNk8u" role="3clFbG">
-                                <node concept="YeOm9" id="4RNNpFeW81B" role="2ShVmc">
-                                  <node concept="1Y3b0j" id="4RNNpFeW81E" role="YeSDq">
-                                    <property role="2bfB8j" value="true" />
-                                    <ref role="37wK5l" to="g51k:~EditorCell_Constant.&lt;init&gt;(jetbrains.mps.openapi.editor.EditorContext,org.jetbrains.mps.openapi.model.SNode,java.lang.String,boolean)" resolve="EditorCell_Constant" />
-                                    <ref role="1Y3XeK" to="g51k:~EditorCell_Constant" resolve="EditorCell_Constant" />
-                                    <node concept="3Tm1VV" id="4RNNpFeW81F" role="1B3o_S" />
-                                    <node concept="1Q80Hx" id="4RNNpFeQwzh" role="37wK5m" />
-                                    <node concept="pncrf" id="4RNNpFeQxAu" role="37wK5m" />
-                                    <node concept="37vLTw" id="4RNNpFeTkRW" role="37wK5m">
-                                      <ref role="3cqZAo" node="4RNNpFeTkRS" resolve="text" />
-                                    </node>
-                                    <node concept="3clFbT" id="4RNNpFeQyw4" role="37wK5m" />
-                                    <node concept="3clFb_" id="4RNNpFeW8eI" role="jymVt">
-                                      <property role="TrG5h" value="getSNode" />
-                                      <node concept="3Tm1VV" id="4RNNpFeW8eJ" role="1B3o_S" />
-                                      <node concept="3uibUv" id="4RNNpFeW8eL" role="3clF45">
-                                        <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
-                                      </node>
-                                      <node concept="3clFbS" id="4RNNpFeW8eT" role="3clF47">
-                                        <node concept="3cpWs6" id="4RNNpFeW9Av" role="3cqZAp">
-                                          <node concept="10Nm6u" id="4RNNpFeW9Ax" role="3cqZAk" />
-                                        </node>
-                                      </node>
-                                      <node concept="2AHcQZ" id="4RNNpFeW8eU" role="2AJF6D">
-                                        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-                                      </node>
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                          <node concept="2AHcQZ" id="4RNNpFeQzCb" role="2AJF6D">
-                            <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-                          </node>
-                        </node>
-                        <node concept="pncrf" id="4RNNpFeQ$Jt" role="37wK5m" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="2iRkQZ" id="73FPRWNrBKv" role="2czzBy" />
+        <node concept="2iRkQZ" id="3DLpMpAbzLm" role="2czzBy" />
       </node>
       <node concept="3F0ifn" id="73FPRWNz96q" role="3EZMnx" />
+      <node concept="2w$q5c" id="3DLpMpAsRd4" role="2whIAn">
+        <node concept="2aJ2om" id="3DLpMpAsRd5" role="2w$qW5">
+          <ref role="2$4xQ3" node="3DLpMpAev2X" resolve="ToCEntry" />
+        </node>
+      </node>
     </node>
     <node concept="3EZMnI" id="73FPRWNmwwJ" role="6VMZX">
       <node concept="2iRkQZ" id="73FPRWNmwwK" role="2iSdaV" />
@@ -12670,6 +11973,432 @@
     </node>
     <node concept="2aJ2om" id="73FPRWNmwwS" role="CpUAK">
       <ref role="2$4xQ3" to="r4b4:7xesQBpJXuT" resolve="presentationMode" />
+    </node>
+  </node>
+  <node concept="2ABfQD" id="3DLpMpAev2W">
+    <property role="TrG5h" value="DocHints" />
+    <property role="3GE5qa" value="structure" />
+    <node concept="2BsEeg" id="3DLpMpAev2X" role="2ABdcP">
+      <property role="2gpH_U" value="true" />
+      <property role="TrG5h" value="ToCEntry" />
+    </node>
+  </node>
+  <node concept="24kQdi" id="3DLpMpAewn4">
+    <property role="3GE5qa" value="structure" />
+    <ref role="1XX52x" to="2c95:2TZO3Dbv6Ju" resolve="AbstractSection" />
+    <node concept="2aJ2om" id="3DLpMpAexi3" role="CpUAK">
+      <ref role="2$4xQ3" node="3DLpMpAev2X" resolve="ToCEntry" />
+    </node>
+    <node concept="3EZMnI" id="3DLpMpAywk4" role="2wV5jI">
+      <node concept="2iRfu4" id="3DLpMpAywk5" role="2iSdaV" />
+      <node concept="gc7cB" id="4RNNpFeNiYC" role="3EZMnx">
+        <node concept="3tD6jV" id="73FPRWNzplR" role="3F10Kt">
+          <ref role="3tD7wE" to="z0fb:vtaHb5XosV" resolve="_margin-left" />
+          <node concept="3sjG9q" id="73FPRWNzplS" role="3tD6jU">
+            <node concept="3clFbS" id="73FPRWNzplT" role="2VODD2">
+              <node concept="3clFbF" id="73FPRWNzpEB" role="3cqZAp">
+                <node concept="17qRlL" id="73FPRWNzrBl" role="3clFbG">
+                  <node concept="3cmrfG" id="73FPRWNzrBo" role="3uHU7w">
+                    <property role="3cmrfH" value="20" />
+                  </node>
+                  <node concept="2OqwBi" id="4vQSg$AqJMZ" role="3uHU7B">
+                    <node concept="2OqwBi" id="3DLpMp__tR8" role="2Oq$k0">
+                      <node concept="2OqwBi" id="4vQSg$AqJN0" role="2Oq$k0">
+                        <node concept="pncrf" id="3DLpMp__rXj" role="2Oq$k0" />
+                        <node concept="z$bX8" id="4vQSg$AqJN2" role="2OqNvi">
+                          <node concept="1xMEDy" id="4vQSg$AqJN3" role="1xVPHs">
+                            <node concept="chp4Y" id="3DLpMp__sjx" role="ri$Ld">
+                              <ref role="cht4Q" to="2c95:3DLpMp_rLlz" resolve="ITocEntry" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3zZkjj" id="3DLpMp__w74" role="2OqNvi">
+                        <node concept="1bVj0M" id="3DLpMp__w76" role="23t8la">
+                          <node concept="3clFbS" id="3DLpMp__w77" role="1bW5cS">
+                            <node concept="3clFbF" id="3DLpMp__w7g" role="3cqZAp">
+                              <node concept="2OqwBi" id="3DLpMp__wsW" role="3clFbG">
+                                <node concept="37vLTw" id="3DLpMp__w7f" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="3DLpMp__w78" resolve="it" />
+                                </node>
+                                <node concept="2qgKlT" id="3DLpMp__wQQ" role="2OqNvi">
+                                  <ref role="37wK5l" to="4gky:3DLpMp_rLmy" resolve="addToTOC" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="Rh6nW" id="3DLpMp__w78" role="1bW2Oz">
+                            <property role="TrG5h" value="it" />
+                            <node concept="2jxLKc" id="3DLpMp__w79" role="1tU5fm" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="34oBXx" id="4vQSg$AqJNq" role="2OqNvi" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="Vb9p2" id="4RNNpFf1GsM" role="3F10Kt" />
+        <node concept="VPM3Z" id="4RNNpFf4yJY" role="3F10Kt" />
+        <node concept="xShMh" id="4RNNpFf4zUk" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+        <node concept="3tD6jV" id="4RNNpFe8FYO" role="3F10Kt">
+          <ref role="3tD7wE" to="tj7y:5A_Zlt6qyoK" resolve="hyperlink-handler" />
+          <node concept="3sjG9q" id="4RNNpFe8FYQ" role="3tD6jU">
+            <node concept="3clFbS" id="4RNNpFe8FYR" role="2VODD2">
+              <node concept="3clFbF" id="4RNNpFe8Gmk" role="3cqZAp">
+                <node concept="2ShNRf" id="4RNNpFe8Gme" role="3clFbG">
+                  <node concept="YeOm9" id="4RNNpFe8Hfk" role="2ShVmc">
+                    <node concept="1Y3b0j" id="4RNNpFe8Hfn" role="YeSDq">
+                      <property role="2bfB8j" value="true" />
+                      <ref role="1Y3XeK" to="ag3p:5A_Zlt6xR6d" resolve="HyperlinkHandler" />
+                      <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
+                      <node concept="3Tm1VV" id="4RNNpFe8Hfo" role="1B3o_S" />
+                      <node concept="3clFb_" id="4RNNpFe8Hft" role="jymVt">
+                        <property role="TrG5h" value="open" />
+                        <node concept="3cqZAl" id="4RNNpFe8Hfu" role="3clF45" />
+                        <node concept="3Tm1VV" id="4RNNpFe8Hfv" role="1B3o_S" />
+                        <node concept="37vLTG" id="4RNNpFe8Hfx" role="3clF46">
+                          <property role="TrG5h" value="util" />
+                          <node concept="3uibUv" id="4RNNpFe8Hfy" role="1tU5fm">
+                            <ref role="3uigEE" to="ag3p:5A_Zlt6xR7j" resolve="HyperlinkUtil" />
+                          </node>
+                        </node>
+                        <node concept="3clFbS" id="4RNNpFe8Hfz" role="3clF47">
+                          <node concept="3cpWs8" id="4RNNpFe8MAM" role="3cqZAp">
+                            <node concept="3cpWsn" id="4RNNpFe8MAN" role="3cpWs9">
+                              <property role="TrG5h" value="root" />
+                              <node concept="3uibUv" id="4RNNpFe8M_M" role="1tU5fm">
+                                <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
+                              </node>
+                              <node concept="2OqwBi" id="4RNNpFe8MAO" role="33vP2m">
+                                <node concept="2OqwBi" id="4RNNpFe8MAP" role="2Oq$k0">
+                                  <node concept="1Q80Hx" id="4RNNpFe8MAQ" role="2Oq$k0" />
+                                  <node concept="liA8E" id="4RNNpFe8MAR" role="2OqNvi">
+                                    <ref role="37wK5l" to="cj4x:~EditorContext.getEditorComponent()" resolve="getEditorComponent" />
+                                  </node>
+                                </node>
+                                <node concept="liA8E" id="4RNNpFe8MAS" role="2OqNvi">
+                                  <ref role="37wK5l" to="cj4x:~EditorComponent.getRootCell()" resolve="getRootCell" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="3cpWs8" id="4RNNpFe9oDy" role="3cqZAp">
+                            <node concept="3cpWsn" id="4RNNpFe9oDz" role="3cpWs9">
+                              <property role="TrG5h" value="toSelect" />
+                              <node concept="3uibUv" id="4RNNpFe9o_L" role="1tU5fm">
+                                <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
+                              </node>
+                              <node concept="2YIFZM" id="4RNNpFe9oD$" role="33vP2m">
+                                <ref role="1Pybhc" to="g51k:~CellFinderUtil" resolve="CellFinderUtil" />
+                                <ref role="37wK5l" to="g51k:~CellFinderUtil.findChildByCondition(jetbrains.mps.openapi.editor.cells.EditorCell,org.jetbrains.mps.util.Condition,boolean)" resolve="findChildByCondition" />
+                                <node concept="37vLTw" id="4RNNpFe9oD_" role="37wK5m">
+                                  <ref role="3cqZAo" node="4RNNpFe8MAN" resolve="root" />
+                                </node>
+                                <node concept="1bVj0M" id="4RNNpFe9oDA" role="37wK5m">
+                                  <node concept="3clFbS" id="4RNNpFe9oDB" role="1bW5cS">
+                                    <node concept="3cpWs6" id="4RNNpFe9oDC" role="3cqZAp">
+                                      <node concept="1Wc70l" id="3DLpMpAP_j9" role="3cqZAk">
+                                        <node concept="3fqX7Q" id="3DLpMpAPEKy" role="3uHU7w">
+                                          <node concept="2OqwBi" id="3DLpMpAPEK$" role="3fr31v">
+                                            <node concept="2OqwBi" id="3DLpMpAPEK_" role="2Oq$k0">
+                                              <node concept="2OqwBi" id="3DLpMpAPEKA" role="2Oq$k0">
+                                                <node concept="37vLTw" id="3DLpMpAPEKB" role="2Oq$k0">
+                                                  <ref role="3cqZAo" node="4RNNpFe9oDI" resolve="cell" />
+                                                </node>
+                                                <node concept="liA8E" id="3DLpMpAPEKC" role="2OqNvi">
+                                                  <ref role="37wK5l" to="f4zo:~EditorCell.getCellContext()" resolve="getCellContext" />
+                                                </node>
+                                              </node>
+                                              <node concept="liA8E" id="3DLpMpAPEKD" role="2OqNvi">
+                                                <ref role="37wK5l" to="f4zo:~EditorCellContext.getHints()" resolve="getHints" />
+                                              </node>
+                                            </node>
+                                            <node concept="liA8E" id="3DLpMpAPEKE" role="2OqNvi">
+                                              <ref role="37wK5l" to="33ny:~Collection.contains(java.lang.Object)" resolve="contains" />
+                                              <node concept="2pYGij" id="3DLpMpAPEKF" role="37wK5m">
+                                                <ref role="2pYH_C" node="3DLpMpAev2X" resolve="ToCEntry" />
+                                              </node>
+                                            </node>
+                                          </node>
+                                        </node>
+                                        <node concept="17R0WA" id="4RNNpFe9oDD" role="3uHU7B">
+                                          <node concept="2OqwBi" id="4RNNpFe9oDF" role="3uHU7B">
+                                            <node concept="37vLTw" id="4RNNpFe9oDG" role="2Oq$k0">
+                                              <ref role="3cqZAo" node="4RNNpFe9oDI" resolve="cell" />
+                                            </node>
+                                            <node concept="liA8E" id="4RNNpFe9oDH" role="2OqNvi">
+                                              <ref role="37wK5l" to="f4zo:~EditorCell.getSNode()" resolve="getSNode" />
+                                            </node>
+                                          </node>
+                                          <node concept="pncrf" id="4RNNpFeykLb" role="3uHU7w" />
+                                        </node>
+                                      </node>
+                                    </node>
+                                  </node>
+                                  <node concept="37vLTG" id="4RNNpFe9oDI" role="1bW2Oz">
+                                    <property role="TrG5h" value="cell" />
+                                    <node concept="3uibUv" id="4RNNpFe9oDJ" role="1tU5fm">
+                                      <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
+                                    </node>
+                                  </node>
+                                </node>
+                                <node concept="3clFbT" id="4RNNpFe9oDK" role="37wK5m">
+                                  <property role="3clFbU" value="true" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="3clFbF" id="4RNNpFe9pMo" role="3cqZAp">
+                            <node concept="2OqwBi" id="4RNNpFe9qsX" role="3clFbG">
+                              <node concept="2OqwBi" id="4RNNpFe9q9$" role="2Oq$k0">
+                                <node concept="1Q80Hx" id="4RNNpFe9pMn" role="2Oq$k0" />
+                                <node concept="liA8E" id="4RNNpFe9qnf" role="2OqNvi">
+                                  <ref role="37wK5l" to="cj4x:~EditorContext.getSelectionManager()" resolve="getSelectionManager" />
+                                </node>
+                              </node>
+                              <node concept="liA8E" id="4RNNpFe9qE1" role="2OqNvi">
+                                <ref role="37wK5l" to="lwvz:~SelectionManager.setSelection(jetbrains.mps.openapi.editor.cells.EditorCell)" resolve="setSelection" />
+                                <node concept="37vLTw" id="4RNNpFe9qPw" role="37wK5m">
+                                  <ref role="3cqZAo" node="4RNNpFe9oDz" resolve="toSelect" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="3clFbF" id="4RNNpFeYSMz" role="3cqZAp">
+                            <node concept="2OqwBi" id="4RNNpFeYW8S" role="3clFbG">
+                              <node concept="2OqwBi" id="4RNNpFeYTtz" role="2Oq$k0">
+                                <node concept="1Q80Hx" id="4RNNpFeYSMA" role="2Oq$k0" />
+                                <node concept="liA8E" id="4RNNpFeYW3a" role="2OqNvi">
+                                  <ref role="37wK5l" to="cj4x:~EditorContext.getEditorComponent()" resolve="getEditorComponent" />
+                                </node>
+                              </node>
+                              <node concept="liA8E" id="4RNNpFeYWnO" role="2OqNvi">
+                                <ref role="37wK5l" to="cj4x:~EditorComponent.scrollToCell(jetbrains.mps.openapi.editor.cells.EditorCell)" resolve="scrollToCell" />
+                                <node concept="37vLTw" id="4RNNpFeYWIL" role="37wK5m">
+                                  <ref role="3cqZAo" node="4RNNpFe9oDz" resolve="toSelect" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="2AHcQZ" id="4RNNpFe8Hf_" role="2AJF6D">
+                          <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3VJUX4" id="4RNNpFeNiYE" role="3YsKMw">
+          <node concept="3clFbS" id="4RNNpFeNiYG" role="2VODD2">
+            <node concept="3clFbF" id="4RNNpFeQyJ6" role="3cqZAp">
+              <node concept="2ShNRf" id="4RNNpFeQyJ2" role="3clFbG">
+                <node concept="YeOm9" id="4RNNpFeQzBW" role="2ShVmc">
+                  <node concept="1Y3b0j" id="4RNNpFeQzBZ" role="YeSDq">
+                    <property role="2bfB8j" value="true" />
+                    <ref role="1Y3XeK" to="exr9:~AbstractCellProvider" resolve="AbstractCellProvider" />
+                    <ref role="37wK5l" to="exr9:~AbstractCellProvider.&lt;init&gt;(org.jetbrains.mps.openapi.model.SNode)" resolve="AbstractCellProvider" />
+                    <node concept="3Tm1VV" id="4RNNpFeQzC0" role="1B3o_S" />
+                    <node concept="3clFb_" id="4RNNpFeQzC3" role="jymVt">
+                      <property role="TrG5h" value="createEditorCell" />
+                      <node concept="3Tm1VV" id="4RNNpFeQzC4" role="1B3o_S" />
+                      <node concept="3uibUv" id="4RNNpFeQzC6" role="3clF45">
+                        <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
+                      </node>
+                      <node concept="37vLTG" id="4RNNpFeQzC7" role="3clF46">
+                        <property role="TrG5h" value="p1" />
+                        <node concept="3uibUv" id="4RNNpFeQzC8" role="1tU5fm">
+                          <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
+                        </node>
+                      </node>
+                      <node concept="3clFbS" id="4RNNpFeQzC9" role="3clF47">
+                        <node concept="3cpWs8" id="4RNNpFeTkRR" role="3cqZAp">
+                          <node concept="3cpWsn" id="4RNNpFeTkRS" role="3cpWs9">
+                            <property role="TrG5h" value="text" />
+                            <node concept="17QB3L" id="4RNNpFeTkn2" role="1tU5fm" />
+                            <node concept="3cpWs3" id="4RNNpFeTl7B" role="33vP2m">
+                              <node concept="Xl_RD" id="4RNNpFeTmB6" role="3uHU7B">
+                                <property role="Xl_RC" value="• " />
+                              </node>
+                              <node concept="2OqwBi" id="4RNNpFeTkRT" role="3uHU7w">
+                                <node concept="pncrf" id="4RNNpFeTkRU" role="2Oq$k0" />
+                                <node concept="2qgKlT" id="3DLpMp__jJ1" role="2OqNvi">
+                                  <ref role="37wK5l" to="4gky:3DLpMp_rLlJ" resolve="tocText" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3clFbF" id="4RNNpFeNk8w" role="3cqZAp">
+                          <node concept="2ShNRf" id="4RNNpFeNk8u" role="3clFbG">
+                            <node concept="YeOm9" id="4RNNpFeW81B" role="2ShVmc">
+                              <node concept="1Y3b0j" id="4RNNpFeW81E" role="YeSDq">
+                                <property role="2bfB8j" value="true" />
+                                <ref role="1Y3XeK" to="g51k:~EditorCell_Constant" resolve="EditorCell_Constant" />
+                                <ref role="37wK5l" to="g51k:~EditorCell_Constant.&lt;init&gt;(jetbrains.mps.openapi.editor.EditorContext,org.jetbrains.mps.openapi.model.SNode,java.lang.String,boolean)" resolve="EditorCell_Constant" />
+                                <node concept="3Tm1VV" id="4RNNpFeW81F" role="1B3o_S" />
+                                <node concept="1Q80Hx" id="4RNNpFeQwzh" role="37wK5m" />
+                                <node concept="pncrf" id="4RNNpFeQxAu" role="37wK5m" />
+                                <node concept="37vLTw" id="4RNNpFeTkRW" role="37wK5m">
+                                  <ref role="3cqZAo" node="4RNNpFeTkRS" resolve="text" />
+                                </node>
+                                <node concept="3clFbT" id="4RNNpFeQyw4" role="37wK5m" />
+                                <node concept="3clFb_" id="4RNNpFeW8eI" role="jymVt">
+                                  <property role="TrG5h" value="getSNode" />
+                                  <node concept="3Tm1VV" id="4RNNpFeW8eJ" role="1B3o_S" />
+                                  <node concept="3uibUv" id="4RNNpFeW8eL" role="3clF45">
+                                    <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
+                                  </node>
+                                  <node concept="3clFbS" id="4RNNpFeW8eT" role="3clF47">
+                                    <node concept="3cpWs6" id="4RNNpFeW9Av" role="3cqZAp">
+                                      <node concept="10Nm6u" id="4RNNpFeW9Ax" role="3cqZAk" />
+                                    </node>
+                                  </node>
+                                  <node concept="2AHcQZ" id="4RNNpFeW8eU" role="2AJF6D">
+                                    <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="2AHcQZ" id="4RNNpFeQzCb" role="2AJF6D">
+                        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                      </node>
+                    </node>
+                    <node concept="pncrf" id="4RNNpFeQ$Jt" role="37wK5m" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="24kQdi" id="3DLpMpA_pHq">
+    <property role="3GE5qa" value="" />
+    <ref role="1XX52x" to="2c95:5mf_X_Lbqjw" resolve="DocumentInclude" />
+    <node concept="2aJ2om" id="3DLpMpA_pHr" role="CpUAK">
+      <ref role="2$4xQ3" node="3DLpMpAev2X" resolve="ToCEntry" />
+    </node>
+    <node concept="3EZMnI" id="3DLpMpA_pHs" role="2wV5jI">
+      <node concept="1HlG4h" id="3DLpMpA_szH" role="3EZMnx">
+        <node concept="3tD6jV" id="3DLpMpA_pHv" role="3F10Kt">
+          <ref role="3tD7wE" to="z0fb:vtaHb5XosV" resolve="_margin-left" />
+          <node concept="3sjG9q" id="3DLpMpA_pHw" role="3tD6jU">
+            <node concept="3clFbS" id="3DLpMpA_pHx" role="2VODD2">
+              <node concept="3clFbF" id="3DLpMpA_pHy" role="3cqZAp">
+                <node concept="17qRlL" id="3DLpMpA_pHz" role="3clFbG">
+                  <node concept="3cmrfG" id="3DLpMpA_pH$" role="3uHU7w">
+                    <property role="3cmrfH" value="20" />
+                  </node>
+                  <node concept="2OqwBi" id="3DLpMpA_pH_" role="3uHU7B">
+                    <node concept="2OqwBi" id="3DLpMpA_pHA" role="2Oq$k0">
+                      <node concept="2OqwBi" id="3DLpMpA_pHB" role="2Oq$k0">
+                        <node concept="pncrf" id="3DLpMpA_pHC" role="2Oq$k0" />
+                        <node concept="z$bX8" id="3DLpMpA_pHD" role="2OqNvi">
+                          <node concept="1xMEDy" id="3DLpMpA_pHE" role="1xVPHs">
+                            <node concept="chp4Y" id="3DLpMpA_pHF" role="ri$Ld">
+                              <ref role="cht4Q" to="2c95:3DLpMp_rLlz" resolve="ITocEntry" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3zZkjj" id="3DLpMpA_pHG" role="2OqNvi">
+                        <node concept="1bVj0M" id="3DLpMpA_pHH" role="23t8la">
+                          <node concept="3clFbS" id="3DLpMpA_pHI" role="1bW5cS">
+                            <node concept="3clFbF" id="3DLpMpA_pHJ" role="3cqZAp">
+                              <node concept="2OqwBi" id="3DLpMpA_pHK" role="3clFbG">
+                                <node concept="37vLTw" id="3DLpMpA_pHL" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="3DLpMpA_pHN" resolve="it" />
+                                </node>
+                                <node concept="2qgKlT" id="3DLpMpA_pHM" role="2OqNvi">
+                                  <ref role="37wK5l" to="4gky:3DLpMp_rLmy" resolve="addToTOC" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="Rh6nW" id="3DLpMpA_pHN" role="1bW2Oz">
+                            <property role="TrG5h" value="it" />
+                            <node concept="2jxLKc" id="3DLpMpA_pHO" role="1tU5fm" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="34oBXx" id="3DLpMpA_pHP" role="2OqNvi" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="Vb9p2" id="3DLpMpA_pHQ" role="3F10Kt" />
+        <node concept="VPM3Z" id="3DLpMpA_pHR" role="3F10Kt" />
+        <node concept="xShMh" id="3DLpMpA_pHS" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+        <node concept="3tD6jV" id="3DLpMpA_$1a" role="3F10Kt">
+          <ref role="3tD7wE" to="tj7y:ojedFZ7Qi6" resolve="hyperlink-node" />
+          <node concept="3sjG9q" id="3DLpMpA_$1c" role="3tD6jU">
+            <node concept="3clFbS" id="3DLpMpA_$1e" role="2VODD2">
+              <node concept="3clFbF" id="3DLpMpA_$ve" role="3cqZAp">
+                <node concept="2OqwBi" id="3DLpMpA__DN" role="3clFbG">
+                  <node concept="2OqwBi" id="3DLpMpA_$Hi" role="2Oq$k0">
+                    <node concept="pncrf" id="3DLpMpA_$vd" role="2Oq$k0" />
+                    <node concept="3TrEf2" id="3DLpMpA__5C" role="2OqNvi">
+                      <ref role="3Tt5mk" to="2c95:5mf_X_Lbqjz" resolve="ref" />
+                    </node>
+                  </node>
+                  <node concept="3TrEf2" id="3DLpMpA__Wm" role="2OqNvi">
+                    <ref role="3Tt5mk" to="2c95:2TZO3DbvI5E" resolve="doc" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1HfYo3" id="3DLpMpA_szJ" role="1HlULh">
+          <node concept="3TQlhw" id="3DLpMpA_szL" role="1Hhtcw">
+            <node concept="3clFbS" id="3DLpMpA_szN" role="2VODD2">
+              <node concept="3clFbF" id="3DLpMpA_sZO" role="3cqZAp">
+                <node concept="3cpWs3" id="3DLpMpA_xJw" role="3clFbG">
+                  <node concept="Xl_RD" id="3DLpMpA_x7t" role="3uHU7B">
+                    <property role="Xl_RC" value="• " />
+                  </node>
+                  <node concept="2OqwBi" id="3DLpMpA_vI1" role="3uHU7w">
+                    <node concept="3TrcHB" id="3DLpMpA_vJD" role="2OqNvi">
+                      <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                    </node>
+                    <node concept="2OqwBi" id="3DLpMpA_ujz" role="2Oq$k0">
+                      <node concept="3TrEf2" id="3DLpMpA_uCN" role="2OqNvi">
+                        <ref role="3Tt5mk" to="2c95:2TZO3DbvI5E" resolve="doc" />
+                      </node>
+                      <node concept="2OqwBi" id="3DLpMpA_tge" role="2Oq$k0">
+                        <node concept="3TrEf2" id="3DLpMpA_yPh" role="2OqNvi">
+                          <ref role="3Tt5mk" to="2c95:5mf_X_Lbqjz" resolve="ref" />
+                        </node>
+                        <node concept="pncrf" id="3DLpMpA_y6g" role="2Oq$k0" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2iRfu4" id="3DLpMpA_pHt" role="2iSdaV" />
     </node>
   </node>
 </model>

--- a/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/languageModels/structure.mps
+++ b/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/languageModels/structure.mps
@@ -159,6 +159,9 @@
     <node concept="PrWs8" id="6jiGbW_JDXF" role="PzmwI">
       <ref role="PrY4T" node="6jiGbW_JBH_" resolve="IDocReferencable" />
     </node>
+    <node concept="PrWs8" id="3DLpMp_rLnZ" role="PzmwI">
+      <ref role="PrY4T" node="3DLpMp_rLlz" resolve="ITocEntry" />
+    </node>
   </node>
   <node concept="PlHQZ" id="2TZO3Dbv6JT">
     <property role="TrG5h" value="IDocContentContainer" />
@@ -679,6 +682,9 @@
     </node>
     <node concept="PrWs8" id="5mf_X_Lbqjx" role="PzmwI">
       <ref role="PrY4T" node="2TZO3DbuxwP" resolve="IDocumentContent" />
+    </node>
+    <node concept="PrWs8" id="3DLpMp_rOzt" role="PzmwI">
+      <ref role="PrY4T" node="3DLpMp_rLlz" resolve="ITocEntry" />
     </node>
   </node>
   <node concept="1TIwiD" id="5mf_X_LbOnj">
@@ -1816,6 +1822,11 @@
     <node concept="PrWs8" id="l3$K9zOTzu" role="PrDN$">
       <ref role="PrY4T" to="87nw:2dWzqxEBBFG" resolve="IWord" />
     </node>
+  </node>
+  <node concept="PlHQZ" id="3DLpMp_rLlz">
+    <property role="EcuMT" value="4211260541176321379" />
+    <property role="TrG5h" value="ITocEntry" />
+    <property role="3GE5qa" value="structure" />
   </node>
 </model>
 

--- a/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/languageModels/typesystem.mps
+++ b/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/languageModels/typesystem.mps
@@ -46,7 +46,7 @@
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
       <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
-      <concept id="1225271283259" name="jetbrains.mps.baseLanguage.structure.NPEEqualsExpression" flags="nn" index="17R0WA" />
+      <concept id="1225271221393" name="jetbrains.mps.baseLanguage.structure.NPENotEqualsExpression" flags="nn" index="17QLQc" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
       </concept>
@@ -98,9 +98,6 @@
     <language id="7a5dda62-9140-4668-ab76-d5ed1746f2b2" name="jetbrains.mps.lang.typesystem">
       <concept id="1207055528241" name="jetbrains.mps.lang.typesystem.structure.WarningStatement" flags="nn" index="a7r0C">
         <child id="1207055552304" name="warningText" index="a7wSD" />
-      </concept>
-      <concept id="1175517400280" name="jetbrains.mps.lang.typesystem.structure.AssertStatement" flags="nn" index="2Mj0R9">
-        <child id="1175517761460" name="condition" index="2MkoU_" />
       </concept>
       <concept id="1175517767210" name="jetbrains.mps.lang.typesystem.structure.ReportErrorStatement" flags="nn" index="2MkqsV">
         <child id="1175517851849" name="errorString" index="2MkJ7o" />
@@ -160,6 +157,10 @@
         <child id="1144104376918" name="parameter" index="1xVPHs" />
       </concept>
       <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
+      <concept id="4693937538533521280" name="jetbrains.mps.lang.smodel.structure.OfConceptOperation" flags="ng" index="v3k3i">
+        <child id="4693937538533538124" name="requestedConcept" index="v3oSu" />
+      </concept>
+      <concept id="8758390115028452779" name="jetbrains.mps.lang.smodel.structure.Node_GetReferencesOperation" flags="nn" index="2z74zc" />
       <concept id="1173122760281" name="jetbrains.mps.lang.smodel.structure.Node_GetAncestorsOperation" flags="nn" index="z$bX8" />
       <concept id="2396822768958367367" name="jetbrains.mps.lang.smodel.structure.AbstractTypeCastExpression" flags="nn" index="$5XWr">
         <child id="6733348108486823193" name="leftExpression" index="1m5AlR" />
@@ -167,10 +168,12 @@
       </concept>
       <concept id="1143234257716" name="jetbrains.mps.lang.smodel.structure.Node_GetModelOperation" flags="nn" index="I4A8Y" />
       <concept id="1171305280644" name="jetbrains.mps.lang.smodel.structure.Node_GetDescendantsOperation" flags="nn" index="2Rf3mk" />
+      <concept id="1171310072040" name="jetbrains.mps.lang.smodel.structure.Node_GetContainingRootOperation" flags="nn" index="2Rxl7S" />
       <concept id="1171315804604" name="jetbrains.mps.lang.smodel.structure.Model_RootsOperation" flags="nn" index="2RRcyG">
         <reference id="1171315804605" name="concept" index="2RRcyH" />
       </concept>
       <concept id="1171407110247" name="jetbrains.mps.lang.smodel.structure.Node_GetAncestorOperation" flags="nn" index="2Xjw5R" />
+      <concept id="4124388153790980106" name="jetbrains.mps.lang.smodel.structure.Reference_GetTargetOperation" flags="nn" index="2ZHEkA" />
       <concept id="2644386474300074836" name="jetbrains.mps.lang.smodel.structure.ConceptIdRefExpression" flags="nn" index="35c_gC">
         <reference id="2644386474300074837" name="conceptDeclaration" index="35c_gD" />
       </concept>
@@ -179,6 +182,7 @@
         <child id="1177027386292" name="conceptArgument" index="cj9EA" />
       </concept>
       <concept id="1172008320231" name="jetbrains.mps.lang.smodel.structure.Node_IsNotNullOperation" flags="nn" index="3x8VRR" />
+      <concept id="1144100932627" name="jetbrains.mps.lang.smodel.structure.OperationParm_Inclusion" flags="ng" index="1xIGOp" />
       <concept id="1144101972840" name="jetbrains.mps.lang.smodel.structure.OperationParm_Concept" flags="ng" index="1xMEDy">
         <child id="1207343664468" name="conceptArgument" index="ri$Ld" />
       </concept>
@@ -221,10 +225,14 @@
       <concept id="540871147943773365" name="jetbrains.mps.baseLanguage.collections.structure.SingleArgumentSequenceOperation" flags="nn" index="25WWJ4">
         <child id="540871147943773366" name="argument" index="25WWJ7" />
       </concept>
+      <concept id="1204980550705" name="jetbrains.mps.baseLanguage.collections.structure.VisitAllOperation" flags="nn" index="2es0OD" />
       <concept id="1226511727824" name="jetbrains.mps.baseLanguage.collections.structure.SetType" flags="in" index="2hMVRd">
         <child id="1226511765987" name="elementType" index="2hN53Y" />
       </concept>
       <concept id="1226516258405" name="jetbrains.mps.baseLanguage.collections.structure.HashSetCreator" flags="nn" index="2i4dXS" />
+      <concept id="1151689724996" name="jetbrains.mps.baseLanguage.collections.structure.SequenceType" flags="in" index="A3Dl8">
+        <child id="1151689745422" name="elementType" index="A3Ik2" />
+      </concept>
       <concept id="1153943597977" name="jetbrains.mps.baseLanguage.collections.structure.ForEachStatement" flags="nn" index="2Gpval">
         <child id="1153944400369" name="variable" index="2Gsz3X" />
         <child id="1153944424730" name="inputSequence" index="2GsD0m" />
@@ -240,12 +248,15 @@
       <concept id="1203518072036" name="jetbrains.mps.baseLanguage.collections.structure.SmartClosureParameterDeclaration" flags="ig" index="Rh6nW" />
       <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="nn" index="34oBXx" />
       <concept id="1240325842691" name="jetbrains.mps.baseLanguage.collections.structure.AsSequenceOperation" flags="nn" index="39bAoz" />
+      <concept id="1201792049884" name="jetbrains.mps.baseLanguage.collections.structure.TranslateOperation" flags="nn" index="3goQfb" />
       <concept id="1165525191778" name="jetbrains.mps.baseLanguage.collections.structure.GetFirstOperation" flags="nn" index="1uHKPH" />
       <concept id="1165530316231" name="jetbrains.mps.baseLanguage.collections.structure.IsEmptyOperation" flags="nn" index="1v1jN8" />
       <concept id="1165595910856" name="jetbrains.mps.baseLanguage.collections.structure.GetLastOperation" flags="nn" index="1yVyf7" />
       <concept id="1225727723840" name="jetbrains.mps.baseLanguage.collections.structure.FindFirstOperation" flags="nn" index="1z4cxt" />
       <concept id="1202120902084" name="jetbrains.mps.baseLanguage.collections.structure.WhereOperation" flags="nn" index="3zZkjj" />
+      <concept id="1202128969694" name="jetbrains.mps.baseLanguage.collections.structure.SelectOperation" flags="nn" index="3$u5V9" />
       <concept id="1172254888721" name="jetbrains.mps.baseLanguage.collections.structure.ContainsOperation" flags="nn" index="3JPx81" />
+      <concept id="1178894719932" name="jetbrains.mps.baseLanguage.collections.structure.DistinctOperation" flags="nn" index="1VAtEI" />
     </language>
   </registry>
   <node concept="18kY7G" id="5yxqZJwzj0q">
@@ -1162,96 +1173,6 @@
       </node>
     </node>
   </node>
-  <node concept="18kY7G" id="2CRkjeisemW">
-    <property role="TrG5h" value="check_DocumentInclude" />
-    <node concept="3clFbS" id="2CRkjeisemX" role="18ibNy">
-      <node concept="3clFbJ" id="2CRkjeisen3" role="3cqZAp">
-        <node concept="2OqwBi" id="2CRkjeisezK" role="3clFbw">
-          <node concept="1YBJjd" id="2CRkjeiseni" role="2Oq$k0">
-            <ref role="1YBMHb" node="2CRkjeisemZ" resolve="documentInclude" />
-          </node>
-          <node concept="3TrcHB" id="2CRkjeiseKe" role="2OqNvi">
-            <ref role="3TsBF5" to="2c95:hZfTLLrEWd" resolve="referenceOnly" />
-          </node>
-        </node>
-        <node concept="3clFbS" id="2CRkjeisen5" role="3clFbx">
-          <node concept="2Mj0R9" id="2CRkjeiseMO" role="3cqZAp">
-            <node concept="17R0WA" id="2CRkjeisfzp" role="2MkoU_">
-              <node concept="2OqwBi" id="2CRkjeishdl" role="3uHU7w">
-                <node concept="2OqwBi" id="2CRkjeisgJe" role="2Oq$k0">
-                  <node concept="2OqwBi" id="2CRkjeisfOw" role="2Oq$k0">
-                    <node concept="1YBJjd" id="2CRkjeisfAB" role="2Oq$k0">
-                      <ref role="1YBMHb" node="2CRkjeisemZ" resolve="documentInclude" />
-                    </node>
-                    <node concept="3TrEf2" id="2CRkjeisg3D" role="2OqNvi">
-                      <ref role="3Tt5mk" to="2c95:5mf_X_Lbqjz" resolve="ref" />
-                    </node>
-                  </node>
-                  <node concept="3TrEf2" id="2CRkjeisgTJ" role="2OqNvi">
-                    <ref role="3Tt5mk" to="2c95:2TZO3DbvI5E" resolve="doc" />
-                  </node>
-                </node>
-                <node concept="I4A8Y" id="2CRkjeisht_" role="2OqNvi" />
-              </node>
-              <node concept="2OqwBi" id="2CRkjeiseZK" role="3uHU7B">
-                <node concept="1YBJjd" id="2CRkjeiseNc" role="2Oq$k0">
-                  <ref role="1YBMHb" node="2CRkjeisemZ" resolve="documentInclude" />
-                </node>
-                <node concept="I4A8Y" id="2CRkjeisfeP" role="2OqNvi" />
-              </node>
-            </node>
-            <node concept="Xl_RD" id="2CRkjeish$$" role="2MkJ7o">
-              <property role="Xl_RC" value="Currently only references to nodes in the same model are supported" />
-            </node>
-            <node concept="1YBJjd" id="2CRkjeishG4" role="1urrMF">
-              <ref role="1YBMHb" node="2CRkjeisemZ" resolve="documentInclude" />
-            </node>
-          </node>
-        </node>
-      </node>
-    </node>
-    <node concept="1YaCAy" id="2CRkjeisemZ" role="1YuTPh">
-      <property role="TrG5h" value="documentInclude" />
-      <ref role="1YaFvo" to="2c95:5mf_X_Lbqjw" resolve="DocumentInclude" />
-    </node>
-  </node>
-  <node concept="18kY7G" id="t5DIOhGZfv">
-    <property role="TrG5h" value="check_DocRefWord" />
-    <property role="3GE5qa" value="words" />
-    <node concept="3clFbS" id="t5DIOhGZfw" role="18ibNy">
-      <node concept="2Mj0R9" id="t5DIOhGZm_" role="3cqZAp">
-        <node concept="17R0WA" id="t5DIOhGZmA" role="2MkoU_">
-          <node concept="2OqwBi" id="t5DIOhGZmB" role="3uHU7B">
-            <node concept="2OqwBi" id="t5DIOhGZmC" role="2Oq$k0">
-              <node concept="1YBJjd" id="t5DIOhGZu1" role="2Oq$k0">
-                <ref role="1YBMHb" node="t5DIOhGZfy" resolve="docRefWord" />
-              </node>
-              <node concept="3TrEf2" id="t5DIOhH4$2" role="2OqNvi">
-                <ref role="3Tt5mk" to="2c95:2T4ELtZGU9" resolve="target" />
-              </node>
-            </node>
-            <node concept="I4A8Y" id="t5DIOhGZmF" role="2OqNvi" />
-          </node>
-          <node concept="2OqwBi" id="t5DIOhGZmG" role="3uHU7w">
-            <node concept="1YBJjd" id="t5DIOhGZB8" role="2Oq$k0">
-              <ref role="1YBMHb" node="t5DIOhGZfy" resolve="docRefWord" />
-            </node>
-            <node concept="I4A8Y" id="t5DIOhGZmI" role="2OqNvi" />
-          </node>
-        </node>
-        <node concept="Xl_RD" id="t5DIOhGZmJ" role="2MkJ7o">
-          <property role="Xl_RC" value="Currently only references to nodes in the same model are supported" />
-        </node>
-        <node concept="1YBJjd" id="5J0kEUnY5sd" role="1urrMF">
-          <ref role="1YBMHb" node="t5DIOhGZfy" resolve="docRefWord" />
-        </node>
-      </node>
-    </node>
-    <node concept="1YaCAy" id="t5DIOhGZfy" role="1YuTPh">
-      <property role="TrG5h" value="docRefWord" />
-      <ref role="1YaFvo" to="2c95:2T4ELtZGU8" resolve="DocRefWord" />
-    </node>
-  </node>
   <node concept="18kY7G" id="hoMN8EQ94W">
     <property role="TrG5h" value="check_BuildConfiguration_Presence" />
     <property role="3GE5qa" value="modelContent" />
@@ -1310,6 +1231,194 @@
     <node concept="1YaCAy" id="hoMN8EQ94Z" role="1YuTPh">
       <property role="TrG5h" value="document" />
       <ref role="1YaFvo" to="2c95:2TZO3DbuxwK" resolve="Document" />
+    </node>
+  </node>
+  <node concept="18kY7G" id="8QSRaj$uI3">
+    <property role="TrG5h" value="check_DependsOn" />
+    <property role="3GE5qa" value="ifaces" />
+    <node concept="3clFbS" id="8QSRaj$uI4" role="18ibNy">
+      <node concept="3cpWs8" id="8QSRaj_ZBO" role="3cqZAp">
+        <node concept="3cpWsn" id="8QSRaj_ZBP" role="3cpWs9">
+          <property role="TrG5h" value="referencedRootNodes" />
+          <node concept="A3Dl8" id="8QSRaj_Zwl" role="1tU5fm">
+            <node concept="3Tqbb2" id="8QSRaj_Zwo" role="A3Ik2" />
+          </node>
+          <node concept="2OqwBi" id="8QSRaj_ZBQ" role="33vP2m">
+            <node concept="2OqwBi" id="8QSRaj_ZBR" role="2Oq$k0">
+              <node concept="2OqwBi" id="8QSRaj_ZBS" role="2Oq$k0">
+                <node concept="1YBJjd" id="8QSRaj_ZBT" role="2Oq$k0">
+                  <ref role="1YBMHb" node="8QSRaj$uI6" resolve="iDocumentLike" />
+                </node>
+                <node concept="3Tsc0h" id="8QSRaj_ZBU" role="2OqNvi">
+                  <ref role="3TtcxE" to="2c95:2TZO3Dbv6JU" resolve="contents" />
+                </node>
+              </node>
+              <node concept="3goQfb" id="8QSRaj_ZBV" role="2OqNvi">
+                <node concept="1bVj0M" id="8QSRaj_ZBW" role="23t8la">
+                  <node concept="3clFbS" id="8QSRaj_ZBX" role="1bW5cS">
+                    <node concept="3clFbF" id="8QSRaj_ZBY" role="3cqZAp">
+                      <node concept="2OqwBi" id="8QSRaj_ZBZ" role="3clFbG">
+                        <node concept="37vLTw" id="8QSRaj_ZC0" role="2Oq$k0">
+                          <ref role="3cqZAo" node="8QSRaj_ZC3" resolve="it" />
+                        </node>
+                        <node concept="2Rf3mk" id="8QSRaj_ZC1" role="2OqNvi">
+                          <node concept="1xIGOp" id="8QSRaj_ZC2" role="1xVPHs" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="Rh6nW" id="8QSRaj_ZC3" role="1bW2Oz">
+                    <property role="TrG5h" value="it" />
+                    <node concept="2jxLKc" id="8QSRaj_ZC4" role="1tU5fm" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3goQfb" id="8QSRaj_ZC5" role="2OqNvi">
+              <node concept="1bVj0M" id="8QSRaj_ZC6" role="23t8la">
+                <node concept="3clFbS" id="8QSRaj_ZC7" role="1bW5cS">
+                  <node concept="3clFbF" id="8QSRaj_ZC8" role="3cqZAp">
+                    <node concept="2OqwBi" id="8QSRaj_ZC9" role="3clFbG">
+                      <node concept="2OqwBi" id="8QSRaj_ZCa" role="2Oq$k0">
+                        <node concept="37vLTw" id="8QSRaj_ZCb" role="2Oq$k0">
+                          <ref role="3cqZAo" node="8QSRaj_ZCm" resolve="it" />
+                        </node>
+                        <node concept="2z74zc" id="8QSRaj_ZCc" role="2OqNvi" />
+                      </node>
+                      <node concept="3$u5V9" id="8QSRaj_ZCd" role="2OqNvi">
+                        <node concept="1bVj0M" id="8QSRaj_ZCe" role="23t8la">
+                          <node concept="3clFbS" id="8QSRaj_ZCf" role="1bW5cS">
+                            <node concept="3clFbF" id="8QSRaj_ZCg" role="3cqZAp">
+                              <node concept="2OqwBi" id="8QSRajCXPt" role="3clFbG">
+                                <node concept="2OqwBi" id="8QSRaj_ZCh" role="2Oq$k0">
+                                  <node concept="37vLTw" id="8QSRaj_ZCi" role="2Oq$k0">
+                                    <ref role="3cqZAo" node="8QSRaj_ZCk" resolve="it" />
+                                  </node>
+                                  <node concept="2ZHEkA" id="8QSRaj_ZCj" role="2OqNvi" />
+                                </node>
+                                <node concept="2Rxl7S" id="8QSRajCYhm" role="2OqNvi" />
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="Rh6nW" id="8QSRaj_ZCk" role="1bW2Oz">
+                            <property role="TrG5h" value="it" />
+                            <node concept="2jxLKc" id="8QSRaj_ZCl" role="1tU5fm" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="Rh6nW" id="8QSRaj_ZCm" role="1bW2Oz">
+                  <property role="TrG5h" value="it" />
+                  <node concept="2jxLKc" id="8QSRaj_ZCn" role="1tU5fm" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3cpWs8" id="8QSRaj_KZo" role="3cqZAp">
+        <node concept="3cpWsn" id="8QSRaj_KZp" role="3cpWs9">
+          <property role="TrG5h" value="usedDocuments" />
+          <node concept="A3Dl8" id="8QSRaj_KY5" role="1tU5fm">
+            <node concept="3Tqbb2" id="8QSRaj_KY8" role="A3Ik2">
+              <ref role="ehGHo" to="2c95:5L$H31Kgq3f" resolve="IDocumentLike" />
+            </node>
+          </node>
+          <node concept="2OqwBi" id="8QSRaj_SzR" role="33vP2m">
+            <node concept="2OqwBi" id="8QSRajA291" role="2Oq$k0">
+              <node concept="2OqwBi" id="8QSRaj_KZq" role="2Oq$k0">
+                <node concept="37vLTw" id="8QSRaj_ZCo" role="2Oq$k0">
+                  <ref role="3cqZAo" node="8QSRaj_ZBP" resolve="referencedRootNodes" />
+                </node>
+                <node concept="v3k3i" id="8QSRaj_KZN" role="2OqNvi">
+                  <node concept="chp4Y" id="8QSRaj_YWO" role="v3oSu">
+                    <ref role="cht4Q" to="2c95:5L$H31Kgq3f" resolve="IDocumentLike" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3zZkjj" id="8QSRajA2$L" role="2OqNvi">
+                <node concept="1bVj0M" id="8QSRajA2$N" role="23t8la">
+                  <node concept="3clFbS" id="8QSRajA2$O" role="1bW5cS">
+                    <node concept="3clFbF" id="8QSRajA2Ws" role="3cqZAp">
+                      <node concept="17QLQc" id="8QSRajA3tn" role="3clFbG">
+                        <node concept="1YBJjd" id="8QSRajA3Mj" role="3uHU7w">
+                          <ref role="1YBMHb" node="8QSRaj$uI6" resolve="iDocumentLike" />
+                        </node>
+                        <node concept="37vLTw" id="8QSRajA2Wr" role="3uHU7B">
+                          <ref role="3cqZAo" node="8QSRajA2$P" resolve="it" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="Rh6nW" id="8QSRajA2$P" role="1bW2Oz">
+                    <property role="TrG5h" value="it" />
+                    <node concept="2jxLKc" id="8QSRajA2$Q" role="1tU5fm" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="1VAtEI" id="8QSRaj_SZq" role="2OqNvi" />
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbH" id="8QSRaj_U05" role="3cqZAp" />
+      <node concept="3clFbF" id="8QSRaj_U3P" role="3cqZAp">
+        <node concept="2OqwBi" id="8QSRaj_VUk" role="3clFbG">
+          <node concept="2OqwBi" id="8QSRaj_UgD" role="2Oq$k0">
+            <node concept="1YBJjd" id="8QSRaj_U3N" role="2Oq$k0">
+              <ref role="1YBMHb" node="8QSRaj$uI6" resolve="iDocumentLike" />
+            </node>
+            <node concept="3Tsc0h" id="8QSRaj_UK5" role="2OqNvi">
+              <ref role="3TtcxE" to="2c95:7$DvC4gRxZ6" resolve="dependsOn" />
+            </node>
+          </node>
+          <node concept="2es0OD" id="8QSRaj_Xhz" role="2OqNvi">
+            <node concept="1bVj0M" id="8QSRaj_Xh_" role="23t8la">
+              <node concept="3clFbS" id="8QSRaj_XhA" role="1bW5cS">
+                <node concept="3clFbJ" id="8QSRajA5BH" role="3cqZAp">
+                  <node concept="3clFbS" id="8QSRajA5BJ" role="3clFbx">
+                    <node concept="a7r0C" id="8QSRajA5Uj" role="3cqZAp">
+                      <node concept="Xl_RD" id="8QSRajA5Xr" role="a7wSD">
+                        <property role="Xl_RC" value="Superfluous depends: Dependent document is not used" />
+                      </node>
+                      <node concept="37vLTw" id="8QSRajA67Z" role="1urrMF">
+                        <ref role="3cqZAo" node="8QSRaj_XhB" resolve="it" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3fqX7Q" id="8QSRajA5Mm" role="3clFbw">
+                    <node concept="2OqwBi" id="8QSRajA5Mo" role="3fr31v">
+                      <node concept="37vLTw" id="8QSRajA5Mp" role="2Oq$k0">
+                        <ref role="3cqZAo" node="8QSRaj_KZp" resolve="usedDocuments" />
+                      </node>
+                      <node concept="3JPx81" id="8QSRajA5Mq" role="2OqNvi">
+                        <node concept="2OqwBi" id="8QSRajA5Mr" role="25WWJ7">
+                          <node concept="37vLTw" id="8QSRajA5Ms" role="2Oq$k0">
+                            <ref role="3cqZAo" node="8QSRaj_XhB" resolve="it" />
+                          </node>
+                          <node concept="3TrEf2" id="8QSRajA5Mt" role="2OqNvi">
+                            <ref role="3Tt5mk" to="2c95:2TZO3DbvI5E" resolve="doc" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="Rh6nW" id="8QSRaj_XhB" role="1bW2Oz">
+                <property role="TrG5h" value="it" />
+                <node concept="2jxLKc" id="8QSRaj_XhC" role="1tU5fm" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1YaCAy" id="8QSRaj$uI6" role="1YuTPh">
+      <property role="TrG5h" value="iDocumentLike" />
+      <ref role="1YaFvo" to="2c95:5L$H31Kgq3f" resolve="IDocumentLike" />
     </node>
   </node>
 </model>

--- a/code/languages/com.mbeddr.doc/solutions/com.mbeddr.doc.test.documents/com.mbeddr.doc.test.documents.msd
+++ b/code/languages/com.mbeddr.doc/solutions/com.mbeddr.doc.test.documents/com.mbeddr.doc.test.documents.msd
@@ -17,11 +17,15 @@
   <languageVersions>
     <language slang="l:d4280a54-f6df-4383-aa41-d1b2bffa7eb1:com.mbeddr.core.base" version="6" />
     <language slang="l:2374bc90-7e37-41f1-a9c4-c2e35194c36a:com.mbeddr.doc" version="3" />
+    <language slang="l:f44f6b9a-bf30-4f73-866e-fac17c177409:com.mbeddr.doc.gen_latex" version="0" />
     <language slang="l:2dec0852-3a21-4c4e-a68c-b05236cc37f2:com.mbeddr.doc.gen_xhtml" version="1" />
     <language slang="l:63e0e566-5131-447e-90e3-12ea330e1a00:com.mbeddr.mpsutil.blutil" version="1" />
     <language slang="l:d3a0fd26-445a-466c-900e-10444ddfed52:com.mbeddr.mpsutil.filepicker" version="0" />
     <language slang="l:d09a16fb-1d68-4a92-a5a4-20b4b2f86a62:com.mbeddr.mpsutil.jung" version="0" />
+    <language slang="l:92f195b6-a209-4804-ad65-f5248ecd5873:com.mbeddr.mpsutil.margincell" version="0" />
     <language slang="l:b4d28e19-7d2d-47e9-943e-3a41f97a0e52:com.mbeddr.mpsutil.plantuml.node" version="0" />
+    <language slang="l:c788b046-2019-4656-8b60-8bb9bbb177b5:com.mbeddr.mpsutil.review" version="0" />
+    <language slang="l:7a060fae-09e0-4372-be36-6696d6554c0e:com.mbeddr.mpsutil.review.annotation" version="0" />
     <language slang="l:92d2ea16-5a42-4fdf-a676-c7604efe3504:de.slisson.mps.richtext" version="0" />
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
     <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />

--- a/code/languages/com.mbeddr.doc/solutions/com.mbeddr.doc.test.documents/models/com.mbeddr.doc.test.documents.chapter_refs.mps
+++ b/code/languages/com.mbeddr.doc/solutions/com.mbeddr.doc.test.documents/models/com.mbeddr.doc.test.documents.chapter_refs.mps
@@ -1,0 +1,194 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:11dd20da-fab8-4606-8637-3a10ba6860a3(com.mbeddr.doc.test.documents.chapter_refs)">
+  <persistence version="9" />
+  <languages>
+    <use id="2dec0852-3a21-4c4e-a68c-b05236cc37f2" name="com.mbeddr.doc.gen_xhtml" version="1" />
+    <use id="2374bc90-7e37-41f1-a9c4-c2e35194c36a" name="com.mbeddr.doc" version="3" />
+  </languages>
+  <imports />
+  <registry>
+    <language id="2dec0852-3a21-4c4e-a68c-b05236cc37f2" name="com.mbeddr.doc.gen_xhtml">
+      <concept id="3350625596580275037" name="com.mbeddr.doc.gen_xhtml.structure.HTMLRenderer" flags="ng" index="1_07dB" />
+      <concept id="3498379661306969557" name="com.mbeddr.doc.gen_xhtml.structure.HTMLDummyRenderer" flags="ng" index="1TaS0h" />
+    </language>
+    <language id="92d2ea16-5a42-4fdf-a676-c7604efe3504" name="de.slisson.mps.richtext">
+      <concept id="2557074442922380897" name="de.slisson.mps.richtext.structure.Text" flags="ng" index="19SGf9">
+        <child id="2557074442922392302" name="words" index="19SJt6" />
+      </concept>
+      <concept id="2557074442922438156" name="de.slisson.mps.richtext.structure.Word" flags="ng" index="19SUe$">
+        <property id="2557074442922438158" name="escapedValue" index="19SUeA" />
+      </concept>
+    </language>
+    <language id="2374bc90-7e37-41f1-a9c4-c2e35194c36a" name="com.mbeddr.doc">
+      <concept id="6165313375056012512" name="com.mbeddr.doc.structure.DocumentInclude" flags="ng" index="$CzcT">
+        <property id="324047639344492301" name="referenceOnly" index="1P4p2h" />
+        <child id="6165313375056012515" name="ref" index="$CzcU" />
+      </concept>
+      <concept id="6657644269295214799" name="com.mbeddr.doc.structure.IDocumentLike" flags="ng" index="G9hjZ">
+        <reference id="6657644269295214800" name="config" index="G9hjw" />
+        <child id="8730648445433290694" name="dependsOn" index="1DXQ57" />
+      </concept>
+      <concept id="6386504476136472795" name="com.mbeddr.doc.structure.PathDefinition" flags="ng" index="2SbYGw">
+        <child id="2642765975824057986" name="pathPicker" index="9PVG_" />
+      </concept>
+      <concept id="6386504476136472782" name="com.mbeddr.doc.structure.DocumentConfig" flags="ng" index="2SbYGP">
+        <child id="3352153450711894224" name="configItems" index="2wNnkt" />
+        <child id="6617418817009206267" name="defaultImagePath" index="A10yx" />
+        <child id="5785245534401182264" name="defaultTempPath" index="Cbewh" />
+      </concept>
+      <concept id="6068976060904002601" name="com.mbeddr.doc.structure.AbstractExport" flags="ng" index="30Gg6V">
+        <child id="6068976060904007487" name="renderer" index="30GjaH" />
+        <child id="6068976060904007489" name="root" index="30Gjbj" />
+      </concept>
+      <concept id="4208238404730191274" name="com.mbeddr.doc.structure.Chapter" flags="ng" index="1mvXsy" />
+      <concept id="988357225295489881" name="com.mbeddr.doc.structure.TableOfContents" flags="ng" index="3xmJbL" />
+      <concept id="3350625596580256366" name="com.mbeddr.doc.structure.DocumentExport" flags="ng" index="1_08Dk">
+        <property id="126932837435324910" name="title" index="WqcPg" />
+      </concept>
+      <concept id="3350625596580225385" name="com.mbeddr.doc.structure.DocumentRef" flags="ng" index="1_0j5j">
+        <reference id="3350625596580225386" name="doc" index="1_0j5g" />
+      </concept>
+      <concept id="3350625596580089586" name="com.mbeddr.doc.structure.TextParagraph" flags="ng" index="1_0LV8">
+        <child id="3350625596580089613" name="text" index="1_0LWR" />
+      </concept>
+      <concept id="3350625596580064249" name="com.mbeddr.doc.structure.IDocContentContainer" flags="ng" index="1_0VJ3">
+        <child id="3350625596580064250" name="contents" index="1_0VJ0" />
+      </concept>
+      <concept id="3350625596580064222" name="com.mbeddr.doc.structure.AbstractSection" flags="ng" index="1_0VJ$">
+        <property id="3350625596580064225" name="text" index="1_0VJr" />
+      </concept>
+      <concept id="3350625596579911728" name="com.mbeddr.doc.structure.Document" flags="ng" index="1_1swa">
+        <property id="5572730672710143343" name="chapterStartIndex" index="yApLE" />
+      </concept>
+      <concept id="3350625596579911760" name="com.mbeddr.doc.structure.EmptyDocContent" flags="ng" index="1_1sxE" />
+    </language>
+    <language id="d3a0fd26-445a-466c-900e-10444ddfed52" name="com.mbeddr.mpsutil.filepicker">
+      <concept id="2642765975824060179" name="com.mbeddr.mpsutil.filepicker.structure.SolutionRelativeDirPicker" flags="ng" index="9PVaO" />
+      <concept id="6156524541422549000" name="com.mbeddr.mpsutil.filepicker.structure.AbstractPicker" flags="ng" index="3N1QpV">
+        <property id="9294901202237533" name="mayBeEmpty" index="3kgbRO" />
+        <property id="6156524541422553710" name="path" index="3N1Lgt" />
+        <property id="2711621784026951428" name="pointOnlyToExistingFile" index="1RwFax" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="1_1swa" id="3cgsogVwvcw">
+    <property role="yApLE" value="1" />
+    <property role="TrG5h" value="MainChapterDoc" />
+    <ref role="G9hjw" node="2khznRHyx6c" resolve="Config" />
+    <node concept="3xmJbL" id="3cgsogVwvdz" role="1_0VJ0" />
+    <node concept="1_1sxE" id="3cgsogVwvdM" role="1_0VJ0">
+      <property role="TrG5h" value="empty_-1" />
+    </node>
+    <node concept="1mvXsy" id="3cgsogVwvc$" role="1_0VJ0">
+      <property role="TrG5h" value="FirstChapter" />
+      <property role="1_0VJr" value="First chapter" />
+      <node concept="1_0LV8" id="3cgsogVwvcZ" role="1_0VJ0">
+        <node concept="19SGf9" id="3cgsogVwvd0" role="1_0LWR">
+          <node concept="19SUe$" id="3cgsogVwvd1" role="19SJt6">
+            <property role="19SUeA" value="This is the first chapter." />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1_1sxE" id="3cgsogVwvfC" role="1_0VJ0">
+      <property role="TrG5h" value="empty_-1" />
+    </node>
+    <node concept="$CzcT" id="3cgsogVwvfk" role="1_0VJ0">
+      <node concept="1_0j5j" id="3cgsogVwvf_" role="$CzcU">
+        <ref role="1_0j5g" node="3cgsogVwvek" resolve="Chapter2" />
+      </node>
+    </node>
+    <node concept="$CzcT" id="3cgsogVwvfW" role="1_0VJ0">
+      <property role="1P4p2h" value="true" />
+      <node concept="1_0j5j" id="3cgsogVwvgl" role="$CzcU">
+        <ref role="1_0j5g" node="3cgsogVwvfR" resolve="Chapter3" />
+      </node>
+    </node>
+    <node concept="1_1sxE" id="3cgsogVwvcD" role="1_0VJ0">
+      <property role="TrG5h" value="empty_-1" />
+    </node>
+    <node concept="1mvXsy" id="3cgsogVwvcM" role="1_0VJ0">
+      <property role="TrG5h" value="LastChapter" />
+      <property role="1_0VJr" value="Last chapter" />
+      <node concept="1_0LV8" id="3cgsogVwvcS" role="1_0VJ0">
+        <node concept="19SGf9" id="3cgsogVwvcT" role="1_0LWR">
+          <node concept="19SUe$" id="3cgsogVwvcU" role="19SJt6">
+            <property role="19SUeA" value="This is the last chapter." />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1_0j5j" id="3cgsogVwveu" role="1DXQ57">
+      <ref role="1_0j5g" node="3cgsogVwvek" resolve="Chapter2" />
+    </node>
+    <node concept="1_0j5j" id="3cgsogVwvgh" role="1DXQ57">
+      <ref role="1_0j5g" node="3cgsogVwvfR" resolve="Chapter3" />
+    </node>
+  </node>
+  <node concept="2SbYGP" id="2khznRHyx6c">
+    <property role="TrG5h" value="Config" />
+    <node concept="1_07dB" id="2khznRHyx6d" role="2wNnkt" />
+    <node concept="2SbYGw" id="2khznRHyx6e" role="Cbewh">
+      <property role="TrG5h" value="main" />
+      <node concept="9PVaO" id="2khznRHyx6f" role="9PVG_">
+        <property role="1RwFax" value="true" />
+        <property role="3kgbRO" value="false" />
+        <property role="3N1Lgt" value="doc_gen" />
+      </node>
+    </node>
+    <node concept="2SbYGw" id="2B9KjOuvX9f" role="A10yx">
+      <property role="TrG5h" value="imgs" />
+      <node concept="9PVaO" id="2B9KjOuvX9e" role="9PVG_">
+        <property role="1RwFax" value="true" />
+        <property role="3kgbRO" value="false" />
+        <property role="3N1Lgt" value="imgs" />
+      </node>
+    </node>
+  </node>
+  <node concept="1_08Dk" id="2khznRHyx68">
+    <property role="TrG5h" value="Export" />
+    <property role="WqcPg" value="Export config for chapter-ref example" />
+    <node concept="1_0j5j" id="3cgsogVwvcx" role="30Gjbj">
+      <ref role="1_0j5g" node="3cgsogVwvcw" resolve="MainChapterDoc" />
+    </node>
+    <node concept="1TaS0h" id="2khznRHyx6b" role="30GjaH" />
+  </node>
+  <node concept="1_1swa" id="3cgsogVwvek">
+    <property role="yApLE" value="2" />
+    <property role="TrG5h" value="Chapter2" />
+    <ref role="G9hjw" node="2khznRHyx6c" resolve="Config" />
+    <node concept="1mvXsy" id="3cgsogVwvel" role="1_0VJ0">
+      <property role="TrG5h" value="SecondChapter" />
+      <property role="1_0VJr" value="Second chapter" />
+      <node concept="1_0LV8" id="3cgsogVwven" role="1_0VJ0">
+        <node concept="19SGf9" id="3cgsogVwveo" role="1_0LWR">
+          <node concept="19SUe$" id="3cgsogVwvep" role="19SJt6">
+            <property role="19SUeA" value="This is a chapter which is included without ref-only." />
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="1_1swa" id="3cgsogVwvfR">
+    <property role="yApLE" value="3" />
+    <property role="TrG5h" value="Chapter3" />
+    <ref role="G9hjw" node="2khznRHyx6c" resolve="Config" />
+    <node concept="1mvXsy" id="3cgsogVwvfS" role="1_0VJ0">
+      <property role="TrG5h" value="ThirdChapter" />
+      <property role="1_0VJr" value="Third chapter" />
+      <node concept="1_0LV8" id="3cgsogVwvfT" role="1_0VJ0">
+        <node concept="19SGf9" id="3cgsogVwvfU" role="1_0LWR">
+          <node concept="19SUe$" id="3cgsogVwvfV" role="19SJt6">
+            <property role="19SUeA" value="This is a chapter from a separate document, which is included ref-only." />
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/code/languages/com.mbeddr.doc/solutions/com.mbeddr.doc.test.documents/models/com.mbeddr.doc.test.documents.doc_refs.mps
+++ b/code/languages/com.mbeddr.doc/solutions/com.mbeddr.doc.test.documents/models/com.mbeddr.doc.test.documents.doc_refs.mps
@@ -1,0 +1,157 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:c20abc99-c3e1-4a29-9270-de587f318ef3(com.mbeddr.doc.test.documents.doc_refs)">
+  <persistence version="9" />
+  <languages>
+    <devkit ref="54c79f9f-f3ba-4167-91f1-eb4e98a9c47c(com.mbeddr.documentation)" />
+  </languages>
+  <imports>
+    <import index="lluw" ref="r:260e0933-d20e-4f4f-88cb-1c3cbbf973a8(com.mbeddr.doc.test.documents.doc2_1)" />
+  </imports>
+  <registry>
+    <language id="2dec0852-3a21-4c4e-a68c-b05236cc37f2" name="com.mbeddr.doc.gen_xhtml">
+      <concept id="3350625596580275037" name="com.mbeddr.doc.gen_xhtml.structure.HTMLRenderer" flags="ng" index="1_07dB" />
+      <concept id="3498379661306969557" name="com.mbeddr.doc.gen_xhtml.structure.HTMLDummyRenderer" flags="ng" index="1TaS0h" />
+    </language>
+    <language id="92d2ea16-5a42-4fdf-a676-c7604efe3504" name="de.slisson.mps.richtext">
+      <concept id="2557074442922380897" name="de.slisson.mps.richtext.structure.Text" flags="ng" index="19SGf9">
+        <child id="2557074442922392302" name="words" index="19SJt6" />
+      </concept>
+      <concept id="2557074442922438156" name="de.slisson.mps.richtext.structure.Word" flags="ng" index="19SUe$">
+        <property id="2557074442922438158" name="escapedValue" index="19SUeA" />
+      </concept>
+    </language>
+    <language id="2374bc90-7e37-41f1-a9c4-c2e35194c36a" name="com.mbeddr.doc">
+      <concept id="3861573051973810887" name="com.mbeddr.doc.structure.ITextOverride" flags="ng" index="0yqFW">
+        <property id="3861573051973810888" name="textOverride" index="0yqFN" />
+      </concept>
+      <concept id="6165313375056012512" name="com.mbeddr.doc.structure.DocumentInclude" flags="ng" index="$CzcT">
+        <property id="324047639344492301" name="referenceOnly" index="1P4p2h" />
+        <child id="6165313375056012515" name="ref" index="$CzcU" />
+      </concept>
+      <concept id="6657644269295214799" name="com.mbeddr.doc.structure.IDocumentLike" flags="ng" index="G9hjZ">
+        <reference id="6657644269295214800" name="config" index="G9hjw" />
+        <child id="8730648445433290694" name="dependsOn" index="1DXQ57" />
+      </concept>
+      <concept id="6386504476136554612" name="com.mbeddr.doc.structure.PathMapping" flags="ng" index="2SbEIf">
+        <property id="6386504476136554614" name="mappedPath" index="2SbEId" />
+        <reference id="6386504476136554613" name="pathDef" index="2SbEIe" />
+      </concept>
+      <concept id="6386504476136472795" name="com.mbeddr.doc.structure.PathDefinition" flags="ng" index="2SbYGw">
+        <child id="2642765975824057986" name="pathPicker" index="9PVG_" />
+      </concept>
+      <concept id="6386504476136472782" name="com.mbeddr.doc.structure.DocumentConfig" flags="ng" index="2SbYGP">
+        <child id="3352153450711894224" name="configItems" index="2wNnkt" />
+        <child id="6617418817009206267" name="defaultImagePath" index="A10yx" />
+        <child id="5785245534401182264" name="defaultTempPath" index="Cbewh" />
+      </concept>
+      <concept id="6068976060904002601" name="com.mbeddr.doc.structure.AbstractExport" flags="ng" index="30Gg6V">
+        <child id="6068976060904007487" name="renderer" index="30GjaH" />
+        <child id="6068976060904007490" name="mappings" index="30Gjbg" />
+        <child id="6068976060904007489" name="root" index="30Gjbj" />
+      </concept>
+      <concept id="52093402212126344" name="com.mbeddr.doc.structure.DocRefWord" flags="ng" index="1thXK$">
+        <reference id="52093402212126345" name="target" index="1thXK_" />
+      </concept>
+      <concept id="988357225295489881" name="com.mbeddr.doc.structure.TableOfContents" flags="ng" index="3xmJbL" />
+      <concept id="3350625596580256366" name="com.mbeddr.doc.structure.DocumentExport" flags="ng" index="1_08Dk">
+        <property id="126932837435324910" name="title" index="WqcPg" />
+      </concept>
+      <concept id="3350625596580225385" name="com.mbeddr.doc.structure.DocumentRef" flags="ng" index="1_0j5j">
+        <reference id="3350625596580225386" name="doc" index="1_0j5g" />
+      </concept>
+      <concept id="3350625596580089586" name="com.mbeddr.doc.structure.TextParagraph" flags="ng" index="1_0LV8">
+        <child id="3350625596580089613" name="text" index="1_0LWR" />
+      </concept>
+      <concept id="3350625596580064249" name="com.mbeddr.doc.structure.IDocContentContainer" flags="ng" index="1_0VJ3">
+        <child id="3350625596580064250" name="contents" index="1_0VJ0" />
+      </concept>
+      <concept id="3350625596579911728" name="com.mbeddr.doc.structure.Document" flags="ng" index="1_1swa">
+        <property id="5572730672710143343" name="chapterStartIndex" index="yApLE" />
+      </concept>
+    </language>
+    <language id="d3a0fd26-445a-466c-900e-10444ddfed52" name="com.mbeddr.mpsutil.filepicker">
+      <concept id="2642765975824060179" name="com.mbeddr.mpsutil.filepicker.structure.SolutionRelativeDirPicker" flags="ng" index="9PVaO" />
+      <concept id="6156524541422549000" name="com.mbeddr.mpsutil.filepicker.structure.AbstractPicker" flags="ng" index="3N1QpV">
+        <property id="9294901202237533" name="mayBeEmpty" index="3kgbRO" />
+        <property id="6156524541422553710" name="path" index="3N1Lgt" />
+        <property id="2711621784026951428" name="pointOnlyToExistingFile" index="1RwFax" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="2SbYGP" id="2khznRHyx6c">
+    <property role="TrG5h" value="Config" />
+    <node concept="1_07dB" id="2khznRHyx6d" role="2wNnkt" />
+    <node concept="2SbYGw" id="2khznRHyx6e" role="Cbewh">
+      <property role="TrG5h" value="main" />
+      <node concept="9PVaO" id="2khznRHyx6f" role="9PVG_">
+        <property role="1RwFax" value="true" />
+        <property role="3kgbRO" value="false" />
+      </node>
+    </node>
+    <node concept="2SbYGw" id="2B9KjOuvX9f" role="A10yx">
+      <property role="TrG5h" value="imgs" />
+      <node concept="9PVaO" id="2B9KjOuvX9e" role="9PVG_">
+        <property role="1RwFax" value="true" />
+        <property role="3kgbRO" value="false" />
+        <property role="3N1Lgt" value="imgs" />
+      </node>
+    </node>
+  </node>
+  <node concept="1_08Dk" id="2khznRHyx68">
+    <property role="TrG5h" value="Export" />
+    <property role="WqcPg" value="My strange export config" />
+    <node concept="2SbEIf" id="4eRbT2iEycg" role="30Gjbg">
+      <property role="2SbEId" value="/Users/kdummann/source/mbeddr/mbeddr.core/" />
+      <ref role="2SbEIe" node="2khznRHyx6e" resolve="main" />
+    </node>
+    <node concept="1_0j5j" id="2khznRHyx6i" role="30Gjbj">
+      <ref role="1_0j5g" node="2khznRHyx5W" resolve="MainDoc" />
+    </node>
+    <node concept="1TaS0h" id="2khznRHyx6b" role="30GjaH" />
+  </node>
+  <node concept="1_1swa" id="2khznRHyx5W">
+    <property role="yApLE" value="1" />
+    <property role="TrG5h" value="MainDoc" />
+    <ref role="G9hjw" node="2khznRHyx6c" resolve="Config" />
+    <node concept="3xmJbL" id="8QSRajVL3G" role="1_0VJ0" />
+    <node concept="1_0LV8" id="8QSRajVL4F" role="1_0VJ0">
+      <node concept="19SGf9" id="8QSRajVL4G" role="1_0LWR">
+        <node concept="19SUe$" id="8QSRajVL4H" role="19SJt6">
+          <property role="19SUeA" value="The document include with the &quot;reference only&quot; option checked will just contribute an entry to the&#10;table of contents. No documentation content is included in the including document body." />
+        </node>
+      </node>
+    </node>
+    <node concept="$CzcT" id="8QSRajVLOi" role="1_0VJ0">
+      <property role="1P4p2h" value="true" />
+      <node concept="1_0j5j" id="8QSRajVLQl" role="$CzcU">
+        <ref role="1_0j5g" to="lluw:2khznRHyx6K" resolve="sub_document_2" />
+      </node>
+    </node>
+    <node concept="1_0LV8" id="8QSRajVLRU" role="1_0VJ0">
+      <node concept="19SGf9" id="8QSRajVLRV" role="1_0LWR">
+        <node concept="19SUe$" id="8QSRajVLRW" role="19SJt6">
+          <property role="19SUeA" value="Using the doc ref word, generates a hyperlink to the referenced document like " />
+        </node>
+        <node concept="1thXK$" id="8QSRajVMcD" role="19SJt6">
+          <property role="0yqFN" value="this" />
+          <ref role="1thXK_" to="lluw:2khznRHyxyJ" resolve="sub_document_3" />
+        </node>
+        <node concept="19SUe$" id="8QSRajVMcE" role="19SJt6">
+          <property role="19SUeA" value="." />
+        </node>
+      </node>
+    </node>
+    <node concept="1_0j5j" id="8QSRajVLPm" role="1DXQ57">
+      <ref role="1_0j5g" to="lluw:2khznRHyx6K" resolve="sub_document_2" />
+    </node>
+    <node concept="1_0j5j" id="8QSRajVLPQ" role="1DXQ57">
+      <ref role="1_0j5g" to="lluw:2khznRHyxyJ" resolve="sub_document_3" />
+    </node>
+  </node>
+</model>
+


### PR DESCRIPTION
It is possible to reference documents from different models in two
different ways:
* Using a document include checking the "reference only" box

This will contribute an entry to the table of contents that links to
the referenced document

* Using a doc ref word

This will generate a "word" link to the referenced document. Nothing is
added to the table of contents.