### PR TITLE
Doc xhtml: generate links to referenced documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,3 +26,5 @@ Semantic Versioning and the changes are simply documented in reverse chronologic
 
 * `CellEditorScreenshooter#takeScreenshotSynchronously` method that renders screenshots synchronously in the caller's
   thread.
+
+* Documentation xhtml generator: links are now generated to referenced documents not only in the table of contents but also in the document itself.

--- a/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc.gen_xhtml/generator/template/com/mbeddr/doc/gen_xhtml/generator/template/main@generator.mps
+++ b/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc.gen_xhtml/generator/template/com/mbeddr/doc/gen_xhtml/generator/template/main@generator.mps
@@ -2066,7 +2066,768 @@
     <property role="TrG5h" value="structure" />
     <node concept="3aamgX" id="2CRkjeiqbCz" role="3acgRq">
       <ref role="30HIoZ" to="2c95:2CRkjeimvKE" resolve="DocumentRefSection" />
-      <node concept="b5Tf3" id="2CRkjeiqcTm" role="1lVwrX" />
+      <node concept="gft3U" id="2pZZiEv2rel" role="1lVwrX">
+        <node concept="2pNNFK" id="2pZZiEv2rem" role="gfFT$">
+          <property role="2pNNFO" value="div" />
+          <node concept="2zltFL" id="2pZZiEv2rep" role="3o6s8t">
+            <property role="2pNNFO" value="a" />
+            <node concept="2zltFL" id="2pZZiEv36mq" role="3o6s8t">
+              <property role="qg3DV" value="false" />
+              <property role="2pNNFO" value="h1" />
+              <node concept="2pNUuL" id="2pZZiEv36mr" role="2pNNFR">
+                <property role="2pNUuO" value="id" />
+                <node concept="2pMdtt" id="2pZZiEv36ms" role="2pMdts">
+                  <property role="2pMdty" value="id" />
+                  <node concept="17Uvod" id="2pZZiEv36mt" role="lGtFl">
+                    <property role="2qtEX9" value="text" />
+                    <property role="P4ACc" value="479c7a8c-02f9-43b5-9139-d910cb22f298/6666499814681541919/6666499814681541920" />
+                    <node concept="3zFVjK" id="2pZZiEv36mu" role="3zH0cK">
+                      <node concept="3clFbS" id="2pZZiEv36mv" role="2VODD2">
+                        <node concept="3clFbF" id="2pZZiEv36mw" role="3cqZAp">
+                          <node concept="2OqwBi" id="2pZZiEv36mx" role="3clFbG">
+                            <node concept="30H73N" id="2pZZiEv36my" role="2Oq$k0" />
+                            <node concept="2qgKlT" id="2pZZiEv36mz" role="2OqNvi">
+                              <ref role="37wK5l" to="4gky:6jiGbW_aIil" resolve="stableId" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="2pNUuL" id="2pZZiEv36m$" role="2pNNFR">
+                <property role="2pNUuO" value="class" />
+                <node concept="2pMdtt" id="2pZZiEv36m_" role="2pMdts">
+                  <property role="2pMdty" value="section" />
+                </node>
+              </node>
+              <node concept="3o6iSG" id="2pZZiEv36mA" role="3o6s8t">
+                <property role="3o6i5n" value="text" />
+                <node concept="17Uvod" id="2pZZiEv36mB" role="lGtFl">
+                  <property role="2qtEX9" value="value" />
+                  <property role="P4ACc" value="479c7a8c-02f9-43b5-9139-d910cb22f298/1622293396948952339/1622293396948953704" />
+                  <node concept="3zFVjK" id="2pZZiEv36mC" role="3zH0cK">
+                    <node concept="3clFbS" id="2pZZiEv36mD" role="2VODD2">
+                      <node concept="3clFbF" id="2pZZiEv36mE" role="3cqZAp">
+                        <node concept="2OqwBi" id="2pZZiEv36mF" role="3clFbG">
+                          <node concept="2qgKlT" id="2pZZiEv36mG" role="2OqNvi">
+                            <ref role="37wK5l" to="4gky:5wmuVxvF0fD" resolve="getIndexedText" />
+                          </node>
+                          <node concept="30H73N" id="2pZZiEv36mH" role="2Oq$k0" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="2pNUuL" id="2pZZiEv2re$" role="2pNNFR">
+              <property role="2pNUuO" value="href" />
+              <node concept="2pMdtt" id="2pZZiEv2re_" role="2pMdts">
+                <property role="2pMdty" value="#index" />
+                <node concept="17Uvod" id="2pZZiEv2reA" role="lGtFl">
+                  <property role="P4ACc" value="479c7a8c-02f9-43b5-9139-d910cb22f298/6666499814681541919/6666499814681541920" />
+                  <property role="2qtEX9" value="text" />
+                  <node concept="3zFVjK" id="2pZZiEv2reB" role="3zH0cK">
+                    <node concept="3clFbS" id="2pZZiEv2reC" role="2VODD2">
+                      <node concept="3cpWs8" id="2pZZiEv2reD" role="3cqZAp">
+                        <node concept="3cpWsn" id="2pZZiEv2reE" role="3cpWs9">
+                          <property role="TrG5h" value="fromDoc" />
+                          <node concept="3Tqbb2" id="2pZZiEv2reF" role="1tU5fm">
+                            <ref role="ehGHo" to="2c95:5L$H31Kgq3f" resolve="IDocumentLike" />
+                          </node>
+                          <node concept="2OqwBi" id="2pZZiEv2reG" role="33vP2m">
+                            <node concept="30H73N" id="2pZZiEv2reH" role="2Oq$k0" />
+                            <node concept="2Xjw5R" id="2pZZiEv2reI" role="2OqNvi">
+                              <node concept="1xMEDy" id="2pZZiEv2reJ" role="1xVPHs">
+                                <node concept="chp4Y" id="2pZZiEv2reK" role="ri$Ld">
+                                  <ref role="cht4Q" to="2c95:2TZO3DbuxwK" resolve="Document" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3cpWs8" id="2pZZiEv2reL" role="3cqZAp">
+                        <node concept="3cpWsn" id="2pZZiEv2reM" role="3cpWs9">
+                          <property role="TrG5h" value="toDoc" />
+                          <node concept="3Tqbb2" id="2pZZiEv2reN" role="1tU5fm">
+                            <ref role="ehGHo" to="2c95:5L$H31Kgq3f" resolve="IDocumentLike" />
+                          </node>
+                          <node concept="2OqwBi" id="2pZZiEv2reO" role="33vP2m">
+                            <node concept="2OqwBi" id="2pZZiEv2reP" role="2Oq$k0">
+                              <node concept="2OqwBi" id="2pZZiEv2reQ" role="2Oq$k0">
+                                <node concept="1PxgMI" id="2pZZiEv2reR" role="2Oq$k0">
+                                  <node concept="chp4Y" id="2pZZiEv2reS" role="3oSUPX">
+                                    <ref role="cht4Q" to="2c95:2CRkjeimvKE" resolve="DocumentRefSection" />
+                                  </node>
+                                  <node concept="30H73N" id="2pZZiEv2saA" role="1m5AlR" />
+                                </node>
+                                <node concept="3TrEf2" id="2pZZiEv2reW" role="2OqNvi">
+                                  <ref role="3Tt5mk" to="2c95:2CRkjeinZAw" resolve="externalDocument" />
+                                </node>
+                              </node>
+                              <node concept="3TrEf2" id="2pZZiEv2reX" role="2OqNvi">
+                                <ref role="3Tt5mk" to="2c95:5gTlpaky6t1" resolve="root" />
+                              </node>
+                            </node>
+                            <node concept="3TrEf2" id="2pZZiEv2reY" role="2OqNvi">
+                              <ref role="3Tt5mk" to="2c95:2TZO3DbvI5E" resolve="doc" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3cpWs6" id="2pZZiEv2reZ" role="3cqZAp">
+                        <node concept="2YIFZM" id="2pZZiEv2rf0" role="3cqZAk">
+                          <ref role="37wK5l" to="jobd:t5DIOhM0$4" resolve="getDocumentRefPath" />
+                          <ref role="1Pybhc" to="jobd:QRmqzHYR8K" resolve="GeneratorHelper" />
+                          <node concept="37vLTw" id="2pZZiEv2rf1" role="37wK5m">
+                            <ref role="3cqZAo" node="2pZZiEv2reE" resolve="fromDoc" />
+                          </node>
+                          <node concept="37vLTw" id="2pZZiEv2rf2" role="37wK5m">
+                            <ref role="3cqZAo" node="2pZZiEv2reM" resolve="toDoc" />
+                          </node>
+                          <node concept="1iwH7S" id="2pZZiEv2rf3" role="37wK5m" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="30G5F_" id="2pZZiEv33wG" role="30HLyM">
+        <node concept="3clFbS" id="2pZZiEv33wH" role="2VODD2">
+          <node concept="3clFbF" id="2pZZiEv33Te" role="3cqZAp">
+            <node concept="3clFbC" id="2pZZiEv35hd" role="3clFbG">
+              <node concept="3cmrfG" id="2pZZiEv35OJ" role="3uHU7w">
+                <property role="3cmrfH" value="0" />
+              </node>
+              <node concept="2OqwBi" id="2pZZiEv34gU" role="3uHU7B">
+                <node concept="30H73N" id="2pZZiEv33Td" role="2Oq$k0" />
+                <node concept="2qgKlT" id="2pZZiEv34rb" role="2OqNvi">
+                  <ref role="37wK5l" to="4gky:4vQSg$AqJMN" resolve="nestingLevel" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3aamgX" id="2pZZiEv36Iu" role="3acgRq">
+      <ref role="30HIoZ" to="2c95:2CRkjeimvKE" resolve="DocumentRefSection" />
+      <node concept="gft3U" id="2pZZiEv36Iv" role="1lVwrX">
+        <node concept="2pNNFK" id="2pZZiEv36Iw" role="gfFT$">
+          <property role="2pNNFO" value="div" />
+          <node concept="2zltFL" id="2pZZiEv36Ix" role="3o6s8t">
+            <property role="2pNNFO" value="a" />
+            <node concept="2zltFL" id="2pZZiEv36Iy" role="3o6s8t">
+              <property role="qg3DV" value="false" />
+              <property role="2pNNFO" value="h2" />
+              <node concept="2pNUuL" id="2pZZiEv36Iz" role="2pNNFR">
+                <property role="2pNUuO" value="id" />
+                <node concept="2pMdtt" id="2pZZiEv36I$" role="2pMdts">
+                  <property role="2pMdty" value="id" />
+                  <node concept="17Uvod" id="2pZZiEv36I_" role="lGtFl">
+                    <property role="2qtEX9" value="text" />
+                    <property role="P4ACc" value="479c7a8c-02f9-43b5-9139-d910cb22f298/6666499814681541919/6666499814681541920" />
+                    <node concept="3zFVjK" id="2pZZiEv36IA" role="3zH0cK">
+                      <node concept="3clFbS" id="2pZZiEv36IB" role="2VODD2">
+                        <node concept="3clFbF" id="2pZZiEv36IC" role="3cqZAp">
+                          <node concept="2OqwBi" id="2pZZiEv36ID" role="3clFbG">
+                            <node concept="30H73N" id="2pZZiEv36IE" role="2Oq$k0" />
+                            <node concept="2qgKlT" id="2pZZiEv36IF" role="2OqNvi">
+                              <ref role="37wK5l" to="4gky:6jiGbW_aIil" resolve="stableId" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="2pNUuL" id="2pZZiEv36IG" role="2pNNFR">
+                <property role="2pNUuO" value="class" />
+                <node concept="2pMdtt" id="2pZZiEv36IH" role="2pMdts">
+                  <property role="2pMdty" value="section" />
+                </node>
+              </node>
+              <node concept="3o6iSG" id="2pZZiEv36II" role="3o6s8t">
+                <property role="3o6i5n" value="text" />
+                <node concept="17Uvod" id="2pZZiEv36IJ" role="lGtFl">
+                  <property role="2qtEX9" value="value" />
+                  <property role="P4ACc" value="479c7a8c-02f9-43b5-9139-d910cb22f298/1622293396948952339/1622293396948953704" />
+                  <node concept="3zFVjK" id="2pZZiEv36IK" role="3zH0cK">
+                    <node concept="3clFbS" id="2pZZiEv36IL" role="2VODD2">
+                      <node concept="3clFbF" id="2pZZiEv36IM" role="3cqZAp">
+                        <node concept="2OqwBi" id="2pZZiEv36IN" role="3clFbG">
+                          <node concept="2qgKlT" id="2pZZiEv36IO" role="2OqNvi">
+                            <ref role="37wK5l" to="4gky:5wmuVxvF0fD" resolve="getIndexedText" />
+                          </node>
+                          <node concept="30H73N" id="2pZZiEv36IP" role="2Oq$k0" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="2pNUuL" id="2pZZiEv36IQ" role="2pNNFR">
+              <property role="2pNUuO" value="href" />
+              <node concept="2pMdtt" id="2pZZiEv36IR" role="2pMdts">
+                <property role="2pMdty" value="#index" />
+                <node concept="17Uvod" id="2pZZiEv36IS" role="lGtFl">
+                  <property role="P4ACc" value="479c7a8c-02f9-43b5-9139-d910cb22f298/6666499814681541919/6666499814681541920" />
+                  <property role="2qtEX9" value="text" />
+                  <node concept="3zFVjK" id="2pZZiEv36IT" role="3zH0cK">
+                    <node concept="3clFbS" id="2pZZiEv36IU" role="2VODD2">
+                      <node concept="3cpWs8" id="2pZZiEv36IV" role="3cqZAp">
+                        <node concept="3cpWsn" id="2pZZiEv36IW" role="3cpWs9">
+                          <property role="TrG5h" value="fromDoc" />
+                          <node concept="3Tqbb2" id="2pZZiEv36IX" role="1tU5fm">
+                            <ref role="ehGHo" to="2c95:5L$H31Kgq3f" resolve="IDocumentLike" />
+                          </node>
+                          <node concept="2OqwBi" id="2pZZiEv36IY" role="33vP2m">
+                            <node concept="30H73N" id="2pZZiEv36IZ" role="2Oq$k0" />
+                            <node concept="2Xjw5R" id="2pZZiEv36J0" role="2OqNvi">
+                              <node concept="1xMEDy" id="2pZZiEv36J1" role="1xVPHs">
+                                <node concept="chp4Y" id="2pZZiEv36J2" role="ri$Ld">
+                                  <ref role="cht4Q" to="2c95:2TZO3DbuxwK" resolve="Document" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3cpWs8" id="2pZZiEv36J3" role="3cqZAp">
+                        <node concept="3cpWsn" id="2pZZiEv36J4" role="3cpWs9">
+                          <property role="TrG5h" value="toDoc" />
+                          <node concept="3Tqbb2" id="2pZZiEv36J5" role="1tU5fm">
+                            <ref role="ehGHo" to="2c95:5L$H31Kgq3f" resolve="IDocumentLike" />
+                          </node>
+                          <node concept="2OqwBi" id="2pZZiEv36J6" role="33vP2m">
+                            <node concept="2OqwBi" id="2pZZiEv36J7" role="2Oq$k0">
+                              <node concept="2OqwBi" id="2pZZiEv36J8" role="2Oq$k0">
+                                <node concept="1PxgMI" id="2pZZiEv36J9" role="2Oq$k0">
+                                  <node concept="chp4Y" id="2pZZiEv36Ja" role="3oSUPX">
+                                    <ref role="cht4Q" to="2c95:2CRkjeimvKE" resolve="DocumentRefSection" />
+                                  </node>
+                                  <node concept="30H73N" id="2pZZiEv36Jb" role="1m5AlR" />
+                                </node>
+                                <node concept="3TrEf2" id="2pZZiEv36Jc" role="2OqNvi">
+                                  <ref role="3Tt5mk" to="2c95:2CRkjeinZAw" resolve="externalDocument" />
+                                </node>
+                              </node>
+                              <node concept="3TrEf2" id="2pZZiEv36Jd" role="2OqNvi">
+                                <ref role="3Tt5mk" to="2c95:5gTlpaky6t1" resolve="root" />
+                              </node>
+                            </node>
+                            <node concept="3TrEf2" id="2pZZiEv36Je" role="2OqNvi">
+                              <ref role="3Tt5mk" to="2c95:2TZO3DbvI5E" resolve="doc" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3cpWs6" id="2pZZiEv36Jf" role="3cqZAp">
+                        <node concept="2YIFZM" id="2pZZiEv36Jg" role="3cqZAk">
+                          <ref role="37wK5l" to="jobd:t5DIOhM0$4" resolve="getDocumentRefPath" />
+                          <ref role="1Pybhc" to="jobd:QRmqzHYR8K" resolve="GeneratorHelper" />
+                          <node concept="37vLTw" id="2pZZiEv36Jh" role="37wK5m">
+                            <ref role="3cqZAo" node="2pZZiEv36IW" resolve="fromDoc" />
+                          </node>
+                          <node concept="37vLTw" id="2pZZiEv36Ji" role="37wK5m">
+                            <ref role="3cqZAo" node="2pZZiEv36J4" resolve="toDoc" />
+                          </node>
+                          <node concept="1iwH7S" id="2pZZiEv36Jj" role="37wK5m" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="30G5F_" id="2pZZiEv36Jk" role="30HLyM">
+        <node concept="3clFbS" id="2pZZiEv36Jl" role="2VODD2">
+          <node concept="3clFbF" id="2pZZiEv36Jm" role="3cqZAp">
+            <node concept="3clFbC" id="2pZZiEv36Jn" role="3clFbG">
+              <node concept="3cmrfG" id="2pZZiEv36Jo" role="3uHU7w">
+                <property role="3cmrfH" value="1" />
+              </node>
+              <node concept="2OqwBi" id="2pZZiEv36Jp" role="3uHU7B">
+                <node concept="30H73N" id="2pZZiEv36Jq" role="2Oq$k0" />
+                <node concept="2qgKlT" id="2pZZiEv36Jr" role="2OqNvi">
+                  <ref role="37wK5l" to="4gky:4vQSg$AqJMN" resolve="nestingLevel" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3aamgX" id="2pZZiEv37Xp" role="3acgRq">
+      <ref role="30HIoZ" to="2c95:2CRkjeimvKE" resolve="DocumentRefSection" />
+      <node concept="gft3U" id="2pZZiEv37Xq" role="1lVwrX">
+        <node concept="2pNNFK" id="2pZZiEv37Xr" role="gfFT$">
+          <property role="2pNNFO" value="div" />
+          <node concept="2zltFL" id="2pZZiEv37Xs" role="3o6s8t">
+            <property role="2pNNFO" value="a" />
+            <node concept="2zltFL" id="2pZZiEv37Xt" role="3o6s8t">
+              <property role="qg3DV" value="false" />
+              <property role="2pNNFO" value="h3" />
+              <node concept="2pNUuL" id="2pZZiEv37Xu" role="2pNNFR">
+                <property role="2pNUuO" value="id" />
+                <node concept="2pMdtt" id="2pZZiEv37Xv" role="2pMdts">
+                  <property role="2pMdty" value="id" />
+                  <node concept="17Uvod" id="2pZZiEv37Xw" role="lGtFl">
+                    <property role="2qtEX9" value="text" />
+                    <property role="P4ACc" value="479c7a8c-02f9-43b5-9139-d910cb22f298/6666499814681541919/6666499814681541920" />
+                    <node concept="3zFVjK" id="2pZZiEv37Xx" role="3zH0cK">
+                      <node concept="3clFbS" id="2pZZiEv37Xy" role="2VODD2">
+                        <node concept="3clFbF" id="2pZZiEv37Xz" role="3cqZAp">
+                          <node concept="2OqwBi" id="2pZZiEv37X$" role="3clFbG">
+                            <node concept="30H73N" id="2pZZiEv37X_" role="2Oq$k0" />
+                            <node concept="2qgKlT" id="2pZZiEv37XA" role="2OqNvi">
+                              <ref role="37wK5l" to="4gky:6jiGbW_aIil" resolve="stableId" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="2pNUuL" id="2pZZiEv37XB" role="2pNNFR">
+                <property role="2pNUuO" value="class" />
+                <node concept="2pMdtt" id="2pZZiEv37XC" role="2pMdts">
+                  <property role="2pMdty" value="section" />
+                </node>
+              </node>
+              <node concept="3o6iSG" id="2pZZiEv37XD" role="3o6s8t">
+                <property role="3o6i5n" value="text" />
+                <node concept="17Uvod" id="2pZZiEv37XE" role="lGtFl">
+                  <property role="2qtEX9" value="value" />
+                  <property role="P4ACc" value="479c7a8c-02f9-43b5-9139-d910cb22f298/1622293396948952339/1622293396948953704" />
+                  <node concept="3zFVjK" id="2pZZiEv37XF" role="3zH0cK">
+                    <node concept="3clFbS" id="2pZZiEv37XG" role="2VODD2">
+                      <node concept="3clFbF" id="2pZZiEv37XH" role="3cqZAp">
+                        <node concept="2OqwBi" id="2pZZiEv37XI" role="3clFbG">
+                          <node concept="2qgKlT" id="2pZZiEv37XJ" role="2OqNvi">
+                            <ref role="37wK5l" to="4gky:5wmuVxvF0fD" resolve="getIndexedText" />
+                          </node>
+                          <node concept="30H73N" id="2pZZiEv37XK" role="2Oq$k0" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="2pNUuL" id="2pZZiEv37XL" role="2pNNFR">
+              <property role="2pNUuO" value="href" />
+              <node concept="2pMdtt" id="2pZZiEv37XM" role="2pMdts">
+                <property role="2pMdty" value="#index" />
+                <node concept="17Uvod" id="2pZZiEv37XN" role="lGtFl">
+                  <property role="P4ACc" value="479c7a8c-02f9-43b5-9139-d910cb22f298/6666499814681541919/6666499814681541920" />
+                  <property role="2qtEX9" value="text" />
+                  <node concept="3zFVjK" id="2pZZiEv37XO" role="3zH0cK">
+                    <node concept="3clFbS" id="2pZZiEv37XP" role="2VODD2">
+                      <node concept="3cpWs8" id="2pZZiEv37XQ" role="3cqZAp">
+                        <node concept="3cpWsn" id="2pZZiEv37XR" role="3cpWs9">
+                          <property role="TrG5h" value="fromDoc" />
+                          <node concept="3Tqbb2" id="2pZZiEv37XS" role="1tU5fm">
+                            <ref role="ehGHo" to="2c95:5L$H31Kgq3f" resolve="IDocumentLike" />
+                          </node>
+                          <node concept="2OqwBi" id="2pZZiEv37XT" role="33vP2m">
+                            <node concept="30H73N" id="2pZZiEv37XU" role="2Oq$k0" />
+                            <node concept="2Xjw5R" id="2pZZiEv37XV" role="2OqNvi">
+                              <node concept="1xMEDy" id="2pZZiEv37XW" role="1xVPHs">
+                                <node concept="chp4Y" id="2pZZiEv37XX" role="ri$Ld">
+                                  <ref role="cht4Q" to="2c95:2TZO3DbuxwK" resolve="Document" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3cpWs8" id="2pZZiEv37XY" role="3cqZAp">
+                        <node concept="3cpWsn" id="2pZZiEv37XZ" role="3cpWs9">
+                          <property role="TrG5h" value="toDoc" />
+                          <node concept="3Tqbb2" id="2pZZiEv37Y0" role="1tU5fm">
+                            <ref role="ehGHo" to="2c95:5L$H31Kgq3f" resolve="IDocumentLike" />
+                          </node>
+                          <node concept="2OqwBi" id="2pZZiEv37Y1" role="33vP2m">
+                            <node concept="2OqwBi" id="2pZZiEv37Y2" role="2Oq$k0">
+                              <node concept="2OqwBi" id="2pZZiEv37Y3" role="2Oq$k0">
+                                <node concept="1PxgMI" id="2pZZiEv37Y4" role="2Oq$k0">
+                                  <node concept="chp4Y" id="2pZZiEv37Y5" role="3oSUPX">
+                                    <ref role="cht4Q" to="2c95:2CRkjeimvKE" resolve="DocumentRefSection" />
+                                  </node>
+                                  <node concept="30H73N" id="2pZZiEv37Y6" role="1m5AlR" />
+                                </node>
+                                <node concept="3TrEf2" id="2pZZiEv37Y7" role="2OqNvi">
+                                  <ref role="3Tt5mk" to="2c95:2CRkjeinZAw" resolve="externalDocument" />
+                                </node>
+                              </node>
+                              <node concept="3TrEf2" id="2pZZiEv37Y8" role="2OqNvi">
+                                <ref role="3Tt5mk" to="2c95:5gTlpaky6t1" resolve="root" />
+                              </node>
+                            </node>
+                            <node concept="3TrEf2" id="2pZZiEv37Y9" role="2OqNvi">
+                              <ref role="3Tt5mk" to="2c95:2TZO3DbvI5E" resolve="doc" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3cpWs6" id="2pZZiEv37Ya" role="3cqZAp">
+                        <node concept="2YIFZM" id="2pZZiEv37Yb" role="3cqZAk">
+                          <ref role="37wK5l" to="jobd:t5DIOhM0$4" resolve="getDocumentRefPath" />
+                          <ref role="1Pybhc" to="jobd:QRmqzHYR8K" resolve="GeneratorHelper" />
+                          <node concept="37vLTw" id="2pZZiEv37Yc" role="37wK5m">
+                            <ref role="3cqZAo" node="2pZZiEv37XR" resolve="fromDoc" />
+                          </node>
+                          <node concept="37vLTw" id="2pZZiEv37Yd" role="37wK5m">
+                            <ref role="3cqZAo" node="2pZZiEv37XZ" resolve="toDoc" />
+                          </node>
+                          <node concept="1iwH7S" id="2pZZiEv37Ye" role="37wK5m" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="30G5F_" id="2pZZiEv37Yf" role="30HLyM">
+        <node concept="3clFbS" id="2pZZiEv37Yg" role="2VODD2">
+          <node concept="3clFbF" id="2pZZiEv37Yh" role="3cqZAp">
+            <node concept="3clFbC" id="2pZZiEv37Yi" role="3clFbG">
+              <node concept="3cmrfG" id="2pZZiEv37Yj" role="3uHU7w">
+                <property role="3cmrfH" value="2" />
+              </node>
+              <node concept="2OqwBi" id="2pZZiEv37Yk" role="3uHU7B">
+                <node concept="30H73N" id="2pZZiEv37Yl" role="2Oq$k0" />
+                <node concept="2qgKlT" id="2pZZiEv37Ym" role="2OqNvi">
+                  <ref role="37wK5l" to="4gky:4vQSg$AqJMN" resolve="nestingLevel" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3aamgX" id="2pZZiEv39im" role="3acgRq">
+      <ref role="30HIoZ" to="2c95:2CRkjeimvKE" resolve="DocumentRefSection" />
+      <node concept="gft3U" id="2pZZiEv39in" role="1lVwrX">
+        <node concept="2pNNFK" id="2pZZiEv39io" role="gfFT$">
+          <property role="2pNNFO" value="div" />
+          <node concept="2zltFL" id="2pZZiEv39ip" role="3o6s8t">
+            <property role="2pNNFO" value="a" />
+            <node concept="2zltFL" id="2pZZiEv39iq" role="3o6s8t">
+              <property role="qg3DV" value="false" />
+              <property role="2pNNFO" value="h4" />
+              <node concept="2pNUuL" id="2pZZiEv39ir" role="2pNNFR">
+                <property role="2pNUuO" value="id" />
+                <node concept="2pMdtt" id="2pZZiEv39is" role="2pMdts">
+                  <property role="2pMdty" value="id" />
+                  <node concept="17Uvod" id="2pZZiEv39it" role="lGtFl">
+                    <property role="2qtEX9" value="text" />
+                    <property role="P4ACc" value="479c7a8c-02f9-43b5-9139-d910cb22f298/6666499814681541919/6666499814681541920" />
+                    <node concept="3zFVjK" id="2pZZiEv39iu" role="3zH0cK">
+                      <node concept="3clFbS" id="2pZZiEv39iv" role="2VODD2">
+                        <node concept="3clFbF" id="2pZZiEv39iw" role="3cqZAp">
+                          <node concept="2OqwBi" id="2pZZiEv39ix" role="3clFbG">
+                            <node concept="30H73N" id="2pZZiEv39iy" role="2Oq$k0" />
+                            <node concept="2qgKlT" id="2pZZiEv39iz" role="2OqNvi">
+                              <ref role="37wK5l" to="4gky:6jiGbW_aIil" resolve="stableId" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="2pNUuL" id="2pZZiEv39i$" role="2pNNFR">
+                <property role="2pNUuO" value="class" />
+                <node concept="2pMdtt" id="2pZZiEv39i_" role="2pMdts">
+                  <property role="2pMdty" value="section" />
+                </node>
+              </node>
+              <node concept="3o6iSG" id="2pZZiEv39iA" role="3o6s8t">
+                <property role="3o6i5n" value="text" />
+                <node concept="17Uvod" id="2pZZiEv39iB" role="lGtFl">
+                  <property role="2qtEX9" value="value" />
+                  <property role="P4ACc" value="479c7a8c-02f9-43b5-9139-d910cb22f298/1622293396948952339/1622293396948953704" />
+                  <node concept="3zFVjK" id="2pZZiEv39iC" role="3zH0cK">
+                    <node concept="3clFbS" id="2pZZiEv39iD" role="2VODD2">
+                      <node concept="3clFbF" id="2pZZiEv39iE" role="3cqZAp">
+                        <node concept="2OqwBi" id="2pZZiEv39iF" role="3clFbG">
+                          <node concept="2qgKlT" id="2pZZiEv39iG" role="2OqNvi">
+                            <ref role="37wK5l" to="4gky:5wmuVxvF0fD" resolve="getIndexedText" />
+                          </node>
+                          <node concept="30H73N" id="2pZZiEv39iH" role="2Oq$k0" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="2pNUuL" id="2pZZiEv39iI" role="2pNNFR">
+              <property role="2pNUuO" value="href" />
+              <node concept="2pMdtt" id="2pZZiEv39iJ" role="2pMdts">
+                <property role="2pMdty" value="#index" />
+                <node concept="17Uvod" id="2pZZiEv39iK" role="lGtFl">
+                  <property role="P4ACc" value="479c7a8c-02f9-43b5-9139-d910cb22f298/6666499814681541919/6666499814681541920" />
+                  <property role="2qtEX9" value="text" />
+                  <node concept="3zFVjK" id="2pZZiEv39iL" role="3zH0cK">
+                    <node concept="3clFbS" id="2pZZiEv39iM" role="2VODD2">
+                      <node concept="3cpWs8" id="2pZZiEv39iN" role="3cqZAp">
+                        <node concept="3cpWsn" id="2pZZiEv39iO" role="3cpWs9">
+                          <property role="TrG5h" value="fromDoc" />
+                          <node concept="3Tqbb2" id="2pZZiEv39iP" role="1tU5fm">
+                            <ref role="ehGHo" to="2c95:5L$H31Kgq3f" resolve="IDocumentLike" />
+                          </node>
+                          <node concept="2OqwBi" id="2pZZiEv39iQ" role="33vP2m">
+                            <node concept="30H73N" id="2pZZiEv39iR" role="2Oq$k0" />
+                            <node concept="2Xjw5R" id="2pZZiEv39iS" role="2OqNvi">
+                              <node concept="1xMEDy" id="2pZZiEv39iT" role="1xVPHs">
+                                <node concept="chp4Y" id="2pZZiEv39iU" role="ri$Ld">
+                                  <ref role="cht4Q" to="2c95:2TZO3DbuxwK" resolve="Document" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3cpWs8" id="2pZZiEv39iV" role="3cqZAp">
+                        <node concept="3cpWsn" id="2pZZiEv39iW" role="3cpWs9">
+                          <property role="TrG5h" value="toDoc" />
+                          <node concept="3Tqbb2" id="2pZZiEv39iX" role="1tU5fm">
+                            <ref role="ehGHo" to="2c95:5L$H31Kgq3f" resolve="IDocumentLike" />
+                          </node>
+                          <node concept="2OqwBi" id="2pZZiEv39iY" role="33vP2m">
+                            <node concept="2OqwBi" id="2pZZiEv39iZ" role="2Oq$k0">
+                              <node concept="2OqwBi" id="2pZZiEv39j0" role="2Oq$k0">
+                                <node concept="1PxgMI" id="2pZZiEv39j1" role="2Oq$k0">
+                                  <node concept="chp4Y" id="2pZZiEv39j2" role="3oSUPX">
+                                    <ref role="cht4Q" to="2c95:2CRkjeimvKE" resolve="DocumentRefSection" />
+                                  </node>
+                                  <node concept="30H73N" id="2pZZiEv39j3" role="1m5AlR" />
+                                </node>
+                                <node concept="3TrEf2" id="2pZZiEv39j4" role="2OqNvi">
+                                  <ref role="3Tt5mk" to="2c95:2CRkjeinZAw" resolve="externalDocument" />
+                                </node>
+                              </node>
+                              <node concept="3TrEf2" id="2pZZiEv39j5" role="2OqNvi">
+                                <ref role="3Tt5mk" to="2c95:5gTlpaky6t1" resolve="root" />
+                              </node>
+                            </node>
+                            <node concept="3TrEf2" id="2pZZiEv39j6" role="2OqNvi">
+                              <ref role="3Tt5mk" to="2c95:2TZO3DbvI5E" resolve="doc" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3cpWs6" id="2pZZiEv39j7" role="3cqZAp">
+                        <node concept="2YIFZM" id="2pZZiEv39j8" role="3cqZAk">
+                          <ref role="37wK5l" to="jobd:t5DIOhM0$4" resolve="getDocumentRefPath" />
+                          <ref role="1Pybhc" to="jobd:QRmqzHYR8K" resolve="GeneratorHelper" />
+                          <node concept="37vLTw" id="2pZZiEv39j9" role="37wK5m">
+                            <ref role="3cqZAo" node="2pZZiEv39iO" resolve="fromDoc" />
+                          </node>
+                          <node concept="37vLTw" id="2pZZiEv39ja" role="37wK5m">
+                            <ref role="3cqZAo" node="2pZZiEv39iW" resolve="toDoc" />
+                          </node>
+                          <node concept="1iwH7S" id="2pZZiEv39jb" role="37wK5m" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="30G5F_" id="2pZZiEv39jc" role="30HLyM">
+        <node concept="3clFbS" id="2pZZiEv39jd" role="2VODD2">
+          <node concept="3clFbF" id="2pZZiEv39je" role="3cqZAp">
+            <node concept="3clFbC" id="2pZZiEv39jf" role="3clFbG">
+              <node concept="3cmrfG" id="2pZZiEv39jg" role="3uHU7w">
+                <property role="3cmrfH" value="3" />
+              </node>
+              <node concept="2OqwBi" id="2pZZiEv39jh" role="3uHU7B">
+                <node concept="30H73N" id="2pZZiEv39ji" role="2Oq$k0" />
+                <node concept="2qgKlT" id="2pZZiEv39jj" role="2OqNvi">
+                  <ref role="37wK5l" to="4gky:4vQSg$AqJMN" resolve="nestingLevel" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3aamgX" id="2pZZiEv3bKm" role="3acgRq">
+      <ref role="30HIoZ" to="2c95:2CRkjeimvKE" resolve="DocumentRefSection" />
+      <node concept="gft3U" id="2pZZiEv3bKn" role="1lVwrX">
+        <node concept="2pNNFK" id="2pZZiEv3bKo" role="gfFT$">
+          <property role="2pNNFO" value="div" />
+          <node concept="2zltFL" id="2pZZiEv3bKp" role="3o6s8t">
+            <property role="2pNNFO" value="a" />
+            <node concept="2zltFL" id="2pZZiEv3bKq" role="3o6s8t">
+              <property role="qg3DV" value="false" />
+              <property role="2pNNFO" value="h5" />
+              <node concept="2pNUuL" id="2pZZiEv3bKr" role="2pNNFR">
+                <property role="2pNUuO" value="id" />
+                <node concept="2pMdtt" id="2pZZiEv3bKs" role="2pMdts">
+                  <property role="2pMdty" value="id" />
+                  <node concept="17Uvod" id="2pZZiEv3bKt" role="lGtFl">
+                    <property role="2qtEX9" value="text" />
+                    <property role="P4ACc" value="479c7a8c-02f9-43b5-9139-d910cb22f298/6666499814681541919/6666499814681541920" />
+                    <node concept="3zFVjK" id="2pZZiEv3bKu" role="3zH0cK">
+                      <node concept="3clFbS" id="2pZZiEv3bKv" role="2VODD2">
+                        <node concept="3clFbF" id="2pZZiEv3bKw" role="3cqZAp">
+                          <node concept="2OqwBi" id="2pZZiEv3bKx" role="3clFbG">
+                            <node concept="30H73N" id="2pZZiEv3bKy" role="2Oq$k0" />
+                            <node concept="2qgKlT" id="2pZZiEv3bKz" role="2OqNvi">
+                              <ref role="37wK5l" to="4gky:6jiGbW_aIil" resolve="stableId" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="2pNUuL" id="2pZZiEv3bK$" role="2pNNFR">
+                <property role="2pNUuO" value="class" />
+                <node concept="2pMdtt" id="2pZZiEv3bK_" role="2pMdts">
+                  <property role="2pMdty" value="section" />
+                </node>
+              </node>
+              <node concept="3o6iSG" id="2pZZiEv3bKA" role="3o6s8t">
+                <property role="3o6i5n" value="text" />
+                <node concept="17Uvod" id="2pZZiEv3bKB" role="lGtFl">
+                  <property role="2qtEX9" value="value" />
+                  <property role="P4ACc" value="479c7a8c-02f9-43b5-9139-d910cb22f298/1622293396948952339/1622293396948953704" />
+                  <node concept="3zFVjK" id="2pZZiEv3bKC" role="3zH0cK">
+                    <node concept="3clFbS" id="2pZZiEv3bKD" role="2VODD2">
+                      <node concept="3clFbF" id="2pZZiEv3bKE" role="3cqZAp">
+                        <node concept="2OqwBi" id="2pZZiEv3bKF" role="3clFbG">
+                          <node concept="2qgKlT" id="2pZZiEv3bKG" role="2OqNvi">
+                            <ref role="37wK5l" to="4gky:5wmuVxvF0fD" resolve="getIndexedText" />
+                          </node>
+                          <node concept="30H73N" id="2pZZiEv3bKH" role="2Oq$k0" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="2pNUuL" id="2pZZiEv3bKI" role="2pNNFR">
+              <property role="2pNUuO" value="href" />
+              <node concept="2pMdtt" id="2pZZiEv3bKJ" role="2pMdts">
+                <property role="2pMdty" value="#index" />
+                <node concept="17Uvod" id="2pZZiEv3bKK" role="lGtFl">
+                  <property role="P4ACc" value="479c7a8c-02f9-43b5-9139-d910cb22f298/6666499814681541919/6666499814681541920" />
+                  <property role="2qtEX9" value="text" />
+                  <node concept="3zFVjK" id="2pZZiEv3bKL" role="3zH0cK">
+                    <node concept="3clFbS" id="2pZZiEv3bKM" role="2VODD2">
+                      <node concept="3cpWs8" id="2pZZiEv3bKN" role="3cqZAp">
+                        <node concept="3cpWsn" id="2pZZiEv3bKO" role="3cpWs9">
+                          <property role="TrG5h" value="fromDoc" />
+                          <node concept="3Tqbb2" id="2pZZiEv3bKP" role="1tU5fm">
+                            <ref role="ehGHo" to="2c95:5L$H31Kgq3f" resolve="IDocumentLike" />
+                          </node>
+                          <node concept="2OqwBi" id="2pZZiEv3bKQ" role="33vP2m">
+                            <node concept="30H73N" id="2pZZiEv3bKR" role="2Oq$k0" />
+                            <node concept="2Xjw5R" id="2pZZiEv3bKS" role="2OqNvi">
+                              <node concept="1xMEDy" id="2pZZiEv3bKT" role="1xVPHs">
+                                <node concept="chp4Y" id="2pZZiEv3bKU" role="ri$Ld">
+                                  <ref role="cht4Q" to="2c95:2TZO3DbuxwK" resolve="Document" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3cpWs8" id="2pZZiEv3bKV" role="3cqZAp">
+                        <node concept="3cpWsn" id="2pZZiEv3bKW" role="3cpWs9">
+                          <property role="TrG5h" value="toDoc" />
+                          <node concept="3Tqbb2" id="2pZZiEv3bKX" role="1tU5fm">
+                            <ref role="ehGHo" to="2c95:5L$H31Kgq3f" resolve="IDocumentLike" />
+                          </node>
+                          <node concept="2OqwBi" id="2pZZiEv3bKY" role="33vP2m">
+                            <node concept="2OqwBi" id="2pZZiEv3bKZ" role="2Oq$k0">
+                              <node concept="2OqwBi" id="2pZZiEv3bL0" role="2Oq$k0">
+                                <node concept="1PxgMI" id="2pZZiEv3bL1" role="2Oq$k0">
+                                  <node concept="chp4Y" id="2pZZiEv3bL2" role="3oSUPX">
+                                    <ref role="cht4Q" to="2c95:2CRkjeimvKE" resolve="DocumentRefSection" />
+                                  </node>
+                                  <node concept="30H73N" id="2pZZiEv3bL3" role="1m5AlR" />
+                                </node>
+                                <node concept="3TrEf2" id="2pZZiEv3bL4" role="2OqNvi">
+                                  <ref role="3Tt5mk" to="2c95:2CRkjeinZAw" resolve="externalDocument" />
+                                </node>
+                              </node>
+                              <node concept="3TrEf2" id="2pZZiEv3bL5" role="2OqNvi">
+                                <ref role="3Tt5mk" to="2c95:5gTlpaky6t1" resolve="root" />
+                              </node>
+                            </node>
+                            <node concept="3TrEf2" id="2pZZiEv3bL6" role="2OqNvi">
+                              <ref role="3Tt5mk" to="2c95:2TZO3DbvI5E" resolve="doc" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3cpWs6" id="2pZZiEv3bL7" role="3cqZAp">
+                        <node concept="2YIFZM" id="2pZZiEv3bL8" role="3cqZAk">
+                          <ref role="37wK5l" to="jobd:t5DIOhM0$4" resolve="getDocumentRefPath" />
+                          <ref role="1Pybhc" to="jobd:QRmqzHYR8K" resolve="GeneratorHelper" />
+                          <node concept="37vLTw" id="2pZZiEv3bL9" role="37wK5m">
+                            <ref role="3cqZAo" node="2pZZiEv3bKO" resolve="fromDoc" />
+                          </node>
+                          <node concept="37vLTw" id="2pZZiEv3bLa" role="37wK5m">
+                            <ref role="3cqZAo" node="2pZZiEv3bKW" resolve="toDoc" />
+                          </node>
+                          <node concept="1iwH7S" id="2pZZiEv3bLb" role="37wK5m" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="30G5F_" id="2pZZiEv3bLc" role="30HLyM">
+        <node concept="3clFbS" id="2pZZiEv3bLd" role="2VODD2">
+          <node concept="3clFbF" id="2pZZiEv3bLe" role="3cqZAp">
+            <node concept="3eOSWO" id="2pZZiEv3dge" role="3clFbG">
+              <node concept="2OqwBi" id="2pZZiEv3bLh" role="3uHU7B">
+                <node concept="30H73N" id="2pZZiEv3bLi" role="2Oq$k0" />
+                <node concept="2qgKlT" id="2pZZiEv3bLj" role="2OqNvi">
+                  <ref role="37wK5l" to="4gky:4vQSg$AqJMN" resolve="nestingLevel" />
+                </node>
+              </node>
+              <node concept="3cmrfG" id="2pZZiEv3bLg" role="3uHU7w">
+                <property role="3cmrfH" value="3" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
     </node>
     <node concept="3aamgX" id="2HzhasNyuz$" role="3acgRq">
       <property role="36QftV" value="true" />


### PR DESCRIPTION
Previously the links were only generated for the TOC and the section in the documentation itself was just skipped.