### PR TITLE
Analyses: fix fonts and exception in results table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is _loosely_ based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). The project does _not_ follow
 Semantic Versioning and the changes are simply documented in reverse chronological order, grouped by calendar month.
 
-# February 2022
+# March 2023
+
+## com.mbeddr.analyses
+
+* Fix exception + adjust fonts in analyses results tool
+
+# February 2023
 
 ## com.mbeddr.mpsutil
 

--- a/code/languages/com.mbeddr.analyses/languages/com.mbeddr.analyses.cbmc.rt/models/com/mbeddr/analyses/cbmc/rt/ui.mps
+++ b/code/languages/com.mbeddr.analyses/languages/com.mbeddr.analyses.cbmc.rt/models/com/mbeddr/analyses/cbmc/rt/ui.mps
@@ -38,6 +38,7 @@
     <import index="tprt" ref="r:00000000-0000-4000-0000-011c895904a5(jetbrains.mps.ide.common)" />
     <import index="vbi4" ref="r:101c6aaa-6376-4550-a0fa-eeca066047cc(com.mbeddr.analyses.utils.results_ui)" />
     <import index="z1c3" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.project(MPS.Platform/)" />
+    <import index="exr9" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor(MPS.Editor/)" />
     <import index="v4mk" ref="4c16cb42-7fa3-47c7-89c7-1c479c287588/java:org.jdesktop.swingx(com.mbeddr.analyses.utils/)" implicit="true" />
   </imports>
   <registry>
@@ -12149,23 +12150,17 @@
       <node concept="3uibUv" id="4c9lfPlFkVN" role="1tU5fm">
         <ref role="3uigEE" to="z60i:~Font" resolve="Font" />
       </node>
-      <node concept="2ShNRf" id="4c9lfPlFkVO" role="33vP2m">
-        <node concept="1pGfFk" id="4c9lfPlFkVP" role="2ShVmc">
-          <ref role="37wK5l" to="z60i:~Font.&lt;init&gt;(java.lang.String,int,int)" resolve="Font" />
-          <node concept="Xl_RD" id="4c9lfPlFkVQ" role="37wK5m">
-            <property role="Xl_RC" value="Arial" />
-          </node>
-          <node concept="10M0yZ" id="4c9lfPlFkVR" role="37wK5m">
-            <ref role="1PxDUh" to="z60i:~Font" resolve="Font" />
-            <ref role="3cqZAo" to="z60i:~Font.PLAIN" resolve="PLAIN" />
-          </node>
-          <node concept="3cmrfG" id="4c9lfPlFkVS" role="37wK5m">
-            <property role="3cmrfH" value="12" />
-          </node>
-        </node>
-      </node>
       <node concept="NWlO9" id="4c9lfPlFkVT" role="lGtFl">
         <property role="NWlVz" value="Font used in different texts." />
+      </node>
+      <node concept="2OqwBi" id="5FbNLoBKcm5" role="33vP2m">
+        <node concept="2YIFZM" id="5FbNLoBKaHr" role="2Oq$k0">
+          <ref role="1Pybhc" to="exr9:~EditorSettings" resolve="EditorSettings" />
+          <ref role="37wK5l" to="exr9:~EditorSettings.getInstance()" resolve="getInstance" />
+        </node>
+        <node concept="liA8E" id="5FbNLoBKjWe" role="2OqNvi">
+          <ref role="37wK5l" to="exr9:~EditorSettings.getDefaultEditorFont()" resolve="getDefaultEditorFont" />
+        </node>
       </node>
     </node>
     <node concept="2tJIrI" id="4c9lfPlDAmK" role="jymVt" />
@@ -15263,7 +15258,20 @@
             <ref role="3cqZAo" node="1wweq9pREYj" resolve="model" />
           </node>
         </node>
-        <node concept="3clFbH" id="1N1oeOqJf5i" role="3cqZAp" />
+        <node concept="3clFbF" id="5FbNLoBRgJe" role="3cqZAp">
+          <node concept="1rXfSq" id="5FbNLoBRgJc" role="3clFbG">
+            <ref role="37wK5l" to="dxuu:~JComponent.setFont(java.awt.Font)" resolve="setFont" />
+            <node concept="2OqwBi" id="5FbNLoBRhQa" role="37wK5m">
+              <node concept="2YIFZM" id="5FbNLoBRhzp" role="2Oq$k0">
+                <ref role="37wK5l" to="exr9:~EditorSettings.getInstance()" resolve="getInstance" />
+                <ref role="1Pybhc" to="exr9:~EditorSettings" resolve="EditorSettings" />
+              </node>
+              <node concept="liA8E" id="5FbNLoBRi9H" role="2OqNvi">
+                <ref role="37wK5l" to="exr9:~EditorSettings.getDefaultEditorFont()" resolve="getDefaultEditorFont" />
+              </node>
+            </node>
+          </node>
+        </node>
         <node concept="3cpWs8" id="1N1oeOqJc_4" role="3cqZAp">
           <node concept="3cpWsn" id="1N1oeOqJc_5" role="3cpWs9">
             <property role="TrG5h" value="colModel" />
@@ -15819,6 +15827,20 @@
           <ref role="37wK5l" to="dxuu:~JTable.&lt;init&gt;(javax.swing.table.TableModel)" resolve="JTable" />
           <node concept="37vLTw" id="4LQJkpcJsCl" role="37wK5m">
             <ref role="3cqZAo" node="4LQJkpcJov$" resolve="model" />
+          </node>
+        </node>
+        <node concept="3clFbF" id="5FbNLoBR_ee" role="3cqZAp">
+          <node concept="1rXfSq" id="5FbNLoBR_ef" role="3clFbG">
+            <ref role="37wK5l" to="dxuu:~JComponent.setFont(java.awt.Font)" resolve="setFont" />
+            <node concept="2OqwBi" id="5FbNLoBR_eg" role="37wK5m">
+              <node concept="2YIFZM" id="5FbNLoBR_eh" role="2Oq$k0">
+                <ref role="1Pybhc" to="exr9:~EditorSettings" resolve="EditorSettings" />
+                <ref role="37wK5l" to="exr9:~EditorSettings.getInstance()" resolve="getInstance" />
+              </node>
+              <node concept="liA8E" id="5FbNLoBR_ei" role="2OqNvi">
+                <ref role="37wK5l" to="exr9:~EditorSettings.getDefaultEditorFont()" resolve="getDefaultEditorFont" />
+              </node>
+            </node>
           </node>
         </node>
         <node concept="3cpWs8" id="4LQJkpcK_5v" role="3cqZAp">

--- a/code/languages/com.mbeddr.analyses/languages/com.mbeddr.analyses.utils/models/com/mbeddr/analyses/utils/results_ui.mps
+++ b/code/languages/com.mbeddr.analyses/languages/com.mbeddr.analyses.utils/models/com/mbeddr/analyses/utils/results_ui.mps
@@ -22,6 +22,7 @@
     <import index="uipx" ref="r:e7b58802-36b0-4e17-a1f6-eb5c442b040c(com.mbeddr.analyses.utils.ui)" />
     <import index="lg3m" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.ide.search(MPS.Platform/)" />
     <import index="btm1" ref="b0f8641f-bd77-4421-8425-30d9088a82f7/java:org.apache.commons.lang3(org.apache.commons/)" />
+    <import index="exr9" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor(MPS.Editor/)" />
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
@@ -1065,7 +1066,28 @@
             </node>
           </node>
         </node>
-        <node concept="3clFbH" id="7LklpYzSwHm" role="3cqZAp" />
+        <node concept="3clFbF" id="5FbNLoBGZ7Y" role="3cqZAp">
+          <node concept="2OqwBi" id="5FbNLoBH1l5" role="3clFbG">
+            <node concept="Xjq3P" id="5FbNLoBGZ7W" role="2Oq$k0" />
+            <node concept="liA8E" id="5FbNLoBH4Jt" role="2OqNvi">
+              <ref role="37wK5l" to="dxuu:~JTable.setEditingRow(int)" resolve="setEditingRow" />
+              <node concept="3cmrfG" id="5FbNLoBIqUW" role="37wK5m">
+                <property role="3cmrfH" value="0" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="5FbNLoBIYDA" role="3cqZAp">
+          <node concept="2OqwBi" id="5FbNLoBIZkZ" role="3clFbG">
+            <node concept="Xjq3P" id="5FbNLoBIYD$" role="2Oq$k0" />
+            <node concept="liA8E" id="5FbNLoBJ2HM" role="2OqNvi">
+              <ref role="37wK5l" to="dxuu:~JTable.setEditingColumn(int)" resolve="setEditingColumn" />
+              <node concept="3cmrfG" id="5FbNLoBJ67g" role="37wK5m">
+                <property role="3cmrfH" value="0" />
+              </node>
+            </node>
+          </node>
+        </node>
         <node concept="3cpWs8" id="4_pSipqULG6" role="3cqZAp">
           <node concept="3cpWsn" id="4_pSipqULG7" role="3cpWs9">
             <property role="TrG5h" value="colModel" />
@@ -5149,6 +5171,9 @@
       <node concept="3uibUv" id="1GgrF83etCj" role="1tU5fm">
         <ref role="3uigEE" to="z60i:~Font" resolve="Font" />
       </node>
+      <node concept="NWlO9" id="2k2dPZH7yNa" role="lGtFl">
+        <property role="NWlVz" value="Font used in different texts." />
+      </node>
       <node concept="2ShNRf" id="1GgrF83dsOg" role="33vP2m">
         <node concept="1pGfFk" id="1GgrF83dsOh" role="2ShVmc">
           <ref role="37wK5l" to="z60i:~Font.&lt;init&gt;(java.lang.String,int,int)" resolve="Font" />
@@ -5163,9 +5188,6 @@
             <property role="3cmrfH" value="11" />
           </node>
         </node>
-      </node>
-      <node concept="NWlO9" id="2k2dPZH7yNa" role="lGtFl">
-        <property role="NWlVz" value="Font used in different texts." />
       </node>
     </node>
     <node concept="2tJIrI" id="2k2dPZH7y$0" role="jymVt" />

--- a/code/languages/com.mbeddr.analyses/languages/com.mbeddr.analyses.utils/models/com/mbeddr/analyses/utils/results_ui.mps
+++ b/code/languages/com.mbeddr.analyses/languages/com.mbeddr.analyses.utils/models/com/mbeddr/analyses/utils/results_ui.mps
@@ -1088,6 +1088,23 @@
             </node>
           </node>
         </node>
+        <node concept="3clFbF" id="5FbNLoBM15l" role="3cqZAp">
+          <node concept="2OqwBi" id="5FbNLoBM1Le" role="3clFbG">
+            <node concept="Xjq3P" id="5FbNLoBM15j" role="2Oq$k0" />
+            <node concept="liA8E" id="5FbNLoBM5qu" role="2OqNvi">
+              <ref role="37wK5l" to="dxuu:~JComponent.setFont(java.awt.Font)" resolve="setFont" />
+              <node concept="2OqwBi" id="5FbNLoBM8Uw" role="37wK5m">
+                <node concept="2YIFZM" id="5FbNLoBM8Ux" role="2Oq$k0">
+                  <ref role="1Pybhc" to="exr9:~EditorSettings" resolve="EditorSettings" />
+                  <ref role="37wK5l" to="exr9:~EditorSettings.getInstance()" resolve="getInstance" />
+                </node>
+                <node concept="liA8E" id="5FbNLoBM8Uy" role="2OqNvi">
+                  <ref role="37wK5l" to="exr9:~EditorSettings.getDefaultEditorFont()" resolve="getDefaultEditorFont" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
         <node concept="3cpWs8" id="4_pSipqULG6" role="3cqZAp">
           <node concept="3cpWsn" id="4_pSipqULG7" role="3cpWs9">
             <property role="TrG5h" value="colModel" />
@@ -4880,6 +4897,21 @@
           </node>
         </node>
         <node concept="3clFbH" id="2k2dPZHdk_K" role="3cqZAp" />
+        <node concept="3clFbF" id="5FbNLoBPdBQ" role="3cqZAp">
+          <node concept="1rXfSq" id="5FbNLoBPg3G" role="3clFbG">
+            <ref role="37wK5l" to="dxuu:~JComponent.setFont(java.awt.Font)" resolve="setFont" />
+            <node concept="2OqwBi" id="5FbNLoBPipr" role="37wK5m">
+              <node concept="2YIFZM" id="5FbNLoBPi98" role="2Oq$k0">
+                <ref role="37wK5l" to="exr9:~EditorSettings.getInstance()" resolve="getInstance" />
+                <ref role="1Pybhc" to="exr9:~EditorSettings" resolve="EditorSettings" />
+              </node>
+              <node concept="liA8E" id="5FbNLoBPjlK" role="2OqNvi">
+                <ref role="37wK5l" to="exr9:~EditorSettings.getDefaultEditorFont()" resolve="getDefaultEditorFont" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="5FbNLoBPcou" role="3cqZAp" />
         <node concept="3cpWs8" id="4wNvmgrc4S6" role="3cqZAp">
           <node concept="3cpWsn" id="4wNvmgrc4S7" role="3cpWs9">
             <property role="TrG5h" value="colModel" />
@@ -5174,19 +5206,13 @@
       <node concept="NWlO9" id="2k2dPZH7yNa" role="lGtFl">
         <property role="NWlVz" value="Font used in different texts." />
       </node>
-      <node concept="2ShNRf" id="1GgrF83dsOg" role="33vP2m">
-        <node concept="1pGfFk" id="1GgrF83dsOh" role="2ShVmc">
-          <ref role="37wK5l" to="z60i:~Font.&lt;init&gt;(java.lang.String,int,int)" resolve="Font" />
-          <node concept="Xl_RD" id="1GgrF83dsOi" role="37wK5m">
-            <property role="Xl_RC" value="Arial" />
-          </node>
-          <node concept="10M0yZ" id="1GgrF83dsOj" role="37wK5m">
-            <ref role="1PxDUh" to="z60i:~Font" resolve="Font" />
-            <ref role="3cqZAo" to="z60i:~Font.PLAIN" resolve="PLAIN" />
-          </node>
-          <node concept="3cmrfG" id="1GgrF83dsOk" role="37wK5m">
-            <property role="3cmrfH" value="11" />
-          </node>
+      <node concept="2OqwBi" id="5FbNLoBKcm5" role="33vP2m">
+        <node concept="2YIFZM" id="5FbNLoBKaHr" role="2Oq$k0">
+          <ref role="1Pybhc" to="exr9:~EditorSettings" resolve="EditorSettings" />
+          <ref role="37wK5l" to="exr9:~EditorSettings.getInstance()" resolve="getInstance" />
+        </node>
+        <node concept="liA8E" id="5FbNLoBKjWe" role="2OqNvi">
+          <ref role="37wK5l" to="exr9:~EditorSettings.getDefaultEditorFont()" resolve="getDefaultEditorFont" />
         </node>
       </node>
     </node>
@@ -6855,6 +6881,25 @@
                 </node>
                 <node concept="3cmrfG" id="3DDJouLFjhh" role="37wK5m">
                   <property role="3cmrfH" value="580" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="5FbNLoBRHkc" role="3cqZAp">
+          <node concept="2OqwBi" id="5FbNLoBRIZa" role="3clFbG">
+            <node concept="37vLTw" id="5FbNLoBRHka" role="2Oq$k0">
+              <ref role="3cqZAo" node="3DDJouLFiBM" resolve="textArea" />
+            </node>
+            <node concept="liA8E" id="5FbNLoBRJVY" role="2OqNvi">
+              <ref role="37wK5l" to="dxuu:~JTextArea.setFont(java.awt.Font)" resolve="setFont" />
+              <node concept="2OqwBi" id="5FbNLoBRhQa" role="37wK5m">
+                <node concept="2YIFZM" id="5FbNLoBRhzp" role="2Oq$k0">
+                  <ref role="1Pybhc" to="exr9:~EditorSettings" resolve="EditorSettings" />
+                  <ref role="37wK5l" to="exr9:~EditorSettings.getInstance()" resolve="getInstance" />
+                </node>
+                <node concept="liA8E" id="5FbNLoBRi9H" role="2OqNvi">
+                  <ref role="37wK5l" to="exr9:~EditorSettings.getDefaultEditorFont()" resolve="getDefaultEditorFont" />
                 </node>
               </node>
             </node>


### PR DESCRIPTION
The original exception was:` java.lang.IllegalArgumentException: column must be valid`.It happened constantly in the CBMC lifted results tool. I've also updated the fonts to make the text more readable.