### PR TITLE
Document aspect: add priorities 

### DIFF
--- a/code/languages/com.mbeddr.doc.aspect/languages/com.mbeddr.doc.aspect.exampleLanguage.extended/models/documentation.mps
+++ b/code/languages/com.mbeddr.doc.aspect/languages/com.mbeddr.doc.aspect.exampleLanguage.extended/models/documentation.mps
@@ -17,6 +17,7 @@
       </concept>
       <concept id="7810506636291686467" name="com.mbeddr.doc.aspect.structure.DocumentedPropertyItemAnnotation" flags="ng" index="fANS$" />
       <concept id="1058510331725720478" name="com.mbeddr.doc.aspect.structure.DocumentedConceptAnnotation" flags="ng" index="3n9NSn">
+        <property id="1881564090922902400" name="priority" index="17ySGi" />
         <reference id="1058510331725761196" name="concept" index="3nadW_" />
       </concept>
     </language>
@@ -110,6 +111,7 @@
         </node>
       </node>
       <node concept="3n9NSn" id="3TrpzyP_FtB" role="lGtFl">
+        <property role="17ySGi" value="10" />
         <ref role="3nadW_" to="hauh:1MEM7LwynlN" resolve="ColoredNode" />
       </node>
     </node>

--- a/code/languages/com.mbeddr.doc.aspect/languages/com.mbeddr.doc.aspect.exampleLanguage/com.mbeddr.doc.aspect.exampleLanguage.mpl
+++ b/code/languages/com.mbeddr.doc.aspect/languages/com.mbeddr.doc.aspect.exampleLanguage/com.mbeddr.doc.aspect.exampleLanguage.mpl
@@ -58,9 +58,15 @@
     <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
     <module reference="3c21902d-b582-4557-b697-84a4dcddff3a(com.mbeddr.doc.aspect.exampleLanguage)" version="0" />
+    <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
+    <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
+    <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
     <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
     <module reference="a9e4c532-c5f5-4bb7-99ef-42abb73bbb70(jetbrains.mps.lang.descriptor.aspects)" version="0" />
+    <module reference="9ded098b-ad6a-4657-bfd9-48636cfe8bc3(jetbrains.mps.lang.traceable)" version="0" />
   </dependencyVersions>
-  <extendedLanguages />
+  <extendedLanguages>
+    <extendedLanguage>f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)</extendedLanguage>
+  </extendedLanguages>
 </language>
 

--- a/code/languages/com.mbeddr.doc.aspect/languages/com.mbeddr.doc.aspect.exampleLanguage/models/com/mbeddr/doc/aspect/exampleLanguage/documentation.mps
+++ b/code/languages/com.mbeddr.doc.aspect/languages/com.mbeddr.doc.aspect.exampleLanguage/models/com/mbeddr/doc/aspect/exampleLanguage/documentation.mps
@@ -10,6 +10,7 @@
   </languages>
   <imports>
     <import index="hauh" ref="r:489c719c-7616-403c-a112-c95a57d1fcd3(com.mbeddr.doc.aspect.exampleLanguage.structure)" />
+    <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" implicit="true" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
   </imports>
   <registry>
@@ -19,6 +20,7 @@
       </concept>
       <concept id="7810506636291686467" name="com.mbeddr.doc.aspect.structure.DocumentedPropertyItemAnnotation" flags="ng" index="fANS$" />
       <concept id="1058510331725720478" name="com.mbeddr.doc.aspect.structure.DocumentedConceptAnnotation" flags="ng" index="3n9NSn">
+        <property id="1881564090922902400" name="priority" index="17ySGi" />
         <reference id="1058510331725761196" name="concept" index="3nadW_" />
       </concept>
     </language>
@@ -110,35 +112,64 @@
           </node>
         </node>
       </node>
-      <node concept="1_0VNX" id="4jXS_uRrcFF" role="1_0VJ0">
+      <node concept="1_0VNX" id="1CsE99tzurx" role="1_0VJ0">
         <property role="TrG5h" value="Node" />
         <property role="1_0VJr" value="Node" />
-        <node concept="3n9NSn" id="4jXS_uRrcGh" role="lGtFl">
+        <node concept="3n9NSn" id="1CsE99tzury" role="lGtFl">
           <ref role="3nadW_" to="hauh:4MORkbYxnx" resolve="Node" />
         </node>
-        <node concept="1_0LV8" id="4jXS_uRrfC6" role="1_0VJ0">
-          <node concept="19SGf9" id="4jXS_uRrfC7" role="1_0LWR">
-            <node concept="19SUe$" id="4jXS_uRrfC8" role="19SJt6">
+        <node concept="1_0LV8" id="1CsE99tzurz" role="1_0VJ0">
+          <node concept="19SGf9" id="1CsE99tzur$" role="1_0LWR">
+            <node concept="19SUe$" id="1CsE99tzur_" role="19SJt6">
               <property role="19SUeA" value="Represents an &quot;object&quot; in a graph." />
             </node>
           </node>
         </node>
-        <node concept="1_0LV8" id="4jXS_uRrfCd" role="1_0VJ0">
-          <node concept="19SGf9" id="4jXS_uRrfCe" role="1_0LWR">
-            <node concept="19SUe$" id="4jXS_uRrfCf" role="19SJt6">
+        <node concept="1_0LV8" id="1CsE99tzurA" role="1_0VJ0">
+          <node concept="19SGf9" id="1CsE99tzurB" role="1_0LWR">
+            <node concept="19SUe$" id="1CsE99tzurC" role="19SJt6">
               <property role="19SUeA" value="See also: " />
             </node>
-            <node concept="1_0GAv" id="4jXS_uRrfCm" role="19SJt6">
+            <node concept="1_0GAv" id="1CsE99tzurD" role="19SJt6">
               <ref role="1_0GAl" node="UK_oBpA4O5" resolve="Graph" />
             </node>
-            <node concept="19SUe$" id="4jXS_uRrfCn" role="19SJt6">
+            <node concept="19SUe$" id="1CsE99tzurE" role="19SJt6">
               <property role="19SUeA" value=", " />
             </node>
-            <node concept="1_0GAv" id="4jXS_uRrfCr" role="19SJt6">
+            <node concept="1_0GAv" id="1CsE99tzurF" role="19SJt6">
               <ref role="1_0GAl" node="UK_oBpCt_h" resolve="Edge" />
             </node>
-            <node concept="19SUe$" id="4jXS_uRrfCs" role="19SJt6" />
+            <node concept="19SUe$" id="1CsE99tzurG" role="19SJt6" />
           </node>
+        </node>
+      </node>
+      <node concept="1_0VNX" id="1CsE99tzuth" role="1_0VJ0">
+        <property role="TrG5h" value="IntLiteral" />
+        <property role="1_0VJr" value="intLiteral" />
+        <node concept="1_0LV8" id="1CsE99tz$39" role="1_0VJ0">
+          <node concept="19SGf9" id="1CsE99tz$3a" role="1_0LWR">
+            <node concept="19SUe$" id="1CsE99tz$3b" role="19SJt6">
+              <property role="19SUeA" value="Integer documentation" />
+            </node>
+          </node>
+        </node>
+        <node concept="3n9NSn" id="1CsE99tzutP" role="lGtFl">
+          <ref role="3nadW_" to="tpee:fzcmrck" resolve="IntegerConstant" />
+        </node>
+      </node>
+      <node concept="1_0VNX" id="1CsE99t_Glc" role="1_0VJ0">
+        <property role="TrG5h" value="ColorNode" />
+        <property role="1_0VJr" value="ColorNode" />
+        <node concept="1_0LV8" id="1CsE99t_GlR" role="1_0VJ0">
+          <node concept="19SGf9" id="1CsE99t_GlS" role="1_0LWR">
+            <node concept="19SUe$" id="1CsE99t_GlT" role="19SJt6">
+              <property role="19SUeA" value="Color node?" />
+            </node>
+          </node>
+        </node>
+        <node concept="3n9NSn" id="1CsE99t_GlY" role="lGtFl">
+          <property role="17ySGi" value="30" />
+          <ref role="3nadW_" to="hauh:1MEM7LwynlN" resolve="ColoredNode" />
         </node>
       </node>
       <node concept="1_0VNX" id="UK_oBpCt_h" role="1_0VJ0">

--- a/code/languages/com.mbeddr.doc.aspect/languages/com.mbeddr.doc.aspect.exampleLanguage/models/com/mbeddr/doc/aspect/exampleLanguage/editor.mps
+++ b/code/languages/com.mbeddr.doc.aspect/languages/com.mbeddr.doc.aspect.exampleLanguage/models/com/mbeddr/doc/aspect/exampleLanguage/editor.mps
@@ -50,6 +50,7 @@
       <concept id="1219418625346" name="jetbrains.mps.lang.editor.structure.IStyleContainer" flags="ng" index="3F0Thp">
         <child id="1219418656006" name="styleItem" index="3F10Kt" />
       </concept>
+      <concept id="1073389882823" name="jetbrains.mps.lang.editor.structure.CellModel_RefNode" flags="sg" stub="730538219795960754" index="3F1sOY" />
       <concept id="1073390211982" name="jetbrains.mps.lang.editor.structure.CellModel_RefNodeList" flags="sg" stub="2794558372793454595" index="3F2HdR" />
       <concept id="1166049232041" name="jetbrains.mps.lang.editor.structure.AbstractComponent" flags="ng" index="1XWOmA">
         <reference id="1166049300910" name="conceptDeclaration" index="1XX52x" />
@@ -211,6 +212,9 @@
       </node>
       <node concept="3F0A7n" id="4MORkbYxo9" role="3EZMnx">
         <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
+      </node>
+      <node concept="3F1sOY" id="1CsE99tzupG" role="3EZMnx">
+        <ref role="1NtTu8" to="hauh:1CsE99tzupA" resolve="expression" />
       </node>
     </node>
   </node>

--- a/code/languages/com.mbeddr.doc.aspect/languages/com.mbeddr.doc.aspect.exampleLanguage/models/com/mbeddr/doc/aspect/exampleLanguage/structure.mps
+++ b/code/languages/com.mbeddr.doc.aspect/languages/com.mbeddr.doc.aspect.exampleLanguage/models/com/mbeddr/doc/aspect/exampleLanguage/structure.mps
@@ -5,6 +5,7 @@
     <devkit ref="78434eb8-b0e5-444b-850d-e7c4ad2da9ab(jetbrains.mps.devkit.aspect.structure)" />
   </languages>
   <imports>
+    <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
   </imports>
   <registry>
@@ -105,6 +106,13 @@
     <property role="TrG5h" value="Node" />
     <property role="34LRSv" value="node" />
     <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
+    <node concept="1TJgyj" id="1CsE99tzupA" role="1TKVEi">
+      <property role="IQ2ns" value="1881564090922296934" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="expression" />
+      <property role="20lbJX" value="fLJekj4/_1" />
+      <ref role="20lvS9" to="tpee:hanubx6" resolve="IntegerLiteral" />
+    </node>
     <node concept="PrWs8" id="1MEM7Lwytq1" role="PzmwI">
       <ref role="PrY4T" node="1MEM7LwytpY" resolve="INode" />
     </node>

--- a/code/languages/com.mbeddr.doc.aspect/languages/com.mbeddr.doc.aspect.exampleLanguage/sandbox/com.mbeddr.doc.aspect.exampleLanguage.sandbox.msd
+++ b/code/languages/com.mbeddr.doc.aspect/languages/com.mbeddr.doc.aspect.exampleLanguage/sandbox/com.mbeddr.doc.aspect.exampleLanguage.sandbox.msd
@@ -24,6 +24,7 @@
     <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
     <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
     <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
+    <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
     <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
   </languageVersions>
   <dependencyVersions>

--- a/code/languages/com.mbeddr.doc.aspect/languages/com.mbeddr.doc.aspect.exampleLanguage/sandbox/models/com/mbeddr/doc/aspect/exampleLanguage/sandbox.mps
+++ b/code/languages/com.mbeddr.doc.aspect/languages/com.mbeddr.doc.aspect.exampleLanguage/sandbox/models/com/mbeddr/doc/aspect/exampleLanguage/sandbox.mps
@@ -4,14 +4,22 @@
   <languages>
     <use id="3c21902d-b582-4557-b697-84a4dcddff3a" name="com.mbeddr.doc.aspect.exampleLanguage" version="0" />
     <use id="1e00450a-fc72-4f66-9571-30e5e083c1fa" name="com.mbeddr.doc.aspect.exampleLanguage.extended" version="0" />
+    <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="11" />
   </languages>
   <imports />
   <registry>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
+        <property id="1068580320021" name="value" index="3cmrfH" />
+      </concept>
+    </language>
     <language id="1e00450a-fc72-4f66-9571-30e5e083c1fa" name="com.mbeddr.doc.aspect.exampleLanguage.extended">
       <concept id="9004279853425732280" name="com.mbeddr.doc.aspect.exampleLanguage.extended.structure.UndirectedEdge" flags="ng" index="2lk0DD" />
     </language>
     <language id="3c21902d-b582-4557-b697-84a4dcddff3a" name="com.mbeddr.doc.aspect.exampleLanguage">
-      <concept id="86363842539034081" name="com.mbeddr.doc.aspect.exampleLanguage.structure.Node" flags="ng" index="aMcqk" />
+      <concept id="86363842539034081" name="com.mbeddr.doc.aspect.exampleLanguage.structure.Node" flags="ng" index="aMcqk">
+        <child id="1881564090922296934" name="expression" index="17$kVO" />
+      </concept>
       <concept id="2065683815623914867" name="com.mbeddr.doc.aspect.exampleLanguage.structure.ColoredNode" flags="ng" index="1W8VOf">
         <property id="2065683815623914868" name="color" index="1W8VO8" />
       </concept>
@@ -54,15 +62,27 @@
     </node>
     <node concept="aMcqk" id="1MEM7Lwynln" role="1WbyPO">
       <property role="TrG5h" value="N1" />
+      <node concept="3cmrfG" id="1CsE99t$v01" role="17$kVO">
+        <property role="3cmrfH" value="10" />
+      </node>
     </node>
     <node concept="aMcqk" id="1MEM7Lwynlp" role="1WbyPO">
       <property role="TrG5h" value="N2" />
+      <node concept="3cmrfG" id="1CsE99tKKEN" role="17$kVO">
+        <property role="3cmrfH" value="10" />
+      </node>
     </node>
     <node concept="aMcqk" id="1MEM7Lwynls" role="1WbyPO">
       <property role="TrG5h" value="N3" />
+      <node concept="3cmrfG" id="1CsE99tKKVo" role="17$kVO">
+        <property role="3cmrfH" value="10" />
+      </node>
     </node>
     <node concept="aMcqk" id="1MEM7Lwynlw" role="1WbyPO">
       <property role="TrG5h" value="N4" />
+      <node concept="3cmrfG" id="1CsE99tKLbV" role="17$kVO">
+        <property role="3cmrfH" value="10" />
+      </node>
     </node>
     <node concept="1W8VOf" id="1MEM7LwyyPS" role="1WbyPO">
       <property role="TrG5h" value="N5" />

--- a/code/languages/com.mbeddr.doc.aspect/languages/com.mbeddr.doc.aspect/generator/template/main@generator.mps
+++ b/code/languages/com.mbeddr.doc.aspect/languages/com.mbeddr.doc.aspect/generator/template/main@generator.mps
@@ -25,10 +25,20 @@
     <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" implicit="true" />
   </imports>
   <registry>
+    <language id="a247e09e-2435-45ba-b8d2-07e93feba96a" name="jetbrains.mps.baseLanguage.tuples">
+      <concept id="1238852151516" name="jetbrains.mps.baseLanguage.tuples.structure.IndexedTupleType" flags="in" index="1LlUBW">
+        <child id="1238852204892" name="componentType" index="1Lm7xW" />
+      </concept>
+      <concept id="1238857743184" name="jetbrains.mps.baseLanguage.tuples.structure.IndexedTupleMemberAccessExpression" flags="nn" index="1LFfDK">
+        <child id="1238857764950" name="tuple" index="1LFl5Q" />
+        <child id="1238857834412" name="index" index="1LF_Uc" />
+      </concept>
+    </language>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
       <concept id="1082485599095" name="jetbrains.mps.baseLanguage.structure.BlockStatement" flags="nn" index="9aQIb">
         <child id="1082485599096" name="statements" index="9aQI4" />
       </concept>
+      <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
       <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="nn" index="2tJIrI" />
       <concept id="2820489544401957797" name="jetbrains.mps.baseLanguage.structure.DefaultClassCreator" flags="nn" index="HV5vD">
@@ -54,6 +64,7 @@
         <reference id="1144433194310" name="classConcept" index="1Pybhc" />
       </concept>
       <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
+      <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
       <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu">
         <child id="1095933932569" name="implementedInterface" index="EKbjA" />
       </concept>
@@ -100,6 +111,9 @@
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
       </concept>
+      <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
+        <property id="1068580320021" name="value" index="3cmrfH" />
+      </concept>
       <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
       <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
         <child id="1068581517676" name="expression" index="3cqZAk" />
@@ -107,6 +121,7 @@
       <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
         <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
       </concept>
+      <concept id="1068581242869" name="jetbrains.mps.baseLanguage.structure.MinusExpression" flags="nn" index="3cpWsd" />
       <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
       <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
@@ -187,6 +202,12 @@
         <child id="1167770376702" name="referentFunction" index="3$ytzL" />
       </concept>
     </language>
+    <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
+      <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
+        <child id="1199569906740" name="parameter" index="1bW2Oz" />
+        <child id="1199569916463" name="body" index="1bW5cS" />
+      </concept>
+    </language>
     <language id="69b8a993-9b87-4d96-bf0c-3559f4bb0c63" name="jetbrains.mps.lang.slanguage">
       <concept id="6171083915388330090" name="jetbrains.mps.lang.slanguage.structure.AspectModelRefExpression" flags="ng" index="1qvjxa">
         <reference id="6171083915388597767" name="aspect" index="1quiSB" />
@@ -253,11 +274,23 @@
       </concept>
     </language>
     <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
+      <concept id="1204796164442" name="jetbrains.mps.baseLanguage.collections.structure.InternalSequenceOperation" flags="nn" index="23sCx2">
+        <child id="1204796294226" name="closure" index="23t8la" />
+      </concept>
       <concept id="1176906603202" name="jetbrains.mps.baseLanguage.collections.structure.BinaryOperation" flags="nn" index="56pJg">
         <child id="1176906787974" name="rightExpression" index="576Qk" />
       </concept>
+      <concept id="540871147943773365" name="jetbrains.mps.baseLanguage.collections.structure.SingleArgumentSequenceOperation" flags="nn" index="25WWJ4">
+        <child id="540871147943773366" name="argument" index="25WWJ7" />
+      </concept>
+      <concept id="1151688443754" name="jetbrains.mps.baseLanguage.collections.structure.ListType" flags="in" index="_YKpA">
+        <child id="1151688676805" name="elementType" index="_ZDj9" />
+      </concept>
       <concept id="1151689724996" name="jetbrains.mps.baseLanguage.collections.structure.SequenceType" flags="in" index="A3Dl8">
         <child id="1151689745422" name="elementType" index="A3Ik2" />
+      </concept>
+      <concept id="1209727891789" name="jetbrains.mps.baseLanguage.collections.structure.ComparatorSortOperation" flags="nn" index="2DpFxk">
+        <child id="1209727996925" name="ascending" index="2Dq5b$" />
       </concept>
       <concept id="1153943597977" name="jetbrains.mps.baseLanguage.collections.structure.ForEachStatement" flags="nn" index="2Gpval">
         <child id="1153944400369" name="variable" index="2Gsz3X" />
@@ -271,6 +304,15 @@
         <child id="1235573175711" name="elementType" index="2HTBi0" />
         <child id="1235573187520" name="singletonValue" index="2HTEbv" />
       </concept>
+      <concept id="1237721394592" name="jetbrains.mps.baseLanguage.collections.structure.AbstractContainerCreator" flags="nn" index="HWqM0">
+        <child id="1237721435807" name="elementType" index="HW$YZ" />
+      </concept>
+      <concept id="1203518072036" name="jetbrains.mps.baseLanguage.collections.structure.SmartClosureParameterDeclaration" flags="ig" index="Rh6nW" />
+      <concept id="1160600644654" name="jetbrains.mps.baseLanguage.collections.structure.ListCreatorWithInit" flags="nn" index="Tc6Ow" />
+      <concept id="1160666733551" name="jetbrains.mps.baseLanguage.collections.structure.AddAllElementsOperation" flags="nn" index="X8dFx" />
+      <concept id="1178286324487" name="jetbrains.mps.baseLanguage.collections.structure.SortDirection" flags="nn" index="1nlBCl" />
+      <concept id="1165525191778" name="jetbrains.mps.baseLanguage.collections.structure.GetFirstOperation" flags="nn" index="1uHKPH" />
+      <concept id="1176501494711" name="jetbrains.mps.baseLanguage.collections.structure.IsNotEmptyOperation" flags="nn" index="3GX2aA" />
       <concept id="1180964022718" name="jetbrains.mps.baseLanguage.collections.structure.ConcatOperation" flags="nn" index="3QWeyG" />
     </language>
   </registry>
@@ -644,6 +686,25 @@
           </node>
         </node>
         <node concept="3clFbH" id="2NM$qy7W3sx" role="3cqZAp" />
+        <node concept="3cpWs8" id="1CsE99tCmkg" role="3cqZAp">
+          <node concept="3cpWsn" id="1CsE99tCmkj" role="3cpWs9">
+            <property role="TrG5h" value="availableDocs" />
+            <node concept="_YKpA" id="1CsE99tCmkc" role="1tU5fm">
+              <node concept="1LlUBW" id="1CsE99tCmx3" role="_ZDj9">
+                <node concept="3Tqbb2" id="1CsE99tCmGH" role="1Lm7xW" />
+                <node concept="10Oyi0" id="1CsE99tCn3L" role="1Lm7xW" />
+              </node>
+            </node>
+            <node concept="2ShNRf" id="1CsE99tCnBg" role="33vP2m">
+              <node concept="Tc6Ow" id="1CsE99tCo9o" role="2ShVmc">
+                <node concept="1LlUBW" id="1CsE99tCoOT" role="HW$YZ">
+                  <node concept="3Tqbb2" id="1CsE99tCp8E" role="1Lm7xW" />
+                  <node concept="10Oyi0" id="1CsE99tCpLN" role="1Lm7xW" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
         <node concept="2Gpval" id="eEuMfA9KyT" role="3cqZAp">
           <node concept="2GrKxI" id="eEuMfA9KyU" role="2Gsz3X">
             <property role="TrG5h" value="language" />
@@ -664,10 +725,10 @@
             </node>
             <node concept="3cpWs8" id="agjuZpaUTF" role="3cqZAp">
               <node concept="3cpWsn" id="agjuZpaUTG" role="3cpWs9">
-                <property role="TrG5h" value="element" />
+                <property role="TrG5h" value="foundDocs" />
                 <property role="3TUv4t" value="true" />
                 <node concept="2YIFZM" id="2NM$qy7XI97" role="33vP2m">
-                  <ref role="37wK5l" to="ttl0:2NM$qy7XAw_" resolve="findDocumentationElement" />
+                  <ref role="37wK5l" to="ttl0:2NM$qy7XAw_" resolve="findDocumentationElements" />
                   <ref role="1Pybhc" to="ttl0:qh7UMGioaa" resolve="DocumentationAspectHelper" />
                   <node concept="37vLTw" id="4MX_x9xFpE" role="37wK5m">
                     <ref role="3cqZAo" node="agjuZpaUTs" resolve="model" />
@@ -679,20 +740,32 @@
                     <ref role="3cqZAo" node="1o6EjwiUhxl" resolve="property" />
                   </node>
                 </node>
-                <node concept="3Tqbb2" id="agjuZpaUTH" role="1tU5fm" />
+                <node concept="_YKpA" id="1CsE99tCtf8" role="1tU5fm">
+                  <node concept="1LlUBW" id="1CsE99tCqNO" role="_ZDj9">
+                    <node concept="3Tqbb2" id="1CsE99tCrfm" role="1Lm7xW" />
+                    <node concept="10Oyi0" id="1CsE99tCrZN" role="1Lm7xW" />
+                  </node>
+                </node>
               </node>
             </node>
             <node concept="3clFbJ" id="eEuMfA9ZjJ" role="3cqZAp">
               <node concept="3y3z36" id="2NM$qy7W3NY" role="3clFbw">
                 <node concept="10Nm6u" id="2NM$qy7W3Wd" role="3uHU7w" />
                 <node concept="37vLTw" id="4MX_x9xFMF" role="3uHU7B">
-                  <ref role="3cqZAo" node="agjuZpaUTG" resolve="element" />
+                  <ref role="3cqZAo" node="agjuZpaUTG" resolve="foundDocs" />
                 </node>
               </node>
               <node concept="3clFbS" id="eEuMfA9ZjL" role="3clFbx">
-                <node concept="3cpWs6" id="eEuMfAa0b5" role="3cqZAp">
-                  <node concept="37vLTw" id="4MX_x9xFPd" role="3cqZAk">
-                    <ref role="3cqZAo" node="agjuZpaUTG" resolve="element" />
+                <node concept="3clFbF" id="1CsE99tCv6J" role="3cqZAp">
+                  <node concept="2OqwBi" id="1CsE99tCwhp" role="3clFbG">
+                    <node concept="37vLTw" id="1CsE99tCv6I" role="2Oq$k0">
+                      <ref role="3cqZAo" node="1CsE99tCmkj" resolve="availableDocs" />
+                    </node>
+                    <node concept="X8dFx" id="1CsE99tCxqM" role="2OqNvi">
+                      <node concept="37vLTw" id="1CsE99tCyLg" role="25WWJ7">
+                        <ref role="3cqZAo" node="agjuZpaUTG" resolve="foundDocs" />
+                      </node>
+                    </node>
                   </node>
                 </node>
               </node>
@@ -703,8 +776,83 @@
           </node>
         </node>
         <node concept="3clFbH" id="2NM$qy7W4wn" role="3cqZAp" />
-        <node concept="3cpWs6" id="agjuZpaUUv" role="3cqZAp">
-          <node concept="10Nm6u" id="eEuMfAa43v" role="3cqZAk" />
+        <node concept="3cpWs8" id="1CsE99tDWUQ" role="3cqZAp">
+          <node concept="3cpWsn" id="1CsE99tDWUR" role="3cpWs9">
+            <property role="TrG5h" value="seq" />
+            <node concept="A3Dl8" id="1CsE99tDU4D" role="1tU5fm">
+              <node concept="1LlUBW" id="1CsE99tDU4M" role="A3Ik2">
+                <node concept="3Tqbb2" id="1CsE99tDU4N" role="1Lm7xW" />
+                <node concept="10Oyi0" id="1CsE99tDU4O" role="1Lm7xW" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="1CsE99tDWUS" role="33vP2m">
+              <node concept="2DpFxk" id="1CsE99tDWUT" role="2OqNvi">
+                <node concept="1bVj0M" id="1CsE99tDWUU" role="23t8la">
+                  <node concept="3clFbS" id="1CsE99tDWUV" role="1bW5cS">
+                    <node concept="3clFbF" id="1CsE99tDWUW" role="3cqZAp">
+                      <node concept="3cpWsd" id="1CsE99tDWUX" role="3clFbG">
+                        <node concept="1LFfDK" id="1CsE99tDWUY" role="3uHU7w">
+                          <node concept="3cmrfG" id="1CsE99tDWUZ" role="1LF_Uc">
+                            <property role="3cmrfH" value="1" />
+                          </node>
+                          <node concept="37vLTw" id="1CsE99tDWV0" role="1LFl5Q">
+                            <ref role="3cqZAo" node="1CsE99tDWV6" resolve="b" />
+                          </node>
+                        </node>
+                        <node concept="1LFfDK" id="1CsE99tDWV1" role="3uHU7B">
+                          <node concept="3cmrfG" id="1CsE99tDWV2" role="1LF_Uc">
+                            <property role="3cmrfH" value="1" />
+                          </node>
+                          <node concept="37vLTw" id="1CsE99tDWV3" role="1LFl5Q">
+                            <ref role="3cqZAo" node="1CsE99tDWV4" resolve="a" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="Rh6nW" id="1CsE99tDWV4" role="1bW2Oz">
+                    <property role="TrG5h" value="a" />
+                    <node concept="2jxLKc" id="1CsE99tDWV5" role="1tU5fm" />
+                  </node>
+                  <node concept="Rh6nW" id="1CsE99tDWV6" role="1bW2Oz">
+                    <property role="TrG5h" value="b" />
+                    <node concept="2jxLKc" id="1CsE99tDWV7" role="1tU5fm" />
+                  </node>
+                </node>
+                <node concept="1nlBCl" id="1CsE99tE41n" role="2Dq5b$" />
+              </node>
+              <node concept="37vLTw" id="1CsE99tDWV9" role="2Oq$k0">
+                <ref role="3cqZAo" node="1CsE99tCmkj" resolve="availableDocs" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="1CsE99tE066" role="3cqZAp">
+          <node concept="3clFbS" id="1CsE99tE068" role="3clFbx">
+            <node concept="3cpWs6" id="1CsE99tE2PL" role="3cqZAp">
+              <node concept="1LFfDK" id="1CsE99tBZ$w" role="3cqZAk">
+                <node concept="3cmrfG" id="1CsE99tBZVX" role="1LF_Uc">
+                  <property role="3cmrfH" value="0" />
+                </node>
+                <node concept="2OqwBi" id="1CsE99tBY0b" role="1LFl5Q">
+                  <node concept="37vLTw" id="1CsE99tDWVa" role="2Oq$k0">
+                    <ref role="3cqZAo" node="1CsE99tDWUR" resolve="seq" />
+                  </node>
+                  <node concept="1uHKPH" id="1CsE99tBYJH" role="2OqNvi" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="1CsE99tE1k0" role="3clFbw">
+            <node concept="37vLTw" id="1CsE99tE0nQ" role="2Oq$k0">
+              <ref role="3cqZAo" node="1CsE99tDWUR" resolve="seq" />
+            </node>
+            <node concept="3GX2aA" id="1CsE99tE2mW" role="2OqNvi" />
+          </node>
+        </node>
+        <node concept="3clFbH" id="1CsE99tE5Bl" role="3cqZAp" />
+        <node concept="3cpWs6" id="1CsE99tE6S1" role="3cqZAp">
+          <node concept="10Nm6u" id="1CsE99tE6US" role="3cqZAk" />
         </node>
       </node>
     </node>

--- a/code/languages/com.mbeddr.doc.aspect/languages/com.mbeddr.doc.aspect/models/com/mbeddr/doc/aspect/editor.mps
+++ b/code/languages/com.mbeddr.doc.aspect/languages/com.mbeddr.doc.aspect/models/com/mbeddr/doc/aspect/editor.mps
@@ -23,6 +23,7 @@
     <language id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor">
       <concept id="1402906326895675325" name="jetbrains.mps.lang.editor.structure.CellActionMap_FunctionParm_selectedNode" flags="nn" index="0IXxy" />
       <concept id="1071666914219" name="jetbrains.mps.lang.editor.structure.ConceptEditorDeclaration" flags="ig" index="24kQdi">
+        <child id="1078153129734" name="inspectedCellModel" index="6VMZX" />
         <child id="2597348684684069742" name="contextHints" index="CpUAK" />
       </concept>
       <concept id="6822301196700715228" name="jetbrains.mps.lang.editor.structure.ConceptEditorHintDeclarationReference" flags="ig" index="2aJ2om">
@@ -75,7 +76,9 @@
         <child id="3982520150122341379" name="query" index="3tD6jU" />
       </concept>
       <concept id="1139848536355" name="jetbrains.mps.lang.editor.structure.CellModel_WithRole" flags="ng" index="1$h60E">
+        <property id="1139852716018" name="noTargetText" index="1$x2rV" />
         <property id="1140017977771" name="readOnly" index="1Intyy" />
+        <property id="1140114345053" name="allowEmptyText" index="1O74Pk" />
         <reference id="1140103550593" name="relationDeclaration" index="1NtTu8" />
       </concept>
       <concept id="1073389214265" name="jetbrains.mps.lang.editor.structure.EditorCellModel" flags="ng" index="3EYTF0">
@@ -238,6 +241,17 @@
       </node>
       <node concept="2SsqMj" id="UK_oBpA4Fi" role="3EZMnx" />
       <node concept="2iRkQZ" id="UK_oBpA4Fe" role="2iSdaV" />
+    </node>
+    <node concept="3EZMnI" id="1CsE99t_Me7" role="6VMZX">
+      <node concept="2iRfu4" id="1CsE99t_Me8" role="2iSdaV" />
+      <node concept="3F0ifn" id="1CsE99t_Me4" role="3EZMnx">
+        <property role="3F0ifm" value="priority" />
+      </node>
+      <node concept="3F0A7n" id="1CsE99t_Meg" role="3EZMnx">
+        <property role="1$x2rV" value="0" />
+        <property role="1O74Pk" value="true" />
+        <ref role="1NtTu8" to="748g:1CsE99t_Me0" resolve="priority" />
+      </node>
     </node>
   </node>
   <node concept="24kQdi" id="agjuZp0xrR">
@@ -432,6 +446,17 @@
       </node>
       <node concept="2SsqMj" id="1o6EjwiSKwu" role="3EZMnx" />
       <node concept="2iRkQZ" id="1o6EjwiSKwv" role="2iSdaV" />
+    </node>
+    <node concept="3EZMnI" id="1CsE99tAQm3" role="6VMZX">
+      <node concept="2iRfu4" id="1CsE99tAQm4" role="2iSdaV" />
+      <node concept="3F0ifn" id="1CsE99tAQm5" role="3EZMnx">
+        <property role="3F0ifm" value="priority" />
+      </node>
+      <node concept="3F0A7n" id="1CsE99tAQm6" role="3EZMnx">
+        <property role="1$x2rV" value="0" />
+        <property role="1O74Pk" value="true" />
+        <ref role="1NtTu8" to="748g:1CsE99t_Me0" resolve="priority" />
+      </node>
     </node>
   </node>
   <node concept="1h_SRR" id="6jNheA9q_CP">

--- a/code/languages/com.mbeddr.doc.aspect/languages/com.mbeddr.doc.aspect/models/com/mbeddr/doc/aspect/structure.mps
+++ b/code/languages/com.mbeddr.doc.aspect/languages/com.mbeddr.doc.aspect/models/com/mbeddr/doc/aspect/structure.mps
@@ -26,9 +26,14 @@
       <concept id="1169125787135" name="jetbrains.mps.lang.structure.structure.AbstractConceptDeclaration" flags="ig" index="PkWjJ">
         <property id="6714410169261853888" name="conceptId" index="EcuMT" />
         <child id="1071489727083" name="linkDeclaration" index="1TKVEi" />
+        <child id="1071489727084" name="propertyDeclaration" index="1TKVEl" />
       </concept>
       <concept id="1071489090640" name="jetbrains.mps.lang.structure.structure.ConceptDeclaration" flags="ig" index="1TIwiD">
         <reference id="1071489389519" name="extends" index="1TJDcQ" />
+      </concept>
+      <concept id="1071489288299" name="jetbrains.mps.lang.structure.structure.PropertyDeclaration" flags="ig" index="1TJgyi">
+        <property id="241647608299431129" name="propertyId" index="IQ2nx" />
+        <reference id="1082985295845" name="dataType" index="AX2Wp" />
       </concept>
       <concept id="1071489288298" name="jetbrains.mps.lang.structure.structure.LinkDeclaration" flags="ig" index="1TJgyj">
         <property id="1071599776563" name="role" index="20kJfa" />
@@ -50,6 +55,11 @@
     <property role="TrG5h" value="DocumentedConceptAnnotation" />
     <property role="EcuMT" value="1058510331725720478" />
     <ref role="1TJDcQ" to="tpck:2ULFgo8_XDk" resolve="NodeAttribute" />
+    <node concept="1TJgyi" id="1CsE99t_Me0" role="1TKVEl">
+      <property role="IQ2nx" value="1881564090922902400" />
+      <property role="TrG5h" value="priority" />
+      <ref role="AX2Wp" to="tpck:fKAQMTA" resolve="integer" />
+    </node>
     <node concept="1TJgyj" id="UK_oBpA4EG" role="1TKVEi">
       <property role="20kJfa" value="concept" />
       <property role="20lbJX" value="fLJekj4/_1" />

--- a/code/languages/com.mbeddr.doc.aspect/solutions/com.mbeddr.doc.aspect.runtime/com.mbeddr.doc.aspect.runtime.msd
+++ b/code/languages/com.mbeddr.doc.aspect/solutions/com.mbeddr.doc.aspect.runtime/com.mbeddr.doc.aspect.runtime.msd
@@ -23,6 +23,7 @@
     <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
     <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
     <language slang="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" version="2" />
+    <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
     <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
     <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
     <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="18" />

--- a/code/languages/com.mbeddr.doc.aspect/solutions/com.mbeddr.doc.aspect.runtime/models/com/mbeddr/doc/aspect/runtime.mps
+++ b/code/languages/com.mbeddr.doc.aspect/solutions/com.mbeddr.doc.aspect.runtime/models/com/mbeddr/doc/aspect/runtime.mps
@@ -796,24 +796,24 @@
       <property role="od$2w" value="false" />
       <property role="2aFKle" value="false" />
       <node concept="3clFbS" id="2NM$qy7XAKR" role="3clF47">
-        <node concept="3clFbJ" id="qmep2m08m9" role="3cqZAp">
-          <node concept="3clFbS" id="qmep2m08mb" role="3clFbx">
-            <node concept="3cpWs8" id="1CsE99tJfDc" role="3cqZAp">
-              <node concept="3cpWsn" id="1CsE99tJfDd" role="3cpWs9">
-                <property role="TrG5h" value="documents" />
-                <node concept="2hMVRd" id="1CsE99tJf59" role="1tU5fm">
-                  <node concept="3Tqbb2" id="1CsE99tJf5c" role="2hN53Y">
-                    <ref role="ehGHo" to="2c95:2TZO3DbuxwK" resolve="Document" />
-                  </node>
-                </node>
-                <node concept="1rXfSq" id="1CsE99tJfDe" role="33vP2m">
-                  <ref role="37wK5l" node="5UWo2tdFe8O" resolve="collectDocuments" />
-                  <node concept="37vLTw" id="1CsE99tJfDf" role="37wK5m">
-                    <ref role="3cqZAo" node="2NM$qy7XAKL" resolve="model" />
-                  </node>
-                </node>
+        <node concept="3cpWs8" id="1CsE99tJfDc" role="3cqZAp">
+          <node concept="3cpWsn" id="1CsE99tJfDd" role="3cpWs9">
+            <property role="TrG5h" value="documents" />
+            <node concept="2hMVRd" id="1CsE99tJf59" role="1tU5fm">
+              <node concept="3Tqbb2" id="1CsE99tJf5c" role="2hN53Y">
+                <ref role="ehGHo" to="2c95:2TZO3DbuxwK" resolve="Document" />
               </node>
             </node>
+            <node concept="1rXfSq" id="1CsE99tJfDe" role="33vP2m">
+              <ref role="37wK5l" node="5UWo2tdFe8O" resolve="collectDocuments" />
+              <node concept="37vLTw" id="1CsE99tJfDf" role="37wK5m">
+                <ref role="3cqZAo" node="2NM$qy7XAKL" resolve="model" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="qmep2m08m9" role="3cqZAp">
+          <node concept="3clFbS" id="qmep2m08mb" role="3clFbx">
             <node concept="2Gpval" id="2NM$qy7XAMI" role="3cqZAp">
               <node concept="2GrKxI" id="2NM$qy7XAMJ" role="2Gsz3X">
                 <property role="TrG5h" value="item" />
@@ -1078,105 +1078,6 @@
             <property role="TrG5h" value="section" />
           </node>
           <node concept="3clFbS" id="2NM$qy7XANi" role="2LFqv$">
-            <node concept="3clFbJ" id="4MORkbYlUX" role="3cqZAp">
-              <node concept="3clFbS" id="4MORkbYlUZ" role="3clFbx">
-                <node concept="3clFbJ" id="2NM$qy7XANG" role="3cqZAp">
-                  <node concept="3clFbS" id="2NM$qy7XANH" role="3clFbx">
-                    <node concept="3cpWs6" id="1CsE99tB1EC" role="3cqZAp">
-                      <node concept="1Ls8ON" id="1CsE99tB2Gt" role="3cqZAk">
-                        <node concept="2GrUjf" id="1CsE99tB3eq" role="1Lso8e">
-                          <ref role="2Gs0qQ" node="2NM$qy7XANh" resolve="section" />
-                        </node>
-                        <node concept="2OqwBi" id="1CsE99tB99y" role="1Lso8e">
-                          <node concept="2OqwBi" id="1CsE99tB5HI" role="2Oq$k0">
-                            <node concept="2GrUjf" id="1CsE99tB4PQ" role="2Oq$k0">
-                              <ref role="2Gs0qQ" node="2NM$qy7XANh" resolve="section" />
-                            </node>
-                            <node concept="3CFZ6_" id="1CsE99tB7Ue" role="2OqNvi">
-                              <node concept="3CFYIy" id="1CsE99tB8sD" role="3CFYIz">
-                                <ref role="3CFYIx" to="748g:1o6EjwiSKvw" resolve="DocumentedPropertyAnnotation" />
-                              </node>
-                            </node>
-                          </node>
-                          <node concept="3TrcHB" id="1CsE99tBavM" role="2OqNvi">
-                            <ref role="3TsBF5" to="748g:1CsE99t_Me0" resolve="priority" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="1Wc70l" id="2NM$qy7XANK" role="3clFbw">
-                    <node concept="1Wc70l" id="2NM$qy7XANW" role="3uHU7B">
-                      <node concept="3y3z36" id="2NM$qy7XAO1" role="3uHU7B">
-                        <node concept="2OqwBi" id="2NM$qy7XAO2" role="3uHU7B">
-                          <node concept="2GrUjf" id="2NM$qy7XAO3" role="2Oq$k0">
-                            <ref role="2Gs0qQ" node="2NM$qy7XANh" resolve="section" />
-                          </node>
-                          <node concept="3CFZ6_" id="2NM$qy7XAO4" role="2OqNvi">
-                            <node concept="3CFYIy" id="2NM$qy7XAO5" role="3CFYIz">
-                              <ref role="3CFYIx" to="748g:1o6EjwiSKvw" resolve="DocumentedPropertyAnnotation" />
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="10Nm6u" id="2NM$qy7XAO6" role="3uHU7w" />
-                      </node>
-                      <node concept="2OqwBi" id="qmep2m0Ocp" role="3uHU7w">
-                        <node concept="2OqwBi" id="2NM$qy7XAO8" role="2Oq$k0">
-                          <node concept="2OqwBi" id="2NM$qy7XAO9" role="2Oq$k0">
-                            <node concept="2GrUjf" id="2NM$qy7XAOa" role="2Oq$k0">
-                              <ref role="2Gs0qQ" node="2NM$qy7XANh" resolve="section" />
-                            </node>
-                            <node concept="3CFZ6_" id="2NM$qy7XAOb" role="2OqNvi">
-                              <node concept="3CFYIy" id="2NM$qy7XAOc" role="3CFYIz">
-                                <ref role="3CFYIx" to="748g:1o6EjwiSKvw" resolve="DocumentedPropertyAnnotation" />
-                              </node>
-                            </node>
-                          </node>
-                          <node concept="3TrEf2" id="2NM$qy7XAOd" role="2OqNvi">
-                            <ref role="3Tt5mk" to="748g:UK_oBpA4EG" resolve="concept" />
-                          </node>
-                        </node>
-                        <node concept="2qgKlT" id="qmep2m0PFi" role="2OqNvi">
-                          <ref role="37wK5l" to="tpcn:4MKjpUYmGW0" resolve="is" />
-                          <node concept="37vLTw" id="qmep2m0QmP" role="37wK5m">
-                            <ref role="3cqZAo" node="2NM$qy7XAKN" resolve="concept" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="2OqwBi" id="qmep2m0TPp" role="3uHU7w">
-                      <node concept="2OqwBi" id="2NM$qy7XANO" role="2Oq$k0">
-                        <node concept="2OqwBi" id="2NM$qy7XANP" role="2Oq$k0">
-                          <node concept="2GrUjf" id="2NM$qy7XANQ" role="2Oq$k0">
-                            <ref role="2Gs0qQ" node="2NM$qy7XANh" resolve="section" />
-                          </node>
-                          <node concept="3CFZ6_" id="2NM$qy7XANR" role="2OqNvi">
-                            <node concept="3CFYIy" id="2NM$qy7XANS" role="3CFYIz">
-                              <ref role="3CFYIx" to="748g:1o6EjwiSKvw" resolve="DocumentedPropertyAnnotation" />
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="3TrEf2" id="2NM$qy7XANT" role="2OqNvi">
-                          <ref role="3Tt5mk" to="748g:1o6EjwiSKvG" resolve="property" />
-                        </node>
-                      </node>
-                      <node concept="2qgKlT" id="qmep2m0V7D" role="2OqNvi">
-                        <ref role="37wK5l" to="tpcn:4MKjpUYnih4" resolve="is" />
-                        <node concept="37vLTw" id="qmep2m0VsM" role="37wK5m">
-                          <ref role="3cqZAo" node="2NM$qy7XAKP" resolve="property" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="3y3z36" id="4MORkbYniO" role="3clFbw">
-                <node concept="10Nm6u" id="4MORkbYnoy" role="3uHU7w" />
-                <node concept="37vLTw" id="4MORkbYmNs" role="3uHU7B">
-                  <ref role="3cqZAo" node="2NM$qy7XAKP" resolve="property" />
-                </node>
-              </node>
-            </node>
             <node concept="3clFbJ" id="2NM$qy7XANj" role="3cqZAp">
               <node concept="3clFbS" id="2NM$qy7XANk" role="3clFbx">
                 <node concept="3cpWs6" id="1CsE99tBc2q" role="3cqZAp">
@@ -1243,12 +1144,6 @@
             </node>
           </node>
           <node concept="2OqwBi" id="5UWo2tdFoA8" role="2GsD0m">
-            <node concept="1rXfSq" id="5UWo2tdFoA9" role="2Oq$k0">
-              <ref role="37wK5l" node="5UWo2tdFe8O" resolve="collectDocuments" />
-              <node concept="37vLTw" id="5UWo2tdFoAa" role="37wK5m">
-                <ref role="3cqZAo" node="2NM$qy7XAKL" resolve="model" />
-              </node>
-            </node>
             <node concept="3goQfb" id="5UWo2tdFoAb" role="2OqNvi">
               <node concept="1bVj0M" id="5UWo2tdFoAc" role="23t8la">
                 <node concept="3clFbS" id="5UWo2tdFoAd" role="1bW5cS">
@@ -1272,6 +1167,9 @@
                   <node concept="2jxLKc" id="5UWo2tdFoAl" role="1tU5fm" />
                 </node>
               </node>
+            </node>
+            <node concept="37vLTw" id="7x3GM_ET1W3" role="2Oq$k0">
+              <ref role="3cqZAo" node="1CsE99tJfDd" resolve="documents" />
             </node>
           </node>
         </node>

--- a/code/languages/com.mbeddr.doc.aspect/solutions/com.mbeddr.doc.aspect.runtime/models/com/mbeddr/doc/aspect/runtime.mps
+++ b/code/languages/com.mbeddr.doc.aspect/solutions/com.mbeddr.doc.aspect.runtime/models/com/mbeddr/doc/aspect/runtime.mps
@@ -6,6 +6,7 @@
     <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="11" />
     <use id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc" version="2" />
     <use id="654422bf-e75f-44dc-936d-188890a746ce" name="de.slisson.mps.reflection" version="0" />
+    <use id="a247e09e-2435-45ba-b8d2-07e93feba96a" name="jetbrains.mps.baseLanguage.tuples" version="0" />
   </languages>
   <imports>
     <import index="ze1i" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel.runtime(MPS.Core/)" />
@@ -21,6 +22,14 @@
     <import index="tpcn" ref="r:00000000-0000-4000-0000-011c8959028b(jetbrains.mps.lang.structure.behavior)" implicit="true" />
   </imports>
   <registry>
+    <language id="a247e09e-2435-45ba-b8d2-07e93feba96a" name="jetbrains.mps.baseLanguage.tuples">
+      <concept id="1238852151516" name="jetbrains.mps.baseLanguage.tuples.structure.IndexedTupleType" flags="in" index="1LlUBW">
+        <child id="1238852204892" name="componentType" index="1Lm7xW" />
+      </concept>
+      <concept id="1238853782547" name="jetbrains.mps.baseLanguage.tuples.structure.IndexedTupleLiteral" flags="nn" index="1Ls8ON">
+        <child id="1238853845806" name="component" index="1Lso8e" />
+      </concept>
+    </language>
     <language id="654422bf-e75f-44dc-936d-188890a746ce" name="de.slisson.mps.reflection">
       <concept id="8473566765275063380" name="de.slisson.mps.reflection.structure.ReflectionFieldAccess" flags="ng" index="1PnCL0">
         <reference id="1197029500499" name="fieldDeclaration" index="2Oxat5" />
@@ -53,6 +62,7 @@
         <child id="1081256993304" name="leftExpression" index="2ZW6bz" />
       </concept>
       <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
+      <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
       <concept id="1070534934090" name="jetbrains.mps.baseLanguage.structure.CastExpression" flags="nn" index="10QFUN">
         <child id="1070534934091" name="type" index="10QFUM" />
         <child id="1070534934092" name="expression" index="10QFUP" />
@@ -187,6 +197,9 @@
       <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
         <reference id="1138405853777" name="concept" index="ehGHo" />
       </concept>
+      <concept id="1138056022639" name="jetbrains.mps.lang.smodel.structure.SPropertyAccess" flags="nn" index="3TrcHB">
+        <reference id="1138056395725" name="property" index="3TsBF5" />
+      </concept>
       <concept id="1138056143562" name="jetbrains.mps.lang.smodel.structure.SLinkAccess" flags="nn" index="3TrEf2">
         <reference id="1138056516764" name="link" index="3Tt5mk" />
       </concept>
@@ -214,6 +227,9 @@
         <child id="1226511765987" name="elementType" index="2hN53Y" />
       </concept>
       <concept id="1226516258405" name="jetbrains.mps.baseLanguage.collections.structure.HashSetCreator" flags="nn" index="2i4dXS" />
+      <concept id="1151688443754" name="jetbrains.mps.baseLanguage.collections.structure.ListType" flags="in" index="_YKpA">
+        <child id="1151688676805" name="elementType" index="_ZDj9" />
+      </concept>
       <concept id="1151689724996" name="jetbrains.mps.baseLanguage.collections.structure.SequenceType" flags="in" index="A3Dl8">
         <child id="1151689745422" name="elementType" index="A3Ik2" />
       </concept>
@@ -233,6 +249,8 @@
         <child id="1237721435807" name="elementType" index="HW$YZ" />
       </concept>
       <concept id="1203518072036" name="jetbrains.mps.baseLanguage.collections.structure.SmartClosureParameterDeclaration" flags="ig" index="Rh6nW" />
+      <concept id="1160600644654" name="jetbrains.mps.baseLanguage.collections.structure.ListCreatorWithInit" flags="nn" index="Tc6Ow" />
+      <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="nn" index="TSZUe" />
       <concept id="1160666733551" name="jetbrains.mps.baseLanguage.collections.structure.AddAllElementsOperation" flags="nn" index="X8dFx" />
       <concept id="1201792049884" name="jetbrains.mps.baseLanguage.collections.structure.TranslateOperation" flags="nn" index="3goQfb" />
       <concept id="1202128969694" name="jetbrains.mps.baseLanguage.collections.structure.SelectOperation" flags="nn" index="3$u5V9" />
@@ -467,11 +485,30 @@
     </node>
     <node concept="2tJIrI" id="2NM$qy7XpEN" role="jymVt" />
     <node concept="2YIFZL" id="2NM$qy7XAw_" role="jymVt">
-      <property role="TrG5h" value="findDocumentationElement" />
+      <property role="TrG5h" value="findDocumentationElements" />
       <property role="DiZV1" value="false" />
       <property role="od$2w" value="false" />
       <property role="2aFKle" value="false" />
       <node concept="3clFbS" id="2NM$qy7XAwH" role="3clF47">
+        <node concept="3cpWs8" id="1CsE99tBw2I" role="3cqZAp">
+          <node concept="3cpWsn" id="1CsE99tBw2L" role="3cpWs9">
+            <property role="TrG5h" value="availableSections" />
+            <node concept="_YKpA" id="1CsE99tBw2E" role="1tU5fm">
+              <node concept="1LlUBW" id="1CsE99tBwcl" role="_ZDj9">
+                <node concept="3Tqbb2" id="1CsE99tBwuF" role="1Lm7xW" />
+                <node concept="10Oyi0" id="1CsE99tBwL8" role="1Lm7xW" />
+              </node>
+            </node>
+            <node concept="2ShNRf" id="1CsE99tBy1f" role="33vP2m">
+              <node concept="Tc6Ow" id="1CsE99tBzo9" role="2ShVmc">
+                <node concept="1LlUBW" id="1CsE99tBzYK" role="HW$YZ">
+                  <node concept="3Tqbb2" id="1CsE99tB$g7" role="1Lm7xW" />
+                  <node concept="10Oyi0" id="1CsE99tB$Oy" role="1Lm7xW" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
         <node concept="2Gpval" id="2NM$qy7XAwI" role="3cqZAp">
           <node concept="2GrKxI" id="2NM$qy7XAwJ" role="2Gsz3X">
             <property role="TrG5h" value="nextConcept" />
@@ -479,9 +516,8 @@
           <node concept="3clFbS" id="2NM$qy7XAwK" role="2LFqv$">
             <node concept="3cpWs8" id="2NM$qy7XAwL" role="3cqZAp">
               <node concept="3cpWsn" id="2NM$qy7XAwM" role="3cpWs9">
-                <property role="TrG5h" value="section" />
+                <property role="TrG5h" value="sectionPlusPriority" />
                 <property role="3TUv4t" value="true" />
-                <node concept="3Tqbb2" id="2NM$qy7XAwN" role="1tU5fm" />
                 <node concept="1rXfSq" id="2NM$qy7XAwO" role="33vP2m">
                   <ref role="37wK5l" node="2NM$qy7XAKH" resolve="findDocumentationElementSingle" />
                   <node concept="37vLTw" id="2NM$qy7XAwP" role="37wK5m">
@@ -494,20 +530,31 @@
                     <ref role="3cqZAo" node="2NM$qy7XAwF" resolve="property" />
                   </node>
                 </node>
+                <node concept="1LlUBW" id="1CsE99tBuKI" role="1tU5fm">
+                  <node concept="3Tqbb2" id="1CsE99tBv7o" role="1Lm7xW" />
+                  <node concept="10Oyi0" id="1CsE99tBvCC" role="1Lm7xW" />
+                </node>
               </node>
             </node>
             <node concept="3clFbJ" id="2NM$qy7XAwS" role="3cqZAp">
               <node concept="3clFbS" id="2NM$qy7XAwT" role="3clFbx">
-                <node concept="3cpWs6" id="2NM$qy7XAwU" role="3cqZAp">
-                  <node concept="37vLTw" id="2NM$qy7XAwV" role="3cqZAk">
-                    <ref role="3cqZAo" node="2NM$qy7XAwM" resolve="section" />
+                <node concept="3clFbF" id="1CsE99tB_fY" role="3cqZAp">
+                  <node concept="2OqwBi" id="1CsE99tBA6R" role="3clFbG">
+                    <node concept="37vLTw" id="1CsE99tB_fW" role="2Oq$k0">
+                      <ref role="3cqZAo" node="1CsE99tBw2L" resolve="availableSections" />
+                    </node>
+                    <node concept="TSZUe" id="1CsE99tBB1X" role="2OqNvi">
+                      <node concept="37vLTw" id="1CsE99tBBiI" role="25WWJ7">
+                        <ref role="3cqZAo" node="2NM$qy7XAwM" resolve="sectionPlusPriority" />
+                      </node>
+                    </node>
                   </node>
                 </node>
               </node>
               <node concept="3y3z36" id="2NM$qy7XAwW" role="3clFbw">
                 <node concept="10Nm6u" id="2NM$qy7XAwX" role="3uHU7w" />
                 <node concept="37vLTw" id="2NM$qy7XAwY" role="3uHU7B">
-                  <ref role="3cqZAo" node="2NM$qy7XAwM" resolve="section" />
+                  <ref role="3cqZAo" node="2NM$qy7XAwM" resolve="sectionPlusPriority" />
                 </node>
               </node>
             </node>
@@ -522,10 +569,11 @@
           </node>
         </node>
         <node concept="3cpWs6" id="2NM$qy7XAx3" role="3cqZAp">
-          <node concept="10Nm6u" id="2NM$qy7XAx4" role="3cqZAk" />
+          <node concept="37vLTw" id="1CsE99tClnN" role="3cqZAk">
+            <ref role="3cqZAo" node="1CsE99tBw2L" resolve="availableSections" />
+          </node>
         </node>
       </node>
-      <node concept="3Tqbb2" id="2NM$qy7XAx6" role="3clF45" />
       <node concept="37vLTG" id="2NM$qy7XAwB" role="3clF46">
         <property role="TrG5h" value="model" />
         <property role="3TUv4t" value="true" />
@@ -544,6 +592,12 @@
         </node>
       </node>
       <node concept="3Tm1VV" id="2NM$qy7XAIx" role="1B3o_S" />
+      <node concept="_YKpA" id="1CsE99tCj70" role="3clF45">
+        <node concept="1LlUBW" id="1CsE99tCjuF" role="_ZDj9">
+          <node concept="3Tqbb2" id="1CsE99tCjQj" role="1Lm7xW" />
+          <node concept="10Oyi0" id="1CsE99tCkBT" role="1Lm7xW" />
+        </node>
+      </node>
     </node>
     <node concept="2tJIrI" id="5UWo2tdFd_C" role="jymVt" />
     <node concept="2YIFZL" id="5UWo2tdFe8O" role="jymVt">
@@ -744,6 +798,22 @@
       <node concept="3clFbS" id="2NM$qy7XAKR" role="3clF47">
         <node concept="3clFbJ" id="qmep2m08m9" role="3cqZAp">
           <node concept="3clFbS" id="qmep2m08mb" role="3clFbx">
+            <node concept="3cpWs8" id="1CsE99tJfDc" role="3cqZAp">
+              <node concept="3cpWsn" id="1CsE99tJfDd" role="3cpWs9">
+                <property role="TrG5h" value="documents" />
+                <node concept="2hMVRd" id="1CsE99tJf59" role="1tU5fm">
+                  <node concept="3Tqbb2" id="1CsE99tJf5c" role="2hN53Y">
+                    <ref role="ehGHo" to="2c95:2TZO3DbuxwK" resolve="Document" />
+                  </node>
+                </node>
+                <node concept="1rXfSq" id="1CsE99tJfDe" role="33vP2m">
+                  <ref role="37wK5l" node="5UWo2tdFe8O" resolve="collectDocuments" />
+                  <node concept="37vLTw" id="1CsE99tJfDf" role="37wK5m">
+                    <ref role="3cqZAo" node="2NM$qy7XAKL" resolve="model" />
+                  </node>
+                </node>
+              </node>
+            </node>
             <node concept="2Gpval" id="2NM$qy7XAMI" role="3cqZAp">
               <node concept="2GrKxI" id="2NM$qy7XAMJ" role="2Gsz3X">
                 <property role="TrG5h" value="item" />
@@ -751,9 +821,26 @@
               <node concept="3clFbS" id="2NM$qy7XAMK" role="2LFqv$">
                 <node concept="3clFbJ" id="qmep2m0vtS" role="3cqZAp">
                   <node concept="3clFbS" id="qmep2m0vtU" role="3clFbx">
-                    <node concept="3cpWs6" id="2NM$qy7XAMN" role="3cqZAp">
-                      <node concept="2GrUjf" id="2NM$qy7XAMO" role="3cqZAk">
-                        <ref role="2Gs0qQ" node="2NM$qy7XAMJ" resolve="item" />
+                    <node concept="3cpWs6" id="1CsE99tBlOQ" role="3cqZAp">
+                      <node concept="1Ls8ON" id="1CsE99tBmMi" role="3cqZAk">
+                        <node concept="2GrUjf" id="1CsE99tBnkq" role="1Lso8e">
+                          <ref role="2Gs0qQ" node="2NM$qy7XAMJ" resolve="item" />
+                        </node>
+                        <node concept="2OqwBi" id="1CsE99tBscw" role="1Lso8e">
+                          <node concept="2OqwBi" id="1CsE99tBpCx" role="2Oq$k0">
+                            <node concept="2GrUjf" id="1CsE99tBoUz" role="2Oq$k0">
+                              <ref role="2Gs0qQ" node="2NM$qy7XAMJ" resolve="item" />
+                            </node>
+                            <node concept="3CFZ6_" id="1CsE99tBqT9" role="2OqNvi">
+                              <node concept="3CFYIy" id="1CsE99tBrsE" role="3CFYIz">
+                                <ref role="3CFYIx" to="748g:6L$vAtzZO13" resolve="DocumentedPropertyItemAnnotation" />
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="3TrcHB" id="1CsE99tBt02" role="2OqNvi">
+                            <ref role="3TsBF5" to="748g:1CsE99t_Me0" resolve="priority" />
+                          </node>
+                        </node>
                       </node>
                     </node>
                   </node>
@@ -823,11 +910,8 @@
                 </node>
               </node>
               <node concept="2OqwBi" id="5UWo2tdFmM1" role="2GsD0m">
-                <node concept="1rXfSq" id="5UWo2tdFmoF" role="2Oq$k0">
-                  <ref role="37wK5l" node="5UWo2tdFe8O" resolve="collectDocuments" />
-                  <node concept="37vLTw" id="5UWo2tdFngW" role="37wK5m">
-                    <ref role="3cqZAo" node="2NM$qy7XAKL" resolve="model" />
-                  </node>
+                <node concept="37vLTw" id="1CsE99tJfDg" role="2Oq$k0">
+                  <ref role="3cqZAo" node="1CsE99tJfDd" resolve="documents" />
                 </node>
                 <node concept="3goQfb" id="5UWo2tdFnzf" role="2OqNvi">
                   <node concept="1bVj0M" id="5UWo2tdFnzh" role="23t8la">
@@ -837,9 +921,9 @@
                           <node concept="37vLTw" id="5UWo2tdFnFo" role="2Oq$k0">
                             <ref role="3cqZAo" node="5UWo2tdFnzj" resolve="it" />
                           </node>
-                          <node concept="2Rf3mk" id="5UWo2tdFnFp" role="2OqNvi">
-                            <node concept="1xMEDy" id="5UWo2tdFnFq" role="1xVPHs">
-                              <node concept="chp4Y" id="5UWo2tdFnFr" role="ri$Ld">
+                          <node concept="2Rf3mk" id="1CsE99tJ4Sw" role="2OqNvi">
+                            <node concept="1xMEDy" id="1CsE99tJ4Sy" role="1xVPHs">
+                              <node concept="chp4Y" id="1CsE99tJ5Kl" role="ri$Ld">
                                 <ref role="cht4Q" to="2c95:4E$PniRJOs$" resolve="Item" />
                               </node>
                             </node>
@@ -850,6 +934,132 @@
                     <node concept="Rh6nW" id="5UWo2tdFnzj" role="1bW2Oz">
                       <property role="TrG5h" value="it" />
                       <node concept="2jxLKc" id="5UWo2tdFnzk" role="1tU5fm" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbH" id="1CsE99tJlCJ" role="3cqZAp" />
+            <node concept="2Gpval" id="1CsE99tJhvk" role="3cqZAp">
+              <node concept="2GrKxI" id="1CsE99tJhvl" role="2Gsz3X">
+                <property role="TrG5h" value="section" />
+              </node>
+              <node concept="3clFbS" id="1CsE99tJhvm" role="2LFqv$">
+                <node concept="3clFbJ" id="1CsE99tJhvn" role="3cqZAp">
+                  <node concept="3clFbS" id="1CsE99tJhvo" role="3clFbx">
+                    <node concept="3cpWs6" id="1CsE99tJhvp" role="3cqZAp">
+                      <node concept="1Ls8ON" id="1CsE99tJhvq" role="3cqZAk">
+                        <node concept="2GrUjf" id="1CsE99tJhvr" role="1Lso8e">
+                          <ref role="2Gs0qQ" node="1CsE99tJhvl" resolve="section" />
+                        </node>
+                        <node concept="2OqwBi" id="1CsE99tJhvs" role="1Lso8e">
+                          <node concept="2OqwBi" id="1CsE99tJhvt" role="2Oq$k0">
+                            <node concept="2GrUjf" id="1CsE99tJhvu" role="2Oq$k0">
+                              <ref role="2Gs0qQ" node="1CsE99tJhvl" resolve="section" />
+                            </node>
+                            <node concept="3CFZ6_" id="1CsE99tJhvv" role="2OqNvi">
+                              <node concept="3CFYIy" id="1CsE99tJhvw" role="3CFYIz">
+                                <ref role="3CFYIx" to="748g:1o6EjwiSKvw" resolve="DocumentedPropertyAnnotation" />
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="3TrcHB" id="1CsE99tJhvx" role="2OqNvi">
+                            <ref role="3TsBF5" to="748g:1CsE99t_Me0" resolve="priority" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="1Wc70l" id="1CsE99tJhvy" role="3clFbw">
+                    <node concept="1Wc70l" id="1CsE99tJhvz" role="3uHU7B">
+                      <node concept="2OqwBi" id="1CsE99tJhv$" role="3uHU7w">
+                        <node concept="2OqwBi" id="1CsE99tJhv_" role="2Oq$k0">
+                          <node concept="2OqwBi" id="1CsE99tJhvA" role="2Oq$k0">
+                            <node concept="2GrUjf" id="1CsE99tJhvB" role="2Oq$k0">
+                              <ref role="2Gs0qQ" node="1CsE99tJhvl" resolve="section" />
+                            </node>
+                            <node concept="3CFZ6_" id="1CsE99tJhvC" role="2OqNvi">
+                              <node concept="3CFYIy" id="1CsE99tJhvD" role="3CFYIz">
+                                <ref role="3CFYIx" to="748g:1o6EjwiSKvw" resolve="DocumentedPropertyAnnotation" />
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="3TrEf2" id="1CsE99tJhvE" role="2OqNvi">
+                            <ref role="3Tt5mk" to="748g:UK_oBpA4EG" resolve="concept" />
+                          </node>
+                        </node>
+                        <node concept="2qgKlT" id="1CsE99tJhvF" role="2OqNvi">
+                          <ref role="37wK5l" to="tpcn:4MKjpUYmGW0" resolve="is" />
+                          <node concept="37vLTw" id="1CsE99tJhvG" role="37wK5m">
+                            <ref role="3cqZAo" node="2NM$qy7XAKN" resolve="concept" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3y3z36" id="1CsE99tJhvH" role="3uHU7B">
+                        <node concept="10Nm6u" id="1CsE99tJhvI" role="3uHU7w" />
+                        <node concept="2OqwBi" id="1CsE99tJhvJ" role="3uHU7B">
+                          <node concept="2GrUjf" id="1CsE99tJhvK" role="2Oq$k0">
+                            <ref role="2Gs0qQ" node="1CsE99tJhvl" resolve="section" />
+                          </node>
+                          <node concept="3CFZ6_" id="1CsE99tJhvL" role="2OqNvi">
+                            <node concept="3CFYIy" id="1CsE99tJhvM" role="3CFYIz">
+                              <ref role="3CFYIx" to="748g:1o6EjwiSKvw" resolve="DocumentedPropertyAnnotation" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="2OqwBi" id="1CsE99tJhvN" role="3uHU7w">
+                      <node concept="2OqwBi" id="1CsE99tJhvO" role="2Oq$k0">
+                        <node concept="2OqwBi" id="1CsE99tJhvP" role="2Oq$k0">
+                          <node concept="2GrUjf" id="1CsE99tJhvQ" role="2Oq$k0">
+                            <ref role="2Gs0qQ" node="1CsE99tJhvl" resolve="section" />
+                          </node>
+                          <node concept="3CFZ6_" id="1CsE99tJhvR" role="2OqNvi">
+                            <node concept="3CFYIy" id="1CsE99tJhvS" role="3CFYIz">
+                              <ref role="3CFYIx" to="748g:1o6EjwiSKvw" resolve="DocumentedPropertyAnnotation" />
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3TrEf2" id="1CsE99tJhvT" role="2OqNvi">
+                          <ref role="3Tt5mk" to="748g:1o6EjwiSKvG" resolve="property" />
+                        </node>
+                      </node>
+                      <node concept="2qgKlT" id="1CsE99tJhvU" role="2OqNvi">
+                        <ref role="37wK5l" to="tpcn:4MKjpUYnih4" resolve="is" />
+                        <node concept="37vLTw" id="1CsE99tJhvV" role="37wK5m">
+                          <ref role="3cqZAo" node="2NM$qy7XAKP" resolve="property" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="2OqwBi" id="1CsE99tJhvW" role="2GsD0m">
+                <node concept="37vLTw" id="1CsE99tJhvX" role="2Oq$k0">
+                  <ref role="3cqZAo" node="1CsE99tJfDd" resolve="documents" />
+                </node>
+                <node concept="3goQfb" id="1CsE99tJhvY" role="2OqNvi">
+                  <node concept="1bVj0M" id="1CsE99tJhvZ" role="23t8la">
+                    <node concept="3clFbS" id="1CsE99tJhw0" role="1bW5cS">
+                      <node concept="3clFbF" id="1CsE99tJhw1" role="3cqZAp">
+                        <node concept="2OqwBi" id="1CsE99tJhw2" role="3clFbG">
+                          <node concept="37vLTw" id="1CsE99tJhw3" role="2Oq$k0">
+                            <ref role="3cqZAo" node="1CsE99tJhw7" resolve="it" />
+                          </node>
+                          <node concept="2Rf3mk" id="1CsE99tJhw4" role="2OqNvi">
+                            <node concept="1xMEDy" id="1CsE99tJhw5" role="1xVPHs">
+                              <node concept="chp4Y" id="1CsE99tJhw6" role="ri$Ld">
+                                <ref role="cht4Q" to="2c95:2TZO3Dbv6N7" resolve="Section" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="Rh6nW" id="1CsE99tJhw7" role="1bW2Oz">
+                      <property role="TrG5h" value="it" />
+                      <node concept="2jxLKc" id="1CsE99tJhw8" role="1tU5fm" />
                     </node>
                   </node>
                 </node>
@@ -872,9 +1082,26 @@
               <node concept="3clFbS" id="4MORkbYlUZ" role="3clFbx">
                 <node concept="3clFbJ" id="2NM$qy7XANG" role="3cqZAp">
                   <node concept="3clFbS" id="2NM$qy7XANH" role="3clFbx">
-                    <node concept="3cpWs6" id="2NM$qy7XANI" role="3cqZAp">
-                      <node concept="2GrUjf" id="2NM$qy7XANJ" role="3cqZAk">
-                        <ref role="2Gs0qQ" node="2NM$qy7XANh" resolve="section" />
+                    <node concept="3cpWs6" id="1CsE99tB1EC" role="3cqZAp">
+                      <node concept="1Ls8ON" id="1CsE99tB2Gt" role="3cqZAk">
+                        <node concept="2GrUjf" id="1CsE99tB3eq" role="1Lso8e">
+                          <ref role="2Gs0qQ" node="2NM$qy7XANh" resolve="section" />
+                        </node>
+                        <node concept="2OqwBi" id="1CsE99tB99y" role="1Lso8e">
+                          <node concept="2OqwBi" id="1CsE99tB5HI" role="2Oq$k0">
+                            <node concept="2GrUjf" id="1CsE99tB4PQ" role="2Oq$k0">
+                              <ref role="2Gs0qQ" node="2NM$qy7XANh" resolve="section" />
+                            </node>
+                            <node concept="3CFZ6_" id="1CsE99tB7Ue" role="2OqNvi">
+                              <node concept="3CFYIy" id="1CsE99tB8sD" role="3CFYIz">
+                                <ref role="3CFYIx" to="748g:1o6EjwiSKvw" resolve="DocumentedPropertyAnnotation" />
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="3TrcHB" id="1CsE99tBavM" role="2OqNvi">
+                            <ref role="3TsBF5" to="748g:1CsE99t_Me0" resolve="priority" />
+                          </node>
+                        </node>
                       </node>
                     </node>
                   </node>
@@ -952,9 +1179,26 @@
             </node>
             <node concept="3clFbJ" id="2NM$qy7XANj" role="3cqZAp">
               <node concept="3clFbS" id="2NM$qy7XANk" role="3clFbx">
-                <node concept="3cpWs6" id="2NM$qy7XANl" role="3cqZAp">
-                  <node concept="2GrUjf" id="2NM$qy7XANm" role="3cqZAk">
-                    <ref role="2Gs0qQ" node="2NM$qy7XANh" resolve="section" />
+                <node concept="3cpWs6" id="1CsE99tBc2q" role="3cqZAp">
+                  <node concept="1Ls8ON" id="1CsE99tBd5l" role="3cqZAk">
+                    <node concept="2GrUjf" id="1CsE99tBdBP" role="1Lso8e">
+                      <ref role="2Gs0qQ" node="2NM$qy7XANh" resolve="section" />
+                    </node>
+                    <node concept="2OqwBi" id="1CsE99tBk2Z" role="1Lso8e">
+                      <node concept="2OqwBi" id="1CsE99tBg8M" role="2Oq$k0">
+                        <node concept="2GrUjf" id="1CsE99tBfgn" role="2Oq$k0">
+                          <ref role="2Gs0qQ" node="2NM$qy7XANh" resolve="section" />
+                        </node>
+                        <node concept="3CFZ6_" id="1CsE99tBhKm" role="2OqNvi">
+                          <node concept="3CFYIy" id="1CsE99tBijk" role="3CFYIz">
+                            <ref role="3CFYIx" to="748g:UK_oBp_UIu" resolve="DocumentedConceptAnnotation" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3TrcHB" id="1CsE99tBkLR" role="2OqNvi">
+                        <ref role="3TsBF5" to="748g:1CsE99t_Me0" resolve="priority" />
+                      </node>
+                    </node>
                   </node>
                 </node>
               </node>
@@ -1035,7 +1279,6 @@
           <node concept="10Nm6u" id="2NM$qy7XAOk" role="3cqZAk" />
         </node>
       </node>
-      <node concept="3Tqbb2" id="2NM$qy7XAKK" role="3clF45" />
       <node concept="37vLTG" id="2NM$qy7XAKL" role="3clF46">
         <property role="TrG5h" value="model" />
         <property role="3TUv4t" value="true" />
@@ -1054,6 +1297,10 @@
         </node>
       </node>
       <node concept="3Tm6S6" id="2NM$qy7XAKJ" role="1B3o_S" />
+      <node concept="1LlUBW" id="1CsE99tAXJB" role="3clF45">
+        <node concept="3Tqbb2" id="1CsE99tAYLD" role="1Lm7xW" />
+        <node concept="10Oyi0" id="1CsE99tB0vz" role="1Lm7xW" />
+      </node>
     </node>
     <node concept="3Tm1VV" id="qh7UMGioab" role="1B3o_S" />
     <node concept="2tJIrI" id="qmep2m2k86" role="jymVt" />

--- a/code/languages/com.mbeddr.doc.aspect/solutions/com.mbeddr.doc.aspect.ui/models/com/mbeddr/doc/aspect/ui/plugin.mps
+++ b/code/languages/com.mbeddr.doc.aspect/solutions/com.mbeddr.doc.aspect.ui/models/com/mbeddr/doc/aspect/ui/plugin.mps
@@ -1117,17 +1117,12 @@
               <node concept="2OqwBi" id="18EYPZeyOxl" role="3uHU7w">
                 <node concept="2WthIp" id="18EYPZeyOxo" role="2Oq$k0" />
                 <node concept="2XshWL" id="18EYPZeyOxq" role="2OqNvi">
-                  <ref role="2WH_rO" node="18EYPZeyuGP" resolve="hasDocAspect" />
-                  <node concept="2OqwBi" id="18EYPZeyPZO" role="2XxRq1">
-                    <node concept="2OqwBi" id="18EYPZeyPth" role="2Oq$k0">
-                      <node concept="37vLTw" id="18EYPZeyPmb" role="2Oq$k0">
-                        <ref role="3cqZAo" node="18EYPZeyMBy" resolve="selectedNode" />
-                      </node>
-                      <node concept="2yIwOk" id="18EYPZeyPEQ" role="2OqNvi" />
+                  <ref role="2WH_rO" node="1CsE99tCRef" resolve="hasDoc" />
+                  <node concept="2OqwBi" id="18EYPZeyPth" role="2XxRq1">
+                    <node concept="37vLTw" id="18EYPZeyPmb" role="2Oq$k0">
+                      <ref role="3cqZAo" node="18EYPZeyMBy" resolve="selectedNode" />
                     </node>
-                    <node concept="liA8E" id="18EYPZeyQko" role="2OqNvi">
-                      <ref role="37wK5l" to="c17a:~SAbstractConcept.getLanguage()" resolve="getLanguage" />
-                    </node>
+                    <node concept="2yIwOk" id="18EYPZeyPEQ" role="2OqNvi" />
                   </node>
                   <node concept="2EnYce" id="2MiGV0HSqeg" role="2XxRq1">
                     <node concept="2OqwBi" id="18EYPZeyQX4" role="2Oq$k0">
@@ -2538,6 +2533,41 @@
         </node>
       </node>
       <node concept="3Tm6S6" id="18EYPZeyKg2" role="1B3o_S" />
+    </node>
+    <node concept="2XrIbr" id="1CsE99tCRef" role="2XNbBy">
+      <property role="TrG5h" value="hasDoc" />
+      <node concept="10P_77" id="1CsE99tCSgo" role="3clF45" />
+      <node concept="3clFbS" id="1CsE99tCReh" role="3clF47">
+        <node concept="3clFbF" id="1CsE99tCSkn" role="3cqZAp">
+          <node concept="3y3z36" id="1CsE99tCTcg" role="3clFbG">
+            <node concept="10Nm6u" id="1CsE99tCTjo" role="3uHU7w" />
+            <node concept="2YIFZM" id="1CsE99tCSmY" role="3uHU7B">
+              <ref role="37wK5l" to="ttl0:qh7UMGipbd" resolve="getDocumentation" />
+              <ref role="1Pybhc" to="ttl0:qh7UMGioaa" resolve="DocumentationAspectHelper" />
+              <node concept="37vLTw" id="1CsE99tCSZI" role="37wK5m">
+                <ref role="3cqZAo" node="1CsE99tCStE" resolve="repository" />
+              </node>
+              <node concept="37vLTw" id="1CsE99tCT2W" role="37wK5m">
+                <ref role="3cqZAo" node="1CsE99tCSE2" resolve="concept" />
+              </node>
+              <node concept="10Nm6u" id="1CsE99tCT5T" role="37wK5m" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm6S6" id="1CsE99tCScR" role="1B3o_S" />
+      <node concept="37vLTG" id="1CsE99tCSE2" role="3clF46">
+        <property role="3TUv4t" value="true" />
+        <property role="TrG5h" value="concept" />
+        <node concept="3bZ5Sz" id="1CsE99tCSQu" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="1CsE99tCStE" role="3clF46">
+        <property role="3TUv4t" value="true" />
+        <property role="TrG5h" value="repository" />
+        <node concept="3uibUv" id="1CsE99tCSA$" role="1tU5fm">
+          <ref role="3uigEE" to="lui2:~SRepository" resolve="SRepository" />
+        </node>
+      </node>
     </node>
     <node concept="2XrIbr" id="ggygV7PAGa" role="2XNbBy">
       <property role="TrG5h" value="showDocumentation" />


### PR DESCRIPTION
This PR adds support for setting priorities for the annotations of the  documentation aspect. Now it is possible to document concepts of other languages in the documentation aspect as well. The annotation with the highest priority is used when there are multiple available documentations for a concept.