### PR TITLE
mpsutil: changed caption for CopySource action

### DIFF
--- a/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.plantuml/solutions/pluginSolution/models/com/mbeddr/mpsutil/plantuml/pluginSolution/plugin.mps
+++ b/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.plantuml/solutions/pluginSolution/models/com/mbeddr/mpsutil/plantuml/pluginSolution/plugin.mps
@@ -5808,7 +5808,7 @@
   </node>
   <node concept="sE7Ow" id="6IuaPRfaRij">
     <property role="TrG5h" value="CopySources" />
-    <property role="2uzpH1" value="Zoom In" />
+    <property role="2uzpH1" value="Copy sources to clipboard" />
     <property role="3GE5qa" value="toolbar" />
     <node concept="tnohg" id="6IuaPRfaRik" role="tncku">
       <node concept="3clFbS" id="6IuaPRfaRil" role="2VODD2">


### PR DESCRIPTION
The caption of the Copy Sources action in the Plantuml Viewer was wrong. It was "Zoom in" and should be "Copy sources to clipboard". Action can be found [here](http://127.0.0.1:63320/node?ref=c0488c1e-322f-4f38-92d4-5520a7ce96c1%2Fr%3Ae053bdde[…]sutil.plantuml.pluginSolution.plugin%29%2F7754683290286257299](http://127.0.0.1:63320/node?ref=c0488c1e-322f-4f38-92d4-5520a7ce96c1%2Fr%3Ae053bdde-b82f-4d5b-a735-e0af382d4ef2%28com.mbeddr.mpsutil.plantuml.pluginSolution%2Fcom.mbeddr.mpsutil.plantuml.pluginSolution.plugin%29%2F7754683290286257299 ) 

This PR fixed it.