### PR TITLE
Bugfix/links between docs via doc ref word

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is _loosely_ based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). The project does _not_ follow
 Semantic Versioning and the changes are simply documented in reverse chronological order, grouped by calendar month.
 
+# April 2023
+
+## com.mbeddr.doc
+
+### Fixed
+
+* @doc\[some document\] causes broken build unless a "some document" was also used in include.
+
+### Changed
+
 # March 2023
 
 ## com.mbeddr.mpsutil

--- a/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc.gen_xhtml/languageModels/structure.mps
+++ b/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc.gen_xhtml/languageModels/structure.mps
@@ -84,7 +84,7 @@
     <property role="19KtqR" value="true" />
     <property role="3GE5qa" value="css" />
     <property role="EcuMT" value="6347396756633822235" />
-    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
+    <ref role="1TJDcQ" to="iuxj:5M4a$b5ikxF" resolve="XmlContent" />
     <node concept="1TJgyj" id="QRmqzIpg44" role="1TKVEi">
       <property role="20lmBu" value="fLJjDmT/aggregation" />
       <property role="20kJfa" value="rulesets" />

--- a/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/generator/template/com/mbeddr/doc/generator/template/main@generator.mps
+++ b/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/generator/template/com/mbeddr/doc/generator/template/main@generator.mps
@@ -4530,6 +4530,27 @@
             <node concept="3oM_SD" id="7U$sKL0$S7g" role="1PaTwD">
               <property role="3oM_SC" value="export" />
             </node>
+            <node concept="3oM_SD" id="2VXLfnCCMEy" role="1PaTwD">
+              <property role="3oM_SC" value="and" />
+            </node>
+            <node concept="3oM_SD" id="2VXLfnCCMEU" role="1PaTwD">
+              <property role="3oM_SC" value="not" />
+            </node>
+            <node concept="3oM_SD" id="2VXLfnCCMFj" role="1PaTwD">
+              <property role="3oM_SC" value="listed" />
+            </node>
+            <node concept="3oM_SD" id="2VXLfnCCMFX" role="1PaTwD">
+              <property role="3oM_SC" value="in" />
+            </node>
+            <node concept="3oM_SD" id="2VXLfnCCMGo" role="1PaTwD">
+              <property role="3oM_SC" value="the" />
+            </node>
+            <node concept="3oM_SD" id="2VXLfnCCMH$" role="1PaTwD">
+              <property role="3oM_SC" value="dependent" />
+            </node>
+            <node concept="3oM_SD" id="2VXLfnCCMI1" role="1PaTwD">
+              <property role="3oM_SC" value="documents" />
+            </node>
             <node concept="3oM_SD" id="7U$sKL0$S7o" role="1PaTwD">
               <property role="3oM_SC" value="are" />
             </node>
@@ -4570,6 +4591,39 @@
             </node>
           </node>
         </node>
+        <node concept="3cpWs8" id="2VXLfnCA4Wd" role="3cqZAp">
+          <node concept="3cpWsn" id="2VXLfnCA4We" role="3cpWs9">
+            <property role="TrG5h" value="dependentDocuments" />
+            <node concept="2I9FWS" id="2VXLfnCA4Wf" role="1tU5fm">
+              <ref role="2I9WkF" to="2c95:2TZO3DbuxwK" resolve="Document" />
+            </node>
+            <node concept="2ShNRf" id="2VXLfnCA4Wg" role="33vP2m">
+              <node concept="2T8Vx0" id="2VXLfnCA4Wh" role="2ShVmc">
+                <node concept="2I9FWS" id="2VXLfnCA4Wi" role="2T96Bj">
+                  <ref role="2I9WkF" to="2c95:2TZO3DbuxwK" resolve="Document" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="2VXLfnCA4Wj" role="3cqZAp">
+          <node concept="2YIFZM" id="2VXLfnCA4Wk" role="3clFbG">
+            <ref role="1Pybhc" to="rqen:mQGf9iIxWv" resolve="CopyDependentDocumentsUtils" />
+            <ref role="37wK5l" to="rqen:mQGf9iIxXJ" resolve="collectDependentDocuments" />
+            <node concept="2OqwBi" id="2VXLfnCA4Wl" role="37wK5m">
+              <node concept="1Q6Npb" id="2VXLfnCA4Wm" role="2Oq$k0" />
+              <node concept="2RRcyG" id="2VXLfnCA4Wn" role="2OqNvi">
+                <node concept="chp4Y" id="2VXLfnCA4Wo" role="3MHsoP">
+                  <ref role="cht4Q" to="2c95:2TZO3DbuxwK" resolve="Document" />
+                </node>
+              </node>
+            </node>
+            <node concept="37vLTw" id="2VXLfnCA4Wp" role="37wK5m">
+              <ref role="3cqZAo" node="2VXLfnCA4We" resolve="dependentDocuments" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="2VXLfnCBSta" role="3cqZAp" />
         <node concept="3clFbF" id="7U$sKL0$xBc" role="3cqZAp">
           <node concept="2OqwBi" id="7U$sKL0$KRS" role="3clFbG">
             <node concept="2OqwBi" id="7U$sKL0$Bnv" role="2Oq$k0">
@@ -4728,12 +4782,28 @@
                       </node>
                     </node>
                   </node>
-                  <node concept="3clFbF" id="7U$sKL0$LmK" role="3cqZAp">
-                    <node concept="2OqwBi" id="7U$sKL0$LDe" role="3clFbG">
-                      <node concept="37vLTw" id="7U$sKL0$LmJ" role="2Oq$k0">
-                        <ref role="3cqZAo" node="7U$sKL0$LkL" resolve="document" />
+                  <node concept="3clFbJ" id="2VXLfnCA5oh" role="3cqZAp">
+                    <node concept="3clFbS" id="2VXLfnCA5oj" role="3clFbx">
+                      <node concept="3clFbF" id="7U$sKL0$LmK" role="3cqZAp">
+                        <node concept="2OqwBi" id="7U$sKL0$LDe" role="3clFbG">
+                          <node concept="37vLTw" id="7U$sKL0$LmJ" role="2Oq$k0">
+                            <ref role="3cqZAo" node="7U$sKL0$LkL" resolve="document" />
+                          </node>
+                          <node concept="3YRAZt" id="7U$sKL0$MOU" role="2OqNvi" />
+                        </node>
                       </node>
-                      <node concept="3YRAZt" id="7U$sKL0$MOU" role="2OqNvi" />
+                    </node>
+                    <node concept="3fqX7Q" id="2VXLfnCAgo8" role="3clFbw">
+                      <node concept="2OqwBi" id="2VXLfnCAgoa" role="3fr31v">
+                        <node concept="37vLTw" id="2VXLfnCAgob" role="2Oq$k0">
+                          <ref role="3cqZAo" node="2VXLfnCA4We" resolve="dependentDocuments" />
+                        </node>
+                        <node concept="3JPx81" id="2VXLfnCAgoc" role="2OqNvi">
+                          <node concept="37vLTw" id="2VXLfnCAgod" role="25WWJ7">
+                            <ref role="3cqZAo" node="7U$sKL0$LkL" resolve="document" />
+                          </node>
+                        </node>
+                      </node>
                     </node>
                   </node>
                 </node>


### PR DESCRIPTION
A customer complains about broken builds when generating documents using mbeddr.doc.
The reason for was found in resolving remaining includes (see according mapping script), where all documents were removed that are not referenced by an include. 

![grafik](https://user-images.githubusercontent.com/38247916/234226835-42b04c46-353d-44ad-8f0d-e53b0395642b.png)

Additionally the warning when generation the doc
![grafik](https://user-images.githubusercontent.com/38247916/234227190-23dd1a9f-6a80-4f96-910b-55714aafd5dd.png)
was fixed.