### PR TITLE
Core base: add missing push-y style in CRHelperCell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Semantic Versioning and the changes are simply documented in reverse chronologic
 
 * Fix exception + adjust fonts in analyses results tool
 
+## com.mbeddr.core.base
+
+* Fix layout issues caused by missing style in CRHelperCell
+
 # February 2023
 
 ## com.mbeddr.mpsutil

--- a/code/languages/com.mbeddr.core/languages/com.mbeddr.core.base/languageModels/editor.mps
+++ b/code/languages/com.mbeddr.core/languages/com.mbeddr.core.base/languageModels/editor.mps
@@ -10750,6 +10750,22 @@
               </node>
             </node>
           </node>
+          <node concept="3clFbF" id="68ugrSVhjyR" role="3cqZAp">
+            <node concept="2OqwBi" id="68ugrSVhjyS" role="3clFbG">
+              <node concept="1rXfSq" id="68ugrSVhjyT" role="2Oq$k0">
+                <ref role="37wK5l" to="g51k:~EditorCell_Basic.getStyle()" resolve="getStyle" />
+              </node>
+              <node concept="liA8E" id="68ugrSVhjyU" role="2OqNvi">
+                <ref role="37wK5l" to="hox0:~Style.set(jetbrains.mps.openapi.editor.style.StyleAttribute,java.lang.Object)" resolve="set" />
+                <node concept="1Z6Ecs" id="68ugrSVhjyV" role="37wK5m">
+                  <ref role="1Z6EpT" to="z0fb:7lS0O5066uD" resolve="_push-y" />
+                </node>
+                <node concept="3clFbT" id="68ugrSVhjyW" role="37wK5m">
+                  <property role="3clFbU" value="true" />
+                </node>
+              </node>
+            </node>
+          </node>
           <node concept="3clFbF" id="5hKIe0b4Kec" role="3cqZAp">
             <node concept="1rXfSq" id="5hKIe0b4Kea" role="3clFbG">
               <ref role="37wK5l" to="g51k:~EditorCell_Basic.setAction(jetbrains.mps.openapi.editor.cells.CellActionType,jetbrains.mps.openapi.editor.cells.CellAction)" resolve="setAction" />


### PR DESCRIPTION
The `CRHelperCell` should include both the grow-y and push-y style, the same way the lines cells in the celllayout language do. Otherwise, such interesting issues can occur:

![Screenshot 2023-03-03 at 19 00 10](https://user-images.githubusercontent.com/88385944/222793955-d1a50da1-35c6-418e-8971-90bcd70de527.png)

The `CRHelperCell` somehow makes the calculation of the last row's width wrong, and therefore the border of the last row is also drawn wrong (too long). With this fix, the calculation is done correctly.