### PR TITLE
Documentation: replace ModuleIdentity with ModulePointer in ModuleRefWord

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Semantic Versioning and the changes are simply documented in reverse chronologic
 
 ## com.mbeddr.mpsutil
 
+* Documentation: replace ModuleIdentity with ModulePointer in ModuleRefWord. This was a deprecated concept.
+
 * Fix exception `NullPointer: Cannot create configurable` in userstyles language.
 
 ## com.mbeddr.core.base

--- a/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc.gen_latex/generator/template/com/mbeddr/doc/gen_latex/generator/template/main@generator.mps
+++ b/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc.gen_latex/generator/template/com/mbeddr/doc/gen_latex/generator/template/main@generator.mps
@@ -25,8 +25,6 @@
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" />
     <import index="48kf" ref="r:5f41c82d-84d1-4fb1-a1cf-6697d2365854(com.mbeddr.mpsutil.filepicker.behavior)" />
-    <import index="tpeu" ref="r:00000000-0000-4000-0000-011c895902fa(jetbrains.mps.lang.smodel.behavior)" implicit="true" />
-    <import index="lui2" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.module(MPS.OpenAPI/)" implicit="true" />
   </imports>
   <registry>
     <language id="13744753-c81f-424a-9c1b-cf8943bf4e86" name="jetbrains.mps.lang.sharedConcepts">
@@ -3492,20 +3490,10 @@
                   <node concept="2YIFZM" id="5kTg4zghvtQ" role="3cqZAk">
                     <ref role="1Pybhc" to="81x8:1LnB5xdq7gS" resolve="LatexEscapeHelper" />
                     <ref role="37wK5l" to="81x8:1LnB5xdq7gY" resolve="escape" />
-                    <node concept="2OqwBi" id="5kTg4zghvtR" role="37wK5m">
-                      <node concept="2OqwBi" id="5kTg4zghvtS" role="2Oq$k0">
-                        <node concept="2OqwBi" id="5kTg4zghvtT" role="2Oq$k0">
-                          <node concept="30H73N" id="5kTg4zghvtU" role="2Oq$k0" />
-                          <node concept="3TrEf2" id="5kTg4zghvtV" role="2OqNvi">
-                            <ref role="3Tt5mk" to="2c95:66AQhBxN1Tt" resolve="identity" />
-                          </node>
-                        </node>
-                        <node concept="2qgKlT" id="5kTg4zghvtW" role="2OqNvi">
-                          <ref role="37wK5l" to="tpeu:nJmxU5cSSU" resolve="getModuleReference" />
-                        </node>
-                      </node>
-                      <node concept="liA8E" id="5kTg4zghvtX" role="2OqNvi">
-                        <ref role="37wK5l" to="lui2:~SModuleReference.getModuleName()" resolve="getModuleName" />
+                    <node concept="2OqwBi" id="7mK357yqYMd" role="37wK5m">
+                      <node concept="30H73N" id="7mK357yqY$d" role="2Oq$k0" />
+                      <node concept="2qgKlT" id="7mK357yqZrk" role="2OqNvi">
+                        <ref role="37wK5l" to="4gky:7mK357yqbs1" resolve="getModuleName" />
                       </node>
                     </node>
                   </node>

--- a/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc.gen_xhtml/generator/template/com/mbeddr/doc/gen_xhtml/generator/template/main@generator.mps
+++ b/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc.gen_xhtml/generator/template/com/mbeddr/doc/gen_xhtml/generator/template/main@generator.mps
@@ -27,8 +27,6 @@
     <import index="iuxj" ref="r:64db3a92-5968-4a73-b456-34504a2d97a6(jetbrains.mps.core.xml.structure)" />
     <import index="hwgx" ref="r:fd2980c8-676c-4b19-b524-18c70e02f8b7(com.mbeddr.core.base.behavior)" />
     <import index="3t5i" ref="r:717da79d-5632-4537-9680-813308745bcf(com.mbeddr.doc.gen_xhtml.defaults)" implicit="true" />
-    <import index="tpeu" ref="r:00000000-0000-4000-0000-011c895902fa(jetbrains.mps.lang.smodel.behavior)" implicit="true" />
-    <import index="lui2" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.module(MPS.OpenAPI/)" implicit="true" />
     <import index="tapt" ref="r:6dfc533c-9e3b-4d5e-b950-90f8ce29851b(com.mbeddr.doc.gen_xhtml.behavior)" implicit="true" />
   </imports>
   <registry>
@@ -1871,20 +1869,10 @@
                   <node concept="3cpWsn" id="5kTg4zghxrW" role="3cpWs9">
                     <property role="TrG5h" value="text" />
                     <node concept="17QB3L" id="5kTg4zghxrX" role="1tU5fm" />
-                    <node concept="2OqwBi" id="5kTg4zghzqV" role="33vP2m">
-                      <node concept="2OqwBi" id="5kTg4zghyKm" role="2Oq$k0">
-                        <node concept="2OqwBi" id="5kTg4zghxrY" role="2Oq$k0">
-                          <node concept="30H73N" id="5kTg4zghxrZ" role="2Oq$k0" />
-                          <node concept="3TrEf2" id="5kTg4zghygO" role="2OqNvi">
-                            <ref role="3Tt5mk" to="2c95:66AQhBxN1Tt" resolve="identity" />
-                          </node>
-                        </node>
-                        <node concept="2qgKlT" id="5kTg4zghz5U" role="2OqNvi">
-                          <ref role="37wK5l" to="tpeu:nJmxU5cSSU" resolve="getModuleReference" />
-                        </node>
-                      </node>
-                      <node concept="liA8E" id="5kTg4zghzKd" role="2OqNvi">
-                        <ref role="37wK5l" to="lui2:~SModuleReference.getModuleName()" resolve="getModuleName" />
+                    <node concept="2OqwBi" id="7mK357yr5lC" role="33vP2m">
+                      <node concept="30H73N" id="7mK357yr57i" role="2Oq$k0" />
+                      <node concept="2qgKlT" id="7mK357yr5IT" role="2OqNvi">
+                        <ref role="37wK5l" to="4gky:7mK357yqbs1" resolve="getModuleName" />
                       </node>
                     </node>
                   </node>

--- a/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/doc.mpl
+++ b/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/doc.mpl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<language namespace="com.mbeddr.doc" uuid="2374bc90-7e37-41f1-a9c4-c2e35194c36a" languageVersion="3" moduleVersion="0">
+<language namespace="com.mbeddr.doc" uuid="2374bc90-7e37-41f1-a9c4-c2e35194c36a" languageVersion="4" moduleVersion="0">
   <models>
     <modelRoot contentPath="${module}" type="default">
       <sourceRoot location="languageModels" />

--- a/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/languageModels/behavior.mps
+++ b/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/languageModels/behavior.mps
@@ -27,6 +27,9 @@
     <import index="48kf" ref="r:5f41c82d-84d1-4fb1-a1cf-6697d2365854(com.mbeddr.mpsutil.filepicker.behavior)" />
     <import index="gtp9" ref="r:007d0985-20e2-4d70-80f1-d0de1aff1076(com.mbeddr.mpsutil.common.graph)" />
     <import index="exr9" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor(MPS.Editor/)" />
+    <import index="dvox" ref="r:9dfd3567-3b1f-4edb-85a0-3981ca2bfd8c(jetbrains.mps.lang.modelapi.structure)" implicit="true" />
+    <import index="tpeu" ref="r:00000000-0000-4000-0000-011c895902fa(jetbrains.mps.lang.smodel.behavior)" implicit="true" />
+    <import index="lui2" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.module(MPS.OpenAPI/)" implicit="true" />
   </imports>
   <registry>
     <language id="af65afd8-f0dd-4942-87d9-63a55f2a9db1" name="jetbrains.mps.lang.behavior">
@@ -9274,6 +9277,60 @@
     </node>
     <node concept="13hLZK" id="3DLpMp_rLl_" role="13h7CW">
       <node concept="3clFbS" id="3DLpMp_rLlA" role="2VODD2" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="7mK357yqbrQ">
+    <property role="3GE5qa" value="modelContent" />
+    <ref role="13h7C2" to="2c95:5IsbCt$w6j_" resolve="ModuleRefWord" />
+    <node concept="13i0hz" id="7mK357yqbs1" role="13h7CS">
+      <property role="TrG5h" value="getModuleName" />
+      <node concept="3Tm1VV" id="7mK357yqbs2" role="1B3o_S" />
+      <node concept="17QB3L" id="7mK357yqbsl" role="3clF45" />
+      <node concept="3clFbS" id="7mK357yqbs4" role="3clF47">
+        <node concept="3clFbF" id="7mK357yqbu$" role="3cqZAp">
+          <node concept="3K4zz7" id="7mK357ypQNm" role="3clFbG">
+            <node concept="2OqwBi" id="7mK357ypSO3" role="3K4GZi">
+              <node concept="2OqwBi" id="7mK357ypRD1" role="2Oq$k0">
+                <node concept="13iPFW" id="7mK357yqbQX" role="2Oq$k0" />
+                <node concept="3TrEf2" id="7mK357ypSdE" role="2OqNvi">
+                  <ref role="3Tt5mk" to="2c95:7mK357ypJVJ" resolve="identity" />
+                </node>
+              </node>
+              <node concept="3TrcHB" id="7mK357ypT67" role="2OqNvi">
+                <ref role="3TsBF5" to="dvox:1Bs_61$mI_D" resolve="moduleName" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="7mK357ypPiU" role="3K4Cdx">
+              <node concept="2OqwBi" id="7mK357ypOCn" role="2Oq$k0">
+                <node concept="13iPFW" id="7mK357yqbHW" role="2Oq$k0" />
+                <node concept="3TrEf2" id="7mK357ypOYC" role="2OqNvi">
+                  <ref role="3Tt5mk" to="2c95:66AQhBxN1Tt" resolve="identity_old" />
+                </node>
+              </node>
+              <node concept="3x8VRR" id="7mK357ypPOo" role="2OqNvi" />
+            </node>
+            <node concept="2OqwBi" id="7mK357ypQQT" role="3K4E3e">
+              <node concept="2OqwBi" id="7mK357ypQQU" role="2Oq$k0">
+                <node concept="2OqwBi" id="7mK357ypQQV" role="2Oq$k0">
+                  <node concept="13iPFW" id="7mK357yqbPE" role="2Oq$k0" />
+                  <node concept="3TrEf2" id="7mK357ypQQX" role="2OqNvi">
+                    <ref role="3Tt5mk" to="2c95:66AQhBxN1Tt" resolve="identity_old" />
+                  </node>
+                </node>
+                <node concept="2qgKlT" id="7mK357ypQQY" role="2OqNvi">
+                  <ref role="37wK5l" to="tpeu:nJmxU5cSSU" resolve="getModuleReference" />
+                </node>
+              </node>
+              <node concept="liA8E" id="7mK357ypQQZ" role="2OqNvi">
+                <ref role="37wK5l" to="lui2:~SModuleReference.getModuleName()" resolve="getModuleName" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="13hLZK" id="7mK357yqbrR" role="13h7CW">
+      <node concept="3clFbS" id="7mK357yqbrS" role="2VODD2" />
     </node>
   </node>
 </model>

--- a/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/languageModels/editor.mps
+++ b/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/languageModels/editor.mps
@@ -15,6 +15,7 @@
     <use id="b1ab8c10-c118-4755-bf2a-cebab35cf533" name="jetbrains.mps.lang.editor.tooltips" version="0" />
     <use id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc" version="2" />
     <use id="af65afd8-f0dd-4942-87d9-63a55f2a9db1" name="jetbrains.mps.lang.behavior" version="2" />
+    <use id="13744753-c81f-424a-9c1b-cf8943bf4e86" name="jetbrains.mps.lang.sharedConcepts" version="0" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
@@ -70,6 +71,8 @@
     <import index="qxi4" ref="r:45c19b6d-dd9a-4f15-973f-0267c5e76303(de.itemis.mps.editor.celllayout.runtime)" />
     <import index="tpen" ref="r:00000000-0000-4000-0000-011c895902c3(jetbrains.mps.baseLanguage.editor)" implicit="true" />
     <import index="22ra" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.update(MPS.Editor/)" implicit="true" />
+    <import index="dvox" ref="r:9dfd3567-3b1f-4edb-85a0-3981ca2bfd8c(jetbrains.mps.lang.modelapi.structure)" implicit="true" />
+    <import index="xlb7" ref="r:cf42fd0a-68d2-493b-8b77-961658617704(jetbrains.mps.lang.modelapi.behavior)" implicit="true" />
     <import index="lwvz" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.selection(MPS.Editor/)" implicit="true" />
   </imports>
   <registry>
@@ -351,6 +354,12 @@
         <child id="3604384757217586546" name="selectionStart" index="3dN3m$" />
       </concept>
       <concept id="1161622981231" name="jetbrains.mps.lang.editor.structure.ConceptFunctionParameter_editorContext" flags="nn" index="1Q80Hx" />
+      <concept id="1088612959204" name="jetbrains.mps.lang.editor.structure.CellModel_Alternation" flags="sg" stub="8104358048506729361" index="1QoScp">
+        <property id="1088613081987" name="vertical" index="1QpmdY" />
+        <child id="1145918517974" name="alternationCondition" index="3e4ffs" />
+        <child id="1088612958265" name="ifTrueCellModel" index="1QoS34" />
+        <child id="1088612973955" name="ifFalseCellModel" index="1QoVPY" />
+      </concept>
       <concept id="625126330682908270" name="jetbrains.mps.lang.editor.structure.CellModel_ReferencePresentation" flags="sg" stub="730538219795961225" index="3SHvHV" />
       <concept id="1176717841777" name="jetbrains.mps.lang.editor.structure.QueryFunction_ModelAccess_Getter" flags="in" index="3TQlhw" />
       <concept id="1176749715029" name="jetbrains.mps.lang.editor.structure.QueryFunction_CellProvider" flags="in" index="3VJUX4" />
@@ -738,6 +747,9 @@
       </concept>
       <concept id="1171407110247" name="jetbrains.mps.lang.smodel.structure.Node_GetAncestorOperation" flags="nn" index="2Xjw5R" />
       <concept id="1143511969223" name="jetbrains.mps.lang.smodel.structure.Node_GetPrevSiblingOperation" flags="nn" index="YBYNd" />
+      <concept id="2644386474300074836" name="jetbrains.mps.lang.smodel.structure.ConceptIdRefExpression" flags="nn" index="35c_gC">
+        <reference id="2644386474300074837" name="conceptDeclaration" index="35c_gD" />
+      </concept>
       <concept id="5168775467716640652" name="jetbrains.mps.lang.smodel.structure.OperationParm_LinkQualifier" flags="ng" index="1aIX9F">
         <child id="5168775467716640653" name="linkQualifier" index="1aIX9E" />
       </concept>
@@ -746,6 +758,7 @@
         <child id="1177027386292" name="conceptArgument" index="cj9EA" />
       </concept>
       <concept id="6870613620390542976" name="jetbrains.mps.lang.smodel.structure.ConceptAliasOperation" flags="ng" index="3n3YKJ" />
+      <concept id="1171999116870" name="jetbrains.mps.lang.smodel.structure.Node_IsNullOperation" flags="nn" index="3w_OXm" />
       <concept id="1172008320231" name="jetbrains.mps.lang.smodel.structure.Node_IsNotNullOperation" flags="nn" index="3x8VRR" />
       <concept id="1144100932627" name="jetbrains.mps.lang.smodel.structure.OperationParm_Inclusion" flags="ng" index="1xIGOp" />
       <concept id="1144101972840" name="jetbrains.mps.lang.smodel.structure.OperationParm_Concept" flags="ng" index="1xMEDy">
@@ -10911,139 +10924,6 @@
         </node>
       </node>
       <node concept="3ZSo5i" id="5kTg4zgbG4p" role="3EZMnx">
-        <node concept="3F1sOY" id="66AQhBxN1U8" role="3EZMny">
-          <ref role="1NtTu8" to="2c95:66AQhBxN1Tt" resolve="identity" />
-          <ref role="1k5W1q" node="3RseghId8o$" resolve="nodeReference" />
-          <node concept="OXEIz" id="66AQhBxN1UH" role="P5bDN">
-            <node concept="1ou48o" id="1t9FffgecRf" role="OY2wv">
-              <property role="1ezIyd" value="gWZP3tU/custom_" />
-              <node concept="1ouSdP" id="1t9FffgecRg" role="1ou48m">
-                <node concept="3clFbS" id="1t9FffgecRh" role="2VODD2">
-                  <node concept="3cpWs8" id="1t9FffgecRi" role="3cqZAp">
-                    <node concept="3cpWsn" id="1t9FffgecRj" role="3cpWs9">
-                      <property role="TrG5h" value="pointer" />
-                      <node concept="3Tqbb2" id="1t9FffgecRk" role="1tU5fm">
-                        <ref role="ehGHo" to="tp25:nJmxU5cSyN" resolve="ModulePointer" />
-                      </node>
-                      <node concept="2OqwBi" id="1t9FffgecRl" role="33vP2m">
-                        <node concept="1Q6Npb" id="1t9FffgecRm" role="2Oq$k0" />
-                        <node concept="I8ghe" id="1t9FffgecRn" role="2OqNvi">
-                          <ref role="I8UWU" to="tp25:nJmxU5cSyN" resolve="ModulePointer" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="3clFbF" id="1t9FffgecRo" role="3cqZAp">
-                    <node concept="2OqwBi" id="1t9FffgecRp" role="3clFbG">
-                      <node concept="37vLTw" id="1t9FffgecRq" role="2Oq$k0">
-                        <ref role="3cqZAo" node="1t9FffgecRj" resolve="pointer" />
-                      </node>
-                      <node concept="2qgKlT" id="1t9FffgeuhL" role="2OqNvi">
-                        <ref role="37wK5l" to="tpeu:nJmxU5cSTj" resolve="setModuleReference" />
-                        <node concept="3GLrbK" id="1t9FffgeuiJ" role="37wK5m" />
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="3clFbF" id="1t9FffgecRt" role="3cqZAp">
-                    <node concept="37vLTI" id="1t9FffgecRu" role="3clFbG">
-                      <node concept="2OqwBi" id="1t9FffgecRv" role="37vLTJ">
-                        <node concept="3GMtW1" id="1t9FffgecRw" role="2Oq$k0" />
-                        <node concept="3TrEf2" id="66AQhBxPhQI" role="2OqNvi">
-                          <ref role="3Tt5mk" to="2c95:66AQhBxN1Tt" resolve="identity" />
-                        </node>
-                      </node>
-                      <node concept="37vLTw" id="1t9FffgecRy" role="37vLTx">
-                        <ref role="3cqZAo" node="1t9FffgecRj" resolve="pointer" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="3GJtP1" id="1t9FffgecRz" role="1ou48n">
-                <node concept="3clFbS" id="1t9FffgecR$" role="2VODD2">
-                  <node concept="3cpWs8" id="1t9Fffgej0q" role="3cqZAp">
-                    <node concept="3cpWsn" id="1t9Fffgej0w" role="3cpWs9">
-                      <property role="TrG5h" value="references" />
-                      <node concept="3uibUv" id="1t9Fffgej0y" role="1tU5fm">
-                        <ref role="3uigEE" to="33ny:~ArrayList" resolve="ArrayList" />
-                        <node concept="3uibUv" id="1t9FffgejbR" role="11_B2D">
-                          <ref role="3uigEE" to="lui2:~SModuleReference" resolve="SModuleReference" />
-                        </node>
-                      </node>
-                      <node concept="2ShNRf" id="1t9Fffgek4a" role="33vP2m">
-                        <node concept="1pGfFk" id="1t9FffgepIR" role="2ShVmc">
-                          <ref role="37wK5l" to="33ny:~ArrayList.&lt;init&gt;()" resolve="ArrayList" />
-                          <node concept="3uibUv" id="1t9Fffgeq5M" role="1pMfVU">
-                            <ref role="3uigEE" to="lui2:~SModuleReference" resolve="SModuleReference" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="1DcWWT" id="1t9Fffgeqt2" role="3cqZAp">
-                    <node concept="3clFbS" id="1t9Fffgeqt4" role="2LFqv$">
-                      <node concept="3clFbF" id="1t9FffgeqOK" role="3cqZAp">
-                        <node concept="2OqwBi" id="1t9Fffger9U" role="3clFbG">
-                          <node concept="37vLTw" id="1t9FffgeqOJ" role="2Oq$k0">
-                            <ref role="3cqZAo" node="1t9Fffgej0w" resolve="references" />
-                          </node>
-                          <node concept="liA8E" id="1t9FffgesvM" role="2OqNvi">
-                            <ref role="37wK5l" to="33ny:~ArrayList.add(java.lang.Object)" resolve="add" />
-                            <node concept="2OqwBi" id="1t9FffgesTk" role="37wK5m">
-                              <node concept="37vLTw" id="1t9FffgesIn" role="2Oq$k0">
-                                <ref role="3cqZAo" node="1t9Fffgeqt6" resolve="m" />
-                              </node>
-                              <node concept="liA8E" id="1t9Fffgeta4" role="2OqNvi">
-                                <ref role="37wK5l" to="lui2:~SModule.getModuleReference()" resolve="getModuleReference" />
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="3cpWsn" id="1t9Fffgeqt6" role="1Duv9x">
-                      <property role="TrG5h" value="m" />
-                      <node concept="3uibUv" id="1t9Fffgeqta" role="1tU5fm">
-                        <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-                      </node>
-                    </node>
-                    <node concept="2OqwBi" id="1t9Fffgeqtb" role="1DdaDG">
-                      <node concept="2OqwBi" id="1t9Fffgeqtc" role="2Oq$k0">
-                        <node concept="1Q80Hx" id="3Z93mP$_dv2" role="2Oq$k0" />
-                        <node concept="liA8E" id="1t9Fffgeqtg" role="2OqNvi">
-                          <ref role="37wK5l" to="cj4x:~EditorContext.getRepository()" resolve="getRepository" />
-                        </node>
-                      </node>
-                      <node concept="liA8E" id="1t9Fffgeqth" role="2OqNvi">
-                        <ref role="37wK5l" to="lui2:~SRepository.getModules()" resolve="getModules" />
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="3cpWs6" id="1t9FffgecRG" role="3cqZAp">
-                    <node concept="37vLTw" id="1t9FffgetFN" role="3cqZAk">
-                      <ref role="3cqZAo" node="1t9Fffgej0w" resolve="references" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="3uibUv" id="1t9Fffgedic" role="1eyP2E">
-                <ref role="3uigEE" to="lui2:~SModuleReference" resolve="SModuleReference" />
-              </node>
-              <node concept="6VE3a" id="1t9FffgewpU" role="1ezQQy">
-                <node concept="3clFbS" id="1t9FffgewpV" role="2VODD2">
-                  <node concept="3cpWs6" id="66AQhBxPhib" role="3cqZAp">
-                    <node concept="2OqwBi" id="66AQhBxPhic" role="3cqZAk">
-                      <node concept="3GLrbK" id="66AQhBxPhid" role="2Oq$k0" />
-                      <node concept="liA8E" id="66AQhBxPhie" role="2OqNvi">
-                        <ref role="37wK5l" to="lui2:~SModuleReference.getModuleName()" resolve="getModuleName" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
         <node concept="3VJUX5" id="5kTg4zgbHaf" role="3ZZHOD">
           <node concept="3clFbS" id="5kTg4zgbHag" role="2VODD2">
             <node concept="3cpWs8" id="5kTg4zgc0__" role="3cqZAp">
@@ -11115,7 +10995,7 @@
                                           <node concept="2OqwBi" id="5kTg4zgcfJK" role="2Oq$k0">
                                             <node concept="pncrf" id="5kTg4zgcgPd" role="2Oq$k0" />
                                             <node concept="3TrEf2" id="5kTg4zgcfJM" role="2OqNvi">
-                                              <ref role="3Tt5mk" to="2c95:66AQhBxN1Tt" resolve="identity" />
+                                              <ref role="3Tt5mk" to="2c95:66AQhBxN1Tt" resolve="identity_old" />
                                             </node>
                                           </node>
                                           <node concept="2qgKlT" id="5kTg4zgcfJN" role="2OqNvi">
@@ -11211,6 +11091,272 @@
             <node concept="3cpWs6" id="5kTg4zgdBSw" role="3cqZAp">
               <node concept="37vLTw" id="5kTg4zgdBSx" role="3cqZAk">
                 <ref role="3cqZAo" node="5kTg4zgc0_A" resolve="wrapper" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1QoScp" id="7mK357ytBRE" role="3EZMny">
+          <property role="1QpmdY" value="true" />
+          <node concept="pkWqt" id="7mK357ytBRF" role="3e4ffs">
+            <node concept="3clFbS" id="7mK357ytBRG" role="2VODD2">
+              <node concept="3clFbF" id="7mK357y_INw" role="3cqZAp">
+                <node concept="2OqwBi" id="7mK357y_Jyz" role="3clFbG">
+                  <node concept="2OqwBi" id="7mK357y_J2M" role="2Oq$k0">
+                    <node concept="pncrf" id="7mK357y_INv" role="2Oq$k0" />
+                    <node concept="3TrEf2" id="7mK357y_JmI" role="2OqNvi">
+                      <ref role="3Tt5mk" to="2c95:66AQhBxN1Tt" resolve="identity_old" />
+                    </node>
+                  </node>
+                  <node concept="3w_OXm" id="7mK357y_JZ4" role="2OqNvi" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3F1sOY" id="66AQhBxN1U8" role="1QoVPY">
+            <ref role="1NtTu8" to="2c95:66AQhBxN1Tt" resolve="identity_old" />
+            <ref role="1k5W1q" node="3RseghId8o$" resolve="nodeReference" />
+            <node concept="OXEIz" id="66AQhBxN1UH" role="P5bDN">
+              <node concept="1ou48o" id="1t9FffgecRf" role="OY2wv">
+                <property role="1ezIyd" value="gWZP3tU/custom_" />
+                <node concept="1ouSdP" id="1t9FffgecRg" role="1ou48m">
+                  <node concept="3clFbS" id="1t9FffgecRh" role="2VODD2">
+                    <node concept="3cpWs8" id="1t9FffgecRi" role="3cqZAp">
+                      <node concept="3cpWsn" id="1t9FffgecRj" role="3cpWs9">
+                        <property role="TrG5h" value="pointer" />
+                        <node concept="3Tqbb2" id="1t9FffgecRk" role="1tU5fm">
+                          <ref role="ehGHo" to="tp25:nJmxU5cSyN" resolve="ModulePointer" />
+                        </node>
+                        <node concept="2OqwBi" id="1t9FffgecRl" role="33vP2m">
+                          <node concept="I8ghe" id="1t9FffgecRn" role="2OqNvi">
+                            <ref role="I8UWU" to="tp25:nJmxU5cSyN" resolve="ModulePointer" />
+                          </node>
+                          <node concept="1Q6Npb" id="7mK357yuwH1" role="2Oq$k0" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbF" id="1t9FffgecRo" role="3cqZAp">
+                      <node concept="2OqwBi" id="1t9FffgecRp" role="3clFbG">
+                        <node concept="37vLTw" id="1t9FffgecRq" role="2Oq$k0">
+                          <ref role="3cqZAo" node="1t9FffgecRj" resolve="pointer" />
+                        </node>
+                        <node concept="2qgKlT" id="1t9FffgeuhL" role="2OqNvi">
+                          <ref role="37wK5l" to="tpeu:nJmxU5cSTj" resolve="setModuleReference" />
+                          <node concept="3GLrbK" id="1t9FffgeuiJ" role="37wK5m" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbF" id="1t9FffgecRt" role="3cqZAp">
+                      <node concept="37vLTI" id="1t9FffgecRu" role="3clFbG">
+                        <node concept="2OqwBi" id="1t9FffgecRv" role="37vLTJ">
+                          <node concept="3GMtW1" id="1t9FffgecRw" role="2Oq$k0" />
+                          <node concept="3TrEf2" id="66AQhBxPhQI" role="2OqNvi">
+                            <ref role="3Tt5mk" to="2c95:66AQhBxN1Tt" resolve="identity_old" />
+                          </node>
+                        </node>
+                        <node concept="37vLTw" id="1t9FffgecRy" role="37vLTx">
+                          <ref role="3cqZAo" node="1t9FffgecRj" resolve="pointer" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3GJtP1" id="1t9FffgecRz" role="1ou48n">
+                  <node concept="3clFbS" id="1t9FffgecR$" role="2VODD2">
+                    <node concept="3cpWs8" id="1t9Fffgej0q" role="3cqZAp">
+                      <node concept="3cpWsn" id="1t9Fffgej0w" role="3cpWs9">
+                        <property role="TrG5h" value="references" />
+                        <node concept="3uibUv" id="1t9Fffgej0y" role="1tU5fm">
+                          <ref role="3uigEE" to="33ny:~ArrayList" resolve="ArrayList" />
+                          <node concept="3uibUv" id="1t9FffgejbR" role="11_B2D">
+                            <ref role="3uigEE" to="lui2:~SModuleReference" resolve="SModuleReference" />
+                          </node>
+                        </node>
+                        <node concept="2ShNRf" id="1t9Fffgek4a" role="33vP2m">
+                          <node concept="1pGfFk" id="1t9FffgepIR" role="2ShVmc">
+                            <ref role="37wK5l" to="33ny:~ArrayList.&lt;init&gt;()" resolve="ArrayList" />
+                            <node concept="3uibUv" id="1t9Fffgeq5M" role="1pMfVU">
+                              <ref role="3uigEE" to="lui2:~SModuleReference" resolve="SModuleReference" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="1DcWWT" id="1t9Fffgeqt2" role="3cqZAp">
+                      <node concept="3clFbS" id="1t9Fffgeqt4" role="2LFqv$">
+                        <node concept="3clFbF" id="1t9FffgeqOK" role="3cqZAp">
+                          <node concept="2OqwBi" id="1t9Fffger9U" role="3clFbG">
+                            <node concept="37vLTw" id="1t9FffgeqOJ" role="2Oq$k0">
+                              <ref role="3cqZAo" node="1t9Fffgej0w" resolve="references" />
+                            </node>
+                            <node concept="liA8E" id="1t9FffgesvM" role="2OqNvi">
+                              <ref role="37wK5l" to="33ny:~ArrayList.add(java.lang.Object)" resolve="add" />
+                              <node concept="2OqwBi" id="1t9FffgesTk" role="37wK5m">
+                                <node concept="37vLTw" id="1t9FffgesIn" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="1t9Fffgeqt6" resolve="m" />
+                                </node>
+                                <node concept="liA8E" id="1t9Fffgeta4" role="2OqNvi">
+                                  <ref role="37wK5l" to="lui2:~SModule.getModuleReference()" resolve="getModuleReference" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3cpWsn" id="1t9Fffgeqt6" role="1Duv9x">
+                        <property role="TrG5h" value="m" />
+                        <node concept="3uibUv" id="1t9Fffgeqta" role="1tU5fm">
+                          <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
+                        </node>
+                      </node>
+                      <node concept="2OqwBi" id="1t9Fffgeqtb" role="1DdaDG">
+                        <node concept="2OqwBi" id="1t9Fffgeqtc" role="2Oq$k0">
+                          <node concept="1Q80Hx" id="3Z93mP$_dv2" role="2Oq$k0" />
+                          <node concept="liA8E" id="1t9Fffgeqtg" role="2OqNvi">
+                            <ref role="37wK5l" to="cj4x:~EditorContext.getRepository()" resolve="getRepository" />
+                          </node>
+                        </node>
+                        <node concept="liA8E" id="1t9Fffgeqth" role="2OqNvi">
+                          <ref role="37wK5l" to="lui2:~SRepository.getModules()" resolve="getModules" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3cpWs6" id="1t9FffgecRG" role="3cqZAp">
+                      <node concept="37vLTw" id="1t9FffgetFN" role="3cqZAk">
+                        <ref role="3cqZAo" node="1t9Fffgej0w" resolve="references" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3uibUv" id="1t9Fffgedic" role="1eyP2E">
+                  <ref role="3uigEE" to="lui2:~SModuleReference" resolve="SModuleReference" />
+                </node>
+                <node concept="6VE3a" id="1t9FffgewpU" role="1ezQQy">
+                  <node concept="3clFbS" id="1t9FffgewpV" role="2VODD2">
+                    <node concept="3cpWs6" id="66AQhBxPhib" role="3cqZAp">
+                      <node concept="2OqwBi" id="66AQhBxPhic" role="3cqZAk">
+                        <node concept="3GLrbK" id="66AQhBxPhid" role="2Oq$k0" />
+                        <node concept="liA8E" id="66AQhBxPhie" role="2OqNvi">
+                          <ref role="37wK5l" to="lui2:~SModuleReference.getModuleName()" resolve="getModuleName" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3F1sOY" id="7mK357ytDaf" role="1QoS34">
+            <ref role="1k5W1q" node="3RseghId8o$" resolve="nodeReference" />
+            <ref role="1NtTu8" to="2c95:7mK357ypJVJ" resolve="identity" />
+            <node concept="OXEIz" id="7mK357ytDag" role="P5bDN">
+              <node concept="1ou48o" id="7mK357ytDah" role="OY2wv">
+                <property role="1ezIyd" value="gWZP3tU/custom_" />
+                <node concept="1ouSdP" id="7mK357ytDai" role="1ou48m">
+                  <node concept="3clFbS" id="7mK357ytDaj" role="2VODD2">
+                    <node concept="3clFbF" id="7mK357yurTn" role="3cqZAp">
+                      <node concept="37vLTI" id="7mK357yurTo" role="3clFbG">
+                        <node concept="2OqwBi" id="7mK357yurTp" role="37vLTJ">
+                          <node concept="3GMtW1" id="7mK357yurTq" role="2Oq$k0" />
+                          <node concept="3TrEf2" id="7mK357yurTr" role="2OqNvi">
+                            <ref role="3Tt5mk" to="2c95:7mK357ypJVJ" resolve="identity" />
+                          </node>
+                        </node>
+                        <node concept="2OqwBi" id="7mK357yut33" role="37vLTx">
+                          <node concept="35c_gC" id="7mK357yusBe" role="2Oq$k0">
+                            <ref role="35c_gD" to="dvox:k2ZBl8Cedx" resolve="ModulePointer" />
+                          </node>
+                          <node concept="2qgKlT" id="7mK357yutrm" role="2OqNvi">
+                            <ref role="37wK5l" to="xlb7:1Bs_61$mIAC" resolve="create" />
+                            <node concept="1Q6Npb" id="7mK357yutxi" role="37wK5m" />
+                            <node concept="3GLrbK" id="7mK357yutDS" role="37wK5m" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3GJtP1" id="7mK357ytDa_" role="1ou48n">
+                  <node concept="3clFbS" id="7mK357ytDaA" role="2VODD2">
+                    <node concept="3cpWs8" id="7mK357ytDaB" role="3cqZAp">
+                      <node concept="3cpWsn" id="7mK357ytDaC" role="3cpWs9">
+                        <property role="TrG5h" value="references" />
+                        <node concept="3uibUv" id="7mK357ytDaD" role="1tU5fm">
+                          <ref role="3uigEE" to="33ny:~ArrayList" resolve="ArrayList" />
+                          <node concept="3uibUv" id="7mK357ytDaE" role="11_B2D">
+                            <ref role="3uigEE" to="lui2:~SModuleReference" resolve="SModuleReference" />
+                          </node>
+                        </node>
+                        <node concept="2ShNRf" id="7mK357ytDaF" role="33vP2m">
+                          <node concept="1pGfFk" id="7mK357ytDaG" role="2ShVmc">
+                            <ref role="37wK5l" to="33ny:~ArrayList.&lt;init&gt;()" resolve="ArrayList" />
+                            <node concept="3uibUv" id="7mK357ytDaH" role="1pMfVU">
+                              <ref role="3uigEE" to="lui2:~SModuleReference" resolve="SModuleReference" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="1DcWWT" id="7mK357ytDaI" role="3cqZAp">
+                      <node concept="3clFbS" id="7mK357ytDaJ" role="2LFqv$">
+                        <node concept="3clFbF" id="7mK357ytDaK" role="3cqZAp">
+                          <node concept="2OqwBi" id="7mK357ytDaL" role="3clFbG">
+                            <node concept="37vLTw" id="7mK357ytDaM" role="2Oq$k0">
+                              <ref role="3cqZAo" node="7mK357ytDaC" resolve="references" />
+                            </node>
+                            <node concept="liA8E" id="7mK357ytDaN" role="2OqNvi">
+                              <ref role="37wK5l" to="33ny:~ArrayList.add(java.lang.Object)" resolve="add" />
+                              <node concept="2OqwBi" id="7mK357ytDaO" role="37wK5m">
+                                <node concept="37vLTw" id="7mK357ytDaP" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="7mK357ytDaR" resolve="m" />
+                                </node>
+                                <node concept="liA8E" id="7mK357ytDaQ" role="2OqNvi">
+                                  <ref role="37wK5l" to="lui2:~SModule.getModuleReference()" resolve="getModuleReference" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3cpWsn" id="7mK357ytDaR" role="1Duv9x">
+                        <property role="TrG5h" value="m" />
+                        <node concept="3uibUv" id="7mK357ytDaS" role="1tU5fm">
+                          <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
+                        </node>
+                      </node>
+                      <node concept="2OqwBi" id="7mK357ytDaT" role="1DdaDG">
+                        <node concept="2OqwBi" id="7mK357ytDaU" role="2Oq$k0">
+                          <node concept="1Q80Hx" id="7mK357ytDaV" role="2Oq$k0" />
+                          <node concept="liA8E" id="7mK357ytDaW" role="2OqNvi">
+                            <ref role="37wK5l" to="cj4x:~EditorContext.getRepository()" resolve="getRepository" />
+                          </node>
+                        </node>
+                        <node concept="liA8E" id="7mK357ytDaX" role="2OqNvi">
+                          <ref role="37wK5l" to="lui2:~SRepository.getModules()" resolve="getModules" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3cpWs6" id="7mK357ytDaY" role="3cqZAp">
+                      <node concept="37vLTw" id="7mK357ytDaZ" role="3cqZAk">
+                        <ref role="3cqZAo" node="7mK357ytDaC" resolve="references" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3uibUv" id="7mK357ytDb0" role="1eyP2E">
+                  <ref role="3uigEE" to="lui2:~SModuleReference" resolve="SModuleReference" />
+                </node>
+                <node concept="6VE3a" id="7mK357ytDb1" role="1ezQQy">
+                  <node concept="3clFbS" id="7mK357ytDb2" role="2VODD2">
+                    <node concept="3cpWs6" id="7mK357ytDb3" role="3cqZAp">
+                      <node concept="2OqwBi" id="7mK357ytDb4" role="3cqZAk">
+                        <node concept="3GLrbK" id="7mK357ytDb5" role="2Oq$k0" />
+                        <node concept="liA8E" id="7mK357ytDb6" role="2OqNvi">
+                          <ref role="37wK5l" to="lui2:~SModuleReference.getModuleName()" resolve="getModuleName" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
               </node>
             </node>
           </node>
@@ -11440,20 +11586,10 @@
         <node concept="3TQlhw" id="5kTg4zgeLME" role="1Hhtcw">
           <node concept="3clFbS" id="5kTg4zgeLOT" role="2VODD2">
             <node concept="3cpWs6" id="5kTg4zgeM7$" role="3cqZAp">
-              <node concept="2OqwBi" id="5kTg4zgeNDO" role="3cqZAk">
-                <node concept="2OqwBi" id="5kTg4zgeN9G" role="2Oq$k0">
-                  <node concept="2OqwBi" id="5kTg4zgeMmb" role="2Oq$k0">
-                    <node concept="pncrf" id="5kTg4zgeM7M" role="2Oq$k0" />
-                    <node concept="3TrEf2" id="5kTg4zgeMEO" role="2OqNvi">
-                      <ref role="3Tt5mk" to="2c95:66AQhBxN1Tt" resolve="identity" />
-                    </node>
-                  </node>
-                  <node concept="2qgKlT" id="5kTg4zgeNuE" role="2OqNvi">
-                    <ref role="37wK5l" to="tpeu:nJmxU5cSSU" resolve="getModuleReference" />
-                  </node>
-                </node>
-                <node concept="liA8E" id="5kTg4zgeNYD" role="2OqNvi">
-                  <ref role="37wK5l" to="lui2:~SModuleReference.getModuleName()" resolve="getModuleName" />
+              <node concept="2OqwBi" id="7mK357y$xQe" role="3cqZAk">
+                <node concept="pncrf" id="7mK357y$xCl" role="2Oq$k0" />
+                <node concept="2qgKlT" id="7mK357y$yec" role="2OqNvi">
+                  <ref role="37wK5l" to="4gky:7mK357yqbs1" resolve="getModuleName" />
                 </node>
               </node>
             </node>

--- a/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/languageModels/migration.mps
+++ b/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/languageModels/migration.mps
@@ -5,13 +5,19 @@
     <use id="90746344-04fd-4286-97d5-b46ae6a81709" name="jetbrains.mps.lang.migration" version="2" />
     <use id="c7d5b9dd-a05f-4be2-bc73-f2e16994cc67" name="jetbrains.mps.baseLanguage.lightweightdsl" version="-1" />
     <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="11" />
+    <use id="28f9e497-3b42-4291-aeba-0a1039153ab1" name="jetbrains.mps.lang.plugin" version="5" />
+    <use id="d4615e3b-d671-4ba9-af01-2b78369b0ba7" name="jetbrains.mps.lang.pattern" version="2" />
     <devkit ref="2677cb18-f558-4e33-bc38-a5139cee06dc(jetbrains.mps.devkit.language-design)" />
   </languages>
   <imports>
     <import index="lui2" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.module(MPS.OpenAPI/)" />
     <import index="2c95" ref="r:5f7188a9-e7b4-4a2e-bef9-38d2cf379fdc(com.mbeddr.doc.structure)" />
     <import index="slm6" ref="90746344-04fd-4286-97d5-b46ae6a81709/r:52a3d974-bd4f-4651-ba6e-a2de5e336d95(jetbrains.mps.lang.migration/jetbrains.mps.lang.migration.methods)" />
+    <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
+    <import index="dvox" ref="r:9dfd3567-3b1f-4edb-85a0-3981ca2bfd8c(jetbrains.mps.lang.modelapi.structure)" implicit="true" />
+    <import index="xlb7" ref="r:cf42fd0a-68d2-493b-8b77-961658617704(jetbrains.mps.lang.modelapi.behavior)" implicit="true" />
+    <import index="tpeu" ref="r:00000000-0000-4000-0000-011c895902fa(jetbrains.mps.lang.smodel.behavior)" implicit="true" />
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
@@ -31,6 +37,9 @@
       </concept>
       <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
       <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
+      <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu">
+        <child id="1165602531693" name="superclass" index="1zkMxy" />
+      </concept>
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <child id="1068431790190" name="initializer" index="33vP2m" />
       </concept>
@@ -64,6 +73,7 @@
       <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
       <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
       <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
         <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
@@ -133,12 +143,18 @@
       <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
         <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
       </concept>
+      <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
       <concept id="1138757581985" name="jetbrains.mps.lang.smodel.structure.Link_SetNewChildOperation" flags="nn" index="zfrQC" />
       <concept id="1143226024141" name="jetbrains.mps.lang.smodel.structure.SModelType" flags="in" index="H_c77" />
+      <concept id="1143234257716" name="jetbrains.mps.lang.smodel.structure.Node_GetModelOperation" flags="nn" index="I4A8Y" />
       <concept id="1171323947159" name="jetbrains.mps.lang.smodel.structure.Model_NodesOperation" flags="nn" index="2SmgA7">
         <child id="1758937410080001570" name="conceptArgument" index="1dBWTz" />
       </concept>
+      <concept id="2644386474300074836" name="jetbrains.mps.lang.smodel.structure.ConceptIdRefExpression" flags="nn" index="35c_gC">
+        <reference id="2644386474300074837" name="conceptDeclaration" index="35c_gD" />
+      </concept>
       <concept id="1171999116870" name="jetbrains.mps.lang.smodel.structure.Node_IsNullOperation" flags="nn" index="3w_OXm" />
+      <concept id="1172008320231" name="jetbrains.mps.lang.smodel.structure.Node_IsNotNullOperation" flags="nn" index="3x8VRR" />
       <concept id="1140131837776" name="jetbrains.mps.lang.smodel.structure.Node_ReplaceWithAnotherOperation" flags="nn" index="1P9Npp">
         <child id="1140131861877" name="replacementNode" index="1P9ThW" />
       </concept>
@@ -151,6 +167,7 @@
       <concept id="1138056143562" name="jetbrains.mps.lang.smodel.structure.SLinkAccess" flags="nn" index="3TrEf2">
         <reference id="1138056516764" name="link" index="3Tt5mk" />
       </concept>
+      <concept id="1228341669568" name="jetbrains.mps.lang.smodel.structure.Node_DetachOperation" flags="nn" index="3YRAZt" />
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
@@ -561,6 +578,177 @@
     <node concept="3tTeZs" id="3WqLVgfGl3z" role="jymVt">
       <property role="3tTeZt" value="&lt;no result checking&gt;" />
       <ref role="3tTeZr" to="slm6:1JWcQ2VeXpD" resolve="check" />
+    </node>
+  </node>
+  <node concept="3SyAh_" id="7mK357yvT2m">
+    <property role="qMTe8" value="3" />
+    <property role="TrG5h" value="moduleRefWord_convert_identity" />
+    <node concept="3Tm1VV" id="7mK357yvT2n" role="1B3o_S" />
+    <node concept="3tTeZs" id="7mK357yvT2o" role="jymVt">
+      <property role="3tTeZt" value="&lt;no execute after&gt;" />
+      <ref role="3tTeZr" to="slm6:7ay_HjIMt1a" resolve="execute after" />
+    </node>
+    <node concept="3tTeZs" id="7mK357yvT2p" role="jymVt">
+      <property role="3tTeZt" value="&lt;no required data&gt;" />
+      <ref role="3tTeZr" to="slm6:5TUCQr2FPTh" resolve="requires annotation data" />
+    </node>
+    <node concept="3tTeZs" id="7mK357yvT2q" role="jymVt">
+      <property role="3tTeZt" value="&lt;no produced data&gt;" />
+      <ref role="3tTeZr" to="slm6:5TUCQr2C271" resolve="produces annotation data" />
+    </node>
+    <node concept="2tJIrI" id="7mK357yvT2r" role="jymVt" />
+    <node concept="3tYpMH" id="7mK357yvT2s" role="jymVt">
+      <property role="TrG5h" value="isRerunnable" />
+      <property role="3tYpME" value="true" />
+      <ref role="25KYV2" to="slm6:1JWcQ2VeWIs" resolve="isRerunnable" />
+      <node concept="3Tm1VV" id="7mK357yvT2t" role="1B3o_S" />
+      <node concept="10P_77" id="7mK357yvT2u" role="1tU5fm" />
+    </node>
+    <node concept="3tTeZs" id="7mK357yvT2v" role="jymVt">
+      <property role="3tTeZt" value="&lt;description&gt;" />
+      <ref role="3tTeZr" to="slm6:1_lSsE3RFpE" resolve="description" />
+    </node>
+    <node concept="q3mfD" id="7mK357yvT2w" role="jymVt">
+      <property role="TrG5h" value="execute" />
+      <ref role="2VtyIY" to="slm6:4ubqdNOF9cA" resolve="execute" />
+      <node concept="3Tm1VV" id="7mK357yvT2y" role="1B3o_S" />
+      <node concept="3clFbS" id="7mK357yvT2$" role="3clF47">
+        <node concept="1DcWWT" id="7mK357yw2Kt" role="3cqZAp">
+          <node concept="3clFbS" id="7mK357yw2Kv" role="2LFqv$">
+            <node concept="3clFbF" id="7mK357yw3Ul" role="3cqZAp">
+              <node concept="2OqwBi" id="7mK357ywb_I" role="3clFbG">
+                <node concept="2OqwBi" id="7mK357yw6B7" role="2Oq$k0">
+                  <node concept="2OqwBi" id="7mK357yw44_" role="2Oq$k0">
+                    <node concept="37vLTw" id="7mK357yw3Uj" role="2Oq$k0">
+                      <ref role="3cqZAo" node="7mK357yw2Kw" resolve="mdl" />
+                    </node>
+                    <node concept="2SmgA7" id="7mK357yw4jy" role="2OqNvi">
+                      <node concept="chp4Y" id="7mK357yw4ya" role="1dBWTz">
+                        <ref role="cht4Q" to="2c95:5IsbCt$w6j_" resolve="ModuleRefWord" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3zZkjj" id="7mK357yw9s9" role="2OqNvi">
+                    <node concept="1bVj0M" id="7mK357yw9sb" role="23t8la">
+                      <node concept="3clFbS" id="7mK357yw9sc" role="1bW5cS">
+                        <node concept="3clFbF" id="7mK357yw9$h" role="3cqZAp">
+                          <node concept="2OqwBi" id="7mK357ywaRp" role="3clFbG">
+                            <node concept="2OqwBi" id="7mK357yw9S5" role="2Oq$k0">
+                              <node concept="37vLTw" id="7mK357yw9$g" role="2Oq$k0">
+                                <ref role="3cqZAo" node="7mK357yw9sd" resolve="it" />
+                              </node>
+                              <node concept="3TrEf2" id="7mK357ywahy" role="2OqNvi">
+                                <ref role="3Tt5mk" to="2c95:66AQhBxN1Tt" resolve="identity_old" />
+                              </node>
+                            </node>
+                            <node concept="3x8VRR" id="7mK357ywbhE" role="2OqNvi" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="Rh6nW" id="7mK357yw9sd" role="1bW2Oz">
+                        <property role="TrG5h" value="it" />
+                        <node concept="2jxLKc" id="7mK357yw9se" role="1tU5fm" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="2es0OD" id="7mK357ywbXK" role="2OqNvi">
+                  <node concept="1bVj0M" id="7mK357ywbXM" role="23t8la">
+                    <node concept="3clFbS" id="7mK357ywbXN" role="1bW5cS">
+                      <node concept="3clFbF" id="7mK357ywc7B" role="3cqZAp">
+                        <node concept="37vLTI" id="7mK357ywcQQ" role="3clFbG">
+                          <node concept="2OqwBi" id="7mK357ywcp1" role="37vLTJ">
+                            <node concept="37vLTw" id="7mK357ywc7A" role="2Oq$k0">
+                              <ref role="3cqZAo" node="7mK357ywbXO" resolve="it" />
+                            </node>
+                            <node concept="3TrEf2" id="7mK357ywcyx" role="2OqNvi">
+                              <ref role="3Tt5mk" to="2c95:7mK357ypJVJ" resolve="identity" />
+                            </node>
+                          </node>
+                          <node concept="2OqwBi" id="7mK357ywgTr" role="37vLTx">
+                            <node concept="35c_gC" id="7mK357ywgcX" role="2Oq$k0">
+                              <ref role="35c_gD" to="dvox:k2ZBl8Cedx" resolve="ModulePointer" />
+                            </node>
+                            <node concept="2qgKlT" id="7mK357ywhtX" role="2OqNvi">
+                              <ref role="37wK5l" to="xlb7:1Bs_61$mIAC" resolve="create" />
+                              <node concept="2OqwBi" id="7mK357ywhYY" role="37wK5m">
+                                <node concept="37vLTw" id="7mK357ywhEq" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="7mK357ywbXO" resolve="it" />
+                                </node>
+                                <node concept="I4A8Y" id="7mK357ywisc" role="2OqNvi" />
+                              </node>
+                              <node concept="2OqwBi" id="7mK357ywk2u" role="37wK5m">
+                                <node concept="2OqwBi" id="7mK357ywjem" role="2Oq$k0">
+                                  <node concept="37vLTw" id="7mK357ywiT$" role="2Oq$k0">
+                                    <ref role="3cqZAo" node="7mK357ywbXO" resolve="it" />
+                                  </node>
+                                  <node concept="3TrEf2" id="7mK357ywjHJ" role="2OqNvi">
+                                    <ref role="3Tt5mk" to="2c95:66AQhBxN1Tt" resolve="identity_old" />
+                                  </node>
+                                </node>
+                                <node concept="2qgKlT" id="7mK357ywku8" role="2OqNvi">
+                                  <ref role="37wK5l" to="tpeu:nJmxU5cSSU" resolve="getModuleReference" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbF" id="7mK357ywkMt" role="3cqZAp">
+                        <node concept="2OqwBi" id="7mK357ywm37" role="3clFbG">
+                          <node concept="2OqwBi" id="7mK357ywl1v" role="2Oq$k0">
+                            <node concept="37vLTw" id="7mK357ywkMr" role="2Oq$k0">
+                              <ref role="3cqZAo" node="7mK357ywbXO" resolve="it" />
+                            </node>
+                            <node concept="3TrEf2" id="7mK357ywlK1" role="2OqNvi">
+                              <ref role="3Tt5mk" to="2c95:66AQhBxN1Tt" resolve="identity_old" />
+                            </node>
+                          </node>
+                          <node concept="3YRAZt" id="7mK357ywmsr" role="2OqNvi" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="Rh6nW" id="7mK357ywbXO" role="1bW2Oz">
+                      <property role="TrG5h" value="it" />
+                      <node concept="2jxLKc" id="7mK357ywbXP" role="1tU5fm" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWsn" id="7mK357yw2Kw" role="1Duv9x">
+            <property role="TrG5h" value="mdl" />
+            <node concept="H_c77" id="7mK357yw30p" role="1tU5fm" />
+          </node>
+          <node concept="2OqwBi" id="7mK357yw3u5" role="1DdaDG">
+            <node concept="37vLTw" id="7mK357yw3jV" role="2Oq$k0">
+              <ref role="3cqZAo" node="7mK357yvT2A" resolve="m" />
+            </node>
+            <node concept="liA8E" id="7mK357yw3KH" role="2OqNvi">
+              <ref role="37wK5l" to="lui2:~SModule.getModels()" resolve="getModels" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="ffn8J" id="7mK357yvT2A" role="3clF46">
+        <property role="TrG5h" value="m" />
+        <ref role="ffrpq" to="slm6:7fCCGqboj9J" resolve="m" />
+        <node concept="3uibUv" id="7mK357yvT2_" role="1tU5fm">
+          <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
+        </node>
+      </node>
+      <node concept="q3mfm" id="7mK357yvT2B" role="3clF45">
+        <ref role="q3mfh" to="slm6:4F5w8gPXEEe" />
+        <ref role="1QQUv3" node="7mK357yvT2w" resolve="execute" />
+      </node>
+    </node>
+    <node concept="3tTeZs" id="7mK357yvT2C" role="jymVt">
+      <property role="3tTeZt" value="&lt;no result checking&gt;" />
+      <ref role="3tTeZr" to="slm6:1JWcQ2VeXpD" resolve="check" />
+    </node>
+    <node concept="3uibUv" id="7mK357yvT2D" role="1zkMxy">
+      <ref role="3uigEE" to="slm6:5TUCQr2ybBO" resolve="HasMigrationScriptReference" />
     </node>
   </node>
 </model>

--- a/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/languageModels/structure.mps
+++ b/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/languageModels/structure.mps
@@ -16,6 +16,7 @@
     <import index="tp25" ref="r:00000000-0000-4000-0000-011c89590301(jetbrains.mps.lang.smodel.structure)" />
     <import index="tpce" ref="r:00000000-0000-4000-0000-011c89590292(jetbrains.mps.lang.structure.structure)" />
     <import index="zqge" ref="r:59e90602-6655-4552-86eb-441a42a9a0e4(jetbrains.mps.lang.text.structure)" />
+    <import index="dvox" ref="r:9dfd3567-3b1f-4edb-85a0-3981ca2bfd8c(jetbrains.mps.lang.modelapi.structure)" implicit="true" />
   </imports>
   <registry>
     <language id="982eb8df-2c96-4bd7-9963-11712ea622e5" name="jetbrains.mps.lang.resources">
@@ -1639,9 +1640,14 @@
     <node concept="1TJgyj" id="66AQhBxN1Tt" role="1TKVEi">
       <property role="IQ2ns" value="7036550172998639197" />
       <property role="20lmBu" value="fLJjDmT/aggregation" />
-      <property role="20kJfa" value="identity" />
-      <property role="20lbJX" value="fLJekj4/_1" />
+      <property role="20kJfa" value="identity_old" />
       <ref role="20lvS9" to="tp25:nJmxU5cSSu" resolve="ModuleIdentity" />
+    </node>
+    <node concept="1TJgyj" id="7mK357ypJVJ" role="1TKVEi">
+      <property role="IQ2ns" value="8480291644168929007" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="identity" />
+      <ref role="20lvS9" to="dvox:k2ZBl8Cedx" resolve="ModulePointer" />
     </node>
   </node>
   <node concept="1TIwiD" id="2CRkjeimvKE">

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.editor.displayControl.sandbox/sandbox/com.mbeddr.mpsutil.editor.displayControl.sandbox.sandbox.msd
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.editor.displayControl.sandbox/sandbox/com.mbeddr.mpsutil.editor.displayControl.sandbox.sandbox.msd
@@ -12,6 +12,7 @@
   </facets>
   <sourcePath />
   <languageVersions>
+    <language slang="l:5fef253e-34b0-443d-8035-9a2928b716d3:com.mbeddr.mpsutil.editor.displayControl" version="0" />
     <language slang="l:c3a9b5df-25f0-466c-a31c-0da4314af7d1:com.mbeddr.mpsutil.editor.displayControl.sandbox" version="0" />
     <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
   </languageVersions>

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.graphstream.example/sandbox/com.mbeddr.mpsutil.graphstream.example.sandbox.msd
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.graphstream.example/sandbox/com.mbeddr.mpsutil.graphstream.example.sandbox.msd
@@ -12,6 +12,7 @@
   </facets>
   <sourcePath />
   <languageVersions>
+    <language slang="l:5787a8ed-1486-4469-94b0-fa3fc6c8538d:com.mbeddr.mpsutil.graphstream" version="0" />
     <language slang="l:72fa8b44-393c-4983-99aa-868cd899b005:com.mbeddr.mpsutil.graphstream.example" version="-1" />
     <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
   </languageVersions>

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.incrementalcomputation.example/sandbox/com.mbeddr.mpsutil.incrementalcomputation.example.sandbox.msd
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.incrementalcomputation.example/sandbox/com.mbeddr.mpsutil.incrementalcomputation.example.sandbox.msd
@@ -12,6 +12,7 @@
   </facets>
   <sourcePath />
   <languageVersions>
+    <language slang="l:fca4b687-11d4-461f-9cd4-f00968145931:com.mbeddr.mpsutil.incrementalcomputation" version="0" />
     <language slang="l:8ecfd3b5-385b-43fc-ace0-9babcff50bdb:com.mbeddr.mpsutil.incrementalcomputation.example" version="-1" />
     <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
   </languageVersions>

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.lantest.assertions/com.mbeddr.mpsutil.lantest.assertions.mpl
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.lantest.assertions/com.mbeddr.mpsutil.lantest.assertions.mpl
@@ -50,6 +50,8 @@
         <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
         <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
         <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
+        <module reference="4c6a28d1-2c60-478d-b36e-db9b3cbb21fb(closures.runtime)" version="0" />
+        <module reference="9b80526e-f0bf-4992-bdf5-cee39c1833f3(collections.runtime)" version="0" />
         <module reference="ccdc24b1-37a8-44ac-8a87-b53bd9c96407(com.mbeddr.mpsutil.lantest.assertions)" version="0" />
         <module reference="9353f7a8-49dc-4354-af85-a1a368c758c4(com.mbeddr.mpsutil.lantest.assertions#4758317971060520154)" version="0" />
         <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />

--- a/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.smodule.runtime/com.mbeddr.mpsutil.smodule.runtime.msd
+++ b/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.smodule.runtime/com.mbeddr.mpsutil.smodule.runtime.msd
@@ -20,6 +20,7 @@
     <language slang="l:fc9fa859-9e8c-4b5f-8a23-d3ba09424d0f:com.mbeddr.mpsutil.uniquenames" version="0" />
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
     <language slang="l:ed6d7656-532c-4bc2-81d1-af945aeb8280:jetbrains.mps.baseLanguage.blTypes" version="0" />
+    <language slang="l:443f4c36-fcf5-4eb6-9500-8d06ed259e3e:jetbrains.mps.baseLanguage.classifiers" version="0" />
     <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
     <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
     <language slang="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" version="2" />
@@ -27,9 +28,11 @@
     <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
     <language slang="l:63650c59-16c8-498a-99c8-005c7ee9515d:jetbrains.mps.lang.access" version="0" />
     <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
+    <language slang="l:18bc6592-03a6-4e29-a83a-7ff23bde13ba:jetbrains.mps.lang.editor" version="14" />
     <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
     <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="5" />
     <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="18" />
+    <language slang="l:c72da2b9-7cce-4447-8389-f407dc1158b7:jetbrains.mps.lang.structure" version="9" />
     <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
     <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
   </languageVersions>


### PR DESCRIPTION
ModuleIdentity is a deprecated concept and shouldn't be used anymore. It also produces a warning when writing the documentation. A migration is provided to automatically switch to the new concept.