### PR TITLE
seca-19.3 to maintenance mps 2020.3

### DIFF
--- a/code/languages/com.mbeddr.core/_spreferences/PlatformTemplates/models/com/mbeddr/core/__spreferences/PlatformTemplates.mps
+++ b/code/languages/com.mbeddr.core/_spreferences/PlatformTemplates/models/com/mbeddr/core/__spreferences/PlatformTemplates.mps
@@ -14,8 +14,8 @@
         <child id="8719112291174072694" name="templates" index="2xbcco" />
       </concept>
       <concept id="5323740605968447022" name="com.mbeddr.core.buildconfig.structure.DesktopPlatform" flags="ng" index="2AWWZL">
-        <property id="5323740605968447025" name="cCompilerOptions" index="2AWWZI" />
-        <property id="5323740605968447024" name="cCompiler" index="2AWWZJ" />
+        <property id="5323740605968447025" name="compilerOptions" index="2AWWZI" />
+        <property id="5323740605968447024" name="compiler" index="2AWWZJ" />
         <property id="1253797277664981186" name="cppCompilerOptions" index="UXd4T" />
         <property id="1253797277664981177" name="cppCompiler" index="UXd52" />
         <property id="3963667026125442601" name="gdb" index="3r8Kw1" />

--- a/code/languages/com.mbeddr.core/languages/com.mbeddr.core.base/languageModels/behavior.mps
+++ b/code/languages/com.mbeddr.core/languages/com.mbeddr.core.base/languageModels/behavior.mps
@@ -4356,6 +4356,29 @@
   </node>
   <node concept="13h7C7" id="IviauXaxW">
     <ref role="13h7C2" to="vs0r:IviauXabd" resolve="IMbeddrIDERoot" />
+    <node concept="13i0hz" id="2daXVy6Qz1j" role="13h7CS">
+      <property role="13i0it" value="true" />
+      <property role="TrG5h" value="isDisplayed" />
+      <node concept="3Tm1VV" id="7jN4X3UX2AX" role="1B3o_S" />
+      <node concept="10P_77" id="7jN4X3UX3Yi" role="3clF45" />
+      <node concept="3clFbS" id="7jN4X3UX2AZ" role="3clF47">
+        <node concept="3clFbF" id="7jN4X3UX40a" role="3cqZAp">
+          <node concept="3clFbT" id="7jN4X3UX409" role="3clFbG">
+            <property role="3clFbU" value="true" />
+          </node>
+        </node>
+      </node>
+      <node concept="P$JXv" id="7jN4X3UX40r" role="lGtFl">
+        <node concept="TZ5HA" id="7jN4X3UX40s" role="TZ5H$">
+          <node concept="1dT_AC" id="7jN4X3UX40t" role="1dT_Ay">
+            <property role="1dT_AB" value="" />
+          </node>
+        </node>
+        <node concept="x79VA" id="7jN4X3UX40u" role="3nqlJM">
+          <property role="x79VB" value="Whether such node can be created from the mbeddr context menu" />
+        </node>
+      </node>
+    </node>
     <node concept="13i0hz" id="IviauXb0g" role="13h7CS">
       <property role="13i0iv" value="true" />
       <property role="13i0it" value="true" />

--- a/code/languages/com.mbeddr.core/languages/com.mbeddr.core.base/languageModels/behavior.mps
+++ b/code/languages/com.mbeddr.core/languages/com.mbeddr.core.base/languageModels/behavior.mps
@@ -344,7 +344,6 @@
       <concept id="1208890769693" name="jetbrains.mps.baseLanguage.structure.ArrayLengthOperation" flags="nn" index="1Rwk04" />
       <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="nn" index="3SKdUt">
         <child id="8356039341262087992" name="line" index="1aUNEU" />
-        <child id="1350122676458893092" name="text" index="3ndbpf" />
       </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
       <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
@@ -20002,7 +20001,7 @@
         <node concept="3clFbJ" id="3ptpjvQq5We" role="3cqZAp">
           <node concept="3clFbS" id="3ptpjvQq5Wf" role="3clFbx">
             <node concept="3SKdUt" id="3ptpjvQq5Wg" role="3cqZAp">
-              <node concept="1PaTwC" id="3ptpjvQq5Wh" role="3ndbpf">
+              <node concept="1PaTwC" id="3ptpjvQq5Wh" role="1aUNEU">
                 <node concept="3oM_SD" id="3ptpjvQq5Wi" role="1PaTwD">
                   <property role="3oM_SC" value="Convert" />
                 </node>
@@ -20129,7 +20128,7 @@
         <node concept="3clFbJ" id="3ptpjvQpV$6" role="3cqZAp">
           <node concept="3clFbS" id="3ptpjvQpV$7" role="3clFbx">
             <node concept="3SKdUt" id="3ptpjvQpXV8" role="3cqZAp">
-              <node concept="1PaTwC" id="3ptpjvQpXV9" role="3ndbpf">
+              <node concept="1PaTwC" id="3ptpjvQpXV9" role="1aUNEU">
                 <node concept="3oM_SD" id="3ptpjvQpXVb" role="1PaTwD">
                   <property role="3oM_SC" value="Convert" />
                 </node>

--- a/code/languages/com.mbeddr.core/languages/com.mbeddr.core.base/languageModels/editor.mps
+++ b/code/languages/com.mbeddr.core/languages/com.mbeddr.core.base/languageModels/editor.mps
@@ -663,7 +663,7 @@
       </concept>
     </language>
     <language id="120e1c9d-4e27-4478-b2af-b2c3bd3850b0" name="com.mbeddr.mpsutil.editor.querylist">
-      <concept id="6202678563380238499" name="com.mbeddr.mpsutil.editor.querylist.structure.Function_GetElements" flags="ig" index="s8sZD" />
+      <concept id="6202678563380238499" name="com.mbeddr.mpsutil.editor.querylist.structure.Function_GetElements" flags="ng" index="s8sZD" />
       <concept id="6202678563380233810" name="com.mbeddr.mpsutil.editor.querylist.structure.CellModel_QueryList" flags="ng" index="s8t4o">
         <property id="730823979356023502" name="duplicatesSafe" index="28Zw97" />
         <reference id="730823979350682502" name="elementsConcept" index="28F8cf" />

--- a/code/languages/com.mbeddr.core/languages/com.mbeddr.core.base/solutions/pluginSolution/models/com/mbeddr/core/base/pluginSolution/plugin.mps
+++ b/code/languages/com.mbeddr.core/languages/com.mbeddr.core.base/solutions/pluginSolution/models/com/mbeddr/core/base/pluginSolution/plugin.mps
@@ -7347,6 +7347,22 @@
         </node>
       </node>
     </node>
+    <node concept="Wx3nA" id="1Xj_MLkhht4" role="jymVt">
+      <property role="TrG5h" value="KEY_CATEGORY_UNKNOWN" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm6S6" id="1Xj_MLkhht5" role="1B3o_S" />
+      <node concept="17QB3L" id="1Xj_MLkhht6" role="1tU5fm" />
+      <node concept="Xl_RD" id="1Xj_MLkhht7" role="33vP2m">
+        <property role="Xl_RC" value="KEY_CATEGORY_UNKNOWN" />
+      </node>
+      <node concept="z59LJ" id="1Xj_MLkhht8" role="lGtFl">
+        <node concept="TZ5HA" id="1Xj_MLkhht9" role="TZ5H$">
+          <node concept="1dT_AC" id="1Xj_MLkhhta" role="1dT_Ay">
+            <property role="1dT_AB" value="category key for all roots without IMbeddrIDERoot implementation" />
+          </node>
+        </node>
+      </node>
+    </node>
     <node concept="2tJIrI" id="1PMOMKdk0uu" role="jymVt" />
     <node concept="2tJIrI" id="1PMOMKdk0vv" role="jymVt" />
     <node concept="2YIFZL" id="IviauU9ix" role="jymVt">
@@ -7964,6 +7980,21 @@
                                     </node>
                                     <node concept="LFhST" id="6r2FnBTb2aa" role="2OqNvi" />
                                   </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="3clFbJ" id="7jN4X3UX8Up" role="3cqZAp">
+                            <node concept="3clFbS" id="7jN4X3UX8Ur" role="3clFbx">
+                              <node concept="3N13vt" id="2yoIUpb$_Ne" role="3cqZAp" />
+                            </node>
+                            <node concept="3fqX7Q" id="CZOBkuwhkX" role="3clFbw">
+                              <node concept="2OqwBi" id="CZOBkuwhkZ" role="3fr31v">
+                                <node concept="37vLTw" id="CZOBkuwhl0" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="4augEjZSVuv" resolve="createNode" />
+                                </node>
+                                <node concept="2qgKlT" id="CZOBkuwhl1" role="2OqNvi">
+                                  <ref role="37wK5l" to="hwgx:2daXVy6Qz1j" resolve="isDisplayed" />
                                 </node>
                               </node>
                             </node>

--- a/code/languages/com.mbeddr.core/languages/com.mbeddr.core.buildconfig/generator/template/main@generator.mps
+++ b/code/languages/com.mbeddr.core/languages/com.mbeddr.core.buildconfig/generator/template/main@generator.mps
@@ -162,8 +162,8 @@
     </language>
     <language id="2d7fadf5-33f6-4e80-a78f-0f739add2bde" name="com.mbeddr.core.buildconfig">
       <concept id="5323740605968447022" name="com.mbeddr.core.buildconfig.structure.DesktopPlatform" flags="ng" index="2AWWZL">
-        <property id="5323740605968447025" name="cCompilerOptions" index="2AWWZI" />
-        <property id="5323740605968447024" name="cCompiler" index="2AWWZJ" />
+        <property id="5323740605968447025" name="compilerOptions" index="2AWWZI" />
+        <property id="5323740605968447024" name="compiler" index="2AWWZJ" />
         <property id="1253797277664981186" name="cppCompilerOptions" index="UXd4T" />
         <property id="1253797277664981177" name="cppCompiler" index="UXd52" />
         <property id="3963667026125442601" name="gdb" index="3r8Kw1" />

--- a/code/languages/com.mbeddr.core/languages/com.mbeddr.core.buildconfig/generator/template/main@generator.mps
+++ b/code/languages/com.mbeddr.core/languages/com.mbeddr.core.buildconfig/generator/template/main@generator.mps
@@ -156,7 +156,7 @@
         <reference id="5497648299878491909" name="baseVariableDeclaration" index="1M0zk5" />
       </concept>
       <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="nn" index="3SKdUt">
-        <child id="1350122676458893092" name="text" index="3ndbpf" />
+        <child id="8356039341262087992" name="line" index="1aUNEU" />
       </concept>
       <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
     </language>
@@ -6080,7 +6080,7 @@
   </node>
   <node concept="1pmfR0" id="7Aba6ByGqqn">
     <property role="TrG5h" value="adjustImplModulePrefixes" />
-    <property role="1v3f2W" value="pre_processing" />
+    <property role="1v3f2W" value="hpv1Zf2/pre_processing" />
     <property role="1v3jST" value="true" />
     <node concept="1pplIY" id="7Aba6ByGqqo" role="1pqMTA">
       <node concept="3clFbS" id="7Aba6ByGqqp" role="2VODD2">
@@ -13232,7 +13232,7 @@
                   </node>
                   <node concept="3clFbH" id="3ptpjvRmU3b" role="3cqZAp" />
                   <node concept="3SKdUt" id="3ptpjvRmU3c" role="3cqZAp">
-                    <node concept="1PaTwC" id="3ptpjvRmU3d" role="3ndbpf">
+                    <node concept="1PaTwC" id="3ptpjvRmU3d" role="1aUNEU">
                       <node concept="3oM_SD" id="3ptpjvRmU3e" role="1PaTwD">
                         <property role="3oM_SC" value="Does" />
                       </node>
@@ -13273,7 +13273,9 @@
                         <property role="3oM_SC" value="" />
                       </node>
                     </node>
-                    <node concept="1PaTwC" id="3ptpjvRmU3r" role="3ndbpf">
+                  </node>
+                  <node concept="3SKdUt" id="4zyhjowSmkX" role="3cqZAp">
+                    <node concept="1PaTwC" id="3ptpjvRmU3r" role="1aUNEU">
                       <node concept="3oM_SD" id="3ptpjvRmU3s" role="1PaTwD">
                         <property role="3oM_SC" value="some" />
                       </node>
@@ -13499,7 +13501,7 @@
                   <node concept="3clFbJ" id="3ptpjvRmU4O" role="3cqZAp">
                     <node concept="3clFbS" id="3ptpjvRmU4P" role="3clFbx">
                       <node concept="3SKdUt" id="3ptpjvRmU4Q" role="3cqZAp">
-                        <node concept="1PaTwC" id="3ptpjvRmU4R" role="3ndbpf">
+                        <node concept="1PaTwC" id="3ptpjvRmU4R" role="1aUNEU">
                           <node concept="3oM_SD" id="3ptpjvRmU4S" role="1PaTwD">
                             <property role="3oM_SC" value="Substitute" />
                           </node>
@@ -13741,7 +13743,7 @@
                 </node>
                 <node concept="3clFbH" id="5GYFpoPrTs_" role="3cqZAp" />
                 <node concept="3SKdUt" id="3ptpjvRni8W" role="3cqZAp">
-                  <node concept="1PaTwC" id="3ptpjvRni8X" role="3ndbpf">
+                  <node concept="1PaTwC" id="3ptpjvRni8X" role="1aUNEU">
                     <node concept="3oM_SD" id="3ptpjvRni8Y" role="1PaTwD">
                       <property role="3oM_SC" value="Establish" />
                     </node>
@@ -13945,7 +13947,7 @@
                 </node>
                 <node concept="3clFbH" id="3ptpjvRniao" role="3cqZAp" />
                 <node concept="3SKdUt" id="3ptpjvRniap" role="3cqZAp">
-                  <node concept="1PaTwC" id="3ptpjvRniaq" role="3ndbpf">
+                  <node concept="1PaTwC" id="3ptpjvRniaq" role="1aUNEU">
                     <node concept="3oM_SD" id="3ptpjvRniar" role="1PaTwD">
                       <property role="3oM_SC" value="Wrap" />
                     </node>
@@ -13984,11 +13986,13 @@
                                     <ref role="2pJxaS" to="tpee:f$Xl_Og" resolve="StringLiteral" />
                                     <node concept="2pJxcG" id="3ptpjvRniaG" role="2pJxcM">
                                       <ref role="2pJxcJ" to="tpee:f$Xl_Oh" resolve="value" />
-                                      <node concept="2OqwBi" id="3ptpjvRniaH" role="28ntcv">
-                                        <node concept="37vLTw" id="3ptpjvRniaI" role="2Oq$k0">
-                                          <ref role="3cqZAo" node="3ptpjvRniaQ" resolve="it" />
+                                      <node concept="WxPPo" id="4zyhjowSmnM" role="28ntcv">
+                                        <node concept="2OqwBi" id="3ptpjvRniaH" role="WxPPp">
+                                          <node concept="37vLTw" id="3ptpjvRniaI" role="2Oq$k0">
+                                            <ref role="3cqZAo" node="3ptpjvRniaQ" resolve="it" />
+                                          </node>
+                                          <node concept="3AY5_j" id="3ptpjvRniaJ" role="2OqNvi" />
                                         </node>
-                                        <node concept="3AY5_j" id="3ptpjvRniaJ" role="2OqNvi" />
                                       </node>
                                     </node>
                                   </node>
@@ -13999,11 +14003,13 @@
                                     <ref role="2pJxaS" to="tpee:f$Xl_Og" resolve="StringLiteral" />
                                     <node concept="2pJxcG" id="3ptpjvRniaM" role="2pJxcM">
                                       <ref role="2pJxcJ" to="tpee:f$Xl_Oh" resolve="value" />
-                                      <node concept="2OqwBi" id="3ptpjvRniaN" role="28ntcv">
-                                        <node concept="37vLTw" id="3ptpjvRniaO" role="2Oq$k0">
-                                          <ref role="3cqZAo" node="3ptpjvRniaQ" resolve="it" />
+                                      <node concept="WxPPo" id="4zyhjowSmnN" role="28ntcv">
+                                        <node concept="2OqwBi" id="3ptpjvRniaN" role="WxPPp">
+                                          <node concept="37vLTw" id="3ptpjvRniaO" role="2Oq$k0">
+                                            <ref role="3cqZAo" node="3ptpjvRniaQ" resolve="it" />
+                                          </node>
+                                          <node concept="3AV6Ez" id="3ptpjvRniaP" role="2OqNvi" />
                                         </node>
-                                        <node concept="3AV6Ez" id="3ptpjvRniaP" role="2OqNvi" />
                                       </node>
                                     </node>
                                   </node>

--- a/code/languages/com.mbeddr.core/languages/com.mbeddr.core.buildconfig/languageModels/behavior.mps
+++ b/code/languages/com.mbeddr.core/languages/com.mbeddr.core.buildconfig/languageModels/behavior.mps
@@ -259,7 +259,6 @@
       </concept>
       <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="nn" index="3SKdUt">
         <child id="8356039341262087992" name="line" index="1aUNEU" />
-        <child id="1350122676458893092" name="text" index="3ndbpf" />
       </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
       <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
@@ -355,7 +354,6 @@
         <child id="6733348108486823193" name="leftExpression" index="1m5AlR" />
         <child id="3906496115198199033" name="conceptArgument" index="3oSUPX" />
       </concept>
-      <concept id="8866923313515890008" name="jetbrains.mps.lang.smodel.structure.AsNodeOperation" flags="nn" index="FGMqu" />
       <concept id="1143226024141" name="jetbrains.mps.lang.smodel.structure.SModelType" flags="in" index="H_c77" />
       <concept id="1143234257716" name="jetbrains.mps.lang.smodel.structure.Node_GetModelOperation" flags="nn" index="I4A8Y" />
       <concept id="1145383075378" name="jetbrains.mps.lang.smodel.structure.SNodeListType" flags="in" index="2I9FWS">
@@ -397,6 +395,9 @@
       </concept>
       <concept id="1180636770613" name="jetbrains.mps.lang.smodel.structure.SNodeCreator" flags="nn" index="3zrR0B">
         <child id="1180636770616" name="createdType" index="3zrR0E" />
+      </concept>
+      <concept id="1219352745532" name="jetbrains.mps.lang.smodel.structure.NodeRefExpression" flags="nn" index="3B5_sB">
+        <reference id="1219352800908" name="referentNode" index="3B5MYn" />
       </concept>
       <concept id="1172326502327" name="jetbrains.mps.lang.smodel.structure.Concept_IsExactlyOperation" flags="nn" index="3O6GUB">
         <child id="1206733650006" name="conceptArgument" index="3QVz_e" />
@@ -4506,7 +4507,7 @@
       <node concept="3Tm1VV" id="3dZgFhDSB3P" role="1B3o_S" />
       <node concept="3clFbS" id="3dZgFhDSB3U" role="3clF47">
         <node concept="3SKdUt" id="5Tkpp$X3djz" role="3cqZAp">
-          <node concept="1PaTwC" id="13p6s1wtilZ" role="3ndbpf">
+          <node concept="1PaTwC" id="13p6s1wtilZ" role="1aUNEU">
             <node concept="3oM_SD" id="13p6s1wtim0" role="1PaTwD">
               <property role="3oM_SC" value="Never" />
             </node>
@@ -5374,11 +5375,8 @@
               <ref role="3cqZAo" node="5Hxjapwguln" resolve="result" />
             </node>
             <node concept="TSZUe" id="5Hxjapwgulu" role="2OqNvi">
-              <node concept="2OqwBi" id="115mCuKLktu" role="25WWJ7">
-                <node concept="35c_gC" id="115mCuKLiSy" role="2Oq$k0">
-                  <ref role="35c_gD" to="51wr:4o9sgv8QoKi" resolve="Executable" />
-                </node>
-                <node concept="FGMqu" id="115mCuKLkWN" role="2OqNvi" />
+              <node concept="3B5_sB" id="115mCuKLktu" role="25WWJ7">
+                <ref role="3B5MYn" to="51wr:4o9sgv8QoKi" resolve="Executable" />
               </node>
             </node>
           </node>
@@ -5389,11 +5387,8 @@
               <ref role="3cqZAo" node="5Hxjapwguln" resolve="result" />
             </node>
             <node concept="TSZUe" id="5Hxjapwgulz" role="2OqNvi">
-              <node concept="2OqwBi" id="115mCuKLmTi" role="25WWJ7">
-                <node concept="35c_gC" id="115mCuKLld7" role="2Oq$k0">
-                  <ref role="35c_gD" to="51wr:2kkumeGQcAy" resolve="Library" />
-                </node>
-                <node concept="FGMqu" id="115mCuKLnqE" role="2OqNvi" />
+              <node concept="3B5_sB" id="115mCuKLmTi" role="25WWJ7">
+                <ref role="3B5MYn" to="51wr:2kkumeGQcAy" resolve="Library" />
               </node>
             </node>
           </node>
@@ -10223,7 +10218,7 @@
       <node concept="17QB3L" id="6xoAPBjOH3d" role="3clF45" />
       <node concept="3clFbS" id="6xoAPBjOH2W" role="3clF47">
         <node concept="3SKdUt" id="6xoAPBjQfMg" role="3cqZAp">
-          <node concept="1PaTwC" id="6xoAPBjQfMh" role="3ndbpf">
+          <node concept="1PaTwC" id="6xoAPBjQfMh" role="1aUNEU">
             <node concept="3oM_SD" id="6xoAPBjQfMi" role="1PaTwD">
               <property role="3oM_SC" value="First:" />
             </node>
@@ -10387,7 +10382,7 @@
         </node>
         <node concept="3clFbH" id="6xoAPBjQfMQ" role="3cqZAp" />
         <node concept="3SKdUt" id="6xoAPBjQfMR" role="3cqZAp">
-          <node concept="1PaTwC" id="6xoAPBjQfMS" role="3ndbpf">
+          <node concept="1PaTwC" id="6xoAPBjQfMS" role="1aUNEU">
             <node concept="3oM_SD" id="6xoAPBjQfMT" role="1PaTwD">
               <property role="3oM_SC" value="Second:" />
             </node>

--- a/code/languages/com.mbeddr.core/languages/com.mbeddr.core.codereview/models/editor.mps
+++ b/code/languages/com.mbeddr.core/languages/com.mbeddr.core.codereview/models/editor.mps
@@ -218,7 +218,7 @@
       <concept id="4079382982702596667" name="jetbrains.mps.baseLanguage.checkedDots.structure.CheckedDotExpression" flags="nn" index="2EnYce" />
     </language>
     <language id="120e1c9d-4e27-4478-b2af-b2c3bd3850b0" name="com.mbeddr.mpsutil.editor.querylist">
-      <concept id="6202678563380238499" name="com.mbeddr.mpsutil.editor.querylist.structure.Function_GetElements" flags="ig" index="s8sZD" />
+      <concept id="6202678563380238499" name="com.mbeddr.mpsutil.editor.querylist.structure.Function_GetElements" flags="ng" index="s8sZD" />
       <concept id="6202678563380233810" name="com.mbeddr.mpsutil.editor.querylist.structure.CellModel_QueryList" flags="ng" index="s8t4o">
         <property id="730823979356023502" name="duplicatesSafe" index="28Zw97" />
         <reference id="730823979350682502" name="elementsConcept" index="28F8cf" />

--- a/code/languages/com.mbeddr.core/languages/com.mbeddr.core.make/languageModels/plugin.mps
+++ b/code/languages/com.mbeddr.core/languages/com.mbeddr.core.make/languageModels/plugin.mps
@@ -7,7 +7,7 @@
     <use id="ef7bf5ac-d06c-4342-b11d-e42104eb9343" name="jetbrains.mps.lang.plugin.standalone" version="0" />
     <use id="63650c59-16c8-498a-99c8-005c7ee9515d" name="jetbrains.mps.lang.access" version="0" />
     <use id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc" version="2" />
-    <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="9" />
+    <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="11" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
@@ -280,7 +280,6 @@
       <concept id="1208890769693" name="jetbrains.mps.baseLanguage.structure.ArrayLengthOperation" flags="nn" index="1Rwk04" />
       <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="nn" index="3SKdUt">
         <child id="8356039341262087992" name="line" index="1aUNEU" />
-        <child id="1350122676458893092" name="text" index="3ndbpf" />
       </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
       <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
@@ -484,7 +483,7 @@
     <node concept="15KeUm" id="bq6A3e6cTK" role="15LFul">
       <property role="TrG5h" value="collectPaths" />
       <node concept="15KeVb" id="bq6A3e6cU7" role="15LFui">
-        <property role="3HPxAp" value="AFTER" />
+        <property role="3HPxAp" value="7fB872ucjBA/AFTER" />
         <ref role="15KeV8" to="tpcq:5L5h3brvz8m" resolve="configure" />
       </node>
       <node concept="15KeVb" id="bq6A3e6cU8" role="15LFui">
@@ -773,9 +772,7 @@
             <node concept="ElOAg" id="bq6A3e6cTU" role="3cqZAp">
               <node concept="ElOhk" id="bq6A3e6cTW" role="ElOA9" />
             </node>
-            <node concept="3D7k6m" id="bq6A3e6i$l" role="3cqZAp">
-              <property role="3D7k6l" value="SUCCESS" />
-            </node>
+            <node concept="3D7k6m" id="bq6A3e6i$l" role="3cqZAp" />
           </node>
         </node>
       </node>
@@ -812,7 +809,7 @@
     </node>
     <node concept="15KeUm" id="5zgShfbCrkR" role="15LFul">
       <property role="TrG5h" value="runMake" />
-      <property role="2w7fpF" value="PASSTHRU" />
+      <property role="2w7fpF" value="1t0JkeRn4G_/PASSTHRU" />
       <node concept="3D36IL" id="6KI2Y3Z4Vdj" role="3D36I4">
         <node concept="3D27Fh" id="6KI2Y3Z5ENC" role="3D36IM">
           <ref role="3uigEE" to="fn29:17BsPLzesis" resolve="DResource" />
@@ -824,19 +821,18 @@
         </node>
       </node>
       <node concept="15KeVb" id="5zgShfbCua4" role="15LFui">
-        <property role="3HPxAp" value="AFTER" />
+        <property role="3HPxAp" value="7fB872ucjBA/AFTER" />
         <ref role="15KeV8" to="tpcq:5L5h3brvDHA" resolve="textGen" />
       </node>
       <node concept="15KeVb" id="5zgShfbCvCA" role="15LFui">
-        <property role="3HPxAp" value="AFTER" />
+        <property role="3HPxAp" value="7fB872ucjBA/AFTER" />
         <ref role="15KeV8" node="bq6A3e6cTK" resolve="collectPaths" />
       </node>
       <node concept="15KeVb" id="16gyj4Crv4v" role="15LFui">
-        <property role="3HPxAp" value="AFTER" />
+        <property role="3HPxAp" value="7fB872ucjBA/AFTER" />
         <ref role="15KeV8" to="fy8e:72EPOrtLo_c" resolve="cleanup" />
       </node>
       <node concept="15KeVb" id="16gyj4BWimQ" role="15LFui">
-        <property role="3HPxAp" value="BEFORE" />
         <ref role="15KeV8" to="fy8e:taepSZ9rBr" resolve="make" />
       </node>
       <node concept="2aLE7I" id="5zgShfbCrkS" role="ElM8M">
@@ -907,9 +903,7 @@
             <node concept="3clFbH" id="6KI2Y3YYDW3" role="3cqZAp" />
             <node concept="3clFbJ" id="5zgShfbCz4g" role="3cqZAp">
               <node concept="3clFbS" id="5zgShfbCz4h" role="3clFbx">
-                <node concept="3D7k6m" id="5zgShfbCz4i" role="3cqZAp">
-                  <property role="3D7k6l" value="SUCCESS" />
-                </node>
+                <node concept="3D7k6m" id="5zgShfbCz4i" role="3cqZAp" />
               </node>
               <node concept="2OqwBi" id="5zgShfbCz4k" role="3clFbw">
                 <node concept="37vLTw" id="5zgShfbCz4l" role="2Oq$k0">
@@ -1009,9 +1003,7 @@
                 <node concept="3clFbH" id="6KI2Y3YYGRM" role="3cqZAp" />
                 <node concept="3clFbJ" id="3s1LyzGgnRW" role="3cqZAp">
                   <node concept="3clFbS" id="3s1LyzGgnRZ" role="3clFbx">
-                    <node concept="3D7k6m" id="3s1LyzGgyDx" role="3cqZAp">
-                      <property role="3D7k6l" value="SUCCESS" />
-                    </node>
+                    <node concept="3D7k6m" id="3s1LyzGgyDx" role="3cqZAp" />
                   </node>
                   <node concept="3fqX7Q" id="3s1LyzGmWlz" role="3clFbw">
                     <node concept="37vLTw" id="3s1LyzGmWl_" role="3fr31v">
@@ -1042,7 +1034,7 @@
                         </node>
                       </node>
                       <node concept="1daRAt" id="3cN5OOfBeWL" role="3cqZAp">
-                        <property role="1daRAr" value="ERROR" />
+                        <property role="1daRAr" value="3bEKrlZKrwH/ERROR" />
                         <node concept="3cpWs3" id="3cN5OOfBeX2" role="1daK9t">
                           <node concept="Xl_RD" id="3cN5OOfBeX3" role="3uHU7B">
                             <property role="Xl_RC" value="make failed: " />
@@ -1082,7 +1074,7 @@
                       </node>
                     </node>
                     <node concept="3SKdUt" id="5zgShfbCz4E" role="3cqZAp">
-                      <node concept="1PaTwC" id="13p6s1wtiws" role="3ndbpf">
+                      <node concept="1PaTwC" id="13p6s1wtiws" role="1aUNEU">
                         <node concept="3oM_SD" id="13p6s1wtiwt" role="1PaTwD">
                           <property role="3oM_SC" value="use" />
                         </node>
@@ -1212,7 +1204,7 @@
                           <node concept="3clFbJ" id="7GmkyIHGcyx" role="3cqZAp">
                             <node concept="3clFbS" id="7GmkyIHGcyz" role="3clFbx">
                               <node concept="3SKdUt" id="3dZgFhDBGCf" role="3cqZAp">
-                                <node concept="1PaTwC" id="13p6s1wtiwB" role="3ndbpf">
+                                <node concept="1PaTwC" id="13p6s1wtiwB" role="1aUNEU">
                                   <node concept="3oM_SD" id="13p6s1wtiwC" role="1PaTwD">
                                     <property role="3oM_SC" value="The" />
                                   </node>
@@ -1378,7 +1370,7 @@
                     </node>
                     <node concept="3clFbH" id="6qXnQYnrE2P" role="3cqZAp" />
                     <node concept="3SKdUt" id="5zgShfbCz56" role="3cqZAp">
-                      <node concept="1PaTwC" id="13p6s1wtiwO" role="3ndbpf">
+                      <node concept="1PaTwC" id="13p6s1wtiwO" role="1aUNEU">
                         <node concept="3oM_SD" id="13p6s1wtiwP" role="1PaTwD">
                           <property role="3oM_SC" value="workaround" />
                         </node>
@@ -1572,7 +1564,7 @@
                       </node>
                       <node concept="3clFbS" id="3NVVczytYnw" role="2LFqv$">
                         <node concept="1daRAt" id="3NVVczytYnx" role="3cqZAp">
-                          <property role="1daRAr" value="MESSAGE" />
+                          <property role="1daRAr" value="5uScuQ2wMwG/MESSAGE" />
                           <node concept="2GrUjf" id="3NVVczzoJnk" role="1daK9t">
                             <ref role="2Gs0qQ" node="3NVVczytYnu" resolve="message" />
                           </node>
@@ -1589,7 +1581,7 @@
                       </node>
                       <node concept="3clFbS" id="3NVVczzoPOq" role="2LFqv$">
                         <node concept="1daRAt" id="3NVVczzoPOr" role="3cqZAp">
-                          <property role="1daRAr" value="MESSAGE" />
+                          <property role="1daRAr" value="5uScuQ2wMwG/MESSAGE" />
                           <node concept="2GrUjf" id="3NVVczzoPOs" role="1daK9t">
                             <ref role="2Gs0qQ" node="3NVVczzoPOo" resolve="message" />
                           </node>
@@ -1621,7 +1613,7 @@
                           </node>
                         </node>
                         <node concept="1daRAt" id="3cN5OOfB11x" role="3cqZAp">
-                          <property role="1daRAr" value="ERROR" />
+                          <property role="1daRAr" value="3bEKrlZKrwH/ERROR" />
                           <node concept="3cpWs3" id="6VqaxF9P7Sl" role="1daK9t">
                             <node concept="2OqwBi" id="6VqaxF9P8Xn" role="3uHU7w">
                               <node concept="37vLTw" id="6VqaxF9P8Na" role="2Oq$k0">
@@ -1679,7 +1671,6 @@
                       <node concept="9aQIb" id="5zgShfbCz6P" role="9aQIa">
                         <node concept="3clFbS" id="5zgShfbCz6Q" role="9aQI4">
                           <node concept="1daRAt" id="7PIfE8orgBY" role="3cqZAp">
-                            <property role="1daRAr" value="INFO" />
                             <node concept="3cpWs3" id="5mK2hjZ_5hv" role="1daK9t">
                               <node concept="3cpWs3" id="5mK2hjZ_10b" role="3uHU7B">
                                 <node concept="3cpWs3" id="7PIfE8orgJu" role="3uHU7B">
@@ -1725,9 +1716,7 @@
             </node>
             <node concept="3clFbJ" id="7PIfE8orjtu" role="3cqZAp">
               <node concept="3clFbS" id="7PIfE8orjtw" role="3clFbx">
-                <node concept="3D7k6m" id="6KI2Y3Z3Zpa" role="3cqZAp">
-                  <property role="3D7k6l" value="SUCCESS" />
-                </node>
+                <node concept="3D7k6m" id="6KI2Y3Z3Zpa" role="3cqZAp" />
               </node>
               <node concept="37vLTw" id="7PIfE8orkwC" role="3clFbw">
                 <ref role="3cqZAo" node="3cN5OOfBf8p" resolve="successfulCompilation" />
@@ -1735,7 +1724,7 @@
               <node concept="9aQIb" id="7PIfE8orncQ" role="9aQIa">
                 <node concept="3clFbS" id="7PIfE8orncR" role="9aQI4">
                   <node concept="3D7k6m" id="7PIfE8orogd" role="3cqZAp">
-                    <property role="3D7k6l" value="FAILURE" />
+                    <property role="3D7k6l" value="230qvwa_7bs/FAILURE" />
                   </node>
                 </node>
               </node>
@@ -1759,7 +1748,7 @@
     <property role="TrG5h" value="CacheReset" />
     <node concept="15KeUm" id="2d4Z3BTCYfB" role="15LFul">
       <property role="TrG5h" value="resetCache" />
-      <property role="2w7fpF" value="PASSTHRU" />
+      <property role="2w7fpF" value="1t0JkeRn4G_/PASSTHRU" />
       <node concept="2aLE7I" id="2d4Z3BTCYfC" role="ElM8M">
         <node concept="ElOhj" id="2d4Z3BTCYfD" role="2aLE7H">
           <node concept="3clFbS" id="2d4Z3BTCYfE" role="2VODD2">
@@ -1773,7 +1762,6 @@
         </node>
       </node>
       <node concept="15KeVb" id="2d4Z3BTCYfN" role="15LFui">
-        <property role="3HPxAp" value="BEFORE" />
         <ref role="15KeV8" to="tpcq:5L5h3brvz7k" resolve="checkParameters" />
       </node>
     </node>
@@ -3391,9 +3379,8 @@
     <node concept="15KeUm" id="1dvvq0YFimA" role="15LFul">
       <property role="TrG5h" value="addLanguages" />
       <property role="1xVfUM" value="50" />
-      <property role="2w7fpF" value="TRANSFORM" />
       <node concept="15KeVb" id="1dvvq0YKGkQ" role="15LFui">
-        <property role="3HPxAp" value="AFTER" />
+        <property role="3HPxAp" value="7fB872ucjBA/AFTER" />
         <ref role="15KeV8" to="tpcq:5L5h3brvz8m" resolve="configure" />
       </node>
       <node concept="15KeVb" id="1dvvq0YL$xX" role="15LFui">
@@ -3600,7 +3587,7 @@
         <node concept="3clFbJ" id="34wrZhDTHot" role="3cqZAp">
           <node concept="3clFbS" id="34wrZhDTHow" role="3clFbx">
             <node concept="2xdQw9" id="2Fugwv5QbpF" role="3cqZAp">
-              <property role="2xdLsb" value="error" />
+              <property role="2xdLsb" value="gZ5fh_4/error" />
               <node concept="3cpWs3" id="34wrZhDTQ$d" role="9lYJi">
                 <node concept="Xl_RD" id="34wrZhDTQFM" role="3uHU7w">
                   <property role="Xl_RC" value=" already added" />

--- a/code/languages/com.mbeddr.core/languages/com.mbeddr.core.make/languageModels/typesystem.mps
+++ b/code/languages/com.mbeddr.core/languages/com.mbeddr.core.make/languageModels/typesystem.mps
@@ -127,7 +127,7 @@
       </concept>
       <concept id="1208890769693" name="jetbrains.mps.baseLanguage.structure.ArrayLengthOperation" flags="nn" index="1Rwk04" />
       <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="nn" index="3SKdUt">
-        <child id="1350122676458893092" name="text" index="3ndbpf" />
+        <child id="8356039341262087992" name="line" index="1aUNEU" />
       </concept>
       <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
     </language>
@@ -894,7 +894,7 @@
     <property role="3GE5qa" value="items" />
     <node concept="3clFbS" id="4QnOXkB1M4R" role="18ibNy">
       <node concept="3SKdUt" id="7EZ1Spo05vQ" role="3cqZAp">
-        <node concept="1PaTwC" id="3thiB5GVRlk" role="3ndbpf">
+        <node concept="1PaTwC" id="3thiB5GVRlk" role="1aUNEU">
           <node concept="3oM_SD" id="3thiB5GVRlm" role="1PaTwD">
             <property role="3oM_SC" value="Automatic" />
           </node>
@@ -995,7 +995,7 @@
                 <node concept="3eNFk2" id="7EZ1Spof9pu" role="3eNLev">
                   <node concept="3clFbS" id="7EZ1Spof9pv" role="3eOfB_">
                     <node concept="3SKdUt" id="7EZ1Spof9pw" role="3cqZAp">
-                      <node concept="1PaTwC" id="3thiB5GVRhx" role="3ndbpf">
+                      <node concept="1PaTwC" id="3thiB5GVRhx" role="1aUNEU">
                         <node concept="3oM_SD" id="3thiB5GVRhz" role="1PaTwD">
                           <property role="3oM_SC" value="Detect" />
                         </node>
@@ -1240,7 +1240,7 @@
                     </node>
                     <node concept="3clFbH" id="7EZ1Spof9qA" role="3cqZAp" />
                     <node concept="3SKdUt" id="7EZ1Spof9qB" role="3cqZAp">
-                      <node concept="1PaTwC" id="3thiB5GVRhi" role="3ndbpf">
+                      <node concept="1PaTwC" id="3thiB5GVRhi" role="1aUNEU">
                         <node concept="3oM_SD" id="3thiB5GVRhk" role="1PaTwD">
                           <property role="3oM_SC" value="Detect" />
                         </node>
@@ -1325,7 +1325,7 @@
                     </node>
                     <node concept="3clFbH" id="7EZ1Spof9r2" role="3cqZAp" />
                     <node concept="3SKdUt" id="7EZ1Spof9r3" role="3cqZAp">
-                      <node concept="1PaTwC" id="3thiB5GVRh3" role="3ndbpf">
+                      <node concept="1PaTwC" id="3thiB5GVRh3" role="1aUNEU">
                         <node concept="3oM_SD" id="3thiB5GVRh5" role="1PaTwD">
                           <property role="3oM_SC" value="Detect" />
                         </node>
@@ -1444,9 +1444,7 @@
                           <ref role="3TsBF5" to="i2y7:2Vizpn2Mx$$" resolve="text" />
                         </node>
                       </node>
-                      <node concept="17S1cR" id="7EZ1SpoffaX" role="2OqNvi">
-                        <property role="17S1cK" value="both" />
-                      </node>
+                      <node concept="17S1cR" id="7EZ1SpoffaX" role="2OqNvi" />
                     </node>
                     <node concept="17RvpY" id="7EZ1Spoflov" role="2OqNvi" />
                   </node>
@@ -1482,7 +1480,7 @@
       </node>
       <node concept="3clFbH" id="2NUzdxFjqeF" role="3cqZAp" />
       <node concept="3SKdUt" id="7EZ1Spo08$t" role="3cqZAp">
-        <node concept="1PaTwC" id="3thiB5GVRgO" role="3ndbpf">
+        <node concept="1PaTwC" id="3thiB5GVRgO" role="1aUNEU">
           <node concept="3oM_SD" id="3thiB5GVRgQ" role="1PaTwD">
             <property role="3oM_SC" value="Manual" />
           </node>
@@ -1500,7 +1498,7 @@
       <node concept="3clFbJ" id="7EZ1SpoFSdI" role="3cqZAp">
         <node concept="3clFbS" id="7EZ1SpoFSdK" role="3clFbx">
           <node concept="3SKdUt" id="7EZ1SpnJPfc" role="3cqZAp">
-            <node concept="1PaTwC" id="3thiB5GVRgy" role="3ndbpf">
+            <node concept="1PaTwC" id="3thiB5GVRgy" role="1aUNEU">
               <node concept="3oM_SD" id="3thiB5GVRg$" role="1PaTwD">
                 <property role="3oM_SC" value="Detect" />
               </node>
@@ -1710,7 +1708,7 @@
           </node>
           <node concept="3clFbH" id="7EZ1SpoGro1" role="3cqZAp" />
           <node concept="3SKdUt" id="7EZ1SpnJXAG" role="3cqZAp">
-            <node concept="1PaTwC" id="3thiB5GVRgj" role="3ndbpf">
+            <node concept="1PaTwC" id="3thiB5GVRgj" role="1aUNEU">
               <node concept="3oM_SD" id="3thiB5GVRgl" role="1PaTwD">
                 <property role="3oM_SC" value="Detect" />
               </node>
@@ -1726,7 +1724,7 @@
             </node>
           </node>
           <node concept="3SKdUt" id="7EZ1SpoarOo" role="3cqZAp">
-            <node concept="1PaTwC" id="3thiB5GVRfe" role="3ndbpf">
+            <node concept="1PaTwC" id="3thiB5GVRfe" role="1aUNEU">
               <node concept="3oM_SD" id="3thiB5GVRfg" role="1PaTwD">
                 <property role="3oM_SC" value="!!" />
               </node>
@@ -1915,7 +1913,7 @@
           </node>
           <node concept="3clFbH" id="7EZ1SpoarIk" role="3cqZAp" />
           <node concept="3SKdUt" id="7EZ1SpnYRE6" role="3cqZAp">
-            <node concept="1PaTwC" id="3thiB5GVReW" role="3ndbpf">
+            <node concept="1PaTwC" id="3thiB5GVReW" role="1aUNEU">
               <node concept="3oM_SD" id="3thiB5GVReY" role="1PaTwD">
                 <property role="3oM_SC" value="Detect" />
               </node>
@@ -2847,9 +2845,7 @@
                               <ref role="3TsBF5" to="i2y7:2Vizpn2Mx$$" resolve="text" />
                             </node>
                           </node>
-                          <node concept="17S1cR" id="ErGx9V99ay" role="2OqNvi">
-                            <property role="17S1cK" value="both" />
-                          </node>
+                          <node concept="17S1cR" id="ErGx9V99ay" role="2OqNvi" />
                         </node>
                         <node concept="17RlXB" id="ErGx9V9d3H" role="2OqNvi" />
                       </node>

--- a/code/languages/com.mbeddr.core/languages/com.mbeddr.core.modules/languageAccessories/com/mbeddr/core/modules/util.mps
+++ b/code/languages/com.mbeddr.core/languages/com.mbeddr.core.modules/languageAccessories/com/mbeddr/core/modules/util.mps
@@ -3,7 +3,7 @@
   <persistence version="9" />
   <languages>
     <use id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc" version="2" />
-    <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="9" />
+    <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="11" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
@@ -86,7 +86,7 @@
         <reference id="5497648299878491909" name="baseVariableDeclaration" index="1M0zk5" />
       </concept>
       <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="nn" index="3SKdUt">
-        <child id="1350122676458893092" name="text" index="3ndbpf" />
+        <child id="8356039341262087992" name="line" index="1aUNEU" />
       </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
     </language>
@@ -318,7 +318,7 @@
         </node>
         <node concept="3clFbH" id="601qOas6EWs" role="3cqZAp" />
         <node concept="3SKdUt" id="601qOas6EWt" role="3cqZAp">
-          <node concept="1PaTwC" id="13p6s1wtiMq" role="3ndbpf">
+          <node concept="1PaTwC" id="13p6s1wtiMq" role="1aUNEU">
             <node concept="3oM_SD" id="13p6s1wtiMr" role="1PaTwD">
               <property role="3oM_SC" value="We" />
             </node>

--- a/code/languages/com.mbeddr.core/languages/com.mbeddr.core.runconfiguration/solutions/pluginSolution/models/com/mbeddr/core/runconfiguration/pluginSolution/plugin.mps
+++ b/code/languages/com.mbeddr.core/languages/com.mbeddr.core.runconfiguration/solutions/pluginSolution/models/com/mbeddr/core/runconfiguration/pluginSolution/plugin.mps
@@ -17,7 +17,7 @@
     <use id="63e0e566-5131-447e-90e3-12ea330e1a00" name="com.mbeddr.mpsutil.blutil" version="1" />
     <use id="92d2ea16-5a42-4fdf-a676-c7604efe3504" name="de.slisson.mps.richtext" version="0" />
     <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="17" />
-    <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="9" />
+    <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="11" />
     <use id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc" version="2" />
     <use id="a247e09e-2435-45ba-b8d2-07e93feba96a" name="jetbrains.mps.baseLanguage.tuples" version="0" />
   </languages>
@@ -390,7 +390,6 @@
       </concept>
       <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="nn" index="3SKdUt">
         <child id="8356039341262087992" name="line" index="1aUNEU" />
-        <child id="1350122676458893092" name="text" index="3ndbpf" />
       </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
       <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
@@ -1724,7 +1723,7 @@
                     <ref role="cht4Q" to="2gv2:7DakfXFco7$" resolve="IBreakpointSupport" />
                   </node>
                 </node>
-                <node concept="3KmjVe" id="59cfP9ua3Sw" role="2Oq$k0" />
+                <node concept="3KmjVe" id="4zyhjowSo2n" role="2Oq$k0" />
               </node>
             </node>
           </node>
@@ -3558,7 +3557,7 @@
                             <node concept="3eNFk2" id="1dHOtDMk2kf" role="3eNLev">
                               <node concept="3clFbS" id="1dHOtDMk2kg" role="3eOfB_">
                                 <node concept="3SKdUt" id="6tcaNIHGg2N" role="3cqZAp">
-                                  <node concept="1PaTwC" id="13p6s1wtiWM" role="3ndbpf">
+                                  <node concept="1PaTwC" id="13p6s1wtiWM" role="1aUNEU">
                                     <node concept="3oM_SD" id="13p6s1wtiWN" role="1PaTwD">
                                       <property role="3oM_SC" value="FIXME" />
                                     </node>
@@ -3604,7 +3603,7 @@
                                   </node>
                                 </node>
                                 <node concept="3SKdUt" id="6tcaNIHHak9" role="3cqZAp">
-                                  <node concept="1PaTwC" id="13p6s1wtiX1" role="3ndbpf">
+                                  <node concept="1PaTwC" id="13p6s1wtiX1" role="1aUNEU">
                                     <node concept="3oM_SD" id="13p6s1wtiX2" role="1PaTwD">
                                       <property role="3oM_SC" value="FIXME" />
                                     </node>
@@ -3842,7 +3841,7 @@
         <node concept="3clFbJ" id="3D3g9moMQSA" role="3cqZAp">
           <node concept="3clFbS" id="3D3g9moMQSB" role="3clFbx">
             <node concept="2xdQw9" id="2Fugwv5QoJn" role="3cqZAp">
-              <property role="2xdLsb" value="error" />
+              <property role="2xdLsb" value="gZ5fh_4/error" />
               <node concept="3cpWs3" id="3D3g9moMQSD" role="9lYJi">
                 <node concept="37vLTw" id="3D3g9moMQUU" role="3uHU7w">
                   <ref role="3cqZAo" node="3D3g9moMQTU" resolve="targetNodeID" />
@@ -5787,7 +5786,7 @@
               </node>
               <node concept="3clFbH" id="17ylwQxlgR9" role="3cqZAp" />
               <node concept="3SKdUt" id="39w1fgPvfJp" role="3cqZAp">
-                <node concept="1PaTwC" id="13p6s1wtiXh" role="3ndbpf">
+                <node concept="1PaTwC" id="13p6s1wtiXh" role="1aUNEU">
                   <node concept="3oM_SD" id="13p6s1wtiXi" role="1PaTwD">
                     <property role="3oM_SC" value="first," />
                   </node>
@@ -10093,7 +10092,7 @@
                                 </node>
                               </node>
                               <node concept="3SKdUt" id="Orr3VbvORT" role="3cqZAp">
-                                <node concept="1PaTwC" id="13p6s1wtiXV" role="3ndbpf">
+                                <node concept="1PaTwC" id="13p6s1wtiXV" role="1aUNEU">
                                   <node concept="3oM_SD" id="13p6s1wtiXW" role="1PaTwD">
                                     <property role="3oM_SC" value="first," />
                                   </node>

--- a/code/languages/com.mbeddr.core/languages/com.mbeddr.core.unittest/generator/template/main@generator.mps
+++ b/code/languages/com.mbeddr.core/languages/com.mbeddr.core.unittest/generator/template/main@generator.mps
@@ -5360,7 +5360,7 @@
   </node>
   <node concept="1pmfR0" id="4JYoVJb56bR">
     <property role="TrG5h" value="resetMessageCountBeforeTest" />
-    <property role="1v3f2W" value="pre_processing" />
+    <property role="1v3f2W" value="hpv1Zf2/pre_processing" />
     <property role="1v3jST" value="true" />
     <node concept="1pplIY" id="4JYoVJb56bS" role="1pqMTA">
       <node concept="3clFbS" id="4JYoVJb56bT" role="2VODD2">
@@ -5463,7 +5463,7 @@
   </node>
   <node concept="1pmfR0" id="5usoWIKpmeA">
     <property role="TrG5h" value="importUnitTestModules" />
-    <property role="1v3f2W" value="pre_processing" />
+    <property role="1v3f2W" value="hpv1Zf2/pre_processing" />
     <property role="1v3jST" value="true" />
     <node concept="1pplIY" id="5usoWIKpmeB" role="1pqMTA">
       <node concept="3clFbS" id="5usoWIKpmeC" role="2VODD2">
@@ -5878,7 +5878,6 @@
   </node>
   <node concept="1pmfR0" id="2dCF6FyLIaI">
     <property role="TrG5h" value="rebindUnitTestMessages" />
-    <property role="1v3f2W" value="post_processing" />
     <property role="1v3jST" value="true" />
     <node concept="1pplIY" id="2dCF6FyLIaJ" role="1pqMTA">
       <node concept="3clFbS" id="2dCF6FyLIaK" role="2VODD2">

--- a/code/languages/com.mbeddr.core/languages/com.mbeddr.core.util/languageModels/behavior.mps
+++ b/code/languages/com.mbeddr.core/languages/com.mbeddr.core.util/languageModels/behavior.mps
@@ -239,7 +239,7 @@
         <reference id="5497648299878491909" name="baseVariableDeclaration" index="1M0zk5" />
       </concept>
       <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="nn" index="3SKdUt">
-        <child id="1350122676458893092" name="text" index="3ndbpf" />
+        <child id="8356039341262087992" name="line" index="1aUNEU" />
       </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
       <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
@@ -7945,7 +7945,7 @@
             </node>
             <node concept="3clFbS" id="2iF7bNc9KlL" role="3Kbo56">
               <node concept="3SKdUt" id="6TPUpo$Sr4g" role="3cqZAp">
-                <node concept="1PaTwC" id="2iF7bNcl0ii" role="3ndbpf">
+                <node concept="1PaTwC" id="2iF7bNcl0ii" role="1aUNEU">
                   <node concept="3oM_SD" id="6TPUpo$Sr4F" role="1PaTwD">
                     <property role="3oM_SC" value="Return" />
                   </node>
@@ -7962,7 +7962,9 @@
                     <property role="3oM_SC" value="message" />
                   </node>
                 </node>
-                <node concept="1PaTwC" id="6TPUpo$Sr5w" role="3ndbpf">
+              </node>
+              <node concept="3SKdUt" id="4zyhjowSn$0" role="3cqZAp">
+                <node concept="1PaTwC" id="6TPUpo$Sr5w" role="1aUNEU">
                   <node concept="3oM_SD" id="6TPUpo$Sr5v" role="1PaTwD">
                     <property role="3oM_SC" value="-" />
                   </node>
@@ -7976,7 +7978,9 @@
                     <property role="3oM_SC" value="or" />
                   </node>
                 </node>
-                <node concept="1PaTwC" id="6TPUpo$Sr6p" role="3ndbpf">
+              </node>
+              <node concept="3SKdUt" id="4zyhjowSnzX" role="3cqZAp">
+                <node concept="1PaTwC" id="6TPUpo$Sr6p" role="1aUNEU">
                   <node concept="3oM_SD" id="6TPUpo$Sr6o" role="1PaTwD">
                     <property role="3oM_SC" value="-" />
                   </node>
@@ -8005,7 +8009,9 @@
                     <property role="3oM_SC" value="or" />
                   </node>
                 </node>
-                <node concept="1PaTwC" id="67sryxwAVw" role="3ndbpf">
+              </node>
+              <node concept="3SKdUt" id="4zyhjowSnzU" role="3cqZAp">
+                <node concept="1PaTwC" id="67sryxwAVw" role="1aUNEU">
                   <node concept="3oM_SD" id="67sryxwAY_" role="1PaTwD">
                     <property role="3oM_SC" value="-" />
                   </node>
@@ -8040,7 +8046,9 @@
                     <property role="3oM_SC" value="or" />
                   </node>
                 </node>
-                <node concept="1PaTwC" id="6TPUpo_egMV" role="3ndbpf">
+              </node>
+              <node concept="3SKdUt" id="4zyhjowSnzR" role="3cqZAp">
+                <node concept="1PaTwC" id="6TPUpo_egMV" role="1aUNEU">
                   <node concept="3oM_SD" id="6TPUpo_egMU" role="1PaTwD">
                     <property role="3oM_SC" value="-" />
                   </node>
@@ -8063,7 +8071,9 @@
                     <property role="3oM_SC" value="or" />
                   </node>
                 </node>
-                <node concept="1PaTwC" id="6TPUpo_egBA" role="3ndbpf">
+              </node>
+              <node concept="3SKdUt" id="4zyhjowSnzO" role="3cqZAp">
+                <node concept="1PaTwC" id="6TPUpo_egBA" role="1aUNEU">
                   <node concept="3oM_SD" id="6TPUpo_egDn" role="1PaTwD">
                     <property role="3oM_SC" value="-" />
                   </node>
@@ -8098,7 +8108,9 @@
                     <property role="3oM_SC" value="or" />
                   </node>
                 </node>
-                <node concept="1PaTwC" id="3$f8hf_MZCU" role="3ndbpf">
+              </node>
+              <node concept="3SKdUt" id="4zyhjowSnzL" role="3cqZAp">
+                <node concept="1PaTwC" id="3$f8hf_MZCU" role="1aUNEU">
                   <node concept="3oM_SD" id="3$f8hf_MZCT" role="1PaTwD">
                     <property role="3oM_SC" value="-" />
                   </node>
@@ -8133,7 +8145,9 @@
                     <property role="3oM_SC" value="or" />
                   </node>
                 </node>
-                <node concept="1PaTwC" id="6leHaJbkWHO" role="3ndbpf">
+              </node>
+              <node concept="3SKdUt" id="4zyhjowSnzI" role="3cqZAp">
+                <node concept="1PaTwC" id="6leHaJbkWHO" role="1aUNEU">
                   <node concept="3oM_SD" id="6leHaJbkWHN" role="1PaTwD">
                     <property role="3oM_SC" value="-" />
                   </node>
@@ -8156,7 +8170,9 @@
                     <property role="3oM_SC" value="or" />
                   </node>
                 </node>
-                <node concept="1PaTwC" id="3$f8hf_N7Zj" role="3ndbpf">
+              </node>
+              <node concept="3SKdUt" id="4zyhjowSnzF" role="3cqZAp">
+                <node concept="1PaTwC" id="3$f8hf_N7Zj" role="1aUNEU">
                   <node concept="3oM_SD" id="3$f8hf_N7Zi" role="1PaTwD">
                     <property role="3oM_SC" value="-" />
                   </node>
@@ -8271,7 +8287,7 @@
             </node>
             <node concept="3clFbS" id="2iF7bNc9gJX" role="3Kbo56">
               <node concept="3SKdUt" id="3PUmE2lLNbI" role="3cqZAp">
-                <node concept="1PaTwC" id="3PUmE2lLNbJ" role="3ndbpf">
+                <node concept="1PaTwC" id="3PUmE2lLNbJ" role="1aUNEU">
                   <node concept="3oM_SD" id="3PUmE2lLNbL" role="1PaTwD">
                     <property role="3oM_SC" value="Return" />
                   </node>
@@ -8291,7 +8307,9 @@
                     <property role="3oM_SC" value="" />
                   </node>
                 </node>
-                <node concept="1PaTwC" id="3PUmE2m979b" role="3ndbpf">
+              </node>
+              <node concept="3SKdUt" id="4zyhjowSn$l" role="3cqZAp">
+                <node concept="1PaTwC" id="3PUmE2m979b" role="1aUNEU">
                   <node concept="3oM_SD" id="3PUmE2m979a" role="1PaTwD">
                     <property role="3oM_SC" value="-" />
                   </node>
@@ -8308,7 +8326,9 @@
                     <property role="3oM_SC" value="" />
                   </node>
                 </node>
-                <node concept="1PaTwC" id="3PUmE2m97tj" role="3ndbpf">
+              </node>
+              <node concept="3SKdUt" id="4zyhjowSn$i" role="3cqZAp">
+                <node concept="1PaTwC" id="3PUmE2m97tj" role="1aUNEU">
                   <node concept="3oM_SD" id="3PUmE2m97ti" role="1PaTwD">
                     <property role="3oM_SC" value="-" />
                   </node>
@@ -8340,7 +8360,9 @@
                     <property role="3oM_SC" value="" />
                   </node>
                 </node>
-                <node concept="1PaTwC" id="3PUmE2m97z5" role="3ndbpf">
+              </node>
+              <node concept="3SKdUt" id="4zyhjowSn$f" role="3cqZAp">
+                <node concept="1PaTwC" id="3PUmE2m97z5" role="1aUNEU">
                   <node concept="3oM_SD" id="3PUmE2m97z4" role="1PaTwD">
                     <property role="3oM_SC" value="-" />
                   </node>
@@ -8381,7 +8403,9 @@
                     <property role="3oM_SC" value="or" />
                   </node>
                 </node>
-                <node concept="1PaTwC" id="3PUmE2m4gX7" role="3ndbpf">
+              </node>
+              <node concept="3SKdUt" id="4zyhjowSn$c" role="3cqZAp">
+                <node concept="1PaTwC" id="3PUmE2m4gX7" role="1aUNEU">
                   <node concept="3oM_SD" id="3PUmE2m4gX6" role="1PaTwD">
                     <property role="3oM_SC" value="-" />
                   </node>
@@ -8416,7 +8440,9 @@
                     <property role="3oM_SC" value="or" />
                   </node>
                 </node>
-                <node concept="1PaTwC" id="3$f8hf_NinG" role="3ndbpf">
+              </node>
+              <node concept="3SKdUt" id="4zyhjowSn$9" role="3cqZAp">
+                <node concept="1PaTwC" id="3$f8hf_NinG" role="1aUNEU">
                   <node concept="3oM_SD" id="3$f8hf_NinF" role="1PaTwD">
                     <property role="3oM_SC" value="-" />
                   </node>
@@ -8451,7 +8477,9 @@
                     <property role="3oM_SC" value="or" />
                   </node>
                 </node>
-                <node concept="1PaTwC" id="6leHaJbl0l8" role="3ndbpf">
+              </node>
+              <node concept="3SKdUt" id="4zyhjowSn$6" role="3cqZAp">
+                <node concept="1PaTwC" id="6leHaJbl0l8" role="1aUNEU">
                   <node concept="3oM_SD" id="6leHaJbl0l7" role="1PaTwD">
                     <property role="3oM_SC" value="-" />
                   </node>
@@ -8474,7 +8502,9 @@
                     <property role="3oM_SC" value="or" />
                   </node>
                 </node>
-                <node concept="1PaTwC" id="3$f8hf_NmoJ" role="3ndbpf">
+              </node>
+              <node concept="3SKdUt" id="4zyhjowSn$3" role="3cqZAp">
+                <node concept="1PaTwC" id="3$f8hf_NmoJ" role="1aUNEU">
                   <node concept="3oM_SD" id="3$f8hf_NmoI" role="1PaTwD">
                     <property role="3oM_SC" value="-" />
                   </node>

--- a/code/languages/com.mbeddr.core/tests/aLibrary/models/aLibrary.lib.mps
+++ b/code/languages/com.mbeddr.core/tests/aLibrary/models/aLibrary.lib.mps
@@ -33,8 +33,8 @@
         <reference id="7717755763392524108" name="module" index="2v9HqP" />
       </concept>
       <concept id="5323740605968447022" name="com.mbeddr.core.buildconfig.structure.DesktopPlatform" flags="ng" index="2AWWZL">
-        <property id="5323740605968447025" name="cCompilerOptions" index="2AWWZI" />
-        <property id="5323740605968447024" name="cCompiler" index="2AWWZJ" />
+        <property id="5323740605968447025" name="compilerOptions" index="2AWWZI" />
+        <property id="5323740605968447024" name="compiler" index="2AWWZJ" />
         <property id="1253797277664981186" name="cppCompilerOptions" index="UXd4T" />
         <property id="1253797277664981177" name="cppCompiler" index="UXd52" />
         <property id="3963667026125442601" name="gdb" index="3r8Kw1" />

--- a/code/languages/com.mbeddr.core/tests/test.ex.core/reexports.mps
+++ b/code/languages/com.mbeddr.core/tests/test.ex.core/reexports.mps
@@ -36,8 +36,8 @@
         <reference id="7717755763392524108" name="module" index="2v9HqP" />
       </concept>
       <concept id="5323740605968447022" name="com.mbeddr.core.buildconfig.structure.DesktopPlatform" flags="ng" index="2AWWZL">
-        <property id="5323740605968447025" name="cCompilerOptions" index="2AWWZI" />
-        <property id="5323740605968447024" name="cCompiler" index="2AWWZJ" />
+        <property id="5323740605968447025" name="compilerOptions" index="2AWWZI" />
+        <property id="5323740605968447024" name="compiler" index="2AWWZJ" />
         <property id="1253797277664981186" name="cppCompilerOptions" index="UXd4T" />
         <property id="1253797277664981177" name="cppCompiler" index="UXd52" />
         <property id="3963667026125442601" name="gdb" index="3r8Kw1" />

--- a/code/languages/com.mbeddr.core/tests/test.ex.core/test/ex/core/c90.mps
+++ b/code/languages/com.mbeddr.core/tests/test.ex.core/test/ex/core/c90.mps
@@ -64,8 +64,8 @@
         <reference id="7717755763392524108" name="module" index="2v9HqP" />
       </concept>
       <concept id="5323740605968447022" name="com.mbeddr.core.buildconfig.structure.DesktopPlatform" flags="ng" index="2AWWZL">
-        <property id="5323740605968447025" name="cCompilerOptions" index="2AWWZI" />
-        <property id="5323740605968447024" name="cCompiler" index="2AWWZJ" />
+        <property id="5323740605968447025" name="compilerOptions" index="2AWWZI" />
+        <property id="5323740605968447024" name="compiler" index="2AWWZJ" />
         <property id="1253797277664981186" name="cppCompilerOptions" index="UXd4T" />
         <property id="1253797277664981177" name="cppCompiler" index="UXd52" />
         <property id="3963667026125442601" name="gdb" index="3r8Kw1" />

--- a/code/languages/com.mbeddr.core/tests/test.ex.core/test/ex/core/globals.mps
+++ b/code/languages/com.mbeddr.core/tests/test.ex.core/test/ex/core/globals.mps
@@ -34,8 +34,8 @@
         <reference id="7717755763392524108" name="module" index="2v9HqP" />
       </concept>
       <concept id="5323740605968447022" name="com.mbeddr.core.buildconfig.structure.DesktopPlatform" flags="ng" index="2AWWZL">
-        <property id="5323740605968447025" name="cCompilerOptions" index="2AWWZI" />
-        <property id="5323740605968447024" name="cCompiler" index="2AWWZJ" />
+        <property id="5323740605968447025" name="compilerOptions" index="2AWWZI" />
+        <property id="5323740605968447024" name="compiler" index="2AWWZJ" />
         <property id="1253797277664981186" name="cppCompilerOptions" index="UXd4T" />
         <property id="1253797277664981177" name="cppCompiler" index="UXd52" />
         <property id="3963667026125442601" name="gdb" index="3r8Kw1" />

--- a/code/languages/com.mbeddr.core/tests/test.ex.core/test/ex/core/gswitchBlockExpr.mps
+++ b/code/languages/com.mbeddr.core/tests/test.ex.core/test/ex/core/gswitchBlockExpr.mps
@@ -52,8 +52,8 @@
         <reference id="7717755763392524108" name="module" index="2v9HqP" />
       </concept>
       <concept id="5323740605968447022" name="com.mbeddr.core.buildconfig.structure.DesktopPlatform" flags="ng" index="2AWWZL">
-        <property id="5323740605968447025" name="cCompilerOptions" index="2AWWZI" />
-        <property id="5323740605968447024" name="cCompiler" index="2AWWZJ" />
+        <property id="5323740605968447025" name="compilerOptions" index="2AWWZI" />
+        <property id="5323740605968447024" name="compiler" index="2AWWZJ" />
         <property id="1253797277664981186" name="cppCompilerOptions" index="UXd4T" />
         <property id="1253797277664981177" name="cppCompiler" index="UXd52" />
         <property id="3963667026125442601" name="gdb" index="3r8Kw1" />

--- a/code/languages/com.mbeddr.core/tests/test.ex.core/test/ex/core/nameShortening.mps
+++ b/code/languages/com.mbeddr.core/tests/test.ex.core/test/ex/core/nameShortening.mps
@@ -31,8 +31,8 @@
         <reference id="7717755763392524108" name="module" index="2v9HqP" />
       </concept>
       <concept id="5323740605968447022" name="com.mbeddr.core.buildconfig.structure.DesktopPlatform" flags="ng" index="2AWWZL">
-        <property id="5323740605968447025" name="cCompilerOptions" index="2AWWZI" />
-        <property id="5323740605968447024" name="cCompiler" index="2AWWZJ" />
+        <property id="5323740605968447025" name="compilerOptions" index="2AWWZI" />
+        <property id="5323740605968447024" name="compiler" index="2AWWZJ" />
         <property id="1253797277664981186" name="cppCompilerOptions" index="UXd4T" />
         <property id="1253797277664981177" name="cppCompiler" index="UXd52" />
         <property id="3963667026125442601" name="gdb" index="3r8Kw1" />

--- a/code/languages/com.mbeddr.core/tests/test.ex.core/test/ex/core/strings.mps
+++ b/code/languages/com.mbeddr.core/tests/test.ex.core/test/ex/core/strings.mps
@@ -38,8 +38,8 @@
         <reference id="7717755763392524108" name="module" index="2v9HqP" />
       </concept>
       <concept id="5323740605968447022" name="com.mbeddr.core.buildconfig.structure.DesktopPlatform" flags="ng" index="2AWWZL">
-        <property id="5323740605968447025" name="cCompilerOptions" index="2AWWZI" />
-        <property id="5323740605968447024" name="cCompiler" index="2AWWZJ" />
+        <property id="5323740605968447025" name="compilerOptions" index="2AWWZI" />
+        <property id="5323740605968447024" name="compiler" index="2AWWZJ" />
         <property id="1253797277664981186" name="cppCompilerOptions" index="UXd4T" />
         <property id="1253797277664981177" name="cppCompiler" index="UXd52" />
         <property id="3963667026125442601" name="gdb" index="3r8Kw1" />

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.actionsfilter/languageModels/behavior.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.actionsfilter/languageModels/behavior.mps
@@ -76,6 +76,7 @@
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
       </concept>
+      <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT" />
       <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
         <child id="1068581517676" name="expression" index="3cqZAk" />
       </concept>
@@ -463,6 +464,71 @@
     </node>
     <node concept="13hLZK" id="5ReuVUpd_x0" role="13h7CW">
       <node concept="3clFbS" id="5ReuVUpd_x1" role="2VODD2" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="5wANKxaV9gi">
+    <property role="3GE5qa" value="toolBar" />
+    <ref role="13h7C2" to="au0v:6nrtUqYelxV" resolve="ToolBarAction" />
+    <node concept="13hLZK" id="5wANKxaV9gj" role="13h7CW">
+      <node concept="3clFbS" id="5wANKxaV9gk" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="5wANKxaV9gt" role="13h7CS">
+      <property role="TrG5h" value="refersToActionId" />
+      <ref role="13i0hy" node="5ReuVUpdzR3" resolve="refersToActionId" />
+      <node concept="3Tm1VV" id="5wANKxaV9gu" role="1B3o_S" />
+      <node concept="3clFbS" id="5wANKxaV9gz" role="3clF47">
+        <node concept="3cpWs6" id="5wANKxaV9D4" role="3cqZAp">
+          <node concept="1Wc70l" id="5wANKxaV9D5" role="3cqZAk">
+            <node concept="3y3z36" id="5wANKxaV9D6" role="3uHU7B">
+              <node concept="10Nm6u" id="5wANKxaV9D7" role="3uHU7w" />
+              <node concept="37vLTw" id="5wANKxaV9D8" role="3uHU7B">
+                <ref role="3cqZAo" node="5wANKxaV9g$" resolve="id" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="5wANKxaV9D9" role="3uHU7w">
+              <node concept="37vLTw" id="5wANKxaV9Da" role="2Oq$k0">
+                <ref role="3cqZAo" node="5wANKxaV9g$" resolve="id" />
+              </node>
+              <node concept="liA8E" id="5wANKxaV9Db" role="2OqNvi">
+                <ref role="37wK5l" to="wyt6:~String.equals(java.lang.Object)" resolve="equals" />
+                <node concept="2OqwBi" id="5wANKxaV9Dc" role="37wK5m">
+                  <node concept="13iPFW" id="5wANKxaV9Dd" role="2Oq$k0" />
+                  <node concept="3TrcHB" id="5wANKxaV9De" role="2OqNvi">
+                    <ref role="3TsBF5" to="au0v:6nrtUqYfdz4" resolve="actionID" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="5wANKxaV9g$" role="3clF46">
+        <property role="TrG5h" value="id" />
+        <node concept="17QB3L" id="5wANKxaV9g_" role="1tU5fm" />
+      </node>
+      <node concept="10P_77" id="5wANKxaV9gA" role="3clF45" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="5wANKxaV9kB">
+    <property role="3GE5qa" value="toolBar" />
+    <ref role="13h7C2" to="au0v:6nrtUqYelxW" resolve="ToolBarSeparator" />
+    <node concept="13hLZK" id="5wANKxaV9kC" role="13h7CW">
+      <node concept="3clFbS" id="5wANKxaV9kD" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="5wANKxaV9kM" role="13h7CS">
+      <property role="TrG5h" value="refersToActionId" />
+      <ref role="13i0hy" node="5ReuVUpdzR3" resolve="refersToActionId" />
+      <node concept="3Tm1VV" id="5wANKxaV9kN" role="1B3o_S" />
+      <node concept="3clFbS" id="5wANKxaV9kS" role="3clF47">
+        <node concept="3clFbF" id="5wANKxaV9kX" role="3cqZAp">
+          <node concept="3clFbT" id="5wANKxaV9kW" role="3clFbG" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="5wANKxaV9kT" role="3clF46">
+        <property role="TrG5h" value="id" />
+        <node concept="17QB3L" id="5wANKxaV9kU" role="1tU5fm" />
+      </node>
+      <node concept="10P_77" id="5wANKxaV9kV" role="3clF45" />
     </node>
   </node>
 </model>

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.actionsfilter/languageModels/editor.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.actionsfilter/languageModels/editor.mps
@@ -1189,7 +1189,7 @@
                 <node concept="1Y3b0j" id="7LkwBl9Kj0N" role="YeSDq">
                   <property role="2bfB8j" value="true" />
                   <ref role="1Y3XeK" to="hdil:4g2H4r3V4OE" resolve="EditorCell_Checkbox" />
-                  <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
+                  <ref role="37wK5l" to="hdil:4g2H4r3V7I2" resolve="EditorCell_Checkbox" />
                   <node concept="3Tm1VV" id="7LkwBl9Kj0O" role="1B3o_S" />
                   <node concept="37vLTw" id="7LkwBl9JNVc" role="37wK5m">
                     <ref role="3cqZAo" node="7LkwBl9ImJ8" resolve="myEditorContext" />

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.asynccell.sandbox/models/behavior.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.asynccell.sandbox/models/behavior.mps
@@ -11,9 +11,13 @@
     <import index="dxuu" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:javax.swing(JDK/)" />
     <import index="hyam" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt.event(JDK/)" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" />
+    <import index="m1yg" ref="f:diff_old#r:515ec77b-87d0-4871-9d0a-f5cfa3bbab14(com.mbeddr.mpsutil.asynccell.sandbox.behavior@old)" implicit="true" />
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1082485599095" name="jetbrains.mps.baseLanguage.structure.BlockStatement" flags="nn" index="9aQIb">
+        <child id="1082485599096" name="statements" index="9aQI4" />
+      </concept>
       <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
         <child id="1068498886297" name="rValue" index="37vLTx" />
         <child id="1068498886295" name="lValue" index="37vLTJ" />
@@ -41,10 +45,10 @@
       <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
         <property id="1070475926801" name="value" index="Xl_RC" />
       </concept>
-      <concept id="1182160077978" name="jetbrains.mps.baseLanguage.structure.AnonymousClassCreator" flags="nn" index="YeOm9">
-        <child id="1182160096073" name="cls" index="YeSDq" />
-      </concept>
       <concept id="1081236700938" name="jetbrains.mps.baseLanguage.structure.StaticMethodDeclaration" flags="ig" index="2YIFZL" />
+      <concept id="1164991038168" name="jetbrains.mps.baseLanguage.structure.ThrowStatement" flags="nn" index="YS8fn">
+        <child id="1164991057263" name="throwable" index="YScLw" />
+      </concept>
       <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
       <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
       <concept id="1068390468200" name="jetbrains.mps.baseLanguage.structure.FieldDeclaration" flags="ig" index="312cEg">
@@ -81,6 +85,7 @@
       </concept>
       <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
       <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
+        <child id="1082485599094" name="ifFalseStatement" index="9aQIa" />
         <child id="1068580123160" name="condition" index="3clFbw" />
         <child id="1068580123161" name="ifTrue" index="3clFbx" />
       </concept>
@@ -101,7 +106,6 @@
       </concept>
       <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk" />
       <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
-        <property id="521412098689998745" name="nonStatic" index="2bfB8j" />
         <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
       </concept>
       <concept id="7812454656619025416" name="jetbrains.mps.baseLanguage.structure.MethodDeclaration" flags="ng" index="1rXfSm">
@@ -122,8 +126,11 @@
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
       <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
       <concept id="1146644641414" name="jetbrains.mps.baseLanguage.structure.ProtectedVisibility" flags="nn" index="3Tmbuc" />
-      <concept id="1170345865475" name="jetbrains.mps.baseLanguage.structure.AnonymousClass" flags="ig" index="1Y3b0j">
-        <reference id="1170346070688" name="classifier" index="1Y3XeK" />
+    </language>
+    <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
+      <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
+        <child id="1199569906740" name="parameter" index="1bW2Oz" />
+        <child id="1199569916463" name="body" index="1bW5cS" />
       </concept>
     </language>
     <language id="760a0a8c-eabb-4521-8bfd-65db761a9ba3" name="jetbrains.mps.baseLanguage.logging">
@@ -168,6 +175,14 @@
       <node concept="Xl_RD" id="2u$73V9sRz5" role="33vP2m">
         <property role="Xl_RC" value="my value" />
       </node>
+    </node>
+    <node concept="312cEg" id="2YOONxNStSE" role="jymVt">
+      <property role="TrG5h" value="exception" />
+      <node concept="3Tmbuc" id="2YOONxNStw7" role="1B3o_S" />
+      <node concept="3uibUv" id="2YOONxNSvNh" role="1tU5fm">
+        <ref role="3uigEE" to="wyt6:~RuntimeException" resolve="RuntimeException" />
+      </node>
+      <node concept="10Nm6u" id="2YOONxNSujU" role="33vP2m" />
     </node>
     <node concept="2tJIrI" id="17HIJlKZysZ" role="jymVt" />
     <node concept="2YIFZL" id="17HIJlL07UK" role="jymVt">
@@ -216,20 +231,55 @@
       <property role="DiZV1" value="false" />
       <property role="2aFKle" value="false" />
       <node concept="3clFbS" id="17HIJlL090f" role="3clF47">
-        <node concept="RRSsy" id="17HIJlL0sRI" role="3cqZAp">
-          <property role="RRSoG" value="gZ5fksE/warn" />
-          <node concept="3cpWs3" id="MypZlGVbiz" role="RRSoy">
-            <node concept="37vLTw" id="MypZlGVbmJ" role="3uHU7w">
-              <ref role="3cqZAo" node="17HIJlKZysM" resolve="value" />
+        <node concept="3clFbJ" id="2YOONxNSuBw" role="3cqZAp">
+          <node concept="3clFbS" id="2YOONxNSuBy" role="3clFbx">
+            <node concept="RRSsy" id="2YOONxNSxKw" role="3cqZAp">
+              <property role="RRSoG" value="warn" />
+              <node concept="3cpWs3" id="2YOONxNSxKx" role="RRSoy">
+                <node concept="Xl_RD" id="2YOONxNSxKz" role="3uHU7B">
+                  <property role="Xl_RC" value="getValue() raises " />
+                </node>
+                <node concept="2OqwBi" id="2YOONxNSyL0" role="3uHU7w">
+                  <node concept="37vLTw" id="2YOONxNSyo6" role="2Oq$k0">
+                    <ref role="3cqZAo" to="m1yg:2YOONxNStSE" resolve="exception" />
+                  </node>
+                  <node concept="liA8E" id="2YOONxNSz1I" role="2OqNvi">
+                    <ref role="37wK5l" to="wyt6:~Throwable.getMessage():java.lang.String" resolve="getMessage" />
+                  </node>
+                </node>
+              </node>
             </node>
-            <node concept="Xl_RD" id="17HIJlL0tmE" role="3uHU7B">
-              <property role="Xl_RC" value="getValue() = " />
+            <node concept="YS8fn" id="2YOONxNSvvx" role="3cqZAp">
+              <node concept="37vLTw" id="2YOONxNSvzI" role="YScLw">
+                <ref role="3cqZAo" to="m1yg:2YOONxNStSE" resolve="exception" />
+              </node>
             </node>
           </node>
-        </node>
-        <node concept="3cpWs6" id="17HIJlL092F" role="3cqZAp">
-          <node concept="37vLTw" id="17HIJlL092U" role="3cqZAk">
-            <ref role="3cqZAo" node="17HIJlKZysM" resolve="value" />
+          <node concept="3y3z36" id="2YOONxNSvlA" role="3clFbw">
+            <node concept="10Nm6u" id="2YOONxNSvpC" role="3uHU7w" />
+            <node concept="37vLTw" id="2YOONxNSuUr" role="3uHU7B">
+              <ref role="3cqZAo" to="m1yg:2YOONxNStSE" resolve="exception" />
+            </node>
+          </node>
+          <node concept="9aQIb" id="2YOONxNSxoE" role="9aQIa">
+            <node concept="3clFbS" id="2YOONxNSxoF" role="9aQI4">
+              <node concept="RRSsy" id="17HIJlL0sRI" role="3cqZAp">
+                <property role="RRSoG" value="warn" />
+                <node concept="3cpWs3" id="MypZlGVbiz" role="RRSoy">
+                  <node concept="37vLTw" id="MypZlGVbmJ" role="3uHU7w">
+                    <ref role="3cqZAo" node="17HIJlKZysM" resolve="value" />
+                  </node>
+                  <node concept="Xl_RD" id="17HIJlL0tmE" role="3uHU7B">
+                    <property role="Xl_RC" value="getValue() = " />
+                  </node>
+                </node>
+              </node>
+              <node concept="3cpWs6" id="17HIJlL092F" role="3cqZAp">
+                <node concept="37vLTw" id="17HIJlL092U" role="3cqZAk">
+                  <ref role="3cqZAo" node="17HIJlKZysM" resolve="value" />
+                </node>
+              </node>
+            </node>
           </node>
         </node>
       </node>
@@ -256,6 +306,17 @@
               </node>
               <node concept="37vLTw" id="17HIJlL0rBK" role="3uHU7w">
                 <ref role="3cqZAo" node="17HIJlL0hC0" resolve="newValue" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="2YOONxNSvXS" role="3cqZAp">
+          <node concept="37vLTI" id="2YOONxNSwG4" role="3clFbG">
+            <node concept="10Nm6u" id="2YOONxNSwNj" role="37vLTx" />
+            <node concept="2OqwBi" id="2YOONxNSw91" role="37vLTJ">
+              <node concept="Xjq3P" id="2YOONxNSvXQ" role="2Oq$k0" />
+              <node concept="2OwXpG" id="2YOONxNSwfa" role="2OqNvi">
+                <ref role="2Oxat5" node="2YOONxNStSE" resolve="exception" />
               </node>
             </node>
           </node>
@@ -289,111 +350,29 @@
       <property role="DiZV1" value="false" />
       <property role="2aFKle" value="false" />
       <node concept="3clFbS" id="17HIJlKZMbi" role="3clF47">
-        <node concept="3clFbF" id="17HIJlL0kz0" role="3cqZAp">
-          <node concept="1rXfSq" id="17HIJlL0kyY" role="3clFbG">
-            <ref role="37wK5l" node="17HIJlL0h$4" resolve="setValue" />
-            <node concept="10Nm6u" id="17HIJlL0kSw" role="37wK5m" />
-          </node>
-        </node>
-        <node concept="3clFbJ" id="17HIJlL0Haz" role="3cqZAp">
-          <node concept="3clFbS" id="17HIJlL0Ha_" role="3clFbx">
-            <node concept="3clFbF" id="17HIJlL0FDE" role="3cqZAp">
-              <node concept="2OqwBi" id="17HIJlL0Gdi" role="3clFbG">
-                <node concept="2OqwBi" id="17HIJlL0FSr" role="2Oq$k0">
-                  <node concept="Xjq3P" id="17HIJlL0FDC" role="2Oq$k0" />
-                  <node concept="2OwXpG" id="17HIJlL0FYQ" role="2OqNvi">
-                    <ref role="2Oxat5" node="17HIJlL0Ew$" resolve="timer" />
-                  </node>
-                </node>
-                <node concept="liA8E" id="17HIJlL0Gns" role="2OqNvi">
-                  <ref role="37wK5l" to="dxuu:~Timer.stop()" resolve="stop" />
-                </node>
-              </node>
+        <node concept="3clFbF" id="2YOONxNRGur" role="3cqZAp">
+          <node concept="1rXfSq" id="2YOONxNRGuq" role="3clFbG">
+            <ref role="37wK5l" node="2YOONxNRGui" resolve="runAfterMsPassed" />
+            <node concept="37vLTw" id="2YOONxNRGup" role="37wK5m">
+              <ref role="3cqZAo" node="17HIJlL0juE" resolve="delayInMs" />
             </node>
-          </node>
-          <node concept="3y3z36" id="17HIJlL0HTv" role="3clFbw">
-            <node concept="10Nm6u" id="17HIJlL0HXo" role="3uHU7w" />
-            <node concept="2OqwBi" id="17HIJlL0Hx1" role="3uHU7B">
-              <node concept="Xjq3P" id="17HIJlL0HkF" role="2Oq$k0" />
-              <node concept="2OwXpG" id="17HIJlL0HCG" role="2OqNvi">
-                <ref role="2Oxat5" node="17HIJlL0Ew$" resolve="timer" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbH" id="17HIJlL0xR0" role="3cqZAp" />
-        <node concept="3clFbF" id="17HIJlL0EwU" role="3cqZAp">
-          <node concept="37vLTI" id="17HIJlL0EwV" role="3clFbG">
-            <node concept="2OqwBi" id="17HIJlL0EwW" role="37vLTJ">
-              <node concept="Xjq3P" id="17HIJlL0EwX" role="2Oq$k0" />
-              <node concept="2OwXpG" id="17HIJlL0EwY" role="2OqNvi">
-                <ref role="2Oxat5" node="17HIJlL0Ew$" resolve="timer" />
-              </node>
-            </node>
-            <node concept="2ShNRf" id="17HIJlL0EwZ" role="37vLTx">
-              <node concept="1pGfFk" id="17HIJlL0Ex0" role="2ShVmc">
-                <ref role="37wK5l" to="dxuu:~Timer.&lt;init&gt;(int,java.awt.event.ActionListener)" resolve="Timer" />
-                <node concept="37vLTw" id="17HIJlL0Ex1" role="37wK5m">
-                  <ref role="3cqZAo" node="17HIJlL0juE" resolve="delayInMs" />
-                </node>
-                <node concept="2ShNRf" id="17HIJlL0Ex2" role="37wK5m">
-                  <node concept="YeOm9" id="17HIJlL0Ex3" role="2ShVmc">
-                    <node concept="1Y3b0j" id="17HIJlL0Ex4" role="YeSDq">
-                      <property role="2bfB8j" value="true" />
-                      <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
-                      <ref role="1Y3XeK" to="hyam:~ActionListener" resolve="ActionListener" />
-                      <node concept="3Tm1VV" id="17HIJlL0Ex5" role="1B3o_S" />
-                      <node concept="3clFb_" id="17HIJlL0Ex6" role="jymVt">
-                        <property role="1EzhhJ" value="false" />
-                        <property role="TrG5h" value="actionPerformed" />
-                        <property role="DiZV1" value="false" />
-                        <property role="od$2w" value="false" />
-                        <node concept="3Tm1VV" id="17HIJlL0Ex7" role="1B3o_S" />
-                        <node concept="3cqZAl" id="17HIJlL0Ex8" role="3clF45" />
-                        <node concept="37vLTG" id="17HIJlL0Ex9" role="3clF46">
-                          <property role="TrG5h" value="p0" />
-                          <node concept="3uibUv" id="17HIJlL0Exa" role="1tU5fm">
-                            <ref role="3uigEE" to="hyam:~ActionEvent" resolve="ActionEvent" />
-                          </node>
-                        </node>
-                        <node concept="3clFbS" id="17HIJlL0Exb" role="3clF47">
-                          <node concept="3clFbF" id="17HIJlL0Exc" role="3cqZAp">
-                            <node concept="1rXfSq" id="17HIJlL0Exd" role="3clFbG">
-                              <ref role="37wK5l" node="17HIJlL0h$4" resolve="setValue" />
-                              <node concept="37vLTw" id="17HIJlL0Exe" role="37wK5m">
-                                <ref role="3cqZAo" node="17HIJlL0js1" resolve="newValue" />
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
+            <node concept="1bVj0M" id="2YOONxNRHGF" role="37wK5m">
+              <node concept="3clFbS" id="2YOONxNRHGH" role="1bW5cS">
+                <node concept="3clFbF" id="2YOONxNRIi1" role="3cqZAp">
+                  <node concept="1rXfSq" id="2YOONxNRGu2" role="3clFbG">
+                    <ref role="37wK5l" node="17HIJlL0h$4" resolve="setValue" />
+                    <node concept="37vLTw" id="2YOONxNRGuo" role="37wK5m">
+                      <ref role="3cqZAo" node="17HIJlL0js1" resolve="newValue" />
                     </node>
                   </node>
                 </node>
               </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="17HIJlL0Bah" role="3cqZAp">
-          <node concept="2OqwBi" id="17HIJlL0Bp7" role="3clFbG">
-            <node concept="37vLTw" id="17HIJlL0GA1" role="2Oq$k0">
-              <ref role="3cqZAo" node="17HIJlL0Ew$" resolve="timer" />
-            </node>
-            <node concept="liA8E" id="17HIJlL0BGc" role="2OqNvi">
-              <ref role="37wK5l" to="dxuu:~Timer.setRepeats(boolean)" resolve="setRepeats" />
-              <node concept="3clFbT" id="17HIJlL0Cz2" role="37wK5m">
-                <property role="3clFbU" value="false" />
+              <node concept="37vLTG" id="2YOONxNRI4J" role="1bW2Oz">
+                <property role="TrG5h" value="p" />
+                <node concept="3uibUv" id="2YOONxNRI4I" role="1tU5fm">
+                  <ref role="3uigEE" to="hyam:~ActionEvent" resolve="ActionEvent" />
+                </node>
               </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="17HIJlL0jEp" role="3cqZAp">
-          <node concept="2OqwBi" id="17HIJlL0pGN" role="3clFbG">
-            <node concept="37vLTw" id="17HIJlL0GGE" role="2Oq$k0">
-              <ref role="3cqZAo" node="17HIJlL0Ew$" resolve="timer" />
-            </node>
-            <node concept="liA8E" id="17HIJlL0pUp" role="2OqNvi">
-              <ref role="37wK5l" to="dxuu:~Timer.start()" resolve="start" />
             </node>
           </node>
         </node>
@@ -411,6 +390,154 @@
       </node>
     </node>
     <node concept="3Tm1VV" id="17HIJlKZys4" role="1B3o_S" />
+    <node concept="3clFb_" id="2YOONxNRN8o" role="jymVt">
+      <property role="1EzhhJ" value="false" />
+      <property role="TrG5h" value="throwAfterMsPassed" />
+      <property role="od$2w" value="false" />
+      <property role="DiZV1" value="false" />
+      <property role="2aFKle" value="false" />
+      <node concept="3clFbS" id="2YOONxNRN8p" role="3clF47">
+        <node concept="3clFbF" id="2YOONxNRN8q" role="3cqZAp">
+          <node concept="1rXfSq" id="2YOONxNRN8r" role="3clFbG">
+            <ref role="37wK5l" node="2YOONxNRGui" resolve="runAfterMsPassed" />
+            <node concept="37vLTw" id="2YOONxNRN8s" role="37wK5m">
+              <ref role="3cqZAo" node="2YOONxNRN8C" resolve="delayInMs" />
+            </node>
+            <node concept="1bVj0M" id="2YOONxNRN8t" role="37wK5m">
+              <node concept="3clFbS" id="2YOONxNRN8u" role="1bW5cS">
+                <node concept="3clFbF" id="2YOONxNSXJA" role="3cqZAp">
+                  <node concept="37vLTI" id="2YOONxNSY7N" role="3clFbG">
+                    <node concept="37vLTw" id="2YOONxNSYnF" role="37vLTx">
+                      <ref role="3cqZAo" node="2YOONxNRN8A" resolve="exception" />
+                    </node>
+                    <node concept="2OqwBi" id="2YOONxNT55h" role="37vLTJ">
+                      <node concept="Xjq3P" id="2YOONxNT4U2" role="2Oq$k0" />
+                      <node concept="2OwXpG" id="2YOONxNT5hB" role="2OqNvi">
+                        <ref role="2Oxat5" node="2YOONxNStSE" resolve="exception" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="37vLTG" id="2YOONxNRN8y" role="1bW2Oz">
+                <property role="TrG5h" value="p" />
+                <node concept="3uibUv" id="2YOONxNRN8z" role="1tU5fm">
+                  <ref role="3uigEE" to="hyam:~ActionEvent" resolve="ActionEvent" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="2YOONxNRN8$" role="1B3o_S" />
+      <node concept="3cqZAl" id="2YOONxNRN8_" role="3clF45" />
+      <node concept="37vLTG" id="2YOONxNRN8A" role="3clF46">
+        <property role="TrG5h" value="exception" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3uibUv" id="2YOONxNT47t" role="1tU5fm">
+          <ref role="3uigEE" to="wyt6:~RuntimeException" resolve="RuntimeException" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="2YOONxNRN8C" role="3clF46">
+        <property role="TrG5h" value="delayInMs" />
+        <node concept="10Oyi0" id="2YOONxNRN8D" role="1tU5fm" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="2YOONxNRGZi" role="jymVt" />
+    <node concept="3clFb_" id="2YOONxNRGui" role="jymVt">
+      <property role="TrG5h" value="runAfterMsPassed" />
+      <node concept="3Tmbuc" id="2YOONxNRGuj" role="1B3o_S" />
+      <node concept="3cqZAl" id="2YOONxNRGuk" role="3clF45" />
+      <node concept="37vLTG" id="2YOONxNRGud" role="3clF46">
+        <property role="TrG5h" value="delayInMs" />
+        <node concept="10Oyi0" id="2YOONxNRGue" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="2YOONxNRMiO" role="3clF46">
+        <property role="TrG5h" value="listener" />
+        <node concept="3uibUv" id="2YOONxNRMF$" role="1tU5fm">
+          <ref role="3uigEE" to="hyam:~ActionListener" resolve="ActionListener" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="2YOONxNRGtt" role="3clF47">
+        <node concept="3clFbF" id="2YOONxNRGtu" role="3cqZAp">
+          <node concept="1rXfSq" id="2YOONxNRGtv" role="3clFbG">
+            <ref role="37wK5l" node="17HIJlL0h$4" resolve="setValue" />
+            <node concept="10Nm6u" id="2YOONxNRGtw" role="37wK5m" />
+          </node>
+        </node>
+        <node concept="3clFbJ" id="2YOONxNRGtx" role="3cqZAp">
+          <node concept="3clFbS" id="2YOONxNRGty" role="3clFbx">
+            <node concept="3clFbF" id="2YOONxNRGtz" role="3cqZAp">
+              <node concept="2OqwBi" id="2YOONxNRGt$" role="3clFbG">
+                <node concept="2OqwBi" id="2YOONxNRGt_" role="2Oq$k0">
+                  <node concept="Xjq3P" id="2YOONxNRGtA" role="2Oq$k0" />
+                  <node concept="2OwXpG" id="2YOONxNRGtB" role="2OqNvi">
+                    <ref role="2Oxat5" node="17HIJlL0Ew$" resolve="timer" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="2YOONxNRGtC" role="2OqNvi">
+                  <ref role="37wK5l" to="dxuu:~Timer.stop():void" resolve="stop" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3y3z36" id="2YOONxNRGtD" role="3clFbw">
+            <node concept="10Nm6u" id="2YOONxNRGtE" role="3uHU7w" />
+            <node concept="2OqwBi" id="2YOONxNRGtF" role="3uHU7B">
+              <node concept="Xjq3P" id="2YOONxNRGtG" role="2Oq$k0" />
+              <node concept="2OwXpG" id="2YOONxNRGtH" role="2OqNvi">
+                <ref role="2Oxat5" node="17HIJlL0Ew$" resolve="timer" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="2YOONxNRGtI" role="3cqZAp" />
+        <node concept="3clFbF" id="2YOONxNRGtJ" role="3cqZAp">
+          <node concept="37vLTI" id="2YOONxNRGtK" role="3clFbG">
+            <node concept="2OqwBi" id="2YOONxNRGtL" role="37vLTJ">
+              <node concept="Xjq3P" id="2YOONxNRGtM" role="2Oq$k0" />
+              <node concept="2OwXpG" id="2YOONxNRGtN" role="2OqNvi">
+                <ref role="2Oxat5" node="17HIJlL0Ew$" resolve="timer" />
+              </node>
+            </node>
+            <node concept="2ShNRf" id="2YOONxNRGtO" role="37vLTx">
+              <node concept="1pGfFk" id="2YOONxNRGtP" role="2ShVmc">
+                <ref role="37wK5l" to="dxuu:~Timer.&lt;init&gt;(int,java.awt.event.ActionListener)" resolve="Timer" />
+                <node concept="37vLTw" id="2YOONxNRGuf" role="37wK5m">
+                  <ref role="3cqZAo" node="2YOONxNRGud" resolve="delayInMs" />
+                </node>
+                <node concept="37vLTw" id="2YOONxNRMWG" role="37wK5m">
+                  <ref role="3cqZAo" node="2YOONxNRMiO" resolve="listener" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="2YOONxNRGu4" role="3cqZAp">
+          <node concept="2OqwBi" id="2YOONxNRGu5" role="3clFbG">
+            <node concept="37vLTw" id="2YOONxNRGu6" role="2Oq$k0">
+              <ref role="3cqZAo" node="17HIJlL0Ew$" resolve="timer" />
+            </node>
+            <node concept="liA8E" id="2YOONxNRGu7" role="2OqNvi">
+              <ref role="37wK5l" to="dxuu:~Timer.setRepeats(boolean):void" resolve="setRepeats" />
+              <node concept="3clFbT" id="2YOONxNRGu8" role="37wK5m">
+                <property role="3clFbU" value="false" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="2YOONxNRGu9" role="3cqZAp">
+          <node concept="2OqwBi" id="2YOONxNRGua" role="3clFbG">
+            <node concept="37vLTw" id="2YOONxNRGub" role="2Oq$k0">
+              <ref role="3cqZAo" node="17HIJlL0Ew$" resolve="timer" />
+            </node>
+            <node concept="liA8E" id="2YOONxNRGuc" role="2OqNvi">
+              <ref role="37wK5l" to="dxuu:~Timer.start():void" resolve="start" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
   </node>
 </model>
 

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.asynccell.sandbox/models/behavior.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.asynccell.sandbox/models/behavior.mps
@@ -11,7 +11,6 @@
     <import index="dxuu" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:javax.swing(JDK/)" />
     <import index="hyam" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt.event(JDK/)" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" />
-    <import index="m1yg" ref="f:diff_old#r:515ec77b-87d0-4871-9d0a-f5cfa3bbab14(com.mbeddr.mpsutil.asynccell.sandbox.behavior@old)" implicit="true" />
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
@@ -241,24 +240,24 @@
                 </node>
                 <node concept="2OqwBi" id="2YOONxNSyL0" role="3uHU7w">
                   <node concept="37vLTw" id="2YOONxNSyo6" role="2Oq$k0">
-                    <ref role="3cqZAo" to="m1yg:2YOONxNStSE" resolve="exception" />
+                    <ref role="3cqZAo" node="2YOONxNStSE" resolve="exception" />
                   </node>
                   <node concept="liA8E" id="2YOONxNSz1I" role="2OqNvi">
-                    <ref role="37wK5l" to="wyt6:~Throwable.getMessage():java.lang.String" resolve="getMessage" />
+                    <ref role="37wK5l" to="wyt6:~Throwable.getMessage()" resolve="getMessage" />
                   </node>
                 </node>
               </node>
             </node>
             <node concept="YS8fn" id="2YOONxNSvvx" role="3cqZAp">
               <node concept="37vLTw" id="2YOONxNSvzI" role="YScLw">
-                <ref role="3cqZAo" to="m1yg:2YOONxNStSE" resolve="exception" />
+                <ref role="3cqZAo" node="2YOONxNStSE" resolve="exception" />
               </node>
             </node>
           </node>
           <node concept="3y3z36" id="2YOONxNSvlA" role="3clFbw">
             <node concept="10Nm6u" id="2YOONxNSvpC" role="3uHU7w" />
             <node concept="37vLTw" id="2YOONxNSuUr" role="3uHU7B">
-              <ref role="3cqZAo" to="m1yg:2YOONxNStSE" resolve="exception" />
+              <ref role="3cqZAo" node="2YOONxNStSE" resolve="exception" />
             </node>
           </node>
           <node concept="9aQIb" id="2YOONxNSxoE" role="9aQIa">

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.asynccell.sandbox/models/behavior.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.asynccell.sandbox/models/behavior.mps
@@ -234,7 +234,7 @@
         <node concept="3clFbJ" id="2YOONxNSuBw" role="3cqZAp">
           <node concept="3clFbS" id="2YOONxNSuBy" role="3clFbx">
             <node concept="RRSsy" id="2YOONxNSxKw" role="3cqZAp">
-              <property role="RRSoG" value="warn" />
+              <property role="RRSoG" value="gZ5fksE/warn" />
               <node concept="3cpWs3" id="2YOONxNSxKx" role="RRSoy">
                 <node concept="Xl_RD" id="2YOONxNSxKz" role="3uHU7B">
                   <property role="Xl_RC" value="getValue() raises " />
@@ -264,7 +264,7 @@
           <node concept="9aQIb" id="2YOONxNSxoE" role="9aQIa">
             <node concept="3clFbS" id="2YOONxNSxoF" role="9aQI4">
               <node concept="RRSsy" id="17HIJlL0sRI" role="3cqZAp">
-                <property role="RRSoG" value="warn" />
+                <property role="RRSoG" value="gZ5fksE/warn" />
                 <node concept="3cpWs3" id="MypZlGVbiz" role="RRSoy">
                   <node concept="37vLTw" id="MypZlGVbmJ" role="3uHU7w">
                     <ref role="3cqZAo" node="17HIJlKZysM" resolve="value" />

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.asynccell.sandbox/models/editor.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.asynccell.sandbox/models/editor.mps
@@ -151,6 +151,7 @@
     </language>
     <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
       <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
+        <child id="1199569906740" name="parameter" index="1bW2Oz" />
         <child id="1199569916463" name="body" index="1bW5cS" />
       </concept>
     </language>
@@ -192,60 +193,44 @@
                     <ref role="3cqZAo" node="17HIJlKZU71" resolve="button" />
                   </node>
                   <node concept="liA8E" id="17HIJlKZWfd" role="2OqNvi">
-                    <ref role="37wK5l" to="dxuu:~AbstractButton.addActionListener(java.awt.event.ActionListener)" resolve="addActionListener" />
-                    <node concept="2ShNRf" id="17HIJlKZWt8" role="37wK5m">
-                      <node concept="YeOm9" id="17HIJlKZXp_" role="2ShVmc">
-                        <node concept="1Y3b0j" id="17HIJlKZXpC" role="YeSDq">
-                          <property role="2bfB8j" value="true" />
-                          <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
-                          <ref role="1Y3XeK" to="hyam:~ActionListener" resolve="ActionListener" />
-                          <node concept="3Tm1VV" id="17HIJlKZXpD" role="1B3o_S" />
-                          <node concept="3clFb_" id="17HIJlKZXpE" role="jymVt">
-                            <property role="1EzhhJ" value="false" />
-                            <property role="TrG5h" value="actionPerformed" />
-                            <property role="DiZV1" value="false" />
-                            <property role="od$2w" value="false" />
-                            <node concept="3Tm1VV" id="17HIJlKZXpF" role="1B3o_S" />
-                            <node concept="3cqZAl" id="17HIJlKZXpH" role="3clF45" />
-                            <node concept="37vLTG" id="17HIJlKZXpI" role="3clF46">
-                              <property role="TrG5h" value="p0" />
-                              <node concept="3uibUv" id="17HIJlKZXpJ" role="1tU5fm">
-                                <ref role="3uigEE" to="hyam:~ActionEvent" resolve="ActionEvent" />
-                              </node>
+                    <ref role="37wK5l" to="dxuu:~AbstractButton.addActionListener(java.awt.event.ActionListener):void" resolve="addActionListener" />
+                    <node concept="1bVj0M" id="2YOONxNRT5i" role="37wK5m">
+                      <node concept="3clFbS" id="2YOONxNRT5j" role="1bW5cS">
+                        <node concept="3clFbF" id="17HIJlL0gGV" role="3cqZAp">
+                          <node concept="2OqwBi" id="17HIJlL0h9$" role="3clFbG">
+                            <node concept="2YIFZM" id="17HIJlL0h3p" role="2Oq$k0">
+                              <ref role="1Pybhc" to="re1d:17HIJlKZys3" resolve="MyAsyncCalculator" />
+                              <ref role="37wK5l" to="re1d:17HIJlL07UK" resolve="getInstance" />
                             </node>
-                            <node concept="3clFbS" id="17HIJlKZXpK" role="3clF47">
-                              <node concept="3clFbF" id="17HIJlL0gGV" role="3cqZAp">
-                                <node concept="2OqwBi" id="17HIJlL0h9$" role="3clFbG">
-                                  <node concept="2YIFZM" id="17HIJlL0h3p" role="2Oq$k0">
-                                    <ref role="37wK5l" to="re1d:17HIJlL07UK" resolve="getInstance" />
-                                    <ref role="1Pybhc" to="re1d:17HIJlKZys3" resolve="MyAsyncCalculator" />
-                                  </node>
-                                  <node concept="liA8E" id="17HIJlL0hhV" role="2OqNvi">
-                                    <ref role="37wK5l" to="re1d:17HIJlKZMbf" resolve="setValueAfterMsPassed" />
-                                    <node concept="Xl_RD" id="17HIJlL0orp" role="37wK5m">
-                                      <property role="Xl_RC" value="my result" />
-                                    </node>
-                                    <node concept="3cmrfG" id="17HIJlL0oNv" role="37wK5m">
-                                      <property role="3cmrfH" value="5000" />
-                                    </node>
-                                  </node>
-                                </node>
+                            <node concept="liA8E" id="17HIJlL0hhV" role="2OqNvi">
+                              <ref role="37wK5l" to="re1d:17HIJlKZMbf" resolve="setValueAfterMsPassed" />
+                              <node concept="Xl_RD" id="17HIJlL0orp" role="37wK5m">
+                                <property role="Xl_RC" value="my result" />
                               </node>
-                              <node concept="3clFbF" id="2u$73V9t9yl" role="3cqZAp">
-                                <node concept="2OqwBi" id="2u$73V9t9ym" role="3clFbG">
-                                  <node concept="2OqwBi" id="2u$73V9t9yn" role="2Oq$k0">
-                                    <node concept="1Q80Hx" id="2u$73V9t9yo" role="2Oq$k0" />
-                                    <node concept="liA8E" id="2u$73V9t9yp" role="2OqNvi">
-                                      <ref role="37wK5l" to="cj4x:~EditorContext.getEditorComponent()" resolve="getEditorComponent" />
-                                    </node>
-                                  </node>
-                                  <node concept="liA8E" id="2u$73V9t9yq" role="2OqNvi">
-                                    <ref role="37wK5l" to="cj4x:~EditorComponent.update()" resolve="update" />
-                                  </node>
-                                </node>
+                              <node concept="3cmrfG" id="17HIJlL0oNv" role="37wK5m">
+                                <property role="3cmrfH" value="5000" />
                               </node>
                             </node>
                           </node>
+                        </node>
+                        <node concept="3clFbF" id="2u$73V9t9yl" role="3cqZAp">
+                          <node concept="2OqwBi" id="2u$73V9t9ym" role="3clFbG">
+                            <node concept="2OqwBi" id="2u$73V9t9yn" role="2Oq$k0">
+                              <node concept="1Q80Hx" id="2u$73V9t9yo" role="2Oq$k0" />
+                              <node concept="liA8E" id="2u$73V9t9yp" role="2OqNvi">
+                                <ref role="37wK5l" to="cj4x:~EditorContext.getEditorComponent():jetbrains.mps.openapi.editor.EditorComponent" resolve="getEditorComponent" />
+                              </node>
+                            </node>
+                            <node concept="liA8E" id="2u$73V9t9yq" role="2OqNvi">
+                              <ref role="37wK5l" to="cj4x:~EditorComponent.update():void" resolve="update" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="37vLTG" id="2YOONxNRTkd" role="1bW2Oz">
+                        <property role="TrG5h" value="e" />
+                        <node concept="3uibUv" id="2YOONxNRTkc" role="1tU5fm">
+                          <ref role="3uigEE" to="hyam:~ActionEvent" resolve="ActionEvent" />
                         </node>
                       </node>
                     </node>
@@ -255,6 +240,88 @@
               <node concept="3cpWs6" id="17HIJlKZXVd" role="3cqZAp">
                 <node concept="37vLTw" id="17HIJlKZXVI" role="3cqZAk">
                   <ref role="3cqZAo" node="17HIJlKZU71" resolve="button" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3gTLQM" id="2YOONxNRDtn" role="3EZMnx">
+          <node concept="3Fmcul" id="2YOONxNRDto" role="3FoqZy">
+            <node concept="3clFbS" id="2YOONxNRDtp" role="2VODD2">
+              <node concept="3cpWs8" id="2YOONxNRDtq" role="3cqZAp">
+                <node concept="3cpWsn" id="2YOONxNRDtr" role="3cpWs9">
+                  <property role="TrG5h" value="button" />
+                  <node concept="3uibUv" id="2YOONxNRDts" role="1tU5fm">
+                    <ref role="3uigEE" to="dxuu:~JButton" resolve="JButton" />
+                  </node>
+                  <node concept="2ShNRf" id="2YOONxNRDtt" role="33vP2m">
+                    <node concept="1pGfFk" id="2YOONxNRDtu" role="2ShVmc">
+                      <ref role="37wK5l" to="dxuu:~JButton.&lt;init&gt;(java.lang.String)" resolve="JButton" />
+                      <node concept="Xl_RD" id="2YOONxNRDtv" role="37wK5m">
+                        <property role="Xl_RC" value="Throw Exception in 5s" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbF" id="2YOONxNRDtw" role="3cqZAp">
+                <node concept="2OqwBi" id="2YOONxNRDtx" role="3clFbG">
+                  <node concept="37vLTw" id="2YOONxNRDty" role="2Oq$k0">
+                    <ref role="3cqZAo" node="2YOONxNRDtr" resolve="button" />
+                  </node>
+                  <node concept="liA8E" id="2YOONxNRDtz" role="2OqNvi">
+                    <ref role="37wK5l" to="dxuu:~AbstractButton.addActionListener(java.awt.event.ActionListener):void" resolve="addActionListener" />
+                    <node concept="1bVj0M" id="2YOONxNRQT4" role="37wK5m">
+                      <node concept="3clFbS" id="2YOONxNRQT5" role="1bW5cS">
+                        <node concept="3clFbF" id="2YOONxNRQqV" role="3cqZAp">
+                          <node concept="2OqwBi" id="2YOONxNRDtJ" role="3clFbG">
+                            <node concept="2YIFZM" id="2YOONxNRDtK" role="2Oq$k0">
+                              <ref role="1Pybhc" to="re1d:17HIJlKZys3" resolve="MyAsyncCalculator" />
+                              <ref role="37wK5l" to="re1d:17HIJlL07UK" resolve="getInstance" />
+                            </node>
+                            <node concept="liA8E" id="2YOONxNRDtL" role="2OqNvi">
+                              <ref role="37wK5l" to="re1d:2YOONxNRN8o" resolve="throwAfterMsPassed" />
+                              <node concept="2ShNRf" id="2YOONxNROY_" role="37wK5m">
+                                <node concept="1pGfFk" id="2YOONxNRPbh" role="2ShVmc">
+                                  <ref role="37wK5l" to="wyt6:~RuntimeException.&lt;init&gt;(java.lang.String)" resolve="RuntimeException" />
+                                  <node concept="Xl_RD" id="2YOONxNT1E6" role="37wK5m">
+                                    <property role="Xl_RC" value="An error happened during calculation" />
+                                  </node>
+                                </node>
+                              </node>
+                              <node concept="3cmrfG" id="2YOONxNRDtN" role="37wK5m">
+                                <property role="3cmrfH" value="5000" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3clFbF" id="2YOONxNRDtO" role="3cqZAp">
+                          <node concept="2OqwBi" id="2YOONxNRDtP" role="3clFbG">
+                            <node concept="2OqwBi" id="2YOONxNRDtQ" role="2Oq$k0">
+                              <node concept="1Q80Hx" id="2YOONxNRDtR" role="2Oq$k0" />
+                              <node concept="liA8E" id="2YOONxNRDtS" role="2OqNvi">
+                                <ref role="37wK5l" to="cj4x:~EditorContext.getEditorComponent():jetbrains.mps.openapi.editor.EditorComponent" resolve="getEditorComponent" />
+                              </node>
+                            </node>
+                            <node concept="liA8E" id="2YOONxNRDtT" role="2OqNvi">
+                              <ref role="37wK5l" to="cj4x:~EditorComponent.update():void" resolve="update" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="37vLTG" id="2YOONxNRRLM" role="1bW2Oz">
+                        <property role="TrG5h" value="e" />
+                        <node concept="3uibUv" id="2YOONxNRRLL" role="1tU5fm">
+                          <ref role="3uigEE" to="hyam:~ActionEvent" resolve="ActionEvent" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3cpWs6" id="2YOONxNRDtU" role="3cqZAp">
+                <node concept="37vLTw" id="2YOONxNRDtV" role="3cqZAk">
+                  <ref role="3cqZAo" node="2YOONxNRDtr" resolve="button" />
                 </node>
               </node>
             </node>
@@ -291,7 +358,7 @@
                     <ref role="3cqZAo" node="2u$73V9r4da" resolve="button" />
                   </node>
                   <node concept="liA8E" id="2u$73V9r4di" role="2OqNvi">
-                    <ref role="37wK5l" to="dxuu:~AbstractButton.addActionListener(java.awt.event.ActionListener)" resolve="addActionListener" />
+                    <ref role="37wK5l" to="dxuu:~AbstractButton.addActionListener(java.awt.event.ActionListener):void" resolve="addActionListener" />
                     <node concept="2ShNRf" id="2u$73V9r4dj" role="37wK5m">
                       <node concept="YeOm9" id="2u$73V9r4dk" role="2ShVmc">
                         <node concept="1Y3b0j" id="2u$73V9r4dl" role="YeSDq">
@@ -330,11 +397,11 @@
                                   <node concept="2OqwBi" id="2u$73V9t9pz" role="2Oq$k0">
                                     <node concept="1Q80Hx" id="2u$73V9t9p$" role="2Oq$k0" />
                                     <node concept="liA8E" id="2u$73V9t9p_" role="2OqNvi">
-                                      <ref role="37wK5l" to="cj4x:~EditorContext.getEditorComponent()" resolve="getEditorComponent" />
+                                      <ref role="37wK5l" to="cj4x:~EditorContext.getEditorComponent():jetbrains.mps.openapi.editor.EditorComponent" resolve="getEditorComponent" />
                                     </node>
                                   </node>
                                   <node concept="liA8E" id="2u$73V9t9pA" role="2OqNvi">
-                                    <ref role="37wK5l" to="cj4x:~EditorComponent.update()" resolve="update" />
+                                    <ref role="37wK5l" to="cj4x:~EditorComponent.update():void" resolve="update" />
                                   </node>
                                 </node>
                               </node>
@@ -379,7 +446,7 @@
                     <ref role="3cqZAo" node="2u$73V9r4Bu" resolve="button" />
                   </node>
                   <node concept="liA8E" id="2u$73V9r4BA" role="2OqNvi">
-                    <ref role="37wK5l" to="dxuu:~AbstractButton.addActionListener(java.awt.event.ActionListener)" resolve="addActionListener" />
+                    <ref role="37wK5l" to="dxuu:~AbstractButton.addActionListener(java.awt.event.ActionListener):void" resolve="addActionListener" />
                     <node concept="2ShNRf" id="2u$73V9r4BB" role="37wK5m">
                       <node concept="YeOm9" id="2u$73V9r4BC" role="2ShVmc">
                         <node concept="1Y3b0j" id="2u$73V9r4BD" role="YeSDq">
@@ -420,11 +487,11 @@
                                   <node concept="2OqwBi" id="2u$73V9r4BN" role="2Oq$k0">
                                     <node concept="1Q80Hx" id="2u$73V9r4BO" role="2Oq$k0" />
                                     <node concept="liA8E" id="2u$73V9r4BP" role="2OqNvi">
-                                      <ref role="37wK5l" to="cj4x:~EditorContext.getEditorComponent()" resolve="getEditorComponent" />
+                                      <ref role="37wK5l" to="cj4x:~EditorContext.getEditorComponent():jetbrains.mps.openapi.editor.EditorComponent" resolve="getEditorComponent" />
                                     </node>
                                   </node>
                                   <node concept="liA8E" id="2u$73V9r4BQ" role="2OqNvi">
-                                    <ref role="37wK5l" to="cj4x:~EditorComponent.update()" resolve="update" />
+                                    <ref role="37wK5l" to="cj4x:~EditorComponent.update():void" resolve="update" />
                                   </node>
                                 </node>
                               </node>
@@ -497,11 +564,11 @@
                             <node concept="2EnYce" id="2u$73V9uyfS" role="2Oq$k0">
                               <node concept="1Q80Hx" id="2u$73V9uwFY" role="2Oq$k0" />
                               <node concept="liA8E" id="2u$73V9uwFZ" role="2OqNvi">
-                                <ref role="37wK5l" to="cj4x:~EditorContext.getContextCell()" resolve="getContextCell" />
+                                <ref role="37wK5l" to="cj4x:~EditorContext.getContextCell():jetbrains.mps.openapi.editor.cells.EditorCell" resolve="getContextCell" />
                               </node>
                             </node>
                             <node concept="liA8E" id="2u$73V9uwG0" role="2OqNvi">
-                              <ref role="37wK5l" to="f4zo:~EditorCell.getStyle()" resolve="getStyle" />
+                              <ref role="37wK5l" to="f4zo:~EditorCell.getStyle():jetbrains.mps.openapi.editor.style.Style" resolve="getStyle" />
                             </node>
                           </node>
                         </node>

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.editingGuide.execution.lang/models/editor.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.editingGuide.execution.lang/models/editor.mps
@@ -340,7 +340,7 @@
       <concept id="2728748097294299101" name="de.itemis.mps.editor.celllayout.structure.MarginLeftStyle" flags="lg" index="3TopCM" />
     </language>
     <language id="120e1c9d-4e27-4478-b2af-b2c3bd3850b0" name="com.mbeddr.mpsutil.editor.querylist">
-      <concept id="6202678563380238499" name="com.mbeddr.mpsutil.editor.querylist.structure.Function_GetElements" flags="ig" index="s8sZD" />
+      <concept id="6202678563380238499" name="com.mbeddr.mpsutil.editor.querylist.structure.Function_GetElements" flags="ng" index="s8sZD" />
       <concept id="6202678563380233810" name="com.mbeddr.mpsutil.editor.querylist.structure.CellModel_QueryList" flags="ng" index="s8t4o">
         <reference id="730823979350682502" name="elementsConcept" index="28F8cf" />
         <child id="6202678563380433923" name="query" index="sbcd9" />

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.editingGuide.execution.lang/models/editor.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.editingGuide.execution.lang/models/editor.mps
@@ -331,6 +331,9 @@
       <concept id="2068944020170241612" name="jetbrains.mps.baseLanguage.javadoc.structure.ClassifierDocComment" flags="ng" index="3UR2Jj" />
     </language>
     <language id="1919c723-b60b-4592-9318-9ce96d91da44" name="de.itemis.mps.editor.celllayout">
+      <concept id="4159435463405238565" name="de.itemis.mps.editor.celllayout.structure.TopDownLayoutCell" flags="ng" index="nPN6x">
+        <child id="4159435463405238566" name="childCell" index="nPN6y" />
+      </concept>
       <concept id="1059142979230420839" name="de.itemis.mps.editor.celllayout.structure.GridLayoutColumnSpanStyle" flags="lg" index="2tOxIa" />
       <concept id="2728748097294685743" name="de.itemis.mps.editor.celllayout.structure.MarginStyle" flags="lg" index="3T6Uf0" />
       <concept id="2728748097294192922" name="de.itemis.mps.editor.celllayout.structure.IntegerStyle" flags="lg" index="3To2jP">
@@ -340,7 +343,7 @@
       <concept id="2728748097294299101" name="de.itemis.mps.editor.celllayout.structure.MarginLeftStyle" flags="lg" index="3TopCM" />
     </language>
     <language id="120e1c9d-4e27-4478-b2af-b2c3bd3850b0" name="com.mbeddr.mpsutil.editor.querylist">
-      <concept id="6202678563380238499" name="com.mbeddr.mpsutil.editor.querylist.structure.Function_GetElements" flags="ng" index="s8sZD" />
+      <concept id="6202678563380238499" name="com.mbeddr.mpsutil.editor.querylist.structure.Function_GetElements" flags="ig" index="s8sZD" />
       <concept id="6202678563380233810" name="com.mbeddr.mpsutil.editor.querylist.structure.CellModel_QueryList" flags="ng" index="s8t4o">
         <reference id="730823979350682502" name="elementsConcept" index="28F8cf" />
         <child id="6202678563380433923" name="query" index="sbcd9" />
@@ -497,8 +500,8 @@
                               </node>
                               <node concept="2OqwBi" id="7lgjy2PT7gp" role="3uHU7B">
                                 <node concept="2YIFZM" id="7lgjy2PT7gq" role="2Oq$k0">
-                                  <ref role="1Pybhc" to="exr9:~EditorSettings" resolve="EditorSettings" />
                                   <ref role="37wK5l" to="exr9:~EditorSettings.getInstance()" resolve="getInstance" />
+                                  <ref role="1Pybhc" to="exr9:~EditorSettings" resolve="EditorSettings" />
                                 </node>
                                 <node concept="liA8E" id="7lgjy2PT7gr" role="2OqNvi">
                                   <ref role="37wK5l" to="exr9:~EditorSettings.getFontSize()" resolve="getFontSize" />
@@ -515,10 +518,12 @@
               </node>
             </node>
             <node concept="2iRkQZ" id="7lgjy2PT7gt" role="2iSdaV" />
-            <node concept="3F1sOY" id="7lgjy2PT7gu" role="3EZMnx">
-              <ref role="1NtTu8" to="k8go:3p1cdQ7_d$Z" resolve="description" />
-              <node concept="VechU" id="7lgjy2PT7gv" role="3F10Kt">
-                <property role="Vb096" value="fLJRk5B/darkGray" />
+            <node concept="nPN6x" id="1lX2_iA$TwY" role="3EZMnx">
+              <node concept="3F1sOY" id="7lgjy2PT7gu" role="nPN6y">
+                <ref role="1NtTu8" to="k8go:3p1cdQ7_d$Z" resolve="description" />
+                <node concept="VechU" id="7lgjy2PT7gv" role="3F10Kt">
+                  <property role="Vb096" value="fLJRk5B/darkGray" />
+                </node>
               </node>
             </node>
           </node>
@@ -532,164 +537,166 @@
               <property role="Vb096" value="hEZAO13/white" />
             </node>
             <node concept="2iRfu4" id="7FOIhAt5dNk" role="2iSdaV" />
-            <node concept="1QoScp" id="47lXHjolKMj" role="3EZMnx">
-              <property role="1QpmdY" value="true" />
-              <node concept="pkWqt" id="47lXHjolKMm" role="3e4ffs">
-                <node concept="3clFbS" id="47lXHjolKMo" role="2VODD2">
-                  <node concept="3clFbF" id="47lXHjolL5i" role="3cqZAp">
-                    <node concept="2EnYce" id="47lXHjolL5j" role="3clFbG">
-                      <node concept="2OqwBi" id="47lXHjolL5k" role="2Oq$k0">
-                        <node concept="2YIFZM" id="47lXHjolL5l" role="2Oq$k0">
-                          <ref role="1Pybhc" to="yuwt:5h2rxDjX6bI" resolve="ExerciseExecutor" />
-                          <ref role="37wK5l" to="yuwt:5h2rxDjXTCb" resolve="getInstance" />
-                          <node concept="1Q80Hx" id="47lXHjolL5m" role="37wK5m" />
-                          <node concept="2OqwBi" id="47lXHjolL5n" role="37wK5m">
-                            <node concept="pncrf" id="47lXHjolL5o" role="2Oq$k0" />
-                            <node concept="2Xjw5R" id="47lXHjolL5p" role="2OqNvi">
-                              <node concept="1xMEDy" id="47lXHjolL5q" role="1xVPHs">
-                                <node concept="chp4Y" id="47lXHjolL5r" role="ri$Ld">
-                                  <ref role="cht4Q" to="k8go:3p1cdQ7_d_Y" resolve="Exercise" />
+            <node concept="nPN6x" id="5YeXIo8fd2F" role="3EZMnx">
+              <node concept="1QoScp" id="47lXHjolKMj" role="nPN6y">
+                <property role="1QpmdY" value="true" />
+                <node concept="pkWqt" id="47lXHjolKMm" role="3e4ffs">
+                  <node concept="3clFbS" id="47lXHjolKMo" role="2VODD2">
+                    <node concept="3clFbF" id="47lXHjolL5i" role="3cqZAp">
+                      <node concept="2EnYce" id="47lXHjolL5j" role="3clFbG">
+                        <node concept="2OqwBi" id="47lXHjolL5k" role="2Oq$k0">
+                          <node concept="2YIFZM" id="47lXHjolL5l" role="2Oq$k0">
+                            <ref role="1Pybhc" to="yuwt:5h2rxDjX6bI" resolve="ExerciseExecutor" />
+                            <ref role="37wK5l" to="yuwt:5h2rxDjXTCb" resolve="getInstance" />
+                            <node concept="1Q80Hx" id="47lXHjolL5m" role="37wK5m" />
+                            <node concept="2OqwBi" id="47lXHjolL5n" role="37wK5m">
+                              <node concept="pncrf" id="47lXHjolL5o" role="2Oq$k0" />
+                              <node concept="2Xjw5R" id="47lXHjolL5p" role="2OqNvi">
+                                <node concept="1xMEDy" id="47lXHjolL5q" role="1xVPHs">
+                                  <node concept="chp4Y" id="47lXHjolL5r" role="ri$Ld">
+                                    <ref role="cht4Q" to="k8go:3p1cdQ7_d_Y" resolve="Exercise" />
+                                  </node>
                                 </node>
                               </node>
                             </node>
                           </node>
-                        </node>
-                        <node concept="liA8E" id="47lXHjolL5s" role="2OqNvi">
-                          <ref role="37wK5l" to="yuwt:4TMjSvbDe$5" resolve="checkTask" />
-                          <node concept="pncrf" id="47lXHjolL5t" role="37wK5m" />
-                        </node>
-                      </node>
-                      <node concept="liA8E" id="47lXHjolL5u" role="2OqNvi">
-                        <ref role="37wK5l" to="2vci:4TMjSvbEtra" resolve="allowNextTask" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="3EZMnI" id="47lXHjol$1R" role="1QoS34">
-                <node concept="1QoScp" id="7t7ujt$mkxe" role="3EZMnx">
-                  <property role="1QpmdY" value="true" />
-                  <node concept="pkWqt" id="7t7ujt$mkxf" role="3e4ffs">
-                    <node concept="3clFbS" id="7t7ujt$mkxg" role="2VODD2">
-                      <node concept="3clFbF" id="7t7ujt$mkxh" role="3cqZAp">
-                        <node concept="2OqwBi" id="7t7ujt$mkxi" role="3clFbG">
-                          <node concept="2OqwBi" id="7t7ujt$mkxj" role="2Oq$k0">
-                            <node concept="pncrf" id="7t7ujt$mkxk" role="2Oq$k0" />
-                            <node concept="3TrcHB" id="7t7ujt$mkxl" role="2OqNvi">
-                              <ref role="3TsBF5" to="k8go:62Mww1ZUmzQ" resolve="resultMessage" />
-                            </node>
-                          </node>
-                          <node concept="17RvpY" id="7t7ujt$mkxm" role="2OqNvi" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="2v7bAL" id="7t7ujt$mkxo" role="1QoS34">
-                    <ref role="1NtTu8" to="k8go:62Mww1ZUmzQ" resolve="resultMessage" />
-                    <ref role="1k5W1q" node="47lXHjokM4S" resolve="editingGuide_hint_completed" />
-                    <node concept="VPxyj" id="7t7ujt$mkxp" role="3F10Kt">
-                      <property role="VOm3f" value="false" />
-                    </node>
-                  </node>
-                  <node concept="3F0ifn" id="7t7ujt$ml2F" role="1QoVPY">
-                    <property role="3F0ifm" value="Task Completed." />
-                    <ref role="1k5W1q" node="47lXHjokM4S" resolve="editingGuide_hint_completed" />
-                  </node>
-                </node>
-                <node concept="2iRfu4" id="7t7ujt$onGm" role="2iSdaV" />
-                <node concept="3F1sOY" id="47lXHjol$2p" role="3EZMnx">
-                  <ref role="1k5W1q" node="47lXHjokM4S" resolve="editingGuide_hint_completed" />
-                  <ref role="1NtTu8" to="k8go:2ZHlC00438k" resolve="explanation" />
-                  <node concept="pkWqt" id="47lXHjolHHL" role="pqm2j">
-                    <node concept="3clFbS" id="47lXHjolHHM" role="2VODD2">
-                      <node concept="3clFbF" id="47lXHjolHP6" role="3cqZAp">
-                        <node concept="3fqX7Q" id="47lXHjolHP7" role="3clFbG">
-                          <node concept="2OqwBi" id="47lXHjolHP8" role="3fr31v">
-                            <node concept="2OqwBi" id="47lXHjolHP9" role="2Oq$k0">
-                              <node concept="pncrf" id="47lXHjolHPa" role="2Oq$k0" />
-                              <node concept="3TrEf2" id="47lXHjolHPb" role="2OqNvi">
-                                <ref role="3Tt5mk" to="k8go:2ZHlC00438k" resolve="explanation" />
-                              </node>
-                            </node>
-                            <node concept="2qgKlT" id="47lXHjolHPc" role="2OqNvi">
-                              <ref role="37wK5l" to="tbr6:2ZHlC004czC" resolve="isEmpty" />
-                            </node>
+                          <node concept="liA8E" id="47lXHjolL5s" role="2OqNvi">
+                            <ref role="37wK5l" to="yuwt:4TMjSvbDe$5" resolve="checkTask" />
+                            <node concept="pncrf" id="47lXHjolL5t" role="37wK5m" />
                           </node>
                         </node>
+                        <node concept="liA8E" id="47lXHjolL5u" role="2OqNvi">
+                          <ref role="37wK5l" to="2vci:4TMjSvbEtra" resolve="allowNextTask" />
+                        </node>
                       </node>
                     </node>
                   </node>
                 </node>
-                <node concept="VPM3Z" id="47lXHjol$2L" role="3F10Kt">
-                  <property role="VOm3f" value="false" />
-                </node>
-              </node>
-              <node concept="3TopCM" id="7FOIhAt56h1" role="3F10Kt">
-                <property role="1lJzqX" value="5" />
-              </node>
-              <node concept="3Too0$" id="7FOIhAt56Kf" role="3F10Kt">
-                <property role="1lJzqX" value="5" />
-              </node>
-              <node concept="3EZMnI" id="icy2A0TVh1" role="1QoVPY">
-                <node concept="3F0ifn" id="icy2A0TVYa" role="3EZMnx">
-                  <property role="3F0ifm" value="Hint:" />
-                  <ref role="1k5W1q" node="icy2A0VXqs" resolve="editingGuide_hint_inactive" />
-                  <node concept="1uO$qF" id="7t7ujt$o7Ex" role="3F10Kt">
-                    <node concept="3nzxsE" id="7t7ujt$o7Ey" role="1uO$qD">
-                      <node concept="3clFbS" id="7t7ujt$o7Ez" role="2VODD2">
-                        <node concept="3clFbF" id="7t7ujt$o7E$" role="3cqZAp">
-                          <node concept="2OqwBi" id="7t7ujt$o7E_" role="3clFbG">
-                            <node concept="2OqwBi" id="7t7ujt$o7EA" role="2Oq$k0">
-                              <node concept="pncrf" id="7t7ujt$o7EB" role="2Oq$k0" />
-                              <node concept="3TrcHB" id="7t7ujt$o7EC" role="2OqNvi">
+                <node concept="3EZMnI" id="47lXHjol$1R" role="1QoS34">
+                  <node concept="1QoScp" id="7t7ujt$mkxe" role="3EZMnx">
+                    <property role="1QpmdY" value="true" />
+                    <node concept="pkWqt" id="7t7ujt$mkxf" role="3e4ffs">
+                      <node concept="3clFbS" id="7t7ujt$mkxg" role="2VODD2">
+                        <node concept="3clFbF" id="7t7ujt$mkxh" role="3cqZAp">
+                          <node concept="2OqwBi" id="7t7ujt$mkxi" role="3clFbG">
+                            <node concept="2OqwBi" id="7t7ujt$mkxj" role="2Oq$k0">
+                              <node concept="pncrf" id="7t7ujt$mkxk" role="2Oq$k0" />
+                              <node concept="3TrcHB" id="7t7ujt$mkxl" role="2OqNvi">
                                 <ref role="3TsBF5" to="k8go:62Mww1ZUmzQ" resolve="resultMessage" />
                               </node>
                             </node>
-                            <node concept="17RvpY" id="7t7ujt$o7ED" role="2OqNvi" />
+                            <node concept="17RvpY" id="7t7ujt$mkxm" role="2OqNvi" />
                           </node>
                         </node>
                       </node>
                     </node>
-                    <node concept="1wgc9g" id="7t7ujt$o7EE" role="3XvnJa">
-                      <ref role="1wgcnl" node="icy2A0TX9M" resolve="editingGuide_hint" />
+                    <node concept="2v7bAL" id="7t7ujt$mkxo" role="1QoS34">
+                      <ref role="1k5W1q" node="47lXHjokM4S" resolve="editingGuide_hint_completed" />
+                      <ref role="1NtTu8" to="k8go:62Mww1ZUmzQ" resolve="resultMessage" />
+                      <node concept="VPxyj" id="7t7ujt$mkxp" role="3F10Kt">
+                        <property role="VOm3f" value="false" />
+                      </node>
+                    </node>
+                    <node concept="3F0ifn" id="7t7ujt$ml2F" role="1QoVPY">
+                      <property role="3F0ifm" value="Task Completed." />
+                      <ref role="1k5W1q" node="47lXHjokM4S" resolve="editingGuide_hint_completed" />
                     </node>
                   </node>
-                  <node concept="VQ3r3" id="icy2A0Wihg" role="3F10Kt">
-                    <property role="2USNnj" value="gtbM8PH/underlined" />
-                  </node>
-                </node>
-                <node concept="1QoScp" id="7t7ujt$o9gt" role="3EZMnx">
-                  <property role="1QpmdY" value="true" />
-                  <node concept="pkWqt" id="7t7ujt$o9gw" role="3e4ffs">
-                    <node concept="3clFbS" id="7t7ujt$o9gy" role="2VODD2">
-                      <node concept="3clFbF" id="7t7ujt$o9$_" role="3cqZAp">
-                        <node concept="2OqwBi" id="7t7ujt$obIF" role="3clFbG">
-                          <node concept="2OqwBi" id="7t7ujt$o9LN" role="2Oq$k0">
-                            <node concept="pncrf" id="7t7ujt$o9$$" role="2Oq$k0" />
-                            <node concept="3TrcHB" id="7t7ujt$ob5O" role="2OqNvi">
-                              <ref role="3TsBF5" to="k8go:62Mww1ZUmzQ" resolve="resultMessage" />
+                  <node concept="2iRfu4" id="7t7ujt$onGm" role="2iSdaV" />
+                  <node concept="3F1sOY" id="47lXHjol$2p" role="3EZMnx">
+                    <ref role="1NtTu8" to="k8go:2ZHlC00438k" resolve="explanation" />
+                    <ref role="1k5W1q" node="47lXHjokM4S" resolve="editingGuide_hint_completed" />
+                    <node concept="pkWqt" id="47lXHjolHHL" role="pqm2j">
+                      <node concept="3clFbS" id="47lXHjolHHM" role="2VODD2">
+                        <node concept="3clFbF" id="47lXHjolHP6" role="3cqZAp">
+                          <node concept="3fqX7Q" id="47lXHjolHP7" role="3clFbG">
+                            <node concept="2OqwBi" id="47lXHjolHP8" role="3fr31v">
+                              <node concept="2OqwBi" id="47lXHjolHP9" role="2Oq$k0">
+                                <node concept="pncrf" id="47lXHjolHPa" role="2Oq$k0" />
+                                <node concept="3TrEf2" id="47lXHjolHPb" role="2OqNvi">
+                                  <ref role="3Tt5mk" to="k8go:2ZHlC00438k" resolve="explanation" />
+                                </node>
+                              </node>
+                              <node concept="2qgKlT" id="47lXHjolHPc" role="2OqNvi">
+                                <ref role="37wK5l" to="tbr6:2ZHlC004czC" resolve="isEmpty" />
+                              </node>
                             </node>
                           </node>
-                          <node concept="17RvpY" id="7t7ujt$odkV" role="2OqNvi" />
                         </node>
                       </node>
                     </node>
                   </node>
-                  <node concept="3F0ifn" id="7t7ujt$odFt" role="1QoVPY">
-                    <property role="3F0ifm" value="none" />
-                    <ref role="1k5W1q" node="icy2A0VXqs" resolve="editingGuide_hint_inactive" />
-                  </node>
-                  <node concept="2v7bAL" id="62Mww1ZUmWi" role="1QoS34">
-                    <ref role="1k5W1q" node="icy2A0TX9M" resolve="editingGuide_hint" />
-                    <ref role="1NtTu8" to="k8go:62Mww1ZUmzQ" resolve="resultMessage" />
-                    <node concept="VPxyj" id="62Mww1ZZS4F" role="3F10Kt">
-                      <property role="VOm3f" value="false" />
-                    </node>
+                  <node concept="VPM3Z" id="47lXHjol$2L" role="3F10Kt">
+                    <property role="VOm3f" value="false" />
                   </node>
                 </node>
-                <node concept="2iRfu4" id="icy2A0TVh2" role="2iSdaV" />
-                <node concept="VPM3Z" id="icy2A0VEEO" role="3F10Kt">
-                  <property role="VOm3f" value="false" />
+                <node concept="3TopCM" id="7FOIhAt56h1" role="3F10Kt">
+                  <property role="1lJzqX" value="5" />
+                </node>
+                <node concept="3Too0$" id="7FOIhAt56Kf" role="3F10Kt">
+                  <property role="1lJzqX" value="5" />
+                </node>
+                <node concept="3EZMnI" id="icy2A0TVh1" role="1QoVPY">
+                  <node concept="3F0ifn" id="icy2A0TVYa" role="3EZMnx">
+                    <property role="3F0ifm" value="Hint:" />
+                    <ref role="1k5W1q" node="icy2A0VXqs" resolve="editingGuide_hint_inactive" />
+                    <node concept="1uO$qF" id="7t7ujt$o7Ex" role="3F10Kt">
+                      <node concept="3nzxsE" id="7t7ujt$o7Ey" role="1uO$qD">
+                        <node concept="3clFbS" id="7t7ujt$o7Ez" role="2VODD2">
+                          <node concept="3clFbF" id="7t7ujt$o7E$" role="3cqZAp">
+                            <node concept="2OqwBi" id="7t7ujt$o7E_" role="3clFbG">
+                              <node concept="2OqwBi" id="7t7ujt$o7EA" role="2Oq$k0">
+                                <node concept="pncrf" id="7t7ujt$o7EB" role="2Oq$k0" />
+                                <node concept="3TrcHB" id="7t7ujt$o7EC" role="2OqNvi">
+                                  <ref role="3TsBF5" to="k8go:62Mww1ZUmzQ" resolve="resultMessage" />
+                                </node>
+                              </node>
+                              <node concept="17RvpY" id="7t7ujt$o7ED" role="2OqNvi" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="1wgc9g" id="7t7ujt$o7EE" role="3XvnJa">
+                        <ref role="1wgcnl" node="icy2A0TX9M" resolve="editingGuide_hint" />
+                      </node>
+                    </node>
+                    <node concept="VQ3r3" id="icy2A0Wihg" role="3F10Kt">
+                      <property role="2USNnj" value="gtbM8PH/underlined" />
+                    </node>
+                  </node>
+                  <node concept="1QoScp" id="7t7ujt$o9gt" role="3EZMnx">
+                    <property role="1QpmdY" value="true" />
+                    <node concept="pkWqt" id="7t7ujt$o9gw" role="3e4ffs">
+                      <node concept="3clFbS" id="7t7ujt$o9gy" role="2VODD2">
+                        <node concept="3clFbF" id="7t7ujt$o9$_" role="3cqZAp">
+                          <node concept="2OqwBi" id="7t7ujt$obIF" role="3clFbG">
+                            <node concept="2OqwBi" id="7t7ujt$o9LN" role="2Oq$k0">
+                              <node concept="pncrf" id="7t7ujt$o9$$" role="2Oq$k0" />
+                              <node concept="3TrcHB" id="7t7ujt$ob5O" role="2OqNvi">
+                                <ref role="3TsBF5" to="k8go:62Mww1ZUmzQ" resolve="resultMessage" />
+                              </node>
+                            </node>
+                            <node concept="17RvpY" id="7t7ujt$odkV" role="2OqNvi" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3F0ifn" id="7t7ujt$odFt" role="1QoVPY">
+                      <property role="3F0ifm" value="none" />
+                      <ref role="1k5W1q" node="icy2A0VXqs" resolve="editingGuide_hint_inactive" />
+                    </node>
+                    <node concept="2v7bAL" id="62Mww1ZUmWi" role="1QoS34">
+                      <ref role="1k5W1q" node="icy2A0TX9M" resolve="editingGuide_hint" />
+                      <ref role="1NtTu8" to="k8go:62Mww1ZUmzQ" resolve="resultMessage" />
+                      <node concept="VPxyj" id="62Mww1ZZS4F" role="3F10Kt">
+                        <property role="VOm3f" value="false" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2iRfu4" id="icy2A0TVh2" role="2iSdaV" />
+                  <node concept="VPM3Z" id="icy2A0VEEO" role="3F10Kt">
+                    <property role="VOm3f" value="false" />
+                  </node>
                 </node>
               </node>
             </node>

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.editingGuide/models/structure.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.editingGuide/models/structure.mps
@@ -163,6 +163,9 @@
     <node concept="PrWs8" id="22irgSmHTqp" role="PzmwI">
       <ref role="PrY4T" node="44LrdWQ3eCt" resolve="INodeExporter" />
     </node>
+    <node concept="PrWs8" id="1_bTRifhdz1" role="PzmwI">
+      <ref role="PrY4T" to="tpck:2WmWrdnSpX3" resolve="ISuppressErrors" />
+    </node>
   </node>
   <node concept="1TIwiD" id="3p1cdQ7_d_V">
     <property role="TrG5h" value="LiteralProgramFragment" />

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.filepicker/models/structure.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.filepicker/models/structure.mps
@@ -2,7 +2,7 @@
 <model ref="r:2a10821d-612f-4a73-b7b0-ed6b57106321(com.mbeddr.mpsutil.filepicker.structure)">
   <persistence version="9" />
   <languages>
-    <use id="c72da2b9-7cce-4447-8389-f407dc1158b7" name="jetbrains.mps.lang.structure" version="9" />
+    <devkit ref="78434eb8-b0e5-444b-850d-e7c4ad2da9ab(jetbrains.mps.devkit.aspect.structure)" />
   </languages>
   <imports>
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" />

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.hyperlink/languageAccessories/com/mbeddr/mpsutil/hyperlink/runtime.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.hyperlink/languageAccessories/com/mbeddr/mpsutil/hyperlink/runtime.mps
@@ -48,6 +48,7 @@
       <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
       <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
       <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
+      <concept id="1225271408483" name="jetbrains.mps.baseLanguage.structure.IsNotEmptyOperation" flags="nn" index="17RvpY" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
       </concept>
@@ -310,11 +311,19 @@
                   </node>
                 </node>
               </node>
-              <node concept="3y3z36" id="3DAECxFHCVI" role="3clFbw">
-                <node concept="37vLTw" id="3DAECxFHCVJ" role="3uHU7B">
-                  <ref role="3cqZAo" node="3DAECxFHCVy" resolve="d" />
+              <node concept="1Wc70l" id="1_bTRifhpRH" role="3clFbw">
+                <node concept="2OqwBi" id="1_bTRifhqrT" role="3uHU7w">
+                  <node concept="37vLTw" id="1_bTRifhq0J" role="2Oq$k0">
+                    <ref role="3cqZAo" node="5A_Zlt6y22D" resolve="url" />
+                  </node>
+                  <node concept="17RvpY" id="1_bTRifhqIT" role="2OqNvi" />
                 </node>
-                <node concept="10Nm6u" id="3DAECxFHCVK" role="3uHU7w" />
+                <node concept="3y3z36" id="3DAECxFHCVI" role="3uHU7B">
+                  <node concept="37vLTw" id="3DAECxFHCVJ" role="3uHU7B">
+                    <ref role="3cqZAo" node="3DAECxFHCVy" resolve="d" />
+                  </node>
+                  <node concept="10Nm6u" id="3DAECxFHCVK" role="3uHU7w" />
+                </node>
               </node>
             </node>
           </node>

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.multilingual.concept/languageModels/editor.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.multilingual.concept/languageModels/editor.mps
@@ -129,13 +129,13 @@
       <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
     </language>
     <language id="120e1c9d-4e27-4478-b2af-b2c3bd3850b0" name="com.mbeddr.mpsutil.editor.querylist">
-      <concept id="6202678563380238499" name="com.mbeddr.mpsutil.editor.querylist.structure.Function_GetElements" flags="ig" index="s8sZD" />
+      <concept id="6202678563380238499" name="com.mbeddr.mpsutil.editor.querylist.structure.Function_GetElements" flags="ng" index="s8sZD" />
       <concept id="6202678563380233810" name="com.mbeddr.mpsutil.editor.querylist.structure.CellModel_QueryList" flags="ng" index="s8t4o">
         <reference id="730823979350682502" name="elementsConcept" index="28F8cf" />
         <child id="6202678563380433923" name="query" index="sbcd9" />
         <child id="5820306262933755617" name="insertNewNode" index="AS3tk" />
       </concept>
-      <concept id="5820306262933110156" name="com.mbeddr.mpsutil.editor.querylist.structure.Function_InsertNewNode" flags="ig" index="ARxKT" />
+      <concept id="5820306262933110156" name="com.mbeddr.mpsutil.editor.querylist.structure.Function_InsertNewNode" flags="ng" index="ARxKT" />
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
       <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />

--- a/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.actionsfilter.runtime/com.mbeddr.mpsutil.actionsfilter.runtime.msd
+++ b/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.actionsfilter.runtime/com.mbeddr.mpsutil.actionsfilter.runtime.msd
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<solution name="com.mbeddr.mpsutil.actionsfilter.runtime" uuid="436eb984-d162-4543-a347-2601ff5bb2a0" moduleVersion="0" pluginKind="PLUGIN_OTHER" compileInMPS="true">
+<solution name="com.mbeddr.mpsutil.actionsfilter.runtime" uuid="436eb984-d162-4543-a347-2601ff5bb2a0" moduleVersion="0" compileInMPS="true">
   <models>
     <modelRoot contentPath="${module}" type="default">
       <sourceRoot location="models" />

--- a/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.actionsfilter.runtime/models/com/mbeddr/mpsutil/actionsfilter/runtime.mps
+++ b/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.actionsfilter.runtime/models/com/mbeddr/mpsutil/actionsfilter/runtime.mps
@@ -331,6 +331,12 @@
         <property id="8970989240999019144" name="text" index="1dT_AB" />
       </concept>
     </language>
+    <language id="760a0a8c-eabb-4521-8bfd-65db761a9ba3" name="jetbrains.mps.baseLanguage.logging">
+      <concept id="2034914114981261497" name="jetbrains.mps.baseLanguage.logging.structure.LogLowLevelStatement" flags="ng" index="RRSsy">
+        <property id="2034914114981261751" name="severity" index="RRSoG" />
+        <child id="2034914114981261753" name="message" index="RRSoy" />
+      </concept>
+    </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
         <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
@@ -13019,8 +13025,8 @@
         <ref role="3uigEE" node="49MflvORAv7" resolve="CustomToolBar" />
       </node>
       <node concept="2ShNRf" id="1IyFrIF3XB8" role="33vP2m">
-        <node concept="HV5vD" id="1IyFrIF4iZP" role="2ShVmc">
-          <ref role="HV5vE" node="49MflvORAv7" resolve="CustomToolBar" />
+        <node concept="1pGfFk" id="7jxV$rv3AZk" role="2ShVmc">
+          <ref role="37wK5l" node="1IyFrIF4jk_" resolve="CustomToolBar" />
         </node>
       </node>
     </node>
@@ -13414,73 +13420,158 @@
                 <node concept="3clFbS" id="2D4mVfzvU3Q" role="1bW5cS">
                   <node concept="3clFbJ" id="2D4mVfzvU3R" role="3cqZAp">
                     <node concept="3clFbS" id="2D4mVfzvU3S" role="3clFbx">
-                      <node concept="3clFbF" id="2D4mVfzvU3T" role="3cqZAp">
-                        <node concept="2OqwBi" id="2D4mVfzvU3U" role="3clFbG">
-                          <node concept="37vLTw" id="2D4mVfzvU3V" role="2Oq$k0">
-                            <ref role="3cqZAo" node="2D4mVfzvU3z" resolve="toolBarActions" />
-                          </node>
-                          <node concept="liA8E" id="2D4mVfzvU3W" role="2OqNvi">
-                            <ref role="37wK5l" to="qkt:~DefaultActionGroup.add(com.intellij.openapi.actionSystem.AnAction)" resolve="add" />
-                            <node concept="2OqwBi" id="2D4mVfzvU3X" role="37wK5m">
-                              <node concept="2YIFZM" id="2D4mVfzvU3Y" role="2Oq$k0">
-                                <ref role="37wK5l" to="qkt:~ActionManager.getInstance()" resolve="getInstance" />
-                                <ref role="1Pybhc" to="qkt:~ActionManager" resolve="ActionManager" />
-                              </node>
-                              <node concept="liA8E" id="2D4mVfzvU3Z" role="2OqNvi">
-                                <ref role="37wK5l" to="qkt:~ActionManager.getAction(java.lang.String)" resolve="getAction" />
-                                <node concept="2OqwBi" id="2D4mVfzvU40" role="37wK5m">
-                                  <node concept="37vLTw" id="2D4mVfzvU41" role="2Oq$k0">
-                                    <ref role="3cqZAo" node="2D4mVfzvU4h" resolve="entry" />
-                                  </node>
-                                  <node concept="liA8E" id="2D4mVfzvU42" role="2OqNvi">
-                                    <ref role="37wK5l" node="3m_GngirHOj" resolve="getId" />
-                                  </node>
-                                </node>
-                              </node>
+                      <node concept="3cpWs8" id="7jxV$rv3ZGK" role="3cqZAp">
+                        <node concept="3cpWsn" id="7jxV$rv3ZGN" role="3cpWs9">
+                          <property role="TrG5h" value="actionId" />
+                          <node concept="17QB3L" id="7jxV$rv3ZGI" role="1tU5fm" />
+                          <node concept="2OqwBi" id="7jxV$rv40Lm" role="33vP2m">
+                            <node concept="37vLTw" id="7jxV$rv40pE" role="2Oq$k0">
+                              <ref role="3cqZAo" node="2D4mVfzvU4h" resolve="entry" />
+                            </node>
+                            <node concept="liA8E" id="7jxV$rv410E" role="2OqNvi">
+                              <ref role="37wK5l" node="3m_GngirHOj" resolve="getId" />
                             </node>
                           </node>
                         </node>
                       </node>
-                      <node concept="3clFbJ" id="fi1uEptEif" role="3cqZAp">
-                        <node concept="3clFbS" id="fi1uEptEih" role="3clFbx">
-                          <node concept="3clFbF" id="59JBFovnJ0m" role="3cqZAp">
-                            <node concept="2OqwBi" id="59JBFovnKBT" role="3clFbG">
-                              <node concept="2YIFZM" id="59JBFovnJFs" role="2Oq$k0">
-                                <ref role="37wK5l" to="8fb:~CustomActionsSchema.getInstance()" resolve="getInstance" />
-                                <ref role="1Pybhc" to="8fb:~CustomActionsSchema" resolve="CustomActionsSchema" />
+                      <node concept="3clFbJ" id="7jxV$rv42w2" role="3cqZAp">
+                        <node concept="3clFbS" id="7jxV$rv42w4" role="3clFbx">
+                          <node concept="RRSsy" id="7jxV$rv44t3" role="3cqZAp">
+                            <property role="RRSoG" value="gZ5fh_4/error" />
+                            <node concept="3cpWs3" id="7jxV$rv4jwt" role="RRSoy">
+                              <node concept="Xl_RD" id="7jxV$rv4k9T" role="3uHU7w">
+                                <property role="Xl_RC" value=". Skipping it!" />
                               </node>
-                              <node concept="liA8E" id="59JBFovnLyG" role="2OqNvi">
-                                <ref role="37wK5l" to="8fb:~CustomActionsSchema.addIconCustomization(java.lang.String,java.lang.String)" resolve="addIconCustomization" />
-                                <node concept="2OqwBi" id="59JBFovnNcg" role="37wK5m">
-                                  <node concept="37vLTw" id="59JBFovnMmy" role="2Oq$k0">
-                                    <ref role="3cqZAo" node="2D4mVfzvU4h" resolve="entry" />
-                                  </node>
-                                  <node concept="liA8E" id="59JBFovnO5U" role="2OqNvi">
-                                    <ref role="37wK5l" node="3m_GngirHOj" resolve="getId" />
-                                  </node>
+                              <node concept="3cpWs3" id="7jxV$rv4665" role="3uHU7B">
+                                <node concept="Xl_RD" id="7jxV$rv44t5" role="3uHU7B">
+                                  <property role="Xl_RC" value="Invalid action-id for entry: " />
                                 </node>
-                                <node concept="2OqwBi" id="59JBFovnQzf" role="37wK5m">
-                                  <node concept="37vLTw" id="59JBFovnPL1" role="2Oq$k0">
+                                <node concept="2OqwBi" id="7jxV$rv46U0" role="3uHU7w">
+                                  <node concept="37vLTw" id="7jxV$rv46qX" role="2Oq$k0">
                                     <ref role="3cqZAo" node="2D4mVfzvU4h" resolve="entry" />
                                   </node>
-                                  <node concept="liA8E" id="59JBFovnRnU" role="2OqNvi">
-                                    <ref role="37wK5l" node="6F5AXb8IsjZ" resolve="getIconPath" />
+                                  <node concept="liA8E" id="7jxV$rv47k3" role="2OqNvi">
+                                    <ref role="37wK5l" to="wyt6:~Object.toString()" resolve="toString" />
                                   </node>
                                 </node>
                               </node>
                             </node>
                           </node>
                         </node>
-                        <node concept="2OqwBi" id="fi1uEptFWy" role="3clFbw">
-                          <node concept="2OqwBi" id="fi1uEptEX0" role="2Oq$k0">
-                            <node concept="37vLTw" id="fi1uEptE$F" role="2Oq$k0">
-                              <ref role="3cqZAo" node="2D4mVfzvU4h" resolve="entry" />
+                        <node concept="2OqwBi" id="7jxV$rv43vU" role="3clFbw">
+                          <node concept="37vLTw" id="7jxV$rv42W7" role="2Oq$k0">
+                            <ref role="3cqZAo" node="7jxV$rv3ZGN" resolve="actionId" />
+                          </node>
+                          <node concept="17RlXB" id="7jxV$rv442k" role="2OqNvi" />
+                        </node>
+                        <node concept="9aQIb" id="7jxV$rv48OI" role="9aQIa">
+                          <node concept="3clFbS" id="7jxV$rv48OJ" role="9aQI4">
+                            <node concept="3cpWs8" id="7jxV$rv41Fy" role="3cqZAp">
+                              <node concept="3cpWsn" id="7jxV$rv41Fz" role="3cpWs9">
+                                <property role="TrG5h" value="action" />
+                                <node concept="3uibUv" id="7jxV$rv41F$" role="1tU5fm">
+                                  <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
+                                </node>
+                                <node concept="2OqwBi" id="7jxV$rv427b" role="33vP2m">
+                                  <node concept="2YIFZM" id="7jxV$rv427c" role="2Oq$k0">
+                                    <ref role="1Pybhc" to="qkt:~ActionManager" resolve="ActionManager" />
+                                    <ref role="37wK5l" to="qkt:~ActionManager.getInstance()" resolve="getInstance" />
+                                  </node>
+                                  <node concept="liA8E" id="7jxV$rv427d" role="2OqNvi">
+                                    <ref role="37wK5l" to="qkt:~ActionManager.getAction(java.lang.String)" resolve="getAction" />
+                                    <node concept="37vLTw" id="7jxV$rv4gqp" role="37wK5m">
+                                      <ref role="3cqZAo" node="7jxV$rv3ZGN" resolve="actionId" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
                             </node>
-                            <node concept="liA8E" id="fi1uEptFgc" role="2OqNvi">
-                              <ref role="37wK5l" node="6F5AXb8IsjZ" resolve="getIconPath" />
+                            <node concept="3clFbJ" id="7jxV$rv49GT" role="3cqZAp">
+                              <node concept="3clFbS" id="7jxV$rv49GV" role="3clFbx">
+                                <node concept="RRSsy" id="7jxV$rv4bsQ" role="3cqZAp">
+                                  <property role="RRSoG" value="gZ5fh_4/error" />
+                                  <node concept="3cpWs3" id="7jxV$rv4kXJ" role="RRSoy">
+                                    <node concept="Xl_RD" id="7jxV$rv4lnw" role="3uHU7w">
+                                      <property role="Xl_RC" value=". Skipping it!" />
+                                    </node>
+                                    <node concept="3cpWs3" id="7jxV$rv4dFl" role="3uHU7B">
+                                      <node concept="Xl_RD" id="7jxV$rv4bsS" role="3uHU7B">
+                                        <property role="Xl_RC" value="action not found for action-id: " />
+                                      </node>
+                                      <node concept="37vLTw" id="7jxV$rv4ecb" role="3uHU7w">
+                                        <ref role="3cqZAo" node="7jxV$rv3ZGN" resolve="actionId" />
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                              <node concept="3clFbC" id="7jxV$rv4aAU" role="3clFbw">
+                                <node concept="10Nm6u" id="7jxV$rv4b7v" role="3uHU7w" />
+                                <node concept="37vLTw" id="7jxV$rv4a2o" role="3uHU7B">
+                                  <ref role="3cqZAo" node="7jxV$rv41Fz" resolve="action" />
+                                </node>
+                              </node>
+                              <node concept="9aQIb" id="7jxV$rv4ekP" role="9aQIa">
+                                <node concept="3clFbS" id="7jxV$rv4ekQ" role="9aQI4">
+                                  <node concept="3clFbF" id="2D4mVfzvU3T" role="3cqZAp">
+                                    <node concept="2OqwBi" id="2D4mVfzvU3U" role="3clFbG">
+                                      <node concept="37vLTw" id="2D4mVfzvU3V" role="2Oq$k0">
+                                        <ref role="3cqZAo" node="2D4mVfzvU3z" resolve="toolBarActions" />
+                                      </node>
+                                      <node concept="liA8E" id="2D4mVfzvU3W" role="2OqNvi">
+                                        <ref role="37wK5l" to="qkt:~DefaultActionGroup.add(com.intellij.openapi.actionSystem.AnAction)" resolve="add" />
+                                        <node concept="37vLTw" id="7jxV$rv4hZu" role="37wK5m">
+                                          <ref role="3cqZAo" node="7jxV$rv41Fz" resolve="action" />
+                                        </node>
+                                      </node>
+                                    </node>
+                                  </node>
+                                  <node concept="3clFbJ" id="fi1uEptEif" role="3cqZAp">
+                                    <node concept="3clFbS" id="fi1uEptEih" role="3clFbx">
+                                      <node concept="3clFbF" id="59JBFovnJ0m" role="3cqZAp">
+                                        <node concept="2OqwBi" id="59JBFovnKBT" role="3clFbG">
+                                          <node concept="2YIFZM" id="59JBFovnJFs" role="2Oq$k0">
+                                            <ref role="37wK5l" to="8fb:~CustomActionsSchema.getInstance()" resolve="getInstance" />
+                                            <ref role="1Pybhc" to="8fb:~CustomActionsSchema" resolve="CustomActionsSchema" />
+                                          </node>
+                                          <node concept="liA8E" id="59JBFovnLyG" role="2OqNvi">
+                                            <ref role="37wK5l" to="8fb:~CustomActionsSchema.addIconCustomization(java.lang.String,java.lang.String)" resolve="addIconCustomization" />
+                                            <node concept="2OqwBi" id="59JBFovnNcg" role="37wK5m">
+                                              <node concept="37vLTw" id="59JBFovnMmy" role="2Oq$k0">
+                                                <ref role="3cqZAo" node="2D4mVfzvU4h" resolve="entry" />
+                                              </node>
+                                              <node concept="liA8E" id="59JBFovnO5U" role="2OqNvi">
+                                                <ref role="37wK5l" node="3m_GngirHOj" resolve="getId" />
+                                              </node>
+                                            </node>
+                                            <node concept="2OqwBi" id="59JBFovnQzf" role="37wK5m">
+                                              <node concept="37vLTw" id="59JBFovnPL1" role="2Oq$k0">
+                                                <ref role="3cqZAo" node="2D4mVfzvU4h" resolve="entry" />
+                                              </node>
+                                              <node concept="liA8E" id="59JBFovnRnU" role="2OqNvi">
+                                                <ref role="37wK5l" node="6F5AXb8IsjZ" resolve="getIconPath" />
+                                              </node>
+                                            </node>
+                                          </node>
+                                        </node>
+                                      </node>
+                                    </node>
+                                    <node concept="2OqwBi" id="fi1uEptFWy" role="3clFbw">
+                                      <node concept="2OqwBi" id="fi1uEptEX0" role="2Oq$k0">
+                                        <node concept="37vLTw" id="fi1uEptE$F" role="2Oq$k0">
+                                          <ref role="3cqZAo" node="2D4mVfzvU4h" resolve="entry" />
+                                        </node>
+                                        <node concept="liA8E" id="fi1uEptFgc" role="2OqNvi">
+                                          <ref role="37wK5l" node="6F5AXb8IsjZ" resolve="getIconPath" />
+                                        </node>
+                                      </node>
+                                      <node concept="17RvpY" id="fi1uEptH92" role="2OqNvi" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
                             </node>
                           </node>
-                          <node concept="17RvpY" id="fi1uEptH92" role="2OqNvi" />
                         </node>
                       </node>
                     </node>

--- a/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.asynccell/README.md
+++ b/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.asynccell/README.md
@@ -38,6 +38,10 @@ cell provider:
 
 As example, see `com.mbeddr.mpsutil.asynccell.sandbox`.
 
+# Errors
+
+If the query callback raises an exception, the exception will be logged to stdout, the value will be set to `ERR` and the cell will stop calling it (until the next editor update).
+
 # State
 It contains automated tests and a sandbox for manual tests.
 So far, only used in Security Analyst.

--- a/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.asynccell/models/plugin.mps
+++ b/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.asynccell/models/plugin.mps
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <model ref="r:73b20a73-cf2c-4df5-ab15-88626acb1e3d(com.mbeddr.mpsutil.asynccell.plugin)">
   <persistence version="9" />
+  <attribute name="doNotGenerate" value="false" />
   <languages>
     <use id="ef7bf5ac-d06c-4342-b11d-e42104eb9343" name="jetbrains.mps.lang.plugin.standalone" version="0" />
     <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="17" />
@@ -22,6 +23,7 @@
     <import index="hox0" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.style(MPS.Editor/)" />
     <import index="lui2" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.module(MPS.OpenAPI/)" />
     <import index="hyam" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt.event(JDK/)" />
+    <import index="5ueo" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.editor.runtime.style(MPS.Editor/)" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
   </imports>
   <registry>
@@ -2141,6 +2143,19 @@
                                   </node>
                                 </node>
                                 <node concept="3clFbS" id="3anL894Mo0G" role="1zc67A">
+                                  <node concept="3SKdUt" id="1_bTRifhsZ6" role="3cqZAp">
+                                    <node concept="1PaTwC" id="1_bTRifhsZ7" role="1aUNEU">
+                                      <node concept="3oM_SD" id="1_bTRifhsZ8" role="1PaTwD">
+                                        <property role="3oM_SC" value="&lt;no" />
+                                      </node>
+                                      <node concept="3oM_SD" id="1_bTRifhsZi" role="1PaTwD">
+                                        <property role="3oM_SC" value="line&gt;" />
+                                      </node>
+                                      <node concept="3oM_SD" id="1_bTRifhsZl" role="1PaTwD">
+                                        <property role="3oM_SC" value="print" />
+                                      </node>
+                                    </node>
+                                  </node>
                                   <node concept="3clFbF" id="3anL894Mo0H" role="3cqZAp">
                                     <node concept="2OqwBi" id="3anL894Mo0I" role="3clFbG">
                                       <node concept="37vLTw" id="3anL894Mo0J" role="2Oq$k0">
@@ -2148,6 +2163,100 @@
                                       </node>
                                       <node concept="liA8E" id="3anL894Mo0K" role="2OqNvi">
                                         <ref role="37wK5l" to="wyt6:~Throwable.printStackTrace()" resolve="printStackTrace" />
+                                      </node>
+                                    </node>
+                                  </node>
+                                  <node concept="3SKdUt" id="1_bTRifhtbV" role="3cqZAp">
+                                    <node concept="1PaTwC" id="1_bTRifhtbW" role="1aUNEU">
+                                      <node concept="3oM_SD" id="1_bTRifhtbX" role="1PaTwD">
+                                        <property role="3oM_SC" value="&lt;no" />
+                                      </node>
+                                      <node concept="3oM_SD" id="1_bTRifhtcc" role="1PaTwD">
+                                        <property role="3oM_SC" value="line&gt;" />
+                                      </node>
+                                      <node concept="3oM_SD" id="1_bTRifhtcf" role="1PaTwD">
+                                        <property role="3oM_SC" value="show" />
+                                      </node>
+                                      <node concept="3oM_SD" id="1_bTRifhtcj" role="1PaTwD">
+                                        <property role="3oM_SC" value="error" />
+                                      </node>
+                                    </node>
+                                  </node>
+                                  <node concept="3cpWs8" id="1_bTRifhulS" role="3cqZAp">
+                                    <node concept="3cpWsn" id="1_bTRifhulT" role="3cpWs9">
+                                      <property role="TrG5h" value="impl" />
+                                      <node concept="3uibUv" id="1_bTRifhulU" role="1tU5fm">
+                                        <ref role="3uigEE" to="5ueo:~StyleImpl" resolve="StyleImpl" />
+                                      </node>
+                                      <node concept="2ShNRf" id="1_bTRifhutz" role="33vP2m">
+                                        <node concept="1pGfFk" id="1_bTRifhvmP" role="2ShVmc">
+                                          <ref role="37wK5l" to="5ueo:~StyleImpl.&lt;init&gt;()" resolve="StyleImpl" />
+                                        </node>
+                                      </node>
+                                    </node>
+                                  </node>
+                                  <node concept="3clFbF" id="1_bTRifhvzM" role="3cqZAp">
+                                    <node concept="37vLTI" id="1_bTRifhvKh" role="3clFbG">
+                                      <node concept="2ShNRf" id="1_bTRifhvZI" role="37vLTx">
+                                        <node concept="1pGfFk" id="1_bTRifhvSs" role="2ShVmc">
+                                          <ref role="37wK5l" node="5HPe_Jxcpw8" resolve="AsyncCellValue" />
+                                          <node concept="Xl_RD" id="1_bTRifhw73" role="37wK5m">
+                                            <property role="Xl_RC" value="ERR_AsyncCell" />
+                                          </node>
+                                          <node concept="37vLTw" id="1_bTRifhwpv" role="37wK5m">
+                                            <ref role="3cqZAo" node="1_bTRifhulT" resolve="impl" />
+                                          </node>
+                                        </node>
+                                      </node>
+                                      <node concept="37vLTw" id="1_bTRifhvzK" role="37vLTJ">
+                                        <ref role="3cqZAo" node="3anL894Mo0i" resolve="result" />
+                                      </node>
+                                    </node>
+                                  </node>
+                                  <node concept="3SKdUt" id="1_bTRifhwFq" role="3cqZAp">
+                                    <node concept="1PaTwC" id="1_bTRifhwFr" role="1aUNEU">
+                                      <node concept="3oM_SD" id="1_bTRifhwFs" role="1PaTwD">
+                                        <property role="3oM_SC" value="&lt;no" />
+                                      </node>
+                                      <node concept="3oM_SD" id="1_bTRifhwFX" role="1PaTwD">
+                                        <property role="3oM_SC" value="line&gt;" />
+                                      </node>
+                                      <node concept="3oM_SD" id="1_bTRifhwG0" role="1PaTwD">
+                                        <property role="3oM_SC" value="and" />
+                                      </node>
+                                      <node concept="3oM_SD" id="1_bTRifhwG4" role="1PaTwD">
+                                        <property role="3oM_SC" value="forget" />
+                                      </node>
+                                      <node concept="3oM_SD" id="1_bTRifhwG9" role="1PaTwD">
+                                        <property role="3oM_SC" value="about" />
+                                      </node>
+                                      <node concept="3oM_SD" id="1_bTRifhwGf" role="1PaTwD">
+                                        <property role="3oM_SC" value="it" />
+                                      </node>
+                                      <node concept="3oM_SD" id="1_bTRifhwGm" role="1PaTwD">
+                                        <property role="3oM_SC" value="immediately" />
+                                      </node>
+                                      <node concept="3oM_SD" id="1_bTRifhwGu" role="1PaTwD">
+                                        <property role="3oM_SC" value="to" />
+                                      </node>
+                                      <node concept="3oM_SD" id="1_bTRifhwGB" role="1PaTwD">
+                                        <property role="3oM_SC" value="prevent" />
+                                      </node>
+                                      <node concept="3oM_SD" id="1_bTRifhwGL" role="1PaTwD">
+                                        <property role="3oM_SC" value="spamming" />
+                                      </node>
+                                    </node>
+                                  </node>
+                                  <node concept="3clFbF" id="1_bTRifhx4r" role="3cqZAp">
+                                    <node concept="2OqwBi" id="1_bTRifhxkD" role="3clFbG">
+                                      <node concept="37vLTw" id="1_bTRifhx4p" role="2Oq$k0">
+                                        <ref role="3cqZAo" node="5HPe_JwXHEl" resolve="_cellManager" />
+                                      </node>
+                                      <node concept="liA8E" id="1_bTRifhxu0" role="2OqNvi">
+                                        <ref role="37wK5l" node="5HPe_JwZDXR" resolve="removeAsyncCell" />
+                                        <node concept="2GrUjf" id="1_bTRifhxAU" role="37wK5m">
+                                          <ref role="2Gs0qQ" node="3anL894Mo04" resolve="cell" />
+                                        </node>
                                       </node>
                                     </node>
                                   </node>

--- a/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.editingGuide.execution/models/com/mbeddr/mpsutil/editingGuide/execution.mps
+++ b/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.editingGuide.execution/models/com/mbeddr/mpsutil/editingGuide/execution.mps
@@ -1498,6 +1498,47 @@
                 </node>
               </node>
             </node>
+            <node concept="3clFbF" id="1_bTRifhjV$" role="3cqZAp">
+              <node concept="2OqwBi" id="1_bTRifhl_8" role="3clFbG">
+                <node concept="1eOMI4" id="1_bTRifhjVy" role="2Oq$k0">
+                  <node concept="10QFUN" id="1_bTRifhjVv" role="1eOMHV">
+                    <node concept="3uibUv" id="1_bTRifhkLV" role="10QFUM">
+                      <ref role="3uigEE" to="z1c3:~AbstractModule" resolve="AbstractModule" />
+                    </node>
+                    <node concept="2OqwBi" id="1_bTRifhl67" role="10QFUP">
+                      <node concept="37vLTw" id="1_bTRifhkUv" role="2Oq$k0">
+                        <ref role="3cqZAo" node="692bXAb5E1e" resolve="tempModel" />
+                      </node>
+                      <node concept="liA8E" id="1_bTRifhlhU" role="2OqNvi">
+                        <ref role="37wK5l" to="mhbf:~SModel.getModule()" resolve="getModule" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="liA8E" id="1_bTRifhlUu" role="2OqNvi">
+                  <ref role="37wK5l" to="z1c3:~AbstractModule.addDependency(org.jetbrains.mps.openapi.module.SModuleReference,boolean)" resolve="addDependency" />
+                  <node concept="2OqwBi" id="1_bTRifho2w" role="37wK5m">
+                    <node concept="2OqwBi" id="1_bTRifhnsN" role="2Oq$k0">
+                      <node concept="2JrnkZ" id="1_bTRifhnbx" role="2Oq$k0">
+                        <node concept="2OqwBi" id="1_bTRifhmxR" role="2JrQYb">
+                          <node concept="37vLTw" id="1_bTRifhm4f" role="2Oq$k0">
+                            <ref role="3cqZAo" node="5h2rxDjX6nB" resolve="myOriginalExercise" />
+                          </node>
+                          <node concept="I4A8Y" id="1_bTRifhmNA" role="2OqNvi" />
+                        </node>
+                      </node>
+                      <node concept="liA8E" id="1_bTRifhnSv" role="2OqNvi">
+                        <ref role="37wK5l" to="mhbf:~SModel.getModule()" resolve="getModule" />
+                      </node>
+                    </node>
+                    <node concept="liA8E" id="1_bTRifhoik" role="2OqNvi">
+                      <ref role="37wK5l" to="lui2:~SModule.getModuleReference()" resolve="getModuleReference" />
+                    </node>
+                  </node>
+                  <node concept="3clFbT" id="1_bTRifhoCs" role="37wK5m" />
+                </node>
+              </node>
+            </node>
             <node concept="3clFbF" id="c5q2Wzl9AX" role="3cqZAp">
               <node concept="2OqwBi" id="c5q2WzlaqL" role="3clFbG">
                 <node concept="1eOMI4" id="c5q2Wzl9AZ" role="2Oq$k0">


### PR DESCRIPTION
Implement remaining changes from `maintenance/mps20193-seca` (not merged PR #2198) on top of `maintenance/mps20203` by hand using MPS version 2020.3.

### Affected
project mpsutil:
- asynccell changes (cherry-picked): updated
- editingGuide: `PropgramFragment` and `ExerciseExecutor`: minor changes
- hyperlink: `HyperlinkUtil`: minor changes
- actionsfilter: minor changes and some error fixes

project mbeddr.core
- `IMbeddrIDERoot` and `MbeddrMenuHelper`

### Changes not transferred
- project build: seems to be up-to-date
- graphstream: seems outdated
- incrementalcomputation: seems outdated
- AssessmentQuery: irrelevant