### PR TITLE
ActionsFilter: add an activation condition

### DIFF
--- a/code/languages/com.mbeddr.build/solutions/com.mbeddr.platform/models/com/mbeddr/platform/build.mps
+++ b/code/languages/com.mbeddr.build/solutions/com.mbeddr.platform/models/com/mbeddr/platform/build.mps
@@ -14295,6 +14295,11 @@
               </node>
             </node>
           </node>
+          <node concept="1SiIV0" id="2jUI4_LVCQc" role="3bR37C">
+            <node concept="3bR9La" id="2jUI4_LVCQd" role="1SiIV1">
+              <ref role="3bR37D" to="ffeo:1ia2VB5guYy" resolve="MPS.IDEA" />
+            </node>
+          </node>
         </node>
         <node concept="1E0d5M" id="7YLbEQvgyh2" role="1E1XAP">
           <ref role="1E0d5P" to="ffeo:2eDSGe9d1q1" resolve="MPS.Workbench" />
@@ -14319,6 +14324,16 @@
             <node concept="3qWCbU" id="4PRpvcZJNNT" role="3LXTna">
               <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
             </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2jUI4_LVCPX" role="3bR37C">
+          <node concept="3bR9La" id="2jUI4_LVCPY" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:7Kfy9QB6KYb" resolve="jetbrains.mps.baseLanguage" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2jUI4_LVCQa" role="3bR37C">
+          <node concept="1Busua" id="2jUI4_LVCQb" role="1SiIV1">
+            <ref role="1Busuk" to="ffeo:7Kfy9QB6KYb" resolve="jetbrains.mps.baseLanguage" />
           </node>
         </node>
       </node>

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.actionsfilter/com.mbeddr.mpsutil.actionsfilter.mpl
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.actionsfilter/com.mbeddr.mpsutil.actionsfilter.mpl
@@ -28,6 +28,7 @@
         <dependency reexport="false">ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)</dependency>
         <dependency reexport="false">ef7bf5ac-d06c-4342-b11d-e42104eb9343(jetbrains.mps.lang.plugin.standalone)</dependency>
         <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
+        <dependency reexport="false">498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)</dependency>
       </dependencies>
       <languageVersions>
         <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
@@ -95,6 +96,7 @@
     <dependency reexport="true">436eb984-d162-4543-a347-2601ff5bb2a0(com.mbeddr.mpsutil.actionsfilter.runtime)</dependency>
     <dependency reexport="false" scope="generate-into">ef7bf5ac-d06c-4342-b11d-e42104eb9343(jetbrains.mps.lang.plugin.standalone)</dependency>
     <dependency reexport="true">982eb8df-2c96-4bd7-9963-11712ea622e5(jetbrains.mps.lang.resources)</dependency>
+    <dependency reexport="false">f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
@@ -160,6 +162,8 @@
     <dependency reexport="false">436eb984-d162-4543-a347-2601ff5bb2a0(com.mbeddr.mpsutil.actionsfilter.runtime)</dependency>
     <dependency reexport="false">86441d7a-e194-42da-81a5-2161ec62a379(MPS.Workbench)</dependency>
   </runtime>
-  <extendedLanguages />
+  <extendedLanguages>
+    <extendedLanguage>f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)</extendedLanguage>
+  </extendedLanguages>
 </language>
 

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.actionsfilter/generator/template/main@generator.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.actionsfilter/generator/template/main@generator.mps
@@ -14,7 +14,10 @@
     <import index="tgbt" ref="r:c70ee934-afb1-4c02-b6a9-1c4d1908a792(jetbrains.mps.lang.plugin.standalone.structure)" />
     <import index="ykkq" ref="r:7171fd48-62d6-4c67-ab22-d7d6b8fa4653(com.mbeddr.mpsutil.actionsfilter.runtime)" />
     <import index="8fb" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ide.ui.customization(MPS.IDEA/)" />
+    <import index="bd8o" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.application(MPS.IDEA/)" />
     <import index="au0v" ref="r:ae24f9b4-2210-4864-8fbf-79fb5fb02754(com.mbeddr.mpsutil.actionsfilter.structure)" implicit="true" />
+    <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" implicit="true" />
+    <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
     <import index="jm5d" ref="r:48ef7588-196b-4d9d-b0a1-f8a83910685c(com.mbeddr.mpsutil.actionsfilter.behavior)" implicit="true" />
   </imports>
   <registry>
@@ -40,6 +43,12 @@
       </concept>
       <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="1188207840427" name="jetbrains.mps.baseLanguage.structure.AnnotationInstance" flags="nn" index="2AHcQZ">
+        <reference id="1188208074048" name="annotation" index="2AI5Lk" />
+      </concept>
+      <concept id="1188208481402" name="jetbrains.mps.baseLanguage.structure.HasAnnotation" flags="ng" index="2AJDlI">
+        <child id="1188208488637" name="annotation" index="2AJF6D" />
+      </concept>
       <concept id="2820489544401957797" name="jetbrains.mps.baseLanguage.structure.DefaultClassCreator" flags="nn" index="HV5vD">
         <reference id="2820489544401957798" name="classifier" index="HV5vE" />
       </concept>
@@ -60,6 +69,9 @@
       <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
         <property id="1070475926801" name="value" index="Xl_RC" />
       </concept>
+      <concept id="1182160077978" name="jetbrains.mps.baseLanguage.structure.AnonymousClassCreator" flags="nn" index="YeOm9">
+        <child id="1182160096073" name="cls" index="YeSDq" />
+      </concept>
       <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
         <reference id="1144433194310" name="classConcept" index="1Pybhc" />
       </concept>
@@ -71,6 +83,7 @@
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
+      <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
       <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
       <concept id="1225271283259" name="jetbrains.mps.baseLanguage.structure.NPEEqualsExpression" flags="nn" index="17R0WA" />
       <concept id="1225271369338" name="jetbrains.mps.baseLanguage.structure.IsEmptyOperation" flags="nn" index="17RlXB" />
@@ -78,6 +91,12 @@
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
       </concept>
+      <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
+        <child id="1068580123133" name="returnType" index="3clF45" />
+        <child id="1068580123134" name="parameter" index="3clF46" />
+        <child id="1068580123135" name="body" index="3clF47" />
+      </concept>
+      <concept id="1068580123165" name="jetbrains.mps.baseLanguage.structure.InstanceMethodDeclaration" flags="ig" index="3clFb_" />
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
@@ -107,6 +126,10 @@
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
       <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk" />
+      <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
+        <property id="521412098689998745" name="nonStatic" index="2bfB8j" />
+        <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
+      </concept>
       <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
         <reference id="1107535924139" name="classifier" index="3uigEE" />
       </concept>
@@ -118,13 +141,20 @@
       <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
       </concept>
+      <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
       <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
       <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
+      <concept id="1170345865475" name="jetbrains.mps.baseLanguage.structure.AnonymousClass" flags="ig" index="1Y3b0j">
+        <reference id="1170346070688" name="classifier" index="1Y3XeK" />
+      </concept>
     </language>
     <language id="b401a680-8325-4110-8fd3-84331ff25bef" name="jetbrains.mps.lang.generator">
       <concept id="1114706874351" name="jetbrains.mps.lang.generator.structure.CopySrcNodeMacro" flags="ln" index="29HgVG" />
       <concept id="1219952072943" name="jetbrains.mps.lang.generator.structure.DropRootRule" flags="lg" index="aNPBN">
         <reference id="1219952338328" name="applicableConcept" index="aOQi4" />
+      </concept>
+      <concept id="1114729360583" name="jetbrains.mps.lang.generator.structure.CopySrcListMacro" flags="ln" index="2b32R4">
+        <child id="1168278589236" name="sourceNodesQuery" index="2P8S$" />
       </concept>
       <concept id="1095416546421" name="jetbrains.mps.lang.generator.structure.MappingConfiguration" flags="ig" index="bUwia">
         <child id="1219952894531" name="dropRootRule" index="aQYdv" />
@@ -563,29 +593,93 @@
                   <ref role="3uigEE" to="ykkq:3NH93czfhb6" resolve="Profile" />
                 </node>
                 <node concept="2ShNRf" id="1_Ri$6xxOBz" role="33vP2m">
-                  <node concept="1pGfFk" id="1_Ri$6xxOBy" role="2ShVmc">
-                    <ref role="37wK5l" to="ykkq:1_Ri$6xA5bf" resolve="Profile" />
-                    <node concept="Xl_RD" id="1_Ri$6xy6hF" role="37wK5m">
-                      <property role="Xl_RC" value="name" />
-                      <node concept="17Uvod" id="1_Ri$6xy84Q" role="lGtFl">
-                        <property role="P4ACc" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1070475926800/1070475926801" />
-                        <property role="2qtEX9" value="value" />
-                        <node concept="3zFVjK" id="1_Ri$6xy84R" role="3zH0cK">
-                          <node concept="3clFbS" id="1_Ri$6xy84S" role="2VODD2">
-                            <node concept="3clFbF" id="1_Ri$6xy8eR" role="3cqZAp">
-                              <node concept="2OqwBi" id="1_Ri$6xy8jI" role="3clFbG">
-                                <node concept="30H73N" id="1_Ri$6xy8eQ" role="2Oq$k0" />
-                                <node concept="3TrcHB" id="1_Ri$6xy9dw" role="2OqNvi">
-                                  <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                  <node concept="YeOm9" id="2jUI4_LRxse" role="2ShVmc">
+                    <node concept="1Y3b0j" id="2jUI4_LRxsh" role="YeSDq">
+                      <property role="2bfB8j" value="true" />
+                      <ref role="37wK5l" to="ykkq:1_Ri$6xA5bf" resolve="Profile" />
+                      <ref role="1Y3XeK" to="ykkq:3NH93czfhb6" resolve="Profile" />
+                      <node concept="3Tm1VV" id="2jUI4_LRxsi" role="1B3o_S" />
+                      <node concept="Xl_RD" id="1_Ri$6xy6hF" role="37wK5m">
+                        <property role="Xl_RC" value="name" />
+                        <node concept="17Uvod" id="1_Ri$6xy84Q" role="lGtFl">
+                          <property role="P4ACc" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1070475926800/1070475926801" />
+                          <property role="2qtEX9" value="value" />
+                          <node concept="3zFVjK" id="1_Ri$6xy84R" role="3zH0cK">
+                            <node concept="3clFbS" id="1_Ri$6xy84S" role="2VODD2">
+                              <node concept="3clFbF" id="1_Ri$6xy8eR" role="3cqZAp">
+                                <node concept="2OqwBi" id="1_Ri$6xy8jI" role="3clFbG">
+                                  <node concept="30H73N" id="1_Ri$6xy8eQ" role="2Oq$k0" />
+                                  <node concept="3TrcHB" id="1_Ri$6xy9dw" role="2OqNvi">
+                                    <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                                  </node>
                                 </node>
                               </node>
                             </node>
                           </node>
                         </node>
                       </node>
-                    </node>
-                    <node concept="3clFbT" id="1_Ri$6xA7c2" role="37wK5m">
-                      <property role="3clFbU" value="true" />
+                      <node concept="3clFbT" id="1_Ri$6xA7c2" role="37wK5m">
+                        <property role="3clFbU" value="true" />
+                      </node>
+                      <node concept="3clFb_" id="2jUI4_LRycf" role="jymVt">
+                        <property role="TrG5h" value="canBeActivated" />
+                        <node concept="3Tm1VV" id="2jUI4_LRycj" role="1B3o_S" />
+                        <node concept="10P_77" id="2jUI4_LRyck" role="3clF45" />
+                        <node concept="37vLTG" id="2jUI4_LRycl" role="3clF46">
+                          <property role="TrG5h" value="applicationInfo" />
+                          <node concept="3uibUv" id="2jUI4_LRycm" role="1tU5fm">
+                            <ref role="3uigEE" to="bd8o:~ApplicationInfo" resolve="ApplicationInfo" />
+                          </node>
+                        </node>
+                        <node concept="3clFbS" id="2jUI4_LRyco" role="3clF47">
+                          <node concept="3clFbH" id="2jUI4_LSmTO" role="3cqZAp">
+                            <node concept="2b32R4" id="2jUI4_LSnzO" role="lGtFl">
+                              <node concept="3JmXsc" id="2jUI4_LSnzP" role="2P8S$">
+                                <node concept="3clFbS" id="2jUI4_LSnzQ" role="2VODD2">
+                                  <node concept="3clFbF" id="2jUI4_LSbbX" role="3cqZAp">
+                                    <node concept="2OqwBi" id="2jUI4_LSe6$" role="3clFbG">
+                                      <node concept="2OqwBi" id="2jUI4_LScLg" role="2Oq$k0">
+                                        <node concept="2OqwBi" id="2jUI4_LSbIL" role="2Oq$k0">
+                                          <node concept="30H73N" id="2jUI4_LSbbW" role="2Oq$k0" />
+                                          <node concept="3TrEf2" id="2jUI4_LSce0" role="2OqNvi">
+                                            <ref role="3Tt5mk" to="au0v:2jUI4_LR89f" resolve="activationCondition" />
+                                          </node>
+                                        </node>
+                                        <node concept="3TrEf2" id="2jUI4_LSdvR" role="2OqNvi">
+                                          <ref role="3Tt5mk" to="tpee:gyVODHa" resolve="body" />
+                                        </node>
+                                      </node>
+                                      <node concept="3Tsc0h" id="2jUI4_LSg4m" role="2OqNvi">
+                                        <ref role="3TtcxE" to="tpee:fzcqZ_x" resolve="statement" />
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="2AHcQZ" id="2jUI4_LRycp" role="2AJF6D">
+                          <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                        </node>
+                        <node concept="1W57fq" id="2jUI4_LR$iY" role="lGtFl">
+                          <node concept="3IZrLx" id="2jUI4_LR$j1" role="3IZSJc">
+                            <node concept="3clFbS" id="2jUI4_LR$j2" role="2VODD2">
+                              <node concept="3clFbF" id="2jUI4_LR$j8" role="3cqZAp">
+                                <node concept="2OqwBi" id="2jUI4_LR_Oa" role="3clFbG">
+                                  <node concept="2OqwBi" id="2jUI4_LR$j3" role="2Oq$k0">
+                                    <node concept="30H73N" id="2jUI4_LR$j7" role="2Oq$k0" />
+                                    <node concept="3TrEf2" id="2jUI4_LR_r7" role="2OqNvi">
+                                      <ref role="3Tt5mk" to="au0v:2jUI4_LR89f" resolve="activationCondition" />
+                                    </node>
+                                  </node>
+                                  <node concept="3x8VRR" id="2jUI4_LRAsO" role="2OqNvi" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
                     </node>
                   </node>
                 </node>
@@ -881,15 +975,29 @@
                   </node>
                 </node>
               </node>
-              <node concept="1Wc70l" id="1KfSgTa_I4C" role="3clFbw">
-                <node concept="3fqX7Q" id="1KfSgTa_Ify" role="3uHU7w">
-                  <node concept="37vLTw" id="1KfSgTa_Iga" role="3fr31v">
-                    <ref role="3cqZAo" node="1KfSgTa_HCe" resolve="defaultProfileLoaded" />
+              <node concept="1Wc70l" id="2jUI4_LSpDG" role="3clFbw">
+                <node concept="2OqwBi" id="2jUI4_LSqzn" role="3uHU7w">
+                  <node concept="37vLTw" id="2jUI4_LSqd8" role="2Oq$k0">
+                    <ref role="3cqZAo" node="1_Ri$6xxOm7" resolve="profile" />
+                  </node>
+                  <node concept="liA8E" id="2jUI4_LSrZO" role="2OqNvi">
+                    <ref role="37wK5l" to="ykkq:2jUI4_LRtLD" resolve="canBeActivated" />
+                    <node concept="2YIFZM" id="2jUI4_LSGOC" role="37wK5m">
+                      <ref role="37wK5l" to="bd8o:~ApplicationInfo.getInstance()" resolve="getInstance" />
+                      <ref role="1Pybhc" to="bd8o:~ApplicationInfo" resolve="ApplicationInfo" />
+                    </node>
                   </node>
                 </node>
-                <node concept="3fqX7Q" id="1KfSgTa_$5Z" role="3uHU7B">
-                  <node concept="37vLTw" id="1KfSgTa_$eA" role="3fr31v">
-                    <ref role="3cqZAo" node="1KfSgTa_yzv" resolve="hasUserSelectedProfile" />
+                <node concept="1Wc70l" id="1KfSgTa_I4C" role="3uHU7B">
+                  <node concept="3fqX7Q" id="1KfSgTa_$5Z" role="3uHU7B">
+                    <node concept="37vLTw" id="1KfSgTa_$eA" role="3fr31v">
+                      <ref role="3cqZAo" node="1KfSgTa_yzv" resolve="hasUserSelectedProfile" />
+                    </node>
+                  </node>
+                  <node concept="3fqX7Q" id="1KfSgTa_Ify" role="3uHU7w">
+                    <node concept="37vLTw" id="1KfSgTa_Iga" role="3fr31v">
+                      <ref role="3cqZAo" node="1KfSgTa_HCe" resolve="defaultProfileLoaded" />
+                    </node>
                   </node>
                 </node>
               </node>

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.actionsfilter/generator/template/main@generator.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.actionsfilter/generator/template/main@generator.mps
@@ -17,7 +17,6 @@
     <import index="bd8o" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.application(MPS.IDEA/)" />
     <import index="au0v" ref="r:ae24f9b4-2210-4864-8fbf-79fb5fb02754(com.mbeddr.mpsutil.actionsfilter.structure)" implicit="true" />
     <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" implicit="true" />
-    <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
     <import index="jm5d" ref="r:48ef7588-196b-4d9d-b0a1-f8a83910685c(com.mbeddr.mpsutil.actionsfilter.behavior)" implicit="true" />
   </imports>
   <registry>
@@ -43,12 +42,6 @@
       </concept>
       <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
-      <concept id="1188207840427" name="jetbrains.mps.baseLanguage.structure.AnnotationInstance" flags="nn" index="2AHcQZ">
-        <reference id="1188208074048" name="annotation" index="2AI5Lk" />
-      </concept>
-      <concept id="1188208481402" name="jetbrains.mps.baseLanguage.structure.HasAnnotation" flags="ng" index="2AJDlI">
-        <child id="1188208488637" name="annotation" index="2AJF6D" />
-      </concept>
       <concept id="2820489544401957797" name="jetbrains.mps.baseLanguage.structure.DefaultClassCreator" flags="nn" index="HV5vD">
         <reference id="2820489544401957798" name="classifier" index="HV5vE" />
       </concept>
@@ -69,9 +62,6 @@
       <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
         <property id="1070475926801" name="value" index="Xl_RC" />
       </concept>
-      <concept id="1182160077978" name="jetbrains.mps.baseLanguage.structure.AnonymousClassCreator" flags="nn" index="YeOm9">
-        <child id="1182160096073" name="cls" index="YeSDq" />
-      </concept>
       <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
         <reference id="1144433194310" name="classConcept" index="1Pybhc" />
       </concept>
@@ -91,12 +81,6 @@
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
       </concept>
-      <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
-        <child id="1068580123133" name="returnType" index="3clF45" />
-        <child id="1068580123134" name="parameter" index="3clF46" />
-        <child id="1068580123135" name="body" index="3clF47" />
-      </concept>
-      <concept id="1068580123165" name="jetbrains.mps.baseLanguage.structure.InstanceMethodDeclaration" flags="ig" index="3clFb_" />
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
@@ -126,10 +110,6 @@
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
       <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk" />
-      <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
-        <property id="521412098689998745" name="nonStatic" index="2bfB8j" />
-        <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
-      </concept>
       <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
         <reference id="1107535924139" name="classifier" index="3uigEE" />
       </concept>
@@ -141,12 +121,8 @@
       <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
       </concept>
-      <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
       <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
       <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
-      <concept id="1170345865475" name="jetbrains.mps.baseLanguage.structure.AnonymousClass" flags="ig" index="1Y3b0j">
-        <reference id="1170346070688" name="classifier" index="1Y3XeK" />
-      </concept>
     </language>
     <language id="b401a680-8325-4110-8fd3-84331ff25bef" name="jetbrains.mps.lang.generator">
       <concept id="1114706874351" name="jetbrains.mps.lang.generator.structure.CopySrcNodeMacro" flags="ln" index="29HgVG" />
@@ -593,87 +569,20 @@
                   <ref role="3uigEE" to="ykkq:3NH93czfhb6" resolve="Profile" />
                 </node>
                 <node concept="2ShNRf" id="1_Ri$6xxOBz" role="33vP2m">
-                  <node concept="YeOm9" id="2jUI4_LRxse" role="2ShVmc">
-                    <node concept="1Y3b0j" id="2jUI4_LRxsh" role="YeSDq">
-                      <property role="2bfB8j" value="true" />
-                      <ref role="37wK5l" to="ykkq:1_Ri$6xA5bf" resolve="Profile" />
-                      <ref role="1Y3XeK" to="ykkq:3NH93czfhb6" resolve="Profile" />
-                      <node concept="3Tm1VV" id="2jUI4_LRxsi" role="1B3o_S" />
-                      <node concept="Xl_RD" id="1_Ri$6xy6hF" role="37wK5m">
-                        <property role="Xl_RC" value="name" />
-                        <node concept="17Uvod" id="1_Ri$6xy84Q" role="lGtFl">
-                          <property role="P4ACc" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1070475926800/1070475926801" />
-                          <property role="2qtEX9" value="value" />
-                          <node concept="3zFVjK" id="1_Ri$6xy84R" role="3zH0cK">
-                            <node concept="3clFbS" id="1_Ri$6xy84S" role="2VODD2">
-                              <node concept="3clFbF" id="1_Ri$6xy8eR" role="3cqZAp">
-                                <node concept="2OqwBi" id="1_Ri$6xy8jI" role="3clFbG">
-                                  <node concept="30H73N" id="1_Ri$6xy8eQ" role="2Oq$k0" />
-                                  <node concept="3TrcHB" id="1_Ri$6xy9dw" role="2OqNvi">
-                                    <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="3clFbT" id="1_Ri$6xA7c2" role="37wK5m">
-                        <property role="3clFbU" value="true" />
-                      </node>
-                      <node concept="3clFb_" id="2jUI4_LRycf" role="jymVt">
-                        <property role="TrG5h" value="canBeActivated" />
-                        <node concept="3Tm1VV" id="2jUI4_LRycj" role="1B3o_S" />
-                        <node concept="10P_77" id="2jUI4_LRyck" role="3clF45" />
-                        <node concept="37vLTG" id="2jUI4_LRycl" role="3clF46">
-                          <property role="TrG5h" value="applicationInfo" />
-                          <node concept="3uibUv" id="2jUI4_LRycm" role="1tU5fm">
-                            <ref role="3uigEE" to="bd8o:~ApplicationInfo" resolve="ApplicationInfo" />
-                          </node>
-                        </node>
-                        <node concept="3clFbS" id="2jUI4_LRyco" role="3clF47">
-                          <node concept="3clFbH" id="2jUI4_LSmTO" role="3cqZAp">
-                            <node concept="2b32R4" id="2jUI4_LSnzO" role="lGtFl">
-                              <node concept="3JmXsc" id="2jUI4_LSnzP" role="2P8S$">
-                                <node concept="3clFbS" id="2jUI4_LSnzQ" role="2VODD2">
-                                  <node concept="3clFbF" id="2jUI4_LSbbX" role="3cqZAp">
-                                    <node concept="2OqwBi" id="2jUI4_LSe6$" role="3clFbG">
-                                      <node concept="2OqwBi" id="2jUI4_LScLg" role="2Oq$k0">
-                                        <node concept="2OqwBi" id="2jUI4_LSbIL" role="2Oq$k0">
-                                          <node concept="30H73N" id="2jUI4_LSbbW" role="2Oq$k0" />
-                                          <node concept="3TrEf2" id="2jUI4_LSce0" role="2OqNvi">
-                                            <ref role="3Tt5mk" to="au0v:2jUI4_LR89f" resolve="activationCondition" />
-                                          </node>
-                                        </node>
-                                        <node concept="3TrEf2" id="2jUI4_LSdvR" role="2OqNvi">
-                                          <ref role="3Tt5mk" to="tpee:gyVODHa" resolve="body" />
-                                        </node>
-                                      </node>
-                                      <node concept="3Tsc0h" id="2jUI4_LSg4m" role="2OqNvi">
-                                        <ref role="3TtcxE" to="tpee:fzcqZ_x" resolve="statement" />
-                                      </node>
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="2AHcQZ" id="2jUI4_LRycp" role="2AJF6D">
-                          <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-                        </node>
-                        <node concept="1W57fq" id="2jUI4_LR$iY" role="lGtFl">
-                          <node concept="3IZrLx" id="2jUI4_LR$j1" role="3IZSJc">
-                            <node concept="3clFbS" id="2jUI4_LR$j2" role="2VODD2">
-                              <node concept="3clFbF" id="2jUI4_LR$j8" role="3cqZAp">
-                                <node concept="2OqwBi" id="2jUI4_LR_Oa" role="3clFbG">
-                                  <node concept="2OqwBi" id="2jUI4_LR$j3" role="2Oq$k0">
-                                    <node concept="30H73N" id="2jUI4_LR$j7" role="2Oq$k0" />
-                                    <node concept="3TrEf2" id="2jUI4_LR_r7" role="2OqNvi">
-                                      <ref role="3Tt5mk" to="au0v:2jUI4_LR89f" resolve="activationCondition" />
-                                    </node>
-                                  </node>
-                                  <node concept="3x8VRR" id="2jUI4_LRAsO" role="2OqNvi" />
+                  <node concept="1pGfFk" id="3VOZakHQVyr" role="2ShVmc">
+                    <ref role="37wK5l" to="ykkq:1_Ri$6xA5bf" resolve="Profile" />
+                    <node concept="Xl_RD" id="1_Ri$6xy6hF" role="37wK5m">
+                      <property role="Xl_RC" value="name" />
+                      <node concept="17Uvod" id="1_Ri$6xy84Q" role="lGtFl">
+                        <property role="P4ACc" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1070475926800/1070475926801" />
+                        <property role="2qtEX9" value="value" />
+                        <node concept="3zFVjK" id="1_Ri$6xy84R" role="3zH0cK">
+                          <node concept="3clFbS" id="1_Ri$6xy84S" role="2VODD2">
+                            <node concept="3clFbF" id="1_Ri$6xy8eR" role="3cqZAp">
+                              <node concept="2OqwBi" id="1_Ri$6xy8jI" role="3clFbG">
+                                <node concept="30H73N" id="1_Ri$6xy8eQ" role="2Oq$k0" />
+                                <node concept="3TrcHB" id="1_Ri$6xy9dw" role="2OqNvi">
+                                  <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
                                 </node>
                               </node>
                             </node>
@@ -681,10 +590,80 @@
                         </node>
                       </node>
                     </node>
+                    <node concept="3clFbT" id="1_Ri$6xA7c2" role="37wK5m">
+                      <property role="3clFbU" value="true" />
+                    </node>
                   </node>
                 </node>
               </node>
             </node>
+            <node concept="3clFbF" id="3VOZakHQX0b" role="3cqZAp">
+              <node concept="2OqwBi" id="3VOZakHQXFW" role="3clFbG">
+                <node concept="37vLTw" id="3VOZakHQX09" role="2Oq$k0">
+                  <ref role="3cqZAo" node="1_Ri$6xxOm7" resolve="profile" />
+                </node>
+                <node concept="liA8E" id="3VOZakHQYPn" role="2OqNvi">
+                  <ref role="37wK5l" to="ykkq:3VOZakHQAq5" resolve="setDefaultActivationCondition" />
+                  <node concept="1bVj0M" id="3VOZakHR29f" role="37wK5m">
+                    <node concept="3clFbS" id="3VOZakHR29g" role="1bW5cS">
+                      <node concept="3cpWs6" id="3VOZakHR7e5" role="3cqZAp">
+                        <node concept="3clFbT" id="3VOZakHR7h8" role="3cqZAk">
+                          <property role="3clFbU" value="true" />
+                        </node>
+                        <node concept="2b32R4" id="3VOZakHR7nq" role="lGtFl">
+                          <node concept="3JmXsc" id="3VOZakHR7nr" role="2P8S$">
+                            <node concept="3clFbS" id="3VOZakHR7ns" role="2VODD2">
+                              <node concept="3clFbF" id="3VOZakHR4oM" role="3cqZAp">
+                                <node concept="2OqwBi" id="2jUI4_LSe6$" role="3clFbG">
+                                  <node concept="2OqwBi" id="2jUI4_LScLg" role="2Oq$k0">
+                                    <node concept="2OqwBi" id="2jUI4_LSbIL" role="2Oq$k0">
+                                      <node concept="30H73N" id="2jUI4_LSbbW" role="2Oq$k0" />
+                                      <node concept="3TrEf2" id="2jUI4_LSce0" role="2OqNvi">
+                                        <ref role="3Tt5mk" to="au0v:2jUI4_LR89f" resolve="defaultActivationCondition" />
+                                      </node>
+                                    </node>
+                                    <node concept="3TrEf2" id="2jUI4_LSdvR" role="2OqNvi">
+                                      <ref role="3Tt5mk" to="tpee:gyVODHa" resolve="body" />
+                                    </node>
+                                  </node>
+                                  <node concept="3Tsc0h" id="2jUI4_LSg4m" role="2OqNvi">
+                                    <ref role="3TtcxE" to="tpee:fzcqZ_x" resolve="statement" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="37vLTG" id="3VOZakHR2eq" role="1bW2Oz">
+                      <property role="TrG5h" value="applicationInfo" />
+                      <node concept="3uibUv" id="3VOZakHR2ep" role="1tU5fm">
+                        <ref role="3uigEE" to="bd8o:~ApplicationInfo" resolve="ApplicationInfo" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="1W57fq" id="3VOZakHR5bc" role="lGtFl">
+                  <node concept="3IZrLx" id="3VOZakHR5bf" role="3IZSJc">
+                    <node concept="3clFbS" id="3VOZakHR5bg" role="2VODD2">
+                      <node concept="3clFbF" id="3VOZakHR5bm" role="3cqZAp">
+                        <node concept="2OqwBi" id="3VOZakHR65m" role="3clFbG">
+                          <node concept="2OqwBi" id="3VOZakHR5bh" role="2Oq$k0">
+                            <node concept="30H73N" id="3VOZakHR5bl" role="2Oq$k0" />
+                            <node concept="3TrEf2" id="3VOZakHR5Gc" role="2OqNvi">
+                              <ref role="3Tt5mk" to="au0v:2jUI4_LR89f" resolve="defaultActivationCondition" />
+                            </node>
+                          </node>
+                          <node concept="3x8VRR" id="3VOZakHR6Cc" role="2OqNvi" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbH" id="3VOZakHQWuP" role="3cqZAp" />
             <node concept="3cpWs8" id="1_Ri$6xxQwO" role="3cqZAp">
               <node concept="3cpWsn" id="1_Ri$6xxQwP" role="3cpWs9">
                 <property role="TrG5h" value="settings" />
@@ -981,7 +960,7 @@
                     <ref role="3cqZAo" node="1_Ri$6xxOm7" resolve="profile" />
                   </node>
                   <node concept="liA8E" id="2jUI4_LSrZO" role="2OqNvi">
-                    <ref role="37wK5l" to="ykkq:2jUI4_LRtLD" resolve="canBeActivated" />
+                    <ref role="37wK5l" to="ykkq:2jUI4_LRtLD" resolve="canBeActivatedByDefault" />
                     <node concept="2YIFZM" id="2jUI4_LSGOC" role="37wK5m">
                       <ref role="37wK5l" to="bd8o:~ApplicationInfo.getInstance()" resolve="getInstance" />
                       <ref role="1Pybhc" to="bd8o:~ApplicationInfo" resolve="ApplicationInfo" />

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.actionsfilter/languageModels/behavior.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.actionsfilter/languageModels/behavior.mps
@@ -8,6 +8,9 @@
   <imports>
     <import index="ykkq" ref="r:7171fd48-62d6-4c67-ab22-d7d6b8fa4653(com.mbeddr.mpsutil.actionsfilter.runtime)" />
     <import index="au0v" ref="r:ae24f9b4-2210-4864-8fbf-79fb5fb02754(com.mbeddr.mpsutil.actionsfilter.structure)" />
+    <import index="tpek" ref="r:00000000-0000-4000-0000-011c895902c0(jetbrains.mps.baseLanguage.behavior)" />
+    <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" />
+    <import index="bd8o" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.application(MPS.IDEA/)" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
   </imports>
   <registry>
@@ -90,6 +93,9 @@
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
+      <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
+        <reference id="1107535924139" name="classifier" index="3uigEE" />
+      </concept>
       <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
         <child id="1081773367579" name="rightExpression" index="3uHU7w" />
         <child id="1081773367580" name="leftExpression" index="3uHU7B" />
@@ -107,6 +113,11 @@
         <child id="1199569916463" name="body" index="1bW5cS" />
       </concept>
     </language>
+    <language id="3a13115c-633c-4c5c-bbcc-75c4219e9555" name="jetbrains.mps.lang.quotation">
+      <concept id="1196350785113" name="jetbrains.mps.lang.quotation.structure.Quotation" flags="nn" index="2c44tf">
+        <child id="1196350785114" name="quotedNode" index="2c44tc" />
+      </concept>
+    </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
       <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
         <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
@@ -114,6 +125,12 @@
       <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
       <concept id="4693937538533521280" name="jetbrains.mps.lang.smodel.structure.OfConceptOperation" flags="ng" index="v3k3i">
         <child id="4693937538533538124" name="requestedConcept" index="v3oSu" />
+      </concept>
+      <concept id="2644386474300074836" name="jetbrains.mps.lang.smodel.structure.ConceptIdRefExpression" flags="nn" index="35c_gC">
+        <reference id="2644386474300074837" name="conceptDeclaration" index="35c_gD" />
+      </concept>
+      <concept id="6677504323281689838" name="jetbrains.mps.lang.smodel.structure.SConceptType" flags="in" index="3bZ5Sz">
+        <reference id="6677504323281689839" name="conceptDeclaraton" index="3bZ5Sy" />
       </concept>
       <concept id="1180636770613" name="jetbrains.mps.lang.smodel.structure.SNodeCreator" flags="nn" index="3zrR0B">
         <child id="1180636770616" name="createdType" index="3zrR0E" />
@@ -143,10 +160,18 @@
       <concept id="540871147943773365" name="jetbrains.mps.baseLanguage.collections.structure.SingleArgumentSequenceOperation" flags="nn" index="25WWJ4">
         <child id="540871147943773366" name="argument" index="25WWJ7" />
       </concept>
+      <concept id="1151688443754" name="jetbrains.mps.baseLanguage.collections.structure.ListType" flags="in" index="_YKpA">
+        <child id="1151688676805" name="elementType" index="_ZDj9" />
+      </concept>
       <concept id="1151689724996" name="jetbrains.mps.baseLanguage.collections.structure.SequenceType" flags="in" index="A3Dl8">
         <child id="1151689745422" name="elementType" index="A3Ik2" />
       </concept>
+      <concept id="1237721394592" name="jetbrains.mps.baseLanguage.collections.structure.AbstractContainerCreator" flags="nn" index="HWqM0">
+        <child id="1237721435807" name="elementType" index="HW$YZ" />
+      </concept>
       <concept id="1203518072036" name="jetbrains.mps.baseLanguage.collections.structure.SmartClosureParameterDeclaration" flags="ig" index="Rh6nW" />
+      <concept id="1160600644654" name="jetbrains.mps.baseLanguage.collections.structure.ListCreatorWithInit" flags="nn" index="Tc6Ow" />
+      <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="nn" index="TSZUe" />
       <concept id="1202120902084" name="jetbrains.mps.baseLanguage.collections.structure.WhereOperation" flags="nn" index="3zZkjj" />
       <concept id="1202128969694" name="jetbrains.mps.baseLanguage.collections.structure.SelectOperation" flags="nn" index="3$u5V9" />
       <concept id="1172254888721" name="jetbrains.mps.baseLanguage.collections.structure.ContainsOperation" flags="nn" index="3JPx81" />
@@ -463,6 +488,94 @@
     </node>
     <node concept="13hLZK" id="5ReuVUpd_x0" role="13h7CW">
       <node concept="3clFbS" id="5ReuVUpd_x1" role="2VODD2" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="2jUI4_LQMcJ">
+    <ref role="13h7C2" to="au0v:2jUI4_LQLA2" resolve="ActivationCondition" />
+    <node concept="13hLZK" id="2jUI4_LQMcK" role="13h7CW">
+      <node concept="3clFbS" id="2jUI4_LQMcL" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="2jUI4_LQM$b" role="13h7CS">
+      <property role="TrG5h" value="getParameterConcepts" />
+      <ref role="13i0hy" to="tpek:2xELmDxyi2v" resolve="getParameterConcepts" />
+      <node concept="3Tm1VV" id="2jUI4_LQM$j" role="1B3o_S" />
+      <node concept="3clFbS" id="2jUI4_LQM$k" role="3clF47">
+        <node concept="3cpWs8" id="2jUI4_LQMMA" role="3cqZAp">
+          <node concept="3cpWsn" id="2jUI4_LQMMD" role="3cpWs9">
+            <property role="TrG5h" value="parameters" />
+            <node concept="_YKpA" id="2jUI4_LQMM$" role="1tU5fm">
+              <node concept="3bZ5Sz" id="2jUI4_LQMMW" role="_ZDj9">
+                <ref role="3bZ5Sy" to="tpee:g76ryKb" resolve="ConceptFunctionParameter" />
+              </node>
+            </node>
+            <node concept="2ShNRf" id="2jUI4_LQMNX" role="33vP2m">
+              <node concept="Tc6Ow" id="2jUI4_LQOt3" role="2ShVmc">
+                <node concept="3bZ5Sz" id="2jUI4_LQOI$" role="HW$YZ">
+                  <ref role="3bZ5Sy" to="tpee:g76ryKb" resolve="ConceptFunctionParameter" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="2jUI4_LR5gR" role="3cqZAp">
+          <node concept="2OqwBi" id="2jUI4_LR5U$" role="3clFbG">
+            <node concept="37vLTw" id="2jUI4_LR5gP" role="2Oq$k0">
+              <ref role="3cqZAo" node="2jUI4_LQMMD" resolve="parameters" />
+            </node>
+            <node concept="TSZUe" id="2jUI4_LR6z$" role="2OqNvi">
+              <node concept="35c_gC" id="2jUI4_LR7Dr" role="25WWJ7">
+                <ref role="35c_gD" to="au0v:2jUI4_LQRKG" resolve="ConceptFunction_ApplicationInfo" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="2jUI4_LQOJ$" role="3cqZAp">
+          <node concept="37vLTw" id="2jUI4_LQOJy" role="3clFbG">
+            <ref role="3cqZAo" node="2jUI4_LQMMD" resolve="parameters" />
+          </node>
+        </node>
+      </node>
+      <node concept="_YKpA" id="2jUI4_LQM$l" role="3clF45">
+        <node concept="3bZ5Sz" id="2jUI4_LQM$m" role="_ZDj9">
+          <ref role="3bZ5Sy" to="tpee:g76ryKb" resolve="ConceptFunctionParameter" />
+        </node>
+      </node>
+    </node>
+    <node concept="13i0hz" id="2jUI4_LQMcU" role="13h7CS">
+      <property role="TrG5h" value="getExpectedReturnType" />
+      <ref role="13i0hy" to="tpek:hEwIGRD" resolve="getExpectedReturnType" />
+      <node concept="3Tm1VV" id="2jUI4_LQMcY" role="1B3o_S" />
+      <node concept="3clFbS" id="2jUI4_LQMd0" role="3clF47">
+        <node concept="3clFbF" id="2jUI4_LQMzd" role="3cqZAp">
+          <node concept="2c44tf" id="2jUI4_LQMzb" role="3clFbG">
+            <node concept="10P_77" id="2jUI4_LQMzH" role="2c44tc" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tqbb2" id="2jUI4_LQMd1" role="3clF45" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="2jUI4_LR4Qq">
+    <ref role="13h7C2" to="au0v:2jUI4_LQRKG" resolve="ConceptFunction_ApplicationInfo" />
+    <node concept="13hLZK" id="2jUI4_LR4Qr" role="13h7CW">
+      <node concept="3clFbS" id="2jUI4_LR4Qs" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="2jUI4_LR4Q_" role="13h7CS">
+      <property role="TrG5h" value="getType" />
+      <ref role="13i0hy" to="tpek:27DJnJtIQ9C" resolve="getType" />
+      <node concept="3Tm1VV" id="2jUI4_LR4QA" role="1B3o_S" />
+      <node concept="3clFbS" id="2jUI4_LR4QF" role="3clF47">
+        <node concept="3clFbF" id="2jUI4_LR4Zw" role="3cqZAp">
+          <node concept="2c44tf" id="2jUI4_LR5b4" role="3clFbG">
+            <node concept="3uibUv" id="2jUI4_LR5d3" role="2c44tc">
+              <ref role="3uigEE" to="bd8o:~ApplicationInfo" resolve="ApplicationInfo" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tqbb2" id="2jUI4_LR4QG" role="3clF45">
+        <ref role="ehGHo" to="tpee:fz3vP1H" resolve="Type" />
+      </node>
     </node>
   </node>
 </model>

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.actionsfilter/languageModels/editor.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.actionsfilter/languageModels/editor.mps
@@ -380,7 +380,7 @@
           </node>
           <node concept="3F1sOY" id="2jUI4_LR9vX" role="3EZMnx">
             <property role="1$x2rV" value="true" />
-            <ref role="1NtTu8" to="au0v:2jUI4_LR89f" resolve="activationCondition" />
+            <ref role="1NtTu8" to="au0v:2jUI4_LR89f" resolve="defaultActivationCondition" />
           </node>
         </node>
         <node concept="2iRfu4" id="2N0FrS4t_7Z" role="2iSdaV" />

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.actionsfilter/languageModels/editor.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.actionsfilter/languageModels/editor.mps
@@ -373,9 +373,19 @@
             <property role="1563Ve" value="[x]" />
           </node>
         </node>
+        <node concept="3EZMnI" id="2jUI4_LR9f8" role="3EZMnx">
+          <node concept="2iRfu4" id="2jUI4_LR9f9" role="2iSdaV" />
+          <node concept="3F0ifn" id="2N0FrS4t$Qu" role="3EZMnx">
+            <property role="3F0ifm" value="if" />
+          </node>
+          <node concept="3F1sOY" id="2jUI4_LR9vX" role="3EZMnx">
+            <property role="1$x2rV" value="true" />
+            <ref role="1NtTu8" to="au0v:2jUI4_LR89f" resolve="activationCondition" />
+          </node>
+        </node>
         <node concept="2iRfu4" id="2N0FrS4t_7Z" role="2iSdaV" />
       </node>
-      <node concept="3F0ifn" id="2N0FrS4t$Qu" role="3EZMnx" />
+      <node concept="3F0ifn" id="2jUI4_LR8Yq" role="3EZMnx" />
       <node concept="3EZMnI" id="5ReuVUpcYAr" role="3EZMnx">
         <node concept="VPM3Z" id="5ReuVUpcYAt" role="3F10Kt">
           <property role="VOm3f" value="false" />

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.actionsfilter/languageModels/structure.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.actionsfilter/languageModels/structure.mps
@@ -85,7 +85,7 @@
     <node concept="1TJgyj" id="2jUI4_LR89f" role="1TKVEi">
       <property role="IQ2ns" value="2664644755125469775" />
       <property role="20lmBu" value="fLJjDmT/aggregation" />
-      <property role="20kJfa" value="activationCondition" />
+      <property role="20kJfa" value="defaultActivationCondition" />
       <ref role="20lvS9" node="2jUI4_LQLA2" resolve="ActivationCondition" />
     </node>
     <node concept="PrWs8" id="5FJiYrlIp_E" role="PzmwI">

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.actionsfilter/languageModels/structure.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.actionsfilter/languageModels/structure.mps
@@ -8,6 +8,7 @@
   <imports>
     <import index="1oap" ref="r:03d44d4c-3d65-461c-9085-0f48e9569e59(jetbrains.mps.lang.resources.structure)" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
+    <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" implicit="true" />
   </imports>
   <registry>
     <language id="c72da2b9-7cce-4447-8389-f407dc1158b7" name="jetbrains.mps.lang.structure">
@@ -80,6 +81,12 @@
       <property role="20lmBu" value="fLJjDmT/aggregation" />
       <property role="20kJfa" value="toolBar" />
       <ref role="20lvS9" node="6nrtUqYelxU" resolve="ToolBar" />
+    </node>
+    <node concept="1TJgyj" id="2jUI4_LR89f" role="1TKVEi">
+      <property role="IQ2ns" value="2664644755125469775" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="activationCondition" />
+      <ref role="20lvS9" node="2jUI4_LQLA2" resolve="ActivationCondition" />
     </node>
     <node concept="PrWs8" id="5FJiYrlIp_E" role="PzmwI">
       <ref role="PrY4T" to="tpck:h0TrEE$" resolve="INamedConcept" />
@@ -177,6 +184,18 @@
         <property role="t5JxN" value="path is always relative to mps_home" />
       </node>
     </node>
+  </node>
+  <node concept="1TIwiD" id="2jUI4_LQLA2">
+    <property role="EcuMT" value="2664644755125377410" />
+    <property role="TrG5h" value="ActivationCondition" />
+    <ref role="1TJDcQ" to="tpee:gyVMwX8" resolve="ConceptFunction" />
+  </node>
+  <node concept="1TIwiD" id="2jUI4_LQRKG">
+    <property role="EcuMT" value="2664644755125402668" />
+    <property role="TrG5h" value="ConceptFunction_ApplicationInfo" />
+    <property role="34LRSv" value="applicationInfo" />
+    <property role="R4oN_" value="provides IDE version/help and vendor information" />
+    <ref role="1TJDcQ" to="tpee:g76ryKb" resolve="ConceptFunctionParameter" />
   </node>
 </model>
 

--- a/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.actionsfilter.runtime/models/com/mbeddr/mpsutil/actionsfilter/runtime.mps
+++ b/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.actionsfilter.runtime/models/com/mbeddr/mpsutil/actionsfilter/runtime.mps
@@ -310,6 +310,14 @@
       <concept id="4079382982702596667" name="jetbrains.mps.baseLanguage.checkedDots.structure.CheckedDotExpression" flags="nn" index="2EnYce" />
     </language>
     <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
+      <concept id="1235746970280" name="jetbrains.mps.baseLanguage.closures.structure.CompactInvokeFunctionExpression" flags="nn" index="2Sg_IR">
+        <child id="1235746996653" name="function" index="2SgG2M" />
+        <child id="1235747002942" name="parameter" index="2SgHGx" />
+      </concept>
+      <concept id="1199542442495" name="jetbrains.mps.baseLanguage.closures.structure.FunctionType" flags="in" index="1ajhzC">
+        <child id="1199542457201" name="resultType" index="1ajl9A" />
+        <child id="1199542501692" name="parameterType" index="1ajw0F" />
+      </concept>
       <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
         <child id="1199569906740" name="parameter" index="1bW2Oz" />
         <child id="1199569916463" name="body" index="1bW5cS" />
@@ -9966,7 +9974,7 @@
                                 <ref role="3cqZAo" node="2y5$DYCdQkI" resolve="it" />
                               </node>
                               <node concept="liA8E" id="2jUI4_LST6W" role="2OqNvi">
-                                <ref role="37wK5l" node="2jUI4_LRtLD" resolve="canBeActivated" />
+                                <ref role="37wK5l" node="2jUI4_LRtLD" resolve="canBeActivatedByDefault" />
                                 <node concept="2YIFZM" id="2jUI4_LSXhI" role="37wK5m">
                                   <ref role="37wK5l" to="bd8o:~ApplicationInfo.getInstance()" resolve="getInstance" />
                                   <ref role="1Pybhc" to="bd8o:~ApplicationInfo" resolve="ApplicationInfo" />
@@ -11422,6 +11430,33 @@
         <property role="3clFbU" value="false" />
       </node>
     </node>
+    <node concept="2tJIrI" id="3VOZakHQ8qn" role="jymVt" />
+    <node concept="312cEg" id="3VOZakHQmfa" role="jymVt">
+      <property role="TrG5h" value="myDefaultActivationCondition" />
+      <property role="eg7rD" value="true" />
+      <node concept="3Tmbuc" id="3VOZakHQkrn" role="1B3o_S" />
+      <node concept="1ajhzC" id="3VOZakHQlU5" role="1tU5fm">
+        <node concept="10P_77" id="3VOZakHQma8" role="1ajl9A" />
+        <node concept="3uibUv" id="3VOZakHQqxX" role="1ajw0F">
+          <ref role="3uigEE" to="bd8o:~ApplicationInfo" resolve="ApplicationInfo" />
+        </node>
+      </node>
+      <node concept="1bVj0M" id="3VOZakHQp50" role="33vP2m">
+        <node concept="3clFbS" id="3VOZakHQp52" role="1bW5cS">
+          <node concept="3clFbF" id="3VOZakHQqb7" role="3cqZAp">
+            <node concept="3clFbT" id="3VOZakHQqb6" role="3clFbG">
+              <property role="3clFbU" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="37vLTG" id="3VOZakHQpmw" role="1bW2Oz">
+          <property role="TrG5h" value="applicationInfo" />
+          <node concept="3uibUv" id="3VOZakHQpmv" role="1tU5fm">
+            <ref role="3uigEE" to="bd8o:~ApplicationInfo" resolve="ApplicationInfo" />
+          </node>
+        </node>
+      </node>
+    </node>
     <node concept="2tJIrI" id="3NH93czfhCb" role="jymVt" />
     <node concept="3clFbW" id="4J$TGpAiwgM" role="jymVt">
       <node concept="3cqZAl" id="4J$TGpAiwgO" role="3clF45" />
@@ -11600,13 +11635,45 @@
         <node concept="10P_77" id="2y5$DYCdK6F" role="1tU5fm" />
       </node>
     </node>
+    <node concept="2tJIrI" id="3VOZakHQs3W" role="jymVt" />
+    <node concept="3clFb_" id="3VOZakHQAq5" role="jymVt">
+      <property role="TrG5h" value="setDefaultActivationCondition" />
+      <node concept="3clFbS" id="3VOZakHQAq8" role="3clF47">
+        <node concept="3clFbF" id="3VOZakHQDoo" role="3cqZAp">
+          <node concept="37vLTI" id="3VOZakHQENE" role="3clFbG">
+            <node concept="37vLTw" id="3VOZakHQGzx" role="37vLTx">
+              <ref role="3cqZAo" node="3VOZakHQBVU" resolve="condition" />
+            </node>
+            <node concept="37vLTw" id="3VOZakHQDon" role="37vLTJ">
+              <ref role="3cqZAo" node="3VOZakHQmfa" resolve="myDefaultActivationCondition" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="3VOZakHQ_sk" role="1B3o_S" />
+      <node concept="3cqZAl" id="3VOZakHQAdp" role="3clF45" />
+      <node concept="37vLTG" id="3VOZakHQBVU" role="3clF46">
+        <property role="TrG5h" value="condition" />
+        <node concept="1ajhzC" id="3VOZakHQBVS" role="1tU5fm">
+          <node concept="10P_77" id="3VOZakHQD3d" role="1ajl9A" />
+          <node concept="3uibUv" id="3VOZakHQCUH" role="1ajw0F">
+            <ref role="3uigEE" to="bd8o:~ApplicationInfo" resolve="ApplicationInfo" />
+          </node>
+        </node>
+      </node>
+    </node>
     <node concept="2tJIrI" id="2jUI4_LRcxE" role="jymVt" />
     <node concept="3clFb_" id="2jUI4_LRtLD" role="jymVt">
-      <property role="TrG5h" value="canBeActivated" />
+      <property role="TrG5h" value="canBeActivatedByDefault" />
       <node concept="3clFbS" id="2jUI4_LRtLG" role="3clF47">
-        <node concept="3clFbF" id="2jUI4_LRuB0" role="3cqZAp">
-          <node concept="3clFbT" id="2jUI4_LRuAZ" role="3clFbG">
-            <property role="3clFbU" value="true" />
+        <node concept="3clFbF" id="3VOZakHQvuq" role="3cqZAp">
+          <node concept="2Sg_IR" id="3VOZakHQzjD" role="3clFbG">
+            <node concept="37vLTw" id="3VOZakHQzjE" role="2SgG2M">
+              <ref role="3cqZAo" node="3VOZakHQmfa" resolve="myDefaultActivationCondition" />
+            </node>
+            <node concept="37vLTw" id="3VOZakHQ$4m" role="2SgHGx">
+              <ref role="3cqZAo" node="2jUI4_LRvD6" resolve="applicationInfo" />
+            </node>
           </node>
         </node>
       </node>

--- a/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.actionsfilter.runtime/models/com/mbeddr/mpsutil/actionsfilter/runtime.mps
+++ b/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.actionsfilter.runtime/models/com/mbeddr/mpsutil/actionsfilter/runtime.mps
@@ -9960,12 +9960,26 @@
                     <node concept="1bVj0M" id="2y5$DYCdQkC" role="23t8la">
                       <node concept="3clFbS" id="2y5$DYCdQkD" role="1bW5cS">
                         <node concept="3clFbF" id="2y5$DYCdQkE" role="3cqZAp">
-                          <node concept="2OqwBi" id="2y5$DYCdQkF" role="3clFbG">
-                            <node concept="37vLTw" id="2y5$DYCdQkG" role="2Oq$k0">
-                              <ref role="3cqZAo" node="2y5$DYCdQkI" resolve="it" />
+                          <node concept="1Wc70l" id="2jUI4_LSLeg" role="3clFbG">
+                            <node concept="2OqwBi" id="2jUI4_LSPT$" role="3uHU7w">
+                              <node concept="37vLTw" id="2jUI4_LSN$N" role="2Oq$k0">
+                                <ref role="3cqZAo" node="2y5$DYCdQkI" resolve="it" />
+                              </node>
+                              <node concept="liA8E" id="2jUI4_LST6W" role="2OqNvi">
+                                <ref role="37wK5l" node="2jUI4_LRtLD" resolve="canBeActivated" />
+                                <node concept="2YIFZM" id="2jUI4_LSXhI" role="37wK5m">
+                                  <ref role="37wK5l" to="bd8o:~ApplicationInfo.getInstance()" resolve="getInstance" />
+                                  <ref role="1Pybhc" to="bd8o:~ApplicationInfo" resolve="ApplicationInfo" />
+                                </node>
+                              </node>
                             </node>
-                            <node concept="liA8E" id="2y5$DYCdQkH" role="2OqNvi">
-                              <ref role="37wK5l" node="2y5$DYCdEUj" resolve="getActiveByDefault" />
+                            <node concept="2OqwBi" id="2y5$DYCdQkF" role="3uHU7B">
+                              <node concept="37vLTw" id="2y5$DYCdQkG" role="2Oq$k0">
+                                <ref role="3cqZAo" node="2y5$DYCdQkI" resolve="it" />
+                              </node>
+                              <node concept="liA8E" id="2y5$DYCdQkH" role="2OqNvi">
+                                <ref role="37wK5l" node="2y5$DYCdEUj" resolve="getActiveByDefault" />
+                              </node>
                             </node>
                           </node>
                         </node>
@@ -11584,6 +11598,25 @@
       <node concept="37vLTG" id="2y5$DYCdK6G" role="3clF46">
         <property role="TrG5h" value="isActiveByDefault" />
         <node concept="10P_77" id="2y5$DYCdK6F" role="1tU5fm" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="2jUI4_LRcxE" role="jymVt" />
+    <node concept="3clFb_" id="2jUI4_LRtLD" role="jymVt">
+      <property role="TrG5h" value="canBeActivated" />
+      <node concept="3clFbS" id="2jUI4_LRtLG" role="3clF47">
+        <node concept="3clFbF" id="2jUI4_LRuB0" role="3cqZAp">
+          <node concept="3clFbT" id="2jUI4_LRuAZ" role="3clFbG">
+            <property role="3clFbU" value="true" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="2jUI4_LRreT" role="1B3o_S" />
+      <node concept="10P_77" id="2jUI4_LRsiX" role="3clF45" />
+      <node concept="37vLTG" id="2jUI4_LRvD6" role="3clF46">
+        <property role="TrG5h" value="applicationInfo" />
+        <node concept="3uibUv" id="2jUI4_LRvD5" role="1tU5fm">
+          <ref role="3uigEE" to="bd8o:~ApplicationInfo" resolve="ApplicationInfo" />
+        </node>
       </node>
     </node>
     <node concept="2tJIrI" id="49MflvOP3v2" role="jymVt" />


### PR DESCRIPTION
This PR fixes https://github.com/mbeddr/mbeddr.core/issues/2199. Action profiles that are active by default now have an additional condition to decide if they should be activated.
That means that you can have multiple profiles that are active by default but have different activation conditions:

<img width="754" alt="Screenshot 2022-08-05 at 17 08 04" src="https://user-images.githubusercontent.com/88385944/183106288-1b1103e6-e6ea-482b-aebc-408d8e68e403.png">

This setting doesn't affect manually activated profiles through the preference page because the  condition isn't (and also can't be) persisted in the user settings.

NOTE: This is a breaking change (generator) and therefore existing action profiles need to be regenerated.