### PR TITLE
Allow override logic for concept-specific documentation in mbeddr.doc.aspect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,15 @@ Semantic Versioning and the changes are simply documented in reverse chronologic
 
 ### Changed
 
-Added possiblity to update the ToolWindow contents of context action 2 evenif the Window is not visible.
+Added possiblity to update the ToolWindow contents of context action 2 even if the Window is not visible.
+
+## com.mbeddr.doc.aspect
+
+### Added
+
+* For documentation annotations of concepts there is a new flag `override children` in the inspector. It allows to show the document of a node even if the currently selected child node would have its own documentation.
+* By default, this new behavior is switched off. The `documentationAspectConfiguration` extension point now has a configuration option `allowOverrideChildren` which has to be set to true in order to use the override functionality.
+* A cache has been added to speed up the look-up and display of concept-specific documentation in the documentation view.
 
 # September 2023
 

--- a/code/languages/com.mbeddr.build/solutions/com.mbeddr.platform/models/com/mbeddr/platform/build.mps
+++ b/code/languages/com.mbeddr.build/solutions/com.mbeddr.platform/models/com/mbeddr/platform/build.mps
@@ -19085,6 +19085,11 @@
             </node>
           </node>
         </node>
+        <node concept="1SiIV0" id="3KxJFmNUEug" role="3bR37C">
+          <node concept="3bR9La" id="3KxJFmNUEuh" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
+          </node>
+        </node>
       </node>
       <node concept="1E1JtA" id="5NpY9mns5GC" role="2G$12L">
         <property role="BnDLt" value="true" />

--- a/code/languages/com.mbeddr.build/solutions/com.mbeddr.platform/models/com/mbeddr/platform/build.mps
+++ b/code/languages/com.mbeddr.build/solutions/com.mbeddr.platform/models/com/mbeddr/platform/build.mps
@@ -19090,6 +19090,11 @@
             <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
           </node>
         </node>
+        <node concept="1SiIV0" id="4V_wlz9WRN4" role="3bR37C">
+          <node concept="3bR9La" id="4V_wlz9WRN5" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:7Kfy9QB6L4p" resolve="jetbrains.mps.lang.behavior" />
+          </node>
+        </node>
       </node>
       <node concept="1E1JtA" id="5NpY9mns5GC" role="2G$12L">
         <property role="BnDLt" value="true" />

--- a/code/languages/com.mbeddr.doc.aspect/languages/com.mbeddr.doc.aspect.exampleLanguage/com.mbeddr.doc.aspect.exampleLanguage.mpl
+++ b/code/languages/com.mbeddr.doc.aspect/languages/com.mbeddr.doc.aspect.exampleLanguage/com.mbeddr.doc.aspect.exampleLanguage.mpl
@@ -14,6 +14,8 @@
   <sourcePath />
   <dependencies>
     <dependency reexport="false">f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)</dependency>
+    <dependency reexport="true">38a074ed-e5ad-4b2d-be31-ca436911b8aa(com.mbeddr.doc.aspect)</dependency>
+    <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:d4280a54-f6df-4383-aa41-d1b2bffa7eb1:com.mbeddr.core.base" version="6" />
@@ -29,9 +31,11 @@
     <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
     <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
     <language slang="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" version="2" />
+    <language slang="l:c7d5b9dd-a05f-4be2-bc73-f2e16994cc67:jetbrains.mps.baseLanguage.lightweightdsl" version="1" />
     <language slang="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" version="0" />
     <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
     <language slang="l:aee9cad2-acd4-4608-aef2-0004f6a1cdbd:jetbrains.mps.lang.actions" version="4" />
+    <language slang="l:f159adf4-3c93-40f9-9c5a-1f245a8697af:jetbrains.mps.lang.aspect" version="2" />
     <language slang="l:af65afd8-f0dd-4942-87d9-63a55f2a9db1:jetbrains.mps.lang.behavior" version="2" />
     <language slang="l:3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1:jetbrains.mps.lang.constraints" version="6" />
     <language slang="l:e51810c5-7308-4642-bcb6-469e61b5dd18:jetbrains.mps.lang.constraints.msg.specification" version="0" />
@@ -43,8 +47,11 @@
     <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
     <language slang="l:f4ad079d-bc71-4ffb-9600-9328705cf998:jetbrains.mps.lang.descriptor" version="0" />
     <language slang="l:18bc6592-03a6-4e29-a83a-7ff23bde13ba:jetbrains.mps.lang.editor" version="14" />
+    <language slang="l:c0080a47-7e37-4558-bee9-9ae18e690549:jetbrains.mps.lang.extension" version="2" />
     <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
     <language slang="l:d4615e3b-d671-4ba9-af01-2b78369b0ba7:jetbrains.mps.lang.pattern" version="2" />
+    <language slang="l:28f9e497-3b42-4291-aeba-0a1039153ab1:jetbrains.mps.lang.plugin" version="5" />
+    <language slang="l:ef7bf5ac-d06c-4342-b11d-e42104eb9343:jetbrains.mps.lang.plugin.standalone" version="0" />
     <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="5" />
     <language slang="l:982eb8df-2c96-4bd7-9963-11712ea622e5:jetbrains.mps.lang.resources" version="2" />
     <language slang="l:b3551702-269c-4f05-ba61-58060cef4292:jetbrains.mps.lang.rulesAndMessages" version="0" />
@@ -54,18 +61,46 @@
     <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
     <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
     <language slang="l:7a5dda62-9140-4668-ab76-d5ed1746f2b2:jetbrains.mps.lang.typesystem" version="5" />
+    <language slang="l:c9d137c4-3259-44f8-80ff-33ab2b506ee4:jetbrains.mps.lang.util.order" version="0" />
+    <language slang="l:696c1165-4a59-463b-bc5d-902caab85dd0:jetbrains.mps.make.facet" version="0" />
   </languageVersions>
   <dependencyVersions>
     <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
     <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
     <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
+    <module reference="1ed103c3-3aa6-49b7-9c21-6765ee11f224(MPS.Editor)" version="0" />
+    <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
+    <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
+    <module reference="d4280a54-f6df-4383-aa41-d1b2bffa7eb1(com.mbeddr.core.base)" version="3" />
+    <module reference="2374bc90-7e37-41f1-a9c4-c2e35194c36a(com.mbeddr.doc)" version="0" />
+    <module reference="38a074ed-e5ad-4b2d-be31-ca436911b8aa(com.mbeddr.doc.aspect)" version="0" />
     <module reference="3c21902d-b582-4557-b697-84a4dcddff3a(com.mbeddr.doc.aspect.exampleLanguage)" version="0" />
+    <module reference="63e0e566-5131-447e-90e3-12ea330e1a00(com.mbeddr.mpsutil.blutil)" version="0" />
+    <module reference="d3a0fd26-445a-466c-900e-10444ddfed52(com.mbeddr.mpsutil.filepicker)" version="0" />
+    <module reference="d09a16fb-1d68-4a92-a5a4-20b4b2f86a62(com.mbeddr.mpsutil.jung)" version="0" />
+    <module reference="b4d28e19-7d2d-47e9-943e-3a41f97a0e52(com.mbeddr.mpsutil.plantuml.node)" version="0" />
+    <module reference="848ef45d-e560-4e35-853c-f35a64cc135c(de.itemis.mps.editor.celllayout.runtime)" version="0" />
+    <module reference="24c96a96-b7a1-4f30-82da-0f8e279a2661(de.itemis.mps.editor.celllayout.styles)" version="0" />
+    <module reference="5c13c612-0f7b-4f0a-ab8b-565186b418de(de.itemis.mps.mouselistener.runtime)" version="0" />
+    <module reference="cce85e64-7b37-4ad5-b0e6-9d18324cdfb3(de.itemis.mps.selection.runtime)" version="0" />
+    <module reference="dc038ceb-b7ea-4fea-ac12-55f7400e97ba(de.slisson.mps.editor.multiline.runtime)" version="0" />
+    <module reference="f0fff802-6d26-4d2e-b89d-391357265626(de.slisson.mps.hacks.editor)" version="0" />
+    <module reference="92d2ea16-5a42-4fdf-a676-c7604efe3504(de.slisson.mps.richtext)" version="0" />
     <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
+    <module reference="fd392034-7849-419d-9071-12563d152375(jetbrains.mps.baseLanguage.closures)" version="0" />
+    <module reference="83888646-71ce-4f1c-9c53-c54016f6ad4f(jetbrains.mps.baseLanguage.collections)" version="0" />
     <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
+    <module reference="23865718-e2ed-41b5-a132-0da1d04e266d(jetbrains.mps.ide.httpsupport.manager)" version="0" />
+    <module reference="ae6d8005-36be-4cb6-945b-8c8cfc033c51(jetbrains.mps.ide.httpsupport.runtime)" version="0" />
     <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
+    <module reference="d936855b-48da-4812-a8a0-2bfddd633ac5(jetbrains.mps.lang.behavior.api)" version="0" />
     <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
     <module reference="a9e4c532-c5f5-4bb7-99ef-42abb73bbb70(jetbrains.mps.lang.descriptor.aspects)" version="0" />
+    <module reference="446c26eb-2b7b-4bf0-9b35-f83fa582753e(jetbrains.mps.lang.modelapi)" version="0" />
+    <module reference="d7eb0a2a-bd50-4576-beae-e4a89db35f20(jetbrains.mps.lang.scopes.runtime)" version="0" />
+    <module reference="7866978e-a0f0-4cc7-81bc-4d213d9375e1(jetbrains.mps.lang.smodel)" version="1" />
+    <module reference="c72da2b9-7cce-4447-8389-f407dc1158b7(jetbrains.mps.lang.structure)" version="0" />
     <module reference="9ded098b-ad6a-4657-bfd9-48636cfe8bc3(jetbrains.mps.lang.traceable)" version="0" />
   </dependencyVersions>
   <extendedLanguages />

--- a/code/languages/com.mbeddr.doc.aspect/languages/com.mbeddr.doc.aspect.exampleLanguage/models/com.mbeddr.doc.aspect.exampleLanguage.plugin.mps
+++ b/code/languages/com.mbeddr.doc.aspect/languages/com.mbeddr.doc.aspect.exampleLanguage/models/com.mbeddr.doc.aspect.exampleLanguage.plugin.mps
@@ -1,0 +1,218 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:a302ee2c-8054-49be-a61b-a22005873d10(com.mbeddr.doc.aspect.exampleLanguage.plugin)">
+  <persistence version="9" />
+  <languages>
+    <use id="f159adf4-3c93-40f9-9c5a-1f245a8697af" name="jetbrains.mps.lang.aspect" version="2" />
+    <use id="696c1165-4a59-463b-bc5d-902caab85dd0" name="jetbrains.mps.make.facet" version="0" />
+    <use id="28f9e497-3b42-4291-aeba-0a1039153ab1" name="jetbrains.mps.lang.plugin" version="5" />
+    <use id="c9d137c4-3259-44f8-80ff-33ab2b506ee4" name="jetbrains.mps.lang.util.order" version="0" />
+    <use id="ef7bf5ac-d06c-4342-b11d-e42104eb9343" name="jetbrains.mps.lang.plugin.standalone" version="0" />
+    <use id="c0080a47-7e37-4558-bee9-9ae18e690549" name="jetbrains.mps.lang.extension" version="2" />
+    <use id="c7d5b9dd-a05f-4be2-bc73-f2e16994cc67" name="jetbrains.mps.baseLanguage.lightweightdsl" version="1" />
+    <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="12" />
+    <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
+  </languages>
+  <imports>
+    <import index="pgte" ref="r:e361f9f2-2afa-4fbe-b895-bdd4fbfe44fa(com.mbeddr.doc.aspect.plugin)" />
+    <import index="90d" ref="r:421d64ed-8024-497f-aeab-8bddeb389dd2(jetbrains.mps.lang.extension.methods)" />
+    <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="ef7bf5ac-d06c-4342-b11d-e42104eb9343" name="jetbrains.mps.lang.plugin.standalone">
+      <concept id="7520713872864775836" name="jetbrains.mps.lang.plugin.standalone.structure.StandalonePluginDescriptor" flags="ng" index="2DaZZR" />
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
+        <child id="1068498886297" name="rValue" index="37vLTx" />
+        <child id="1068498886295" name="lValue" index="37vLTJ" />
+      </concept>
+      <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="nn" index="2tJIrI" />
+      <concept id="1188207840427" name="jetbrains.mps.baseLanguage.structure.AnnotationInstance" flags="nn" index="2AHcQZ">
+        <reference id="1188208074048" name="annotation" index="2AI5Lk" />
+      </concept>
+      <concept id="1188208481402" name="jetbrains.mps.baseLanguage.structure.HasAnnotation" flags="ng" index="2AJDlI">
+        <child id="1188208488637" name="annotation" index="2AJF6D" />
+      </concept>
+      <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
+        <child id="1145553007750" name="creator" index="2ShVmc" />
+      </concept>
+      <concept id="1182160077978" name="jetbrains.mps.baseLanguage.structure.AnonymousClassCreator" flags="nn" index="YeOm9">
+        <child id="1182160096073" name="cls" index="YeSDq" />
+      </concept>
+      <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
+      <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
+      <concept id="1068390468200" name="jetbrains.mps.baseLanguage.structure.FieldDeclaration" flags="ig" index="312cEg" />
+      <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
+        <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ng" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
+      </concept>
+      <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
+        <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
+      </concept>
+      <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
+      <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
+        <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
+      <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
+        <child id="1068580123133" name="returnType" index="3clF45" />
+        <child id="1068580123135" name="body" index="3clF47" />
+      </concept>
+      <concept id="1068580123165" name="jetbrains.mps.baseLanguage.structure.InstanceMethodDeclaration" flags="ig" index="3clFb_" />
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT">
+        <property id="1068580123138" name="value" index="3clFbU" />
+      </concept>
+      <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+      </concept>
+      <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
+        <property id="521412098689998745" name="nonStatic" index="2bfB8j" />
+        <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
+      </concept>
+      <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
+        <reference id="1107535924139" name="classifier" index="3uigEE" />
+      </concept>
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
+        <child id="1178549979242" name="visibility" index="1B3o_S" />
+      </concept>
+      <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
+      <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
+      <concept id="1170345865475" name="jetbrains.mps.baseLanguage.structure.AnonymousClass" flags="ig" index="1Y3b0j">
+        <reference id="1170346070688" name="classifier" index="1Y3XeK" />
+      </concept>
+    </language>
+    <language id="c0080a47-7e37-4558-bee9-9ae18e690549" name="jetbrains.mps.lang.extension">
+      <concept id="126958800891274162" name="jetbrains.mps.lang.extension.structure.Extension" flags="ig" index="1lYeZD">
+        <reference id="126958800891274597" name="extensionPoint" index="1lYe$Y" />
+      </concept>
+    </language>
+    <language id="c7d5b9dd-a05f-4be2-bc73-f2e16994cc67" name="jetbrains.mps.baseLanguage.lightweightdsl">
+      <concept id="3751132065236767083" name="jetbrains.mps.baseLanguage.lightweightdsl.structure.DependentTypeInstance" flags="ig" index="q3mfm">
+        <reference id="3751132065236767084" name="decl" index="q3mfh" />
+        <reference id="9097849371505568270" name="point" index="1QQUv3" />
+      </concept>
+      <concept id="3751132065236767060" name="jetbrains.mps.baseLanguage.lightweightdsl.structure.MethodInstance" flags="ig" index="q3mfD">
+        <reference id="19209059688387895" name="decl" index="2VtyIY" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="2DaZZR" id="1SjQlrSIbaD" />
+  <node concept="1lYeZD" id="3qokpdXS6Iq">
+    <property role="TrG5h" value="ExampleDocAspectConfigExt" />
+    <ref role="1lYe$Y" to="pgte:1T8cMxCROk6" resolve="documentationAspectConfiguration" />
+    <node concept="3Tm1VV" id="3qokpdXS6Ir" role="1B3o_S" />
+    <node concept="2tJIrI" id="3qokpdXS6QO" role="jymVt" />
+    <node concept="312cEg" id="2JMQ0QpYAFM" role="jymVt">
+      <property role="TrG5h" value="instance" />
+      <node concept="3Tm6S6" id="2JMQ0QpY$hN" role="1B3o_S" />
+      <node concept="3uibUv" id="2JMQ0QpYAD1" role="1tU5fm">
+        <ref role="3uigEE" to="pgte:1T8cMxCROto" resolve="IDocumentationAspectConfiguration" />
+      </node>
+      <node concept="10Nm6u" id="2JMQ0QpYAT0" role="33vP2m" />
+    </node>
+    <node concept="2tJIrI" id="2JMQ0QpYE0C" role="jymVt" />
+    <node concept="q3mfD" id="2JMQ0QpYATl" role="jymVt">
+      <property role="TrG5h" value="activate" />
+      <ref role="2VtyIY" to="90d:3zLwYDe0CPy" resolve="activate" />
+      <node concept="3Tm1VV" id="2JMQ0QpYATn" role="1B3o_S" />
+      <node concept="3clFbS" id="2JMQ0QpYATp" role="3clF47">
+        <node concept="3clFbF" id="2JMQ0QpYBzu" role="3cqZAp">
+          <node concept="37vLTI" id="2JMQ0QpYBPR" role="3clFbG">
+            <node concept="37vLTw" id="2JMQ0QpYBzt" role="37vLTJ">
+              <ref role="3cqZAo" node="2JMQ0QpYAFM" resolve="instance" />
+            </node>
+            <node concept="2ShNRf" id="2JMQ0QpYqoJ" role="37vLTx">
+              <node concept="YeOm9" id="2JMQ0QpYwBJ" role="2ShVmc">
+                <node concept="1Y3b0j" id="2JMQ0QpYwBM" role="YeSDq">
+                  <property role="2bfB8j" value="true" />
+                  <property role="373rjd" value="true" />
+                  <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
+                  <ref role="1Y3XeK" to="pgte:1T8cMxCROto" resolve="IDocumentationAspectConfiguration" />
+                  <node concept="3Tm1VV" id="2JMQ0QpYwBN" role="1B3o_S" />
+                  <node concept="3clFb_" id="2JMQ0QpYwC1" role="jymVt">
+                    <property role="TrG5h" value="showReferenceConceptDocumentation" />
+                    <node concept="3Tm1VV" id="2JMQ0QpYwC3" role="1B3o_S" />
+                    <node concept="10P_77" id="2JMQ0QpYwC4" role="3clF45" />
+                    <node concept="3clFbS" id="2JMQ0QpYwC8" role="3clF47">
+                      <node concept="3clFbF" id="2JMQ0QpYxoy" role="3cqZAp">
+                        <node concept="3clFbT" id="2JMQ0QpYxox" role="3clFbG" />
+                      </node>
+                    </node>
+                    <node concept="2AHcQZ" id="2JMQ0QpYwCa" role="2AJF6D">
+                      <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                    </node>
+                  </node>
+                  <node concept="2tJIrI" id="2JMQ0QpYwCb" role="jymVt" />
+                  <node concept="3clFb_" id="2JMQ0QpYwCc" role="jymVt">
+                    <property role="TrG5h" value="allowOverrideChildren" />
+                    <node concept="3Tm1VV" id="2JMQ0QpYwCe" role="1B3o_S" />
+                    <node concept="10P_77" id="2JMQ0QpYwCf" role="3clF45" />
+                    <node concept="3clFbS" id="2JMQ0QpYwCv" role="3clF47">
+                      <node concept="3clFbF" id="2JMQ0QpYxGY" role="3cqZAp">
+                        <node concept="3clFbT" id="2JMQ0QpYxGX" role="3clFbG">
+                          <property role="3clFbU" value="true" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="2AHcQZ" id="2JMQ0QpYwCx" role="2AJF6D">
+                      <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3cqZAl" id="2JMQ0QpYATs" role="3clF45" />
+    </node>
+    <node concept="2tJIrI" id="2JMQ0QpYDVd" role="jymVt" />
+    <node concept="q3mfD" id="2JMQ0QpYD3V" role="jymVt">
+      <property role="TrG5h" value="deactivate" />
+      <ref role="2VtyIY" to="90d:3zLwYDe0BDO" resolve="deactivate" />
+      <node concept="3Tm1VV" id="2JMQ0QpYD3X" role="1B3o_S" />
+      <node concept="3clFbS" id="2JMQ0QpYD3Z" role="3clF47">
+        <node concept="3clFbF" id="2JMQ0QpYDAl" role="3cqZAp">
+          <node concept="37vLTI" id="2JMQ0QpYDMw" role="3clFbG">
+            <node concept="10Nm6u" id="2JMQ0QpYDO5" role="37vLTx" />
+            <node concept="37vLTw" id="2JMQ0QpYDAk" role="37vLTJ">
+              <ref role="3cqZAo" node="2JMQ0QpYAFM" resolve="instance" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3cqZAl" id="2JMQ0QpYD42" role="3clF45" />
+    </node>
+    <node concept="2tJIrI" id="3qokpdXS6Iv" role="jymVt" />
+    <node concept="q3mfD" id="3qokpdXS6Iw" role="jymVt">
+      <property role="TrG5h" value="get" />
+      <ref role="2VtyIY" to="90d:3zLwYDe0svr" resolve="get" />
+      <node concept="3Tm1VV" id="3qokpdXS6Iy" role="1B3o_S" />
+      <node concept="3clFbS" id="3qokpdXS6I$" role="3clF47">
+        <node concept="3clFbF" id="2JMQ0QpYCRF" role="3cqZAp">
+          <node concept="37vLTw" id="2JMQ0Qq3bL4" role="3clFbG">
+            <ref role="3cqZAo" node="2JMQ0QpYAFM" resolve="instance" />
+          </node>
+        </node>
+      </node>
+      <node concept="q3mfm" id="3qokpdXS6I_" role="3clF45">
+        <ref role="q3mfh" to="90d:3zLwYDe0sv$" />
+        <ref role="1QQUv3" node="3qokpdXS6Iw" resolve="get" />
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/code/languages/com.mbeddr.doc.aspect/languages/com.mbeddr.doc.aspect.exampleLanguage/models/com/mbeddr/doc/aspect/exampleLanguage/documentation.mps
+++ b/code/languages/com.mbeddr.doc.aspect/languages/com.mbeddr.doc.aspect.exampleLanguage/models/com/mbeddr/doc/aspect/exampleLanguage/documentation.mps
@@ -20,6 +20,7 @@
       </concept>
       <concept id="7810506636291686467" name="com.mbeddr.doc.aspect.structure.DocumentedPropertyItemAnnotation" flags="ng" index="fANS$" />
       <concept id="1058510331725720478" name="com.mbeddr.doc.aspect.structure.DocumentedConceptAnnotation" flags="ng" index="3n9NSn">
+        <property id="2265458908609337334" name="overrideChildren" index="33_X4D" />
         <property id="1881564090922902400" name="priority" index="17ySGi" />
         <reference id="1058510331725761196" name="concept" index="3nadW_" />
       </concept>
@@ -240,6 +241,21 @@
             <ref role="3nadW_" to="hauh:4MORkbYxnx" resolve="Node" />
             <ref role="4TqVk" to="tpck:h0TrG11" resolve="name" />
           </node>
+        </node>
+      </node>
+      <node concept="1_0VNX" id="1XKxHZsLVso" role="1_0VJ0">
+        <property role="TrG5h" value="CostAttribute" />
+        <property role="1_0VJr" value="Cost attribute" />
+        <node concept="1_0LV8" id="1XKxHZsLVtc" role="1_0VJ0">
+          <node concept="19SGf9" id="1XKxHZsLVtd" role="1_0LWR">
+            <node concept="19SUe$" id="1XKxHZsLVte" role="19SJt6">
+              <property role="19SUeA" value="This is an attribute for defining cost via an expression." />
+            </node>
+          </node>
+        </node>
+        <node concept="3n9NSn" id="1XKxHZsLVtj" role="lGtFl">
+          <property role="33_X4D" value="true" />
+          <ref role="3nadW_" to="hauh:1XKxHZsLKOm" resolve="CostAttribute" />
         </node>
       </node>
     </node>

--- a/code/languages/com.mbeddr.doc.aspect/languages/com.mbeddr.doc.aspect.exampleLanguage/models/com/mbeddr/doc/aspect/exampleLanguage/editor.mps
+++ b/code/languages/com.mbeddr.doc.aspect/languages/com.mbeddr.doc.aspect.exampleLanguage/models/com/mbeddr/doc/aspect/exampleLanguage/editor.mps
@@ -18,6 +18,7 @@
         <child id="1176897874615" name="nodeFactory" index="4_6I_" />
         <child id="1140524464360" name="cellLayout" index="2czzBx" />
       </concept>
+      <concept id="1106270549637" name="jetbrains.mps.lang.editor.structure.CellLayout_Horizontal" flags="nn" index="2iRfu4" />
       <concept id="1237303669825" name="jetbrains.mps.lang.editor.structure.CellLayout_Indent" flags="nn" index="l2Vlx" />
       <concept id="1237307900041" name="jetbrains.mps.lang.editor.structure.IndentLayoutIndentStyleClassItem" flags="ln" index="lj46D" />
       <concept id="1237375020029" name="jetbrains.mps.lang.editor.structure.IndentLayoutNewLineChildrenStyleClassItem" flags="ln" index="pj6Ft" />
@@ -31,6 +32,7 @@
       <concept id="1186414536763" name="jetbrains.mps.lang.editor.structure.BooleanStyleSheetItem" flags="ln" index="VOi$J">
         <property id="1186414551515" name="flag" index="VOm3f" />
       </concept>
+      <concept id="1233758997495" name="jetbrains.mps.lang.editor.structure.PunctuationLeftStyleClassItem" flags="ln" index="11L4FC" />
       <concept id="1088013125922" name="jetbrains.mps.lang.editor.structure.CellModel_RefCell" flags="sg" stub="730538219795941030" index="1iCGBv">
         <child id="1088186146602" name="editorComponent" index="1sWHZn" />
       </concept>
@@ -201,6 +203,38 @@
           </node>
         </node>
       </node>
+      <node concept="3F0ifn" id="1XKxHZsLKKL" role="3EZMnx">
+        <property role="3F0ifm" value="attributes:" />
+        <node concept="pVoyu" id="1XKxHZsLKKM" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+      <node concept="3F2HdR" id="1XKxHZsLKKN" role="3EZMnx">
+        <ref role="1NtTu8" to="hauh:1XKxHZsLKHO" resolve="attributes" />
+        <node concept="l2Vlx" id="1XKxHZsLKKO" role="2czzBx" />
+        <node concept="pVoyu" id="1XKxHZsLKKP" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+        <node concept="pj6Ft" id="1XKxHZsLKKQ" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+        <node concept="lj46D" id="1XKxHZsLKKR" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+        <node concept="4$FPG" id="1XKxHZsLKKS" role="4_6I_">
+          <node concept="3clFbS" id="1XKxHZsLKKT" role="2VODD2">
+            <node concept="3cpWs6" id="1XKxHZsLKKU" role="3cqZAp">
+              <node concept="2ShNRf" id="1XKxHZsLKKV" role="3cqZAk">
+                <node concept="3zrR0B" id="1XKxHZsLKKW" role="2ShVmc">
+                  <node concept="3Tqbb2" id="1XKxHZsLKKX" role="3zrR0E">
+                    <ref role="ehGHo" to="hauh:7NPCd7DDwAT" resolve="IEdge" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
     </node>
   </node>
   <node concept="24kQdi" id="4MORkbYxo7">
@@ -215,6 +249,24 @@
       </node>
       <node concept="3F1sOY" id="1CsE99tzupG" role="3EZMnx">
         <ref role="1NtTu8" to="hauh:1CsE99tzupA" resolve="expression" />
+      </node>
+    </node>
+  </node>
+  <node concept="24kQdi" id="1XKxHZsLKOS">
+    <ref role="1XX52x" to="hauh:1XKxHZsLKOm" resolve="CostAttribute" />
+    <node concept="3EZMnI" id="1XKxHZsLKOU" role="2wV5jI">
+      <node concept="PMmxH" id="1XKxHZsLKP1" role="3EZMnx">
+        <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
+      </node>
+      <node concept="2iRfu4" id="1XKxHZsLKOX" role="2iSdaV" />
+      <node concept="3F0ifn" id="1XKxHZsLQ2D" role="3EZMnx">
+        <property role="3F0ifm" value=":" />
+        <node concept="11L4FC" id="1XKxHZsLQ2I" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+      <node concept="3F1sOY" id="1XKxHZsLKPe" role="3EZMnx">
+        <ref role="1NtTu8" to="hauh:1XKxHZsLKOs" resolve="expression" />
       </node>
     </node>
   </node>

--- a/code/languages/com.mbeddr.doc.aspect/languages/com.mbeddr.doc.aspect.exampleLanguage/models/com/mbeddr/doc/aspect/exampleLanguage/structure.mps
+++ b/code/languages/com.mbeddr.doc.aspect/languages/com.mbeddr.doc.aspect.exampleLanguage/models/com/mbeddr/doc/aspect/exampleLanguage/structure.mps
@@ -93,6 +93,13 @@
       <property role="20lbJX" value="fLJekj5/_0__n" />
       <ref role="20lvS9" node="7NPCd7DDwAT" resolve="IEdge" />
     </node>
+    <node concept="1TJgyj" id="1XKxHZsLKHO" role="1TKVEi">
+      <property role="IQ2ns" value="2265458908607220596" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="attributes" />
+      <property role="20lbJX" value="fLJekj5/_0__n" />
+      <ref role="20lvS9" node="1XKxHZsLKOl" resolve="IAttribute" />
+    </node>
     <node concept="PrWs8" id="1MEM7Lwxekd" role="PzmwI">
       <ref role="PrY4T" to="tpck:h0TrEE$" resolve="INamedConcept" />
     </node>
@@ -129,6 +136,26 @@
     </node>
     <node concept="PrWs8" id="1MEM7Lwytq4" role="PzmwI">
       <ref role="PrY4T" node="1MEM7LwytpY" resolve="INode" />
+    </node>
+  </node>
+  <node concept="PlHQZ" id="1XKxHZsLKOl">
+    <property role="TrG5h" value="IAttribute" />
+    <property role="EcuMT" value="2265458908607221012" />
+  </node>
+  <node concept="1TIwiD" id="1XKxHZsLKOm">
+    <property role="EcuMT" value="2265458908607221014" />
+    <property role="TrG5h" value="CostAttribute" />
+    <property role="34LRSv" value="cost" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" />
+    <node concept="PrWs8" id="1XKxHZsLKOp" role="PzmwI">
+      <ref role="PrY4T" node="1XKxHZsLKOl" resolve="IAttribute" />
+    </node>
+    <node concept="1TJgyj" id="1XKxHZsLKOs" role="1TKVEi">
+      <property role="IQ2ns" value="2265458908607221020" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="expression" />
+      <property role="20lbJX" value="fLJekj4/_1" />
+      <ref role="20lvS9" to="tpee:fz3vP1J" resolve="Expression" />
     </node>
   </node>
 </model>

--- a/code/languages/com.mbeddr.doc.aspect/languages/com.mbeddr.doc.aspect.exampleLanguage/sandbox/models/com/mbeddr/doc/aspect/exampleLanguage/sandbox.mps
+++ b/code/languages/com.mbeddr.doc.aspect/languages/com.mbeddr.doc.aspect.exampleLanguage/sandbox/models/com/mbeddr/doc/aspect/exampleLanguage/sandbox.mps
@@ -12,6 +12,11 @@
       <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
         <property id="1068580320021" name="value" index="3cmrfH" />
       </concept>
+      <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
+      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
+        <child id="1081773367579" name="rightExpression" index="3uHU7w" />
+        <child id="1081773367580" name="leftExpression" index="3uHU7B" />
+      </concept>
     </language>
     <language id="1e00450a-fc72-4f66-9571-30e5e083c1fa" name="com.mbeddr.doc.aspect.exampleLanguage.extended">
       <concept id="9004279853425732280" name="com.mbeddr.doc.aspect.exampleLanguage.extended.structure.UndirectedEdge" flags="ng" index="2lk0DD" />
@@ -19,6 +24,9 @@
     <language id="3c21902d-b582-4557-b697-84a4dcddff3a" name="com.mbeddr.doc.aspect.exampleLanguage">
       <concept id="86363842539034081" name="com.mbeddr.doc.aspect.exampleLanguage.structure.Node" flags="ng" index="aMcqk">
         <child id="1881564090922296934" name="expression" index="17$kVO" />
+      </concept>
+      <concept id="2265458908607221014" name="com.mbeddr.doc.aspect.exampleLanguage.structure.CostAttribute" flags="ng" index="33HSJ9">
+        <child id="2265458908607221020" name="expression" index="33HSJ3" />
       </concept>
       <concept id="2065683815623914867" name="com.mbeddr.doc.aspect.exampleLanguage.structure.ColoredNode" flags="ng" index="1W8VOf">
         <property id="2065683815623914868" name="color" index="1W8VO8" />
@@ -28,6 +36,7 @@
         <reference id="2065683815623615658" name="target" index="1WbyNm" />
       </concept>
       <concept id="2065683815623615751" name="com.mbeddr.doc.aspect.exampleLanguage.structure.Graph" flags="ng" index="1WbyPV">
+        <child id="2265458908607220596" name="attributes" index="33HSQF" />
         <child id="2065683815623615752" name="nodes" index="1WbyPO" />
         <child id="2065683815623615754" name="edges" index="1WbyPQ" />
       </concept>
@@ -87,6 +96,21 @@
     <node concept="1W8VOf" id="1MEM7LwyyPS" role="1WbyPO">
       <property role="TrG5h" value="N5" />
       <property role="1W8VO8" value="1" />
+    </node>
+    <node concept="33HSJ9" id="1XKxHZsLUK_" role="33HSQF">
+      <node concept="3cpWs3" id="1XKxHZsLVr2" role="33HSJ3">
+        <node concept="3cmrfG" id="1XKxHZsLVr5" role="3uHU7w">
+          <property role="3cmrfH" value="30" />
+        </node>
+        <node concept="3cpWs3" id="1XKxHZsLVbL" role="3uHU7B">
+          <node concept="3cmrfG" id="1XKxHZsLUKD" role="3uHU7B">
+            <property role="3cmrfH" value="10" />
+          </node>
+          <node concept="3cmrfG" id="1XKxHZsLVbO" role="3uHU7w">
+            <property role="3cmrfH" value="20" />
+          </node>
+        </node>
+      </node>
     </node>
   </node>
 </model>

--- a/code/languages/com.mbeddr.doc.aspect/languages/com.mbeddr.doc.aspect/models/com/mbeddr/doc/aspect/editor.mps
+++ b/code/languages/com.mbeddr.doc.aspect/languages/com.mbeddr.doc.aspect/models/com/mbeddr/doc/aspect/editor.mps
@@ -43,6 +43,7 @@
         <property id="168363875802087287" name="showInUI" index="2gpH_U" />
         <property id="5944657839012629576" name="presentation" index="2BUmq6" />
       </concept>
+      <concept id="1239814640496" name="jetbrains.mps.lang.editor.structure.CellLayout_VerticalGrid" flags="nn" index="2EHx9g" />
       <concept id="1149850725784" name="jetbrains.mps.lang.editor.structure.CellModel_AttributedNodeCell" flags="ng" index="2SsqMj" />
       <concept id="1186403694788" name="jetbrains.mps.lang.editor.structure.ColorStyleClassItem" flags="ln" index="VaVBg">
         <property id="1186403713874" name="color" index="Vb096" />
@@ -54,6 +55,7 @@
       <concept id="1186414536763" name="jetbrains.mps.lang.editor.structure.BooleanStyleSheetItem" flags="ln" index="VOi$J">
         <property id="1186414551515" name="flag" index="VOm3f" />
       </concept>
+      <concept id="1186414928363" name="jetbrains.mps.lang.editor.structure.SelectableStyleSheetItem" flags="ln" index="VPM3Z" />
       <concept id="1233758997495" name="jetbrains.mps.lang.editor.structure.PunctuationLeftStyleClassItem" flags="ln" index="11L4FC" />
       <concept id="1233759184865" name="jetbrains.mps.lang.editor.structure.PunctuationRightStyleClassItem" flags="ln" index="11LMrY" />
       <concept id="1139535219966" name="jetbrains.mps.lang.editor.structure.CellActionMapDeclaration" flags="ig" index="1h_SRR">
@@ -282,15 +284,28 @@
       <node concept="2SsqMj" id="UK_oBpA4Fi" role="3EZMnx" />
       <node concept="2iRkQZ" id="UK_oBpA4Fe" role="2iSdaV" />
     </node>
-    <node concept="3EZMnI" id="1CsE99t_Me7" role="6VMZX">
-      <node concept="2iRfu4" id="1CsE99t_Me8" role="2iSdaV" />
-      <node concept="3F0ifn" id="1CsE99t_Me4" role="3EZMnx">
-        <property role="3F0ifm" value="priority" />
+    <node concept="3EZMnI" id="1XKxHZsTPvT" role="6VMZX">
+      <node concept="2EHx9g" id="1XKxHZsTPwz" role="2iSdaV" />
+      <node concept="3EZMnI" id="1CsE99t_Me7" role="3EZMnx">
+        <node concept="2iRfu4" id="1CsE99t_Me8" role="2iSdaV" />
+        <node concept="3F0ifn" id="1CsE99t_Me4" role="3EZMnx">
+          <property role="3F0ifm" value="priority" />
+        </node>
+        <node concept="3F0A7n" id="1CsE99t_Meg" role="3EZMnx">
+          <property role="1$x2rV" value="0" />
+          <property role="1O74Pk" value="true" />
+          <ref role="1NtTu8" to="748g:1CsE99t_Me0" resolve="priority" />
+        </node>
       </node>
-      <node concept="3F0A7n" id="1CsE99t_Meg" role="3EZMnx">
-        <property role="1$x2rV" value="0" />
-        <property role="1O74Pk" value="true" />
-        <ref role="1NtTu8" to="748g:1CsE99t_Me0" resolve="priority" />
+      <node concept="3EZMnI" id="1XKxHZsTPwb" role="3EZMnx">
+        <node concept="VPM3Z" id="1XKxHZsTPwd" role="3F10Kt" />
+        <node concept="3F0ifn" id="1XKxHZsTPwp" role="3EZMnx">
+          <property role="3F0ifm" value="override children" />
+        </node>
+        <node concept="2iRfu4" id="1XKxHZsTPwg" role="2iSdaV" />
+        <node concept="3F0A7n" id="1XKxHZsTPwv" role="3EZMnx">
+          <ref role="1NtTu8" to="748g:1XKxHZsTPvQ" resolve="overrideChildren" />
+        </node>
       </node>
     </node>
   </node>

--- a/code/languages/com.mbeddr.doc.aspect/languages/com.mbeddr.doc.aspect/models/com/mbeddr/doc/aspect/plugin.mps
+++ b/code/languages/com.mbeddr.doc.aspect/languages/com.mbeddr.doc.aspect/models/com/mbeddr/doc/aspect/plugin.mps
@@ -6,9 +6,12 @@
     <use id="f159adf4-3c93-40f9-9c5a-1f245a8697af" name="jetbrains.mps.lang.aspect" version="2" />
     <use id="982eb8df-2c96-4bd7-9963-11712ea622e5" name="jetbrains.mps.lang.resources" version="2" />
     <use id="c0080a47-7e37-4558-bee9-9ae18e690549" name="jetbrains.mps.lang.extension" version="2" />
+    <use id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc" version="2" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
-  <imports />
+  <imports>
+    <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
+  </imports>
   <registry>
     <language id="982eb8df-2c96-4bd7-9963-11712ea622e5" name="jetbrains.mps.lang.resources">
       <concept id="8974276187400029883" name="jetbrains.mps.lang.resources.structure.FileIcon" flags="ng" index="1QGGSu">
@@ -23,13 +26,29 @@
       </concept>
     </language>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="nn" index="2tJIrI" />
+      <concept id="1188207840427" name="jetbrains.mps.baseLanguage.structure.AnnotationInstance" flags="nn" index="2AHcQZ">
+        <reference id="1188208074048" name="annotation" index="2AI5Lk" />
+      </concept>
+      <concept id="1188208481402" name="jetbrains.mps.baseLanguage.structure.HasAnnotation" flags="ng" index="2AJDlI">
+        <child id="1188208488637" name="annotation" index="2AJF6D" />
+      </concept>
       <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
+      <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu">
+        <child id="1095933932569" name="implementedInterface" index="EKbjA" />
+      </concept>
       <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
         <child id="1068580123133" name="returnType" index="3clF45" />
         <child id="1068580123135" name="body" index="3clF47" />
       </concept>
       <concept id="1068580123165" name="jetbrains.mps.baseLanguage.structure.InstanceMethodDeclaration" flags="ig" index="3clFb_" />
-      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS" />
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT" />
       <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
         <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
       </concept>
@@ -47,6 +66,19 @@
         <child id="8029776554053057803" name="objectType" index="luc8K" />
       </concept>
     </language>
+    <language id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc">
+      <concept id="5349172909345501395" name="jetbrains.mps.baseLanguage.javadoc.structure.BaseDocComment" flags="ng" index="P$AiS">
+        <child id="8465538089690331502" name="body" index="TZ5H$" />
+      </concept>
+      <concept id="5349172909345532724" name="jetbrains.mps.baseLanguage.javadoc.structure.MethodDocComment" flags="ng" index="P$JXv" />
+      <concept id="8465538089690331500" name="jetbrains.mps.baseLanguage.javadoc.structure.CommentLine" flags="ng" index="TZ5HA">
+        <child id="8970989240999019149" name="part" index="1dT_Ay" />
+      </concept>
+      <concept id="8970989240999019143" name="jetbrains.mps.baseLanguage.javadoc.structure.TextCommentLinePart" flags="ng" index="1dT_AC">
+        <property id="8970989240999019144" name="text" index="1dT_AB" />
+      </concept>
+      <concept id="2068944020170241612" name="jetbrains.mps.baseLanguage.javadoc.structure.ClassifierDocComment" flags="ng" index="3UR2Jj" />
+    </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
       <concept id="3542851458883438784" name="jetbrains.mps.lang.smodel.structure.LanguageId" flags="nn" index="2V$Bhx">
         <property id="3542851458883439831" name="namespace" index="2V$B1Q" />
@@ -54,6 +86,9 @@
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
@@ -90,8 +125,110 @@
       <node concept="3clFbS" id="1T8cMxCROxn" role="3clF47" />
       <node concept="3Tm1VV" id="1T8cMxCROxo" role="1B3o_S" />
       <node concept="10P_77" id="1T8cMxCShjv" role="3clF45" />
+      <node concept="P$JXv" id="3KxJFmNUFo7" role="lGtFl">
+        <node concept="TZ5HA" id="3KxJFmNUFo8" role="TZ5H$">
+          <node concept="1dT_AC" id="3KxJFmNUFo9" role="1dT_Ay">
+            <property role="1dT_AB" value="TODO." />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="5ut4bh9p_Up" role="jymVt" />
+    <node concept="3clFb_" id="5ut4bh9pm1v" role="jymVt">
+      <property role="TrG5h" value="allowOverrideChildren" />
+      <node concept="3clFbS" id="5ut4bh9pm1y" role="3clF47" />
+      <node concept="3Tm1VV" id="5ut4bh9pm1z" role="1B3o_S" />
+      <node concept="10P_77" id="5ut4bh9pm15" role="3clF45" />
+      <node concept="P$JXv" id="5ut4bh9p_Od" role="lGtFl">
+        <node concept="TZ5HA" id="5ut4bh9p_Oe" role="TZ5H$">
+          <node concept="1dT_AC" id="5ut4bh9p_Of" role="1dT_Ay">
+            <property role="1dT_AB" value="Flag to activate the overrideChildren flag of DocumentedConceptAnnotation nodes." />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="5ut4bh9p_Tf" role="TZ5H$">
+          <node concept="1dT_AC" id="5ut4bh9p_Tg" role="1dT_Ay">
+            <property role="1dT_AB" value="" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="5ut4bh9p_TN" role="TZ5H$">
+          <node concept="1dT_AC" id="5ut4bh9p_TO" role="1dT_Ay">
+            <property role="1dT_AB" value="Note: Activate this if any DocumentedConceptAnnotation in your application uses" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="5ut4bh9p_V8" role="TZ5H$">
+          <node concept="1dT_AC" id="5ut4bh9p_V9" role="1dT_Ay">
+            <property role="1dT_AB" value="the overrideChildren flag. Although a cache will be used to ensure that the IDE" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="5ut4bh9p_VK" role="TZ5H$">
+          <node concept="1dT_AC" id="5ut4bh9p_VL" role="1dT_Ay">
+            <property role="1dT_AB" value="performance is acceptable, selecting nodes in the editor while the documentation" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="5ut4bh9p_Wq" role="TZ5H$">
+          <node concept="1dT_AC" id="5ut4bh9p_Wr" role="1dT_Ay">
+            <property role="1dT_AB" value="view is opened might have a slight delay when the concept of the node hasn't been " />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="5ut4bh9p_X6" role="TZ5H$">
+          <node concept="1dT_AC" id="5ut4bh9p_X7" role="1dT_Ay">
+            <property role="1dT_AB" value="encountered in the current IDE session." />
+          </node>
+        </node>
+      </node>
     </node>
     <node concept="3Tm1VV" id="1T8cMxCROtp" role="1B3o_S" />
+    <node concept="3UR2Jj" id="3qokpdXQck2" role="lGtFl">
+      <node concept="TZ5HA" id="3qokpdXQck3" role="TZ5H$">
+        <node concept="1dT_AC" id="3qokpdXQck4" role="1dT_Ay">
+          <property role="1dT_AB" value="Provide an extension point in your application to configure this." />
+        </node>
+      </node>
+      <node concept="TZ5HA" id="3qokpdXQck_" role="TZ5H$">
+        <node concept="1dT_AC" id="3qokpdXQckA" role="1dT_Ay">
+          <property role="1dT_AB" value="" />
+        </node>
+      </node>
+      <node concept="TZ5HA" id="3qokpdXQckF" role="TZ5H$">
+        <node concept="1dT_AC" id="3qokpdXQckG" role="1dT_Ay">
+          <property role="1dT_AB" value="See class &quot;DefaultDocAspectConfiguration&quot; for defaults." />
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="312cEu" id="3qokpdXQc0N">
+    <property role="TrG5h" value="DefaultDocAspectConfiguration" />
+    <node concept="3Tm1VV" id="3qokpdXQc0O" role="1B3o_S" />
+    <node concept="3uibUv" id="3qokpdXQc21" role="EKbjA">
+      <ref role="3uigEE" node="1T8cMxCROto" resolve="IDocumentationAspectConfiguration" />
+    </node>
+    <node concept="3clFb_" id="3qokpdXQc2t" role="jymVt">
+      <property role="TrG5h" value="showReferenceConceptDocumentation" />
+      <node concept="3Tm1VV" id="3qokpdXQc2v" role="1B3o_S" />
+      <node concept="10P_77" id="3qokpdXQc2w" role="3clF45" />
+      <node concept="3clFbS" id="3qokpdXQc2$" role="3clF47">
+        <node concept="3clFbF" id="3qokpdXQc2B" role="3cqZAp">
+          <node concept="3clFbT" id="3qokpdXQc2A" role="3clFbG" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="3qokpdXQc2_" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="3qokpdXQcd5" role="jymVt" />
+    <node concept="3clFb_" id="3qokpdXQc2C" role="jymVt">
+      <property role="TrG5h" value="allowOverrideChildren" />
+      <node concept="3Tm1VV" id="3qokpdXQc2E" role="1B3o_S" />
+      <node concept="10P_77" id="3qokpdXQc2F" role="3clF45" />
+      <node concept="3clFbS" id="3qokpdXQc2Z" role="3clF47">
+        <node concept="3clFbF" id="3qokpdXQc32" role="3cqZAp">
+          <node concept="3clFbT" id="3qokpdXQc31" role="3clFbG" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="3qokpdXQc30" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" />
+      </node>
+    </node>
   </node>
 </model>
 

--- a/code/languages/com.mbeddr.doc.aspect/languages/com.mbeddr.doc.aspect/models/com/mbeddr/doc/aspect/plugin.mps
+++ b/code/languages/com.mbeddr.doc.aspect/languages/com.mbeddr.doc.aspect/models/com/mbeddr/doc/aspect/plugin.mps
@@ -128,7 +128,17 @@
       <node concept="P$JXv" id="3KxJFmNUFo7" role="lGtFl">
         <node concept="TZ5HA" id="3KxJFmNUFo8" role="TZ5H$">
           <node concept="1dT_AC" id="3KxJFmNUFo9" role="1dT_Ay">
-            <property role="1dT_AB" value="TODO." />
+            <property role="1dT_AB" value="For references under the cursor, show the documentation of the referenced concept." />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="2z92rvRqna3" role="TZ5H$">
+          <node concept="1dT_AC" id="2z92rvRqna4" role="1dT_Ay">
+            <property role="1dT_AB" value="" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="2z92rvRqnaB" role="TZ5H$">
+          <node concept="1dT_AC" id="2z92rvRqnaC" role="1dT_Ay">
+            <property role="1dT_AB" value="Activate this flag to show the documentation of the referencing concept instead." />
           </node>
         </node>
       </node>

--- a/code/languages/com.mbeddr.doc.aspect/languages/com.mbeddr.doc.aspect/models/com/mbeddr/doc/aspect/structure.mps
+++ b/code/languages/com.mbeddr.doc.aspect/languages/com.mbeddr.doc.aspect/models/com/mbeddr/doc/aspect/structure.mps
@@ -60,6 +60,11 @@
       <property role="TrG5h" value="priority" />
       <ref role="AX2Wp" to="tpck:fKAQMTA" resolve="integer" />
     </node>
+    <node concept="1TJgyi" id="1XKxHZsTPvQ" role="1TKVEl">
+      <property role="IQ2nx" value="2265458908609337334" />
+      <property role="TrG5h" value="overrideChildren" />
+      <ref role="AX2Wp" to="tpck:fKAQMTB" resolve="boolean" />
+    </node>
     <node concept="1TJgyj" id="UK_oBpA4EG" role="1TKVEi">
       <property role="20kJfa" value="concept" />
       <property role="20lbJX" value="fLJekj4/_1" />

--- a/code/languages/com.mbeddr.doc.aspect/solutions/com.mbeddr.doc.aspect.runtime/com.mbeddr.doc.aspect.runtime.msd
+++ b/code/languages/com.mbeddr.doc.aspect/solutions/com.mbeddr.doc.aspect.runtime/com.mbeddr.doc.aspect.runtime.msd
@@ -17,6 +17,7 @@
     <dependency reexport="false">38a074ed-e5ad-4b2d-be31-ca436911b8aa(com.mbeddr.doc.aspect)</dependency>
     <dependency reexport="false">c72da2b9-7cce-4447-8389-f407dc1158b7(jetbrains.mps.lang.structure)</dependency>
     <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
+    <dependency reexport="false">af65afd8-f0dd-4942-87d9-63a55f2a9db1(jetbrains.mps.lang.behavior)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:654422bf-e75f-44dc-936d-188890a746ce:de.slisson.mps.reflection" version="0" />
@@ -61,6 +62,7 @@
     <module reference="23865718-e2ed-41b5-a132-0da1d04e266d(jetbrains.mps.ide.httpsupport.manager)" version="0" />
     <module reference="ae6d8005-36be-4cb6-945b-8c8cfc033c51(jetbrains.mps.ide.httpsupport.runtime)" version="0" />
     <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
+    <module reference="af65afd8-f0dd-4942-87d9-63a55f2a9db1(jetbrains.mps.lang.behavior)" version="0" />
     <module reference="d936855b-48da-4812-a8a0-2bfddd633ac5(jetbrains.mps.lang.behavior.api)" version="0" />
     <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
     <module reference="446c26eb-2b7b-4bf0-9b35-f83fa582753e(jetbrains.mps.lang.modelapi)" version="0" />

--- a/code/languages/com.mbeddr.doc.aspect/solutions/com.mbeddr.doc.aspect.runtime/com.mbeddr.doc.aspect.runtime.msd
+++ b/code/languages/com.mbeddr.doc.aspect/solutions/com.mbeddr.doc.aspect.runtime/com.mbeddr.doc.aspect.runtime.msd
@@ -16,6 +16,7 @@
     <dependency reexport="false">2374bc90-7e37-41f1-a9c4-c2e35194c36a(com.mbeddr.doc)</dependency>
     <dependency reexport="false">38a074ed-e5ad-4b2d-be31-ca436911b8aa(com.mbeddr.doc.aspect)</dependency>
     <dependency reexport="false">c72da2b9-7cce-4447-8389-f407dc1158b7(jetbrains.mps.lang.structure)</dependency>
+    <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:654422bf-e75f-44dc-936d-188890a746ce:de.slisson.mps.reflection" version="0" />
@@ -23,7 +24,6 @@
     <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
     <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
     <language slang="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" version="2" />
-    <language slang="l:c7d5b9dd-a05f-4be2-bc73-f2e16994cc67:jetbrains.mps.baseLanguage.lightweightdsl" version="1" />
     <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
     <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
     <language slang="l:c0080a47-7e37-4558-bee9-9ae18e690549:jetbrains.mps.lang.extension" version="2" />

--- a/code/languages/com.mbeddr.doc.aspect/solutions/com.mbeddr.doc.aspect.runtime/models/com/mbeddr/doc/aspect/runtime.mps
+++ b/code/languages/com.mbeddr.doc.aspect/solutions/com.mbeddr.doc.aspect.runtime/models/com/mbeddr/doc/aspect/runtime.mps
@@ -1120,96 +1120,13 @@
                 </node>
               </node>
             </node>
-            <node concept="3SKdUt" id="1GfgNpVWUnQ" role="3cqZAp">
-              <node concept="1PaTwC" id="1GfgNpVWUnR" role="1aUNEU">
-                <node concept="3oM_SD" id="1GfgNpVWV3e" role="1PaTwD">
-                  <property role="3oM_SC" value="Note" />
-                </node>
-                <node concept="3oM_SD" id="1GfgNpVWV3n" role="1PaTwD">
-                  <property role="3oM_SC" value="that" />
-                </node>
-                <node concept="3oM_SD" id="1GfgNpVWV3q" role="1PaTwD">
-                  <property role="3oM_SC" value="this" />
-                </node>
-                <node concept="3oM_SD" id="1GfgNpVWV3u" role="1PaTwD">
-                  <property role="3oM_SC" value="is" />
-                </node>
-                <node concept="3oM_SD" id="1GfgNpVWV3z" role="1PaTwD">
-                  <property role="3oM_SC" value="the" />
-                </node>
-                <node concept="3oM_SD" id="1GfgNpVWV3D" role="1PaTwD">
-                  <property role="3oM_SC" value="only" />
-                </node>
-                <node concept="3oM_SD" id="1GfgNpVWV3K" role="1PaTwD">
-                  <property role="3oM_SC" value="call" />
-                </node>
-                <node concept="3oM_SD" id="1GfgNpVWV5c" role="1PaTwD">
-                  <property role="3oM_SC" value="site" />
-                </node>
-                <node concept="3oM_SD" id="1GfgNpVWV4y" role="1PaTwD">
-                  <property role="3oM_SC" value="of" />
-                </node>
-                <node concept="3oM_SD" id="1GfgNpVWV4J" role="1PaTwD">
-                  <property role="3oM_SC" value="getDocumentationAux" />
-                </node>
-                <node concept="3oM_SD" id="1GfgNpVWV4X" role="1PaTwD">
-                  <property role="3oM_SC" value="which" />
-                </node>
-                <node concept="3oM_SD" id="1GfgNpVWV41" role="1PaTwD">
-                  <property role="3oM_SC" value="is" />
-                </node>
-                <node concept="3oM_SD" id="1GfgNpVWV4b" role="1PaTwD">
-                  <property role="3oM_SC" value="intended." />
-                </node>
-              </node>
-            </node>
-            <node concept="3SKdUt" id="1GfgNpVWVPf" role="3cqZAp">
-              <node concept="1PaTwC" id="1GfgNpVWVPg" role="1aUNEU">
-                <node concept="3oM_SD" id="1GfgNpVWWwQ" role="1PaTwD">
-                  <property role="3oM_SC" value="After" />
-                </node>
-                <node concept="3oM_SD" id="1GfgNpVWWwS" role="1PaTwD">
-                  <property role="3oM_SC" value="getDocumentationAux" />
-                </node>
-                <node concept="3oM_SD" id="1GfgNpVWWwV" role="1PaTwD">
-                  <property role="3oM_SC" value="is" />
-                </node>
-                <node concept="3oM_SD" id="1GfgNpVWWwZ" role="1PaTwD">
-                  <property role="3oM_SC" value="set" />
-                </node>
-                <node concept="3oM_SD" id="1GfgNpVWWx4" role="1PaTwD">
-                  <property role="3oM_SC" value="to" />
-                </node>
-                <node concept="3oM_SD" id="1GfgNpVWWxa" role="1PaTwD">
-                  <property role="3oM_SC" value="private" />
-                </node>
-                <node concept="3oM_SD" id="1GfgNpVWWxh" role="1PaTwD">
-                  <property role="3oM_SC" value="visibility," />
-                </node>
-                <node concept="3oM_SD" id="1GfgNpVWWxp" role="1PaTwD">
-                  <property role="3oM_SC" value="the" />
-                </node>
-                <node concept="3oM_SD" id="1GfgNpVWWxy" role="1PaTwD">
-                  <property role="3oM_SC" value="deprecation" />
-                </node>
-                <node concept="3oM_SD" id="1GfgNpVWWxG" role="1PaTwD">
-                  <property role="3oM_SC" value="can" />
-                </node>
-                <node concept="3oM_SD" id="1GfgNpVWWxR" role="1PaTwD">
-                  <property role="3oM_SC" value="be" />
-                </node>
-                <node concept="3oM_SD" id="1GfgNpVWWy3" role="1PaTwD">
-                  <property role="3oM_SC" value="removed." />
-                </node>
-              </node>
-            </node>
             <node concept="3clFbF" id="1GfgNpVTHe8" role="3cqZAp">
               <node concept="37vLTI" id="1GfgNpVTJiZ" role="3clFbG">
                 <node concept="2YIFZM" id="1GfgNpVTMtU" role="37vLTx">
                   <ref role="37wK5l" to="33ny:~Optional.ofNullable(java.lang.Object)" resolve="ofNullable" />
                   <ref role="1Pybhc" to="33ny:~Optional" resolve="Optional" />
                   <node concept="1rXfSq" id="1GfgNpVJAd4" role="37wK5m">
-                    <ref role="37wK5l" node="qh7UMGipbd" resolve="getDocumentationAux" />
+                    <ref role="37wK5l" node="6SZYYyyjxld" resolve="getDocumentationAux" />
                     <node concept="37vLTw" id="1GfgNpVJAd5" role="37wK5m">
                       <ref role="3cqZAo" node="2DFA9RLl8eW" resolve="repository" />
                     </node>
@@ -1577,8 +1494,85 @@
       <property role="od$2w" value="false" />
       <property role="DiZV1" value="false" />
       <property role="2aFKle" value="false" />
-      <property role="TrG5h" value="getDocumentationAux" />
+      <property role="TrG5h" value="getDocumentationOld" />
       <node concept="3clFbS" id="qh7UMGipbg" role="3clF47">
+        <node concept="3clFbF" id="6SZYYyyjXH9" role="3cqZAp">
+          <node concept="1rXfSq" id="6SZYYyyjXH8" role="3clFbG">
+            <ref role="37wK5l" node="6SZYYyyjxld" resolve="getDocumentationAux" />
+            <node concept="37vLTw" id="6SZYYyyjYxX" role="37wK5m">
+              <ref role="3cqZAo" node="qh7UMGiq55" resolve="repository" />
+            </node>
+            <node concept="37vLTw" id="6SZYYyyjZtd" role="37wK5m">
+              <ref role="3cqZAo" node="qh7UMGipdd" resolve="concept" />
+            </node>
+            <node concept="37vLTw" id="6SZYYyyk0Q3" role="37wK5m">
+              <ref role="3cqZAo" node="1o6EjwiUgm7" resolve="property" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="qh7UMGip9e" role="1B3o_S" />
+      <node concept="37vLTG" id="qh7UMGiq55" role="3clF46">
+        <property role="TrG5h" value="repository" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3uibUv" id="qh7UMGiqr7" role="1tU5fm">
+          <ref role="3uigEE" to="lui2:~SRepository" resolve="SRepository" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="qh7UMGipdd" role="3clF46">
+        <property role="TrG5h" value="concept" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3bZ5Sz" id="qh7UMGipdc" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="1o6EjwiUgm7" role="3clF46">
+        <property role="TrG5h" value="property" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3uibUv" id="qmep2lZQkS" role="1tU5fm">
+          <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
+        </node>
+      </node>
+      <node concept="3Tqbb2" id="qh7UMGiC3j" role="3clF45" />
+      <node concept="P$JXv" id="qh7UMGiEZg" role="lGtFl">
+        <node concept="TZ5HI" id="1XKxHZsW5vn" role="3nqlJM">
+          <node concept="TZ5HA" id="1XKxHZsW5vo" role="3HnX3l">
+            <node concept="1dT_AC" id="1XKxHZsW7gh" role="1dT_Ay">
+              <property role="1dT_AB" value="Use getDocumentation(node) instead." />
+            </node>
+          </node>
+        </node>
+        <node concept="TZ5HA" id="1XKxHZsULOU" role="TZ5H$">
+          <node concept="1dT_AC" id="1XKxHZsULOV" role="1dT_Ay">
+            <property role="1dT_AB" value="This method does not handle the override-child logic, so it is deprecated now and will be deleted." />
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="1XKxHZsW5vp" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="6SZYYyyjrZw" role="jymVt" />
+    <node concept="2YIFZL" id="6SZYYyyjxld" role="jymVt">
+      <property role="TrG5h" value="getDocumentationAux" />
+      <node concept="37vLTG" id="6SZYYyyjzc5" role="3clF46">
+        <property role="TrG5h" value="repository" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3uibUv" id="6SZYYyyjzc6" role="1tU5fm">
+          <ref role="3uigEE" to="lui2:~SRepository" resolve="SRepository" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="6SZYYyyjzc7" role="3clF46">
+        <property role="TrG5h" value="concept" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3bZ5Sz" id="6SZYYyyjzc8" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="6SZYYyyjzc9" role="3clF46">
+        <property role="TrG5h" value="property" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3uibUv" id="6SZYYyyjzca" role="1tU5fm">
+          <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="6SZYYyyjxlg" role="3clF47">
         <node concept="3cpWs8" id="69s3uhHTelK" role="3cqZAp">
           <node concept="3cpWsn" id="69s3uhHTelL" role="3cpWs9">
             <property role="TrG5h" value="language" />
@@ -1591,14 +1585,14 @@
                 <ref role="1Pybhc" to="vndm:~LanguageRegistry" resolve="LanguageRegistry" />
                 <ref role="37wK5l" to="vndm:~LanguageRegistry.getInstance(org.jetbrains.mps.openapi.module.SRepository)" resolve="getInstance" />
                 <node concept="37vLTw" id="qh7UMGiqvd" role="37wK5m">
-                  <ref role="3cqZAo" node="qh7UMGiq55" resolve="repository" />
+                  <ref role="3cqZAo" node="6SZYYyyjzc5" resolve="repository" />
                 </node>
               </node>
               <node concept="liA8E" id="69s3uhHTelR" role="2OqNvi">
                 <ref role="37wK5l" to="vndm:~LanguageRegistry.getLanguage(org.jetbrains.mps.openapi.language.SLanguage)" resolve="getLanguage" />
                 <node concept="2OqwBi" id="69s3uhHTelS" role="37wK5m">
                   <node concept="37vLTw" id="69s3uhHTelT" role="2Oq$k0">
-                    <ref role="3cqZAo" node="qh7UMGipdd" resolve="concept" />
+                    <ref role="3cqZAo" node="6SZYYyyjzc7" resolve="concept" />
                   </node>
                   <node concept="liA8E" id="69s3uhHTelU" role="2OqNvi">
                     <ref role="37wK5l" to="c17a:~SAbstractConcept.getLanguage()" resolve="getLanguage" />
@@ -1697,10 +1691,10 @@
                       <node concept="liA8E" id="qh7UMGiCwz" role="2OqNvi">
                         <ref role="37wK5l" node="tBHOvWexSF" resolve="getDocumentation" />
                         <node concept="37vLTw" id="qh7UMGiCw$" role="37wK5m">
-                          <ref role="3cqZAo" node="qh7UMGipdd" resolve="concept" />
+                          <ref role="3cqZAo" node="6SZYYyyjzc7" resolve="concept" />
                         </node>
                         <node concept="37vLTw" id="1o6EjwiUha5" role="37wK5m">
-                          <ref role="3cqZAo" node="1o6EjwiUgm7" resolve="property" />
+                          <ref role="3cqZAo" node="6SZYYyyjzc9" resolve="property" />
                         </node>
                       </node>
                     </node>
@@ -1731,6 +1725,7 @@
             </node>
           </node>
         </node>
+        <node concept="3clFbH" id="6SZYYyyk9Vl" role="3cqZAp" />
         <node concept="3SKdUt" id="3G5jYxl6xlj" role="3cqZAp">
           <node concept="1PaTwC" id="3G5jYxl6xlk" role="1aUNEU">
             <node concept="3oM_SD" id="3G5jYxl6xKt" role="1PaTwD">
@@ -1762,13 +1757,13 @@
             <node concept="1rXfSq" id="4LTL3HuDl4F" role="33vP2m">
               <ref role="37wK5l" node="4LTL3HuCZ4$" resolve="findSolutionDoc" />
               <node concept="37vLTw" id="4LTL3HuDmhv" role="37wK5m">
-                <ref role="3cqZAo" node="qh7UMGiq55" resolve="repository" />
+                <ref role="3cqZAo" node="6SZYYyyjzc5" resolve="repository" />
               </node>
               <node concept="37vLTw" id="4LTL3HuDoDG" role="37wK5m">
-                <ref role="3cqZAo" node="qh7UMGipdd" resolve="concept" />
+                <ref role="3cqZAo" node="6SZYYyyjzc7" resolve="concept" />
               </node>
               <node concept="37vLTw" id="4LTL3HuDqbT" role="37wK5m">
-                <ref role="3cqZAo" node="1o6EjwiUgm7" resolve="property" />
+                <ref role="3cqZAo" node="6SZYYyyjzc9" resolve="property" />
               </node>
             </node>
           </node>
@@ -1862,28 +1857,9 @@
           <node concept="10Nm6u" id="qh7UMGiy1a" role="3cqZAk" />
         </node>
       </node>
-      <node concept="3Tm1VV" id="qh7UMGip9e" role="1B3o_S" />
-      <node concept="37vLTG" id="qh7UMGiq55" role="3clF46">
-        <property role="TrG5h" value="repository" />
-        <property role="3TUv4t" value="true" />
-        <node concept="3uibUv" id="qh7UMGiqr7" role="1tU5fm">
-          <ref role="3uigEE" to="lui2:~SRepository" resolve="SRepository" />
-        </node>
-      </node>
-      <node concept="37vLTG" id="qh7UMGipdd" role="3clF46">
-        <property role="TrG5h" value="concept" />
-        <property role="3TUv4t" value="true" />
-        <node concept="3bZ5Sz" id="qh7UMGipdc" role="1tU5fm" />
-      </node>
-      <node concept="37vLTG" id="1o6EjwiUgm7" role="3clF46">
-        <property role="TrG5h" value="property" />
-        <property role="3TUv4t" value="true" />
-        <node concept="3uibUv" id="qmep2lZQkS" role="1tU5fm">
-          <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
-        </node>
-      </node>
-      <node concept="3Tqbb2" id="qh7UMGiC3j" role="3clF45" />
-      <node concept="P$JXv" id="qh7UMGiEZg" role="lGtFl">
+      <node concept="3Tm6S6" id="6SZYYyyjv4p" role="1B3o_S" />
+      <node concept="3Tqbb2" id="6SZYYyyjTF4" role="3clF45" />
+      <node concept="P$JXv" id="6SZYYyyk1_w" role="lGtFl">
         <node concept="TZ5HA" id="qh7UMGiEZh" role="TZ5H$">
           <node concept="1dT_AC" id="qh7UMGiEZi" role="1dT_Ay">
             <property role="1dT_AB" value="Retrieves the documentation node for the given concept by searching first in the documentation aspect of the concept " />
@@ -1899,26 +1875,6 @@
             <property role="1dT_AB" value="solution that depends on the concept's language." />
           </node>
         </node>
-        <node concept="TZ5HA" id="1XKxHZsUKdX" role="TZ5H$">
-          <node concept="1dT_AC" id="1XKxHZsUKdY" role="1dT_Ay">
-            <property role="1dT_AB" value="" />
-          </node>
-        </node>
-        <node concept="TZ5HA" id="1XKxHZsULOU" role="TZ5H$">
-          <node concept="1dT_AC" id="1XKxHZsULOV" role="1dT_Ay">
-            <property role="1dT_AB" value="This method does not handle the override-child logic, so it is deprecated now." />
-          </node>
-        </node>
-        <node concept="TZ5HI" id="1XKxHZsW5vn" role="3nqlJM">
-          <node concept="TZ5HA" id="1XKxHZsW5vo" role="3HnX3l">
-            <node concept="1dT_AC" id="1XKxHZsW7gh" role="1dT_Ay">
-              <property role="1dT_AB" value="This method will become private later. Use getDocumentation(node) instead." />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="1XKxHZsW5vp" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" />
       </node>
     </node>
     <node concept="2tJIrI" id="2NM$qy7XpEN" role="jymVt" />

--- a/code/languages/com.mbeddr.doc.aspect/solutions/com.mbeddr.doc.aspect.runtime/models/com/mbeddr/doc/aspect/runtime.mps
+++ b/code/languages/com.mbeddr.doc.aspect/solutions/com.mbeddr.doc.aspect.runtime/models/com/mbeddr/doc/aspect/runtime.mps
@@ -22,6 +22,8 @@
     <import index="pgte" ref="r:e361f9f2-2afa-4fbe-b895-bdd4fbfe44fa(com.mbeddr.doc.aspect.plugin)" />
     <import index="sgh3" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.google.common.cache(MPS.IDEA/)" />
     <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
+    <import index="1i04" ref="r:3270011d-8b2d-4938-8dff-d256a759e017(jetbrains.mps.lang.behavior.structure)" />
+    <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" implicit="true" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
     <import index="4gky" ref="r:e1dfab1d-c7a7-43e7-9f26-028afd483e82(com.mbeddr.doc.behavior)" implicit="true" />
     <import index="tpcn" ref="r:00000000-0000-4000-0000-011c8959028b(jetbrains.mps.lang.structure.behavior)" implicit="true" />
@@ -259,8 +261,12 @@
         <child id="1145404616321" name="leftExpression" index="2JrQYb" />
       </concept>
       <concept id="1171305280644" name="jetbrains.mps.lang.smodel.structure.Node_GetDescendantsOperation" flags="nn" index="2Rf3mk" />
+      <concept id="1171310072040" name="jetbrains.mps.lang.smodel.structure.Node_GetContainingRootOperation" flags="nn" index="2Rxl7S" />
       <concept id="1171323947159" name="jetbrains.mps.lang.smodel.structure.Model_NodesOperation" flags="nn" index="2SmgA7">
         <child id="1758937410080001570" name="conceptArgument" index="1dBWTz" />
+      </concept>
+      <concept id="2644386474300074836" name="jetbrains.mps.lang.smodel.structure.ConceptIdRefExpression" flags="nn" index="35c_gC">
+        <reference id="2644386474300074837" name="conceptDeclaration" index="35c_gD" />
       </concept>
       <concept id="6677504323281689838" name="jetbrains.mps.lang.smodel.structure.SConceptType" flags="in" index="3bZ5Sz" />
       <concept id="1139613262185" name="jetbrains.mps.lang.smodel.structure.Node_GetParentOperation" flags="nn" index="1mfA1w" />
@@ -827,12 +833,22 @@
               </node>
             </node>
           </node>
-          <node concept="2OqwBi" id="3qokpdXQIHO" role="3clFbw">
-            <node concept="1rXfSq" id="3qokpdXQKcA" role="2Oq$k0">
-              <ref role="37wK5l" node="5ut4bh9phV1" resolve="getConfig" />
+          <node concept="1Wc70l" id="6SZYYyywY1E" role="3clFbw">
+            <node concept="3fqX7Q" id="6SZYYyyx3mZ" role="3uHU7w">
+              <node concept="1rXfSq" id="6SZYYyyx3n1" role="3fr31v">
+                <ref role="37wK5l" node="6SZYYyywZfu" resolve="isBlacklistedForOverride" />
+                <node concept="37vLTw" id="6SZYYyyx4_J" role="37wK5m">
+                  <ref role="3cqZAo" node="1XKxHZsSvB2" resolve="selectedNode" />
+                </node>
+              </node>
             </node>
-            <node concept="liA8E" id="3qokpdXQJgL" role="2OqNvi">
-              <ref role="37wK5l" to="pgte:5ut4bh9pm1v" resolve="allowOverrideChildren" />
+            <node concept="2OqwBi" id="3qokpdXQIHO" role="3uHU7B">
+              <node concept="1rXfSq" id="3qokpdXQKcA" role="2Oq$k0">
+                <ref role="37wK5l" node="5ut4bh9phV1" resolve="config" />
+              </node>
+              <node concept="liA8E" id="3qokpdXQJgL" role="2OqNvi">
+                <ref role="37wK5l" to="pgte:5ut4bh9pm1v" resolve="allowOverrideChildren" />
+              </node>
             </node>
           </node>
         </node>
@@ -963,6 +979,80 @@
         </node>
         <node concept="x79VA" id="1GfgNpVWOW5" role="3nqlJM">
           <property role="x79VB" value="a documentation node, if any" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="6SZYYyywieq" role="jymVt" />
+    <node concept="2YIFZL" id="6SZYYyywZfu" role="jymVt">
+      <property role="TrG5h" value="isBlacklistedForOverride" />
+      <node concept="3clFbS" id="6SZYYyywqMt" role="3clF47">
+        <node concept="3cpWs8" id="6SZYYyywIX6" role="3cqZAp">
+          <node concept="3cpWsn" id="6SZYYyywIX7" role="3cpWs9">
+            <property role="TrG5h" value="rootConcept" />
+            <node concept="3bZ5Sz" id="6SZYYyywHZZ" role="1tU5fm" />
+            <node concept="2OqwBi" id="6SZYYyywIX8" role="33vP2m">
+              <node concept="2OqwBi" id="6SZYYyywIX9" role="2Oq$k0">
+                <node concept="37vLTw" id="6SZYYyywIXa" role="2Oq$k0">
+                  <ref role="3cqZAo" node="6SZYYyyw$Mv" resolve="n" />
+                </node>
+                <node concept="2Rxl7S" id="6SZYYyywIXb" role="2OqNvi" />
+              </node>
+              <node concept="2yIwOk" id="6SZYYyywIXc" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="6SZYYyywANq" role="3cqZAp">
+          <node concept="22lmx$" id="6SZYYyyxIxf" role="3clFbG">
+            <node concept="17R0WA" id="6SZYYyyxLuN" role="3uHU7w">
+              <node concept="35c_gC" id="6SZYYyyxN0o" role="3uHU7w">
+                <ref role="35c_gD" to="1i04:hP3h7Gq" resolve="ConceptBehavior" />
+              </node>
+              <node concept="37vLTw" id="6SZYYyyxJYC" role="3uHU7B">
+                <ref role="3cqZAo" node="6SZYYyywIX7" resolve="rootConcept" />
+              </node>
+            </node>
+            <node concept="22lmx$" id="6SZYYyyx9G$" role="3uHU7B">
+              <node concept="17R0WA" id="6SZYYyywSlk" role="3uHU7B">
+                <node concept="37vLTw" id="6SZYYyywIXd" role="3uHU7B">
+                  <ref role="3cqZAo" node="6SZYYyywIX7" resolve="rootConcept" />
+                </node>
+                <node concept="35c_gC" id="6SZYYyywUeI" role="3uHU7w">
+                  <ref role="35c_gD" to="tpee:fz12cDA" resolve="ClassConcept" />
+                </node>
+              </node>
+              <node concept="17R0WA" id="6SZYYyyxdqB" role="3uHU7w">
+                <node concept="37vLTw" id="6SZYYyyxb$H" role="3uHU7B">
+                  <ref role="3cqZAo" node="6SZYYyywIX7" resolve="rootConcept" />
+                </node>
+                <node concept="35c_gC" id="6SZYYyyxgtf" role="3uHU7w">
+                  <ref role="35c_gD" to="tpee:g7HP654" resolve="Interface" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="6SZYYyyw$Mv" role="3clF46">
+        <property role="TrG5h" value="n" />
+        <node concept="3Tqbb2" id="6SZYYyyw$Mu" role="1tU5fm" />
+      </node>
+      <node concept="10P_77" id="6SZYYyywqzu" role="3clF45" />
+      <node concept="3Tm6S6" id="6SZYYyywnDq" role="1B3o_S" />
+      <node concept="P$JXv" id="6SZYYyyx5R$" role="lGtFl">
+        <node concept="TZ5HA" id="6SZYYyyx5R_" role="TZ5H$">
+          <node concept="1dT_AC" id="6SZYYyyx5RA" role="1dT_Ay">
+            <property role="1dT_AB" value="Usually there is no mbeddr-doc documentation for baselang, blacklist the corresponding roots." />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="4V_wlz9VahQ" role="TZ5H$">
+          <node concept="1dT_AC" id="4V_wlz9VahR" role="1dT_Ay">
+            <property role="1dT_AB" value="" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="4V_wlz9VahW" role="TZ5H$">
+          <node concept="1dT_AC" id="4V_wlz9VahX" role="1dT_Ay">
+            <property role="1dT_AB" value="Note: The idea here is to do a quick check which can be done without much overhead." />
+          </node>
         </node>
       </node>
     </node>

--- a/code/languages/com.mbeddr.doc.aspect/solutions/com.mbeddr.doc.aspect.runtime/models/com/mbeddr/doc/aspect/runtime.mps
+++ b/code/languages/com.mbeddr.doc.aspect/solutions/com.mbeddr.doc.aspect.runtime/models/com/mbeddr/doc/aspect/runtime.mps
@@ -20,6 +20,8 @@
     <import index="f4zo" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.cells(MPS.Editor/)" />
     <import index="g51k" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor.cells(MPS.Editor/)" />
     <import index="pgte" ref="r:e361f9f2-2afa-4fbe-b895-bdd4fbfe44fa(com.mbeddr.doc.aspect.plugin)" />
+    <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
+    <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
     <import index="4gky" ref="r:e1dfab1d-c7a7-43e7-9f26-028afd483e82(com.mbeddr.doc.behavior)" implicit="true" />
     <import index="tpcn" ref="r:00000000-0000-4000-0000-011c8959028b(jetbrains.mps.lang.structure.behavior)" implicit="true" />
   </imports>
@@ -49,6 +51,15 @@
       <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
       <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="nn" index="2tJIrI" />
+      <concept id="1076505808687" name="jetbrains.mps.baseLanguage.structure.WhileStatement" flags="nn" index="2$JKZl">
+        <child id="1076505808688" name="condition" index="2$JKZa" />
+      </concept>
+      <concept id="1188207840427" name="jetbrains.mps.baseLanguage.structure.AnnotationInstance" flags="nn" index="2AHcQZ">
+        <reference id="1188208074048" name="annotation" index="2AI5Lk" />
+      </concept>
+      <concept id="1188208481402" name="jetbrains.mps.baseLanguage.structure.HasAnnotation" flags="ng" index="2AJDlI">
+        <child id="1188208488637" name="annotation" index="2AJF6D" />
+      </concept>
       <concept id="1154032098014" name="jetbrains.mps.baseLanguage.structure.AbstractLoopStatement" flags="nn" index="2LF5Ji">
         <child id="1154032183016" name="body" index="2LFqv$" />
       </concept>
@@ -183,10 +194,14 @@
     <language id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc">
       <concept id="5349172909345501395" name="jetbrains.mps.baseLanguage.javadoc.structure.BaseDocComment" flags="ng" index="P$AiS">
         <child id="8465538089690331502" name="body" index="TZ5H$" />
+        <child id="5383422241790532083" name="tags" index="3nqlJM" />
       </concept>
       <concept id="5349172909345532724" name="jetbrains.mps.baseLanguage.javadoc.structure.MethodDocComment" flags="ng" index="P$JXv" />
       <concept id="8465538089690331500" name="jetbrains.mps.baseLanguage.javadoc.structure.CommentLine" flags="ng" index="TZ5HA">
         <child id="8970989240999019149" name="part" index="1dT_Ay" />
+      </concept>
+      <concept id="8465538089690331492" name="jetbrains.mps.baseLanguage.javadoc.structure.DeprecatedBlockDocTag" flags="ng" index="TZ5HI">
+        <child id="2667874559098216723" name="text" index="3HnX3l" />
       </concept>
       <concept id="8970989240999019143" name="jetbrains.mps.baseLanguage.javadoc.structure.TextCommentLinePart" flags="ng" index="1dT_AC">
         <property id="8970989240999019144" name="text" index="1dT_AB" />
@@ -214,6 +229,7 @@
         <child id="1758937410080001570" name="conceptArgument" index="1dBWTz" />
       </concept>
       <concept id="6677504323281689838" name="jetbrains.mps.lang.smodel.structure.SConceptType" flags="in" index="3bZ5Sz" />
+      <concept id="1139613262185" name="jetbrains.mps.lang.smodel.structure.Node_GetParentOperation" flags="nn" index="1mfA1w" />
       <concept id="1180457458947" name="jetbrains.mps.lang.smodel.structure.Concept_GetAllSuperConcepts" flags="nn" index="3oJPKh" />
       <concept id="1172008320231" name="jetbrains.mps.lang.smodel.structure.Node_IsNotNullOperation" flags="nn" index="3x8VRR" />
       <concept id="1144100932627" name="jetbrains.mps.lang.smodel.structure.OperationParm_Inclusion" flags="ng" index="1xIGOp" />
@@ -234,6 +250,9 @@
       </concept>
       <concept id="1138056143562" name="jetbrains.mps.lang.smodel.structure.SLinkAccess" flags="nn" index="3TrEf2">
         <reference id="1138056516764" name="link" index="3Tt5mk" />
+      </concept>
+      <concept id="1138056282393" name="jetbrains.mps.lang.smodel.structure.SLinkListAccess" flags="nn" index="3Tsc0h">
+        <reference id="1138056546658" name="link" index="3TtcxE" />
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
@@ -334,11 +353,299 @@
   <node concept="312cEu" id="qh7UMGioaa">
     <property role="TrG5h" value="DocumentationAspectHelper" />
     <node concept="2tJIrI" id="qh7UMGip8X" role="jymVt" />
+    <node concept="2YIFZL" id="1XKxHZsSs$9" role="jymVt">
+      <property role="TrG5h" value="getDocumentation" />
+      <node concept="37vLTG" id="1XKxHZsSvB0" role="3clF46">
+        <property role="TrG5h" value="repository" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3uibUv" id="1XKxHZsSvB1" role="1tU5fm">
+          <ref role="3uigEE" to="lui2:~SRepository" resolve="SRepository" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="1XKxHZsSvB2" role="3clF46">
+        <property role="TrG5h" value="selectedNode" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3Tqbb2" id="1XKxHZsSwCm" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="1XKxHZsSvB4" role="3clF46">
+        <property role="TrG5h" value="property" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3uibUv" id="1XKxHZsSvB5" role="1tU5fm">
+          <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="1XKxHZsSs$c" role="3clF47">
+        <node concept="3cpWs8" id="1XKxHZsUjEH" role="3cqZAp">
+          <node concept="3cpWsn" id="1XKxHZsUjEI" role="3cpWs9">
+            <property role="TrG5h" value="localDocNode" />
+            <node concept="3Tqbb2" id="1XKxHZsUjoY" role="1tU5fm" />
+            <node concept="1rXfSq" id="1XKxHZsUjEJ" role="33vP2m">
+              <ref role="37wK5l" node="qh7UMGipbd" resolve="getDocumentationAux" />
+              <node concept="37vLTw" id="1XKxHZsUjEK" role="37wK5m">
+                <ref role="3cqZAo" node="1XKxHZsSvB0" resolve="repository" />
+              </node>
+              <node concept="2OqwBi" id="1XKxHZsSBhJ" role="37wK5m">
+                <node concept="37vLTw" id="11K_5nNfofu" role="2Oq$k0">
+                  <ref role="3cqZAo" node="1XKxHZsSvB2" resolve="selectedNode" />
+                </node>
+                <node concept="2yIwOk" id="1XKxHZsSBhK" role="2OqNvi" />
+              </node>
+              <node concept="37vLTw" id="1XKxHZsUjEM" role="37wK5m">
+                <ref role="3cqZAo" node="1XKxHZsSvB4" resolve="property" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="1XKxHZsUpiK" role="3cqZAp" />
+        <node concept="3cpWs8" id="1XKxHZsSGQz" role="3cqZAp">
+          <node concept="3cpWsn" id="1XKxHZsSGQA" role="3cpWs9">
+            <property role="TrG5h" value="n" />
+            <node concept="3Tqbb2" id="1XKxHZsSGQx" role="1tU5fm" />
+            <node concept="2OqwBi" id="1XKxHZsUs$K" role="33vP2m">
+              <node concept="37vLTw" id="1XKxHZsSHqA" role="2Oq$k0">
+                <ref role="3cqZAo" node="1XKxHZsSvB2" resolve="selectedNode" />
+              </node>
+              <node concept="1mfA1w" id="1XKxHZsUt1a" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+        <node concept="2$JKZl" id="1XKxHZsUn9_" role="3cqZAp">
+          <node concept="3clFbS" id="1XKxHZsUn9B" role="2LFqv$">
+            <node concept="3cpWs8" id="1XKxHZsUudA" role="3cqZAp">
+              <node concept="3cpWsn" id="1XKxHZsUudB" role="3cpWs9">
+                <property role="TrG5h" value="parentDocNode" />
+                <node concept="3Tqbb2" id="1XKxHZsUudC" role="1tU5fm" />
+                <node concept="1rXfSq" id="1XKxHZsUudD" role="33vP2m">
+                  <ref role="37wK5l" node="qh7UMGipbd" resolve="getDocumentationAux" />
+                  <node concept="37vLTw" id="1XKxHZsUudE" role="37wK5m">
+                    <ref role="3cqZAo" node="1XKxHZsSvB0" resolve="repository" />
+                  </node>
+                  <node concept="2OqwBi" id="1XKxHZsUudF" role="37wK5m">
+                    <node concept="37vLTw" id="1XKxHZsUudG" role="2Oq$k0">
+                      <ref role="3cqZAo" node="1XKxHZsSGQA" resolve="n" />
+                    </node>
+                    <node concept="2yIwOk" id="1XKxHZsUudH" role="2OqNvi" />
+                  </node>
+                  <node concept="10Nm6u" id="1XKxHZsUxbz" role="37wK5m" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbJ" id="1XKxHZsWd4O" role="3cqZAp">
+              <node concept="3clFbS" id="1XKxHZsWd4Q" role="3clFbx">
+                <node concept="3cpWs8" id="1XKxHZsWm1X" role="3cqZAp">
+                  <node concept="3cpWsn" id="1XKxHZsWm1Y" role="3cpWs9">
+                    <property role="TrG5h" value="annotations" />
+                    <node concept="A3Dl8" id="1XKxHZsWlJW" role="1tU5fm">
+                      <node concept="3Tqbb2" id="1XKxHZsWlJZ" role="A3Ik2">
+                        <ref role="ehGHo" to="748g:UK_oBp_UIu" resolve="DocumentedConceptAnnotation" />
+                      </node>
+                    </node>
+                    <node concept="2OqwBi" id="1XKxHZsWm1Z" role="33vP2m">
+                      <node concept="2OqwBi" id="1XKxHZsWm20" role="2Oq$k0">
+                        <node concept="37vLTw" id="1XKxHZsWm21" role="2Oq$k0">
+                          <ref role="3cqZAo" node="1XKxHZsUudB" resolve="parentDocNode" />
+                        </node>
+                        <node concept="3Tsc0h" id="1XKxHZsWm22" role="2OqNvi">
+                          <ref role="3TtcxE" to="tpck:4uZwTti3__2" resolve="smodelAttribute" />
+                        </node>
+                      </node>
+                      <node concept="v3k3i" id="1XKxHZsWm23" role="2OqNvi">
+                        <node concept="chp4Y" id="1XKxHZsWm24" role="v3oSu">
+                          <ref role="cht4Q" to="748g:UK_oBp_UIu" resolve="DocumentedConceptAnnotation" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbJ" id="1XKxHZsWmWJ" role="3cqZAp">
+                  <node concept="3clFbS" id="1XKxHZsWmWL" role="3clFbx">
+                    <node concept="3cpWs8" id="1XKxHZsWrqC" role="3cqZAp">
+                      <node concept="3cpWsn" id="1XKxHZsWrqD" role="3cpWs9">
+                        <property role="TrG5h" value="override" />
+                        <node concept="10P_77" id="1XKxHZsWr5Z" role="1tU5fm" />
+                        <node concept="2OqwBi" id="1XKxHZsWrqE" role="33vP2m">
+                          <node concept="2OqwBi" id="1XKxHZsWrqF" role="2Oq$k0">
+                            <node concept="37vLTw" id="1XKxHZsWrqG" role="2Oq$k0">
+                              <ref role="3cqZAo" node="1XKxHZsWm1Y" resolve="annotations" />
+                            </node>
+                            <node concept="1uHKPH" id="1XKxHZsWrqH" role="2OqNvi" />
+                          </node>
+                          <node concept="3TrcHB" id="1XKxHZsWrqI" role="2OqNvi">
+                            <ref role="3TsBF5" to="748g:1XKxHZsTPvQ" resolve="overrideChildren" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbJ" id="1XKxHZsWsph" role="3cqZAp">
+                      <node concept="3clFbS" id="1XKxHZsWspj" role="3clFbx">
+                        <node concept="3SKdUt" id="1XKxHZsWuY8" role="3cqZAp">
+                          <node concept="1PaTwC" id="1XKxHZsWuY9" role="1aUNEU">
+                            <node concept="3oM_SD" id="1XKxHZsWuYe" role="1PaTwD">
+                              <property role="3oM_SC" value="we" />
+                            </node>
+                            <node concept="3oM_SD" id="1XKxHZsWvmr" role="1PaTwD">
+                              <property role="3oM_SC" value="found" />
+                            </node>
+                            <node concept="3oM_SD" id="1XKxHZsWvmR" role="1PaTwD">
+                              <property role="3oM_SC" value="an" />
+                            </node>
+                            <node concept="3oM_SD" id="1XKxHZsWvmV" role="1PaTwD">
+                              <property role="3oM_SC" value="ancestor" />
+                            </node>
+                            <node concept="3oM_SD" id="1XKxHZsWvoR" role="1PaTwD">
+                              <property role="3oM_SC" value="whose" />
+                            </node>
+                            <node concept="3oM_SD" id="1XKxHZsWvp8" role="1PaTwD">
+                              <property role="3oM_SC" value="concept-documentation" />
+                            </node>
+                            <node concept="3oM_SD" id="1XKxHZsWvnH" role="1PaTwD">
+                              <property role="3oM_SC" value="has" />
+                            </node>
+                            <node concept="3oM_SD" id="1XKxHZsWvpU" role="1PaTwD">
+                              <property role="3oM_SC" value="its" />
+                            </node>
+                            <node concept="3oM_SD" id="1XKxHZsWvnX" role="1PaTwD">
+                              <property role="3oM_SC" value="overrideChild" />
+                            </node>
+                            <node concept="3oM_SD" id="1XKxHZsWvoe" role="1PaTwD">
+                              <property role="3oM_SC" value="flag" />
+                            </node>
+                            <node concept="3oM_SD" id="1XKxHZsWvqd" role="1PaTwD">
+                              <property role="3oM_SC" value="set" />
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3SKdUt" id="1XKxHZsWvPw" role="3cqZAp">
+                          <node concept="1PaTwC" id="1XKxHZsWvPx" role="1aUNEU">
+                            <node concept="3oM_SD" id="1XKxHZsWwdY" role="1PaTwD">
+                              <property role="3oM_SC" value="show" />
+                            </node>
+                            <node concept="3oM_SD" id="1XKxHZsWwe0" role="1PaTwD">
+                              <property role="3oM_SC" value="the" />
+                            </node>
+                            <node concept="3oM_SD" id="1XKxHZsWwe3" role="1PaTwD">
+                              <property role="3oM_SC" value="ancestors" />
+                            </node>
+                            <node concept="3oM_SD" id="1XKxHZsWwei" role="1PaTwD">
+                              <property role="3oM_SC" value="concept-documentation" />
+                            </node>
+                            <node concept="3oM_SD" id="1XKxHZsWwen" role="1PaTwD">
+                              <property role="3oM_SC" value="instead" />
+                            </node>
+                            <node concept="3oM_SD" id="1XKxHZsWwet" role="1PaTwD">
+                              <property role="3oM_SC" value="of" />
+                            </node>
+                            <node concept="3oM_SD" id="1XKxHZsWwe$" role="1PaTwD">
+                              <property role="3oM_SC" value="the" />
+                            </node>
+                            <node concept="3oM_SD" id="1XKxHZsWweG" role="1PaTwD">
+                              <property role="3oM_SC" value="selectedNode's" />
+                            </node>
+                            <node concept="3oM_SD" id="1XKxHZsWweP" role="1PaTwD">
+                              <property role="3oM_SC" value="documentation" />
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3cpWs6" id="1XKxHZsWwIx" role="3cqZAp">
+                          <node concept="37vLTw" id="1XKxHZsWxsY" role="3cqZAk">
+                            <ref role="3cqZAo" node="1XKxHZsUudB" resolve="parentDocNode" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="37vLTw" id="1XKxHZsWsUY" role="3clFbw">
+                        <ref role="3cqZAo" node="1XKxHZsWrqD" resolve="override" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2OqwBi" id="1XKxHZsWnKx" role="3clFbw">
+                    <node concept="37vLTw" id="1XKxHZsWncA" role="2Oq$k0">
+                      <ref role="3cqZAo" node="1XKxHZsWm1Y" resolve="annotations" />
+                    </node>
+                    <node concept="3GX2aA" id="1XKxHZsWosm" role="2OqNvi" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2OqwBi" id="1XKxHZsWdO9" role="3clFbw">
+                <node concept="37vLTw" id="1XKxHZsWdrp" role="2Oq$k0">
+                  <ref role="3cqZAo" node="1XKxHZsUudB" resolve="parentDocNode" />
+                </node>
+                <node concept="3x8VRR" id="1XKxHZsWedT" role="2OqNvi" />
+              </node>
+            </node>
+            <node concept="3clFbF" id="1XKxHZsWtCF" role="3cqZAp">
+              <node concept="37vLTI" id="1XKxHZsWu3C" role="3clFbG">
+                <node concept="2OqwBi" id="1XKxHZsWukA" role="37vLTx">
+                  <node concept="37vLTw" id="1XKxHZsWu8d" role="2Oq$k0">
+                    <ref role="3cqZAo" node="1XKxHZsSGQA" resolve="n" />
+                  </node>
+                  <node concept="1mfA1w" id="1XKxHZsWuzj" role="2OqNvi" />
+                </node>
+                <node concept="37vLTw" id="1XKxHZsWtCD" role="37vLTJ">
+                  <ref role="3cqZAo" node="1XKxHZsSGQA" resolve="n" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="1XKxHZsUnCm" role="2$JKZa">
+            <node concept="37vLTw" id="1XKxHZsUnv6" role="2Oq$k0">
+              <ref role="3cqZAo" node="1XKxHZsSGQA" resolve="n" />
+            </node>
+            <node concept="3x8VRR" id="1XKxHZsUo9o" role="2OqNvi" />
+          </node>
+        </node>
+        <node concept="3clFbH" id="1XKxHZsWxJh" role="3cqZAp" />
+        <node concept="3SKdUt" id="1XKxHZsWywH" role="3cqZAp">
+          <node concept="1PaTwC" id="1XKxHZsWyVA" role="1aUNEU">
+            <node concept="3oM_SD" id="1XKxHZsWzka" role="1PaTwD">
+              <property role="3oM_SC" value="no" />
+            </node>
+            <node concept="3oM_SD" id="1XKxHZsWzkk" role="1PaTwD">
+              <property role="3oM_SC" value="ancestor" />
+            </node>
+            <node concept="3oM_SD" id="1XKxHZsWzkv" role="1PaTwD">
+              <property role="3oM_SC" value="with" />
+            </node>
+            <node concept="3oM_SD" id="1XKxHZsWzle" role="1PaTwD">
+              <property role="3oM_SC" value="overrideFlag" />
+            </node>
+            <node concept="3oM_SD" id="1XKxHZsWzlj" role="1PaTwD">
+              <property role="3oM_SC" value="set," />
+            </node>
+            <node concept="3oM_SD" id="1XKxHZsWzlx" role="1PaTwD">
+              <property role="3oM_SC" value="just" />
+            </node>
+            <node concept="3oM_SD" id="1XKxHZsWzlK" role="1PaTwD">
+              <property role="3oM_SC" value="show" />
+            </node>
+            <node concept="3oM_SD" id="1XKxHZsWzna" role="1PaTwD">
+              <property role="3oM_SC" value="documentation" />
+            </node>
+            <node concept="3oM_SD" id="1XKxHZsWznj" role="1PaTwD">
+              <property role="3oM_SC" value="for" />
+            </node>
+            <node concept="3oM_SD" id="1XKxHZsWzn_" role="1PaTwD">
+              <property role="3oM_SC" value="selected" />
+            </node>
+            <node concept="3oM_SD" id="1XKxHZsWznS" role="1PaTwD">
+              <property role="3oM_SC" value="node" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="1XKxHZsSCRO" role="3cqZAp">
+          <node concept="37vLTw" id="1XKxHZsUjEN" role="3clFbG">
+            <ref role="3cqZAo" node="1XKxHZsUjEI" resolve="documentation" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="1XKxHZsSqFL" role="1B3o_S" />
+      <node concept="3Tqbb2" id="1XKxHZsSsoZ" role="3clF45" />
+    </node>
+    <node concept="2tJIrI" id="1XKxHZsSu63" role="jymVt" />
     <node concept="2YIFZL" id="qh7UMGipbd" role="jymVt">
       <property role="od$2w" value="false" />
       <property role="DiZV1" value="false" />
       <property role="2aFKle" value="false" />
-      <property role="TrG5h" value="getDocumentation" />
+      <property role="TrG5h" value="getDocumentationAux" />
       <node concept="3clFbS" id="qh7UMGipbg" role="3clF47">
         <node concept="3cpWs8" id="69s3uhHTelK" role="3cqZAp">
           <node concept="3cpWsn" id="69s3uhHTelL" role="3cpWs9">
@@ -657,13 +964,32 @@
         </node>
         <node concept="TZ5HA" id="7ts$qmyJV5D" role="TZ5H$">
           <node concept="1dT_AC" id="7ts$qmyJV5E" role="1dT_Ay">
-            <property role="1dT_AB" value="solution that depends on the concepts language." />
+            <property role="1dT_AB" value="solution that depends on the concept's language." />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="1XKxHZsUKdX" role="TZ5H$">
+          <node concept="1dT_AC" id="1XKxHZsUKdY" role="1dT_Ay">
+            <property role="1dT_AB" value="" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="1XKxHZsULOU" role="TZ5H$">
+          <node concept="1dT_AC" id="1XKxHZsULOV" role="1dT_Ay">
+            <property role="1dT_AB" value="This method does not handle the override-child logic, so it is deprecated now." />
+          </node>
+        </node>
+        <node concept="TZ5HI" id="1XKxHZsW5vn" role="3nqlJM">
+          <node concept="TZ5HA" id="1XKxHZsW5vo" role="3HnX3l">
+            <node concept="1dT_AC" id="1XKxHZsW7gh" role="1dT_Ay">
+              <property role="1dT_AB" value="This method will become private later. Use getDocumentation(node) instead." />
+            </node>
           </node>
         </node>
       </node>
+      <node concept="2AHcQZ" id="1XKxHZsW5vp" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" />
+      </node>
     </node>
     <node concept="2tJIrI" id="2NM$qy7XpEN" role="jymVt" />
-    <node concept="2tJIrI" id="7ts$qmyJVIT" role="jymVt" />
     <node concept="2YIFZL" id="4LTL3HuCZ4$" role="jymVt">
       <property role="TrG5h" value="findSolutionDoc" />
       <node concept="37vLTG" id="4LTL3HuD1h_" role="3clF46">
@@ -878,7 +1204,7 @@
         </node>
         <node concept="TZ5HA" id="7ts$qmyJXRg" role="TZ5H$">
           <node concept="1dT_AC" id="7ts$qmyJXRh" role="1dT_Ay">
-            <property role="1dT_AB" value="language of the concept" />
+            <property role="1dT_AB" value="language of the concept." />
           </node>
         </node>
       </node>

--- a/code/languages/com.mbeddr.doc.aspect/solutions/com.mbeddr.doc.aspect.runtime/models/com/mbeddr/doc/aspect/runtime.mps
+++ b/code/languages/com.mbeddr.doc.aspect/solutions/com.mbeddr.doc.aspect.runtime/models/com/mbeddr/doc/aspect/runtime.mps
@@ -21,7 +21,6 @@
     <import index="g51k" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor.cells(MPS.Editor/)" />
     <import index="pgte" ref="r:e361f9f2-2afa-4fbe-b895-bdd4fbfe44fa(com.mbeddr.doc.aspect.plugin)" />
     <import index="sgh3" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.google.common.cache(MPS.IDEA/)" />
-    <import index="5zyv" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util.concurrent(JDK/)" />
     <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
     <import index="4gky" ref="r:e1dfab1d-c7a7-43e7-9f26-028afd483e82(com.mbeddr.doc.behavior)" implicit="true" />

--- a/code/languages/com.mbeddr.doc.aspect/solutions/com.mbeddr.doc.aspect.runtime/models/com/mbeddr/doc/aspect/runtime.mps
+++ b/code/languages/com.mbeddr.doc.aspect/solutions/com.mbeddr.doc.aspect.runtime/models/com/mbeddr/doc/aspect/runtime.mps
@@ -2884,16 +2884,52 @@
             </node>
             <node concept="3clFbJ" id="68WEpgCyVT8" role="3cqZAp">
               <node concept="3clFbS" id="68WEpgCyVTa" role="3clFbx">
-                <node concept="3cpWs8" id="11K_5nNfofq" role="3cqZAp">
-                  <node concept="3cpWsn" id="11K_5nNfofr" role="3cpWs9">
-                    <property role="TrG5h" value="concept" />
-                    <property role="3TUv4t" value="true" />
-                    <node concept="3bZ5Sz" id="11K_5nNfofs" role="1tU5fm" />
-                    <node concept="2OqwBi" id="11K_5nNfoft" role="33vP2m">
-                      <node concept="2yIwOk" id="11K_5nNfofv" role="2OqNvi" />
-                      <node concept="37vLTw" id="68WEpgC$QwK" role="2Oq$k0">
-                        <ref role="3cqZAo" node="68WEpgCynYA" resolve="n" />
-                      </node>
+                <node concept="3SKdUt" id="2z92rvRpYFL" role="3cqZAp">
+                  <node concept="1PaTwC" id="2z92rvRpYFM" role="1aUNEU">
+                    <node concept="3oM_SD" id="2z92rvRpZTC" role="1PaTwD">
+                      <property role="3oM_SC" value="don't" />
+                    </node>
+                    <node concept="3oM_SD" id="2z92rvRpZ2o" role="1PaTwD">
+                      <property role="3oM_SC" value="follow" />
+                    </node>
+                    <node concept="3oM_SD" id="2z92rvRpZ2v" role="1PaTwD">
+                      <property role="3oM_SC" value="the" />
+                    </node>
+                    <node concept="3oM_SD" id="2z92rvRpZ2C" role="1PaTwD">
+                      <property role="3oM_SC" value="reference" />
+                    </node>
+                    <node concept="3oM_SD" id="2z92rvRpZ2N" role="1PaTwD">
+                      <property role="3oM_SC" value="at" />
+                    </node>
+                    <node concept="3oM_SD" id="2z92rvRpZ30" role="1PaTwD">
+                      <property role="3oM_SC" value="the" />
+                    </node>
+                    <node concept="3oM_SD" id="2z92rvRpZUh" role="1PaTwD">
+                      <property role="3oM_SC" value="cursor," />
+                    </node>
+                    <node concept="3oM_SD" id="2z92rvRpZ3N" role="1PaTwD">
+                      <property role="3oM_SC" value="but" />
+                    </node>
+                    <node concept="3oM_SD" id="2z92rvRpZ48" role="1PaTwD">
+                      <property role="3oM_SC" value="show" />
+                    </node>
+                    <node concept="3oM_SD" id="2z92rvRpZ7j" role="1PaTwD">
+                      <property role="3oM_SC" value="documentation" />
+                    </node>
+                    <node concept="3oM_SD" id="2z92rvRpZSX" role="1PaTwD">
+                      <property role="3oM_SC" value="for" />
+                    </node>
+                    <node concept="3oM_SD" id="2z92rvRpZ5j" role="1PaTwD">
+                      <property role="3oM_SC" value="the" />
+                    </node>
+                    <node concept="3oM_SD" id="2z92rvRpZ5K" role="1PaTwD">
+                      <property role="3oM_SC" value="reference" />
+                    </node>
+                    <node concept="3oM_SD" id="2z92rvRpZ6f" role="1PaTwD">
+                      <property role="3oM_SC" value="node" />
+                    </node>
+                    <node concept="3oM_SD" id="2z92rvRpZ6K" role="1PaTwD">
+                      <property role="3oM_SC" value="itself" />
                     </node>
                   </node>
                 </node>
@@ -2903,7 +2939,7 @@
                     <property role="TrG5h" value="conceptDoc" />
                     <node concept="3Tqbb2" id="11K_5nNfog1" role="1tU5fm" />
                     <node concept="1rXfSq" id="1GfgNpVXlZA" role="33vP2m">
-                      <ref role="37wK5l" node="2DFA9RLm5bh" resolve="getDocForConceptCached" />
+                      <ref role="37wK5l" node="1XKxHZsSs$9" resolve="getDocumentation" />
                       <node concept="2OqwBi" id="1GfgNpVXlsH" role="37wK5m">
                         <node concept="2JrnkZ" id="1GfgNpVXlsI" role="2Oq$k0">
                           <node concept="2OqwBi" id="1GfgNpVXlsJ" role="2JrQYb">
@@ -2918,7 +2954,7 @@
                         </node>
                       </node>
                       <node concept="37vLTw" id="1GfgNpVXlsN" role="37wK5m">
-                        <ref role="3cqZAo" node="11K_5nNfofr" resolve="concept" />
+                        <ref role="3cqZAo" node="68WEpgCynYA" resolve="n" />
                       </node>
                       <node concept="10Nm6u" id="1GfgNpVXlsO" role="37wK5m" />
                     </node>
@@ -2939,6 +2975,65 @@
                     <node concept="3x8VRR" id="68WEpgCyr0h" role="2OqNvi" />
                   </node>
                 </node>
+                <node concept="3SKdUt" id="2z92rvRq0nG" role="3cqZAp">
+                  <node concept="1PaTwC" id="2z92rvRq0nH" role="1aUNEU">
+                    <node concept="3oM_SD" id="2z92rvRq0IH" role="1PaTwD">
+                      <property role="3oM_SC" value="if" />
+                    </node>
+                    <node concept="3oM_SD" id="2z92rvRq0IK" role="1PaTwD">
+                      <property role="3oM_SC" value="the" />
+                    </node>
+                    <node concept="3oM_SD" id="2z92rvRq0IP" role="1PaTwD">
+                      <property role="3oM_SC" value="reference" />
+                    </node>
+                    <node concept="3oM_SD" id="2z92rvRq0IW" role="1PaTwD">
+                      <property role="3oM_SC" value="concept" />
+                    </node>
+                    <node concept="3oM_SD" id="2z92rvRq0J5" role="1PaTwD">
+                      <property role="3oM_SC" value="doesn't" />
+                    </node>
+                    <node concept="3oM_SD" id="2z92rvRq0Jg" role="1PaTwD">
+                      <property role="3oM_SC" value="have" />
+                    </node>
+                    <node concept="3oM_SD" id="2z92rvRq0Jt" role="1PaTwD">
+                      <property role="3oM_SC" value="a" />
+                    </node>
+                    <node concept="3oM_SD" id="2z92rvRq0JG" role="1PaTwD">
+                      <property role="3oM_SC" value="documentation" />
+                    </node>
+                    <node concept="3oM_SD" id="2z92rvRq0JX" role="1PaTwD">
+                      <property role="3oM_SC" value="annotation," />
+                    </node>
+                    <node concept="3oM_SD" id="6SZYYyyj62L" role="1PaTwD">
+                      <property role="3oM_SC" value="fall" />
+                    </node>
+                    <node concept="3oM_SD" id="6SZYYyyj63c" role="1PaTwD">
+                      <property role="3oM_SC" value="through" />
+                    </node>
+                    <node concept="3oM_SD" id="6SZYYyyj63C" role="1PaTwD">
+                      <property role="3oM_SC" value="and" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3SKdUt" id="6SZYYyyj6ue" role="3cqZAp">
+                  <node concept="1PaTwC" id="6SZYYyyj6uf" role="1aUNEU">
+                    <node concept="3oM_SD" id="6SZYYyyj6Py" role="1PaTwD">
+                      <property role="3oM_SC" value="show" />
+                    </node>
+                    <node concept="3oM_SD" id="6SZYYyyj6P$" role="1PaTwD">
+                      <property role="3oM_SC" value="the" />
+                    </node>
+                    <node concept="3oM_SD" id="6SZYYyyj6PB" role="1PaTwD">
+                      <property role="3oM_SC" value="target's" />
+                    </node>
+                    <node concept="3oM_SD" id="6SZYYyyj6PF" role="1PaTwD">
+                      <property role="3oM_SC" value="documentation" />
+                    </node>
+                    <node concept="3oM_SD" id="6SZYYyyj6PK" role="1PaTwD">
+                      <property role="3oM_SC" value="anyway" />
+                    </node>
+                  </node>
+                </node>
               </node>
               <node concept="2OqwBi" id="3qokpdXQLXn" role="3clFbw">
                 <node concept="1rXfSq" id="3qokpdXQLiQ" role="2Oq$k0">
@@ -2946,6 +3041,44 @@
                 </node>
                 <node concept="liA8E" id="3qokpdXQMvJ" role="2OqNvi">
                   <ref role="37wK5l" to="pgte:1T8cMxCROxk" resolve="showReferenceConceptDocumentation" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbH" id="6SZYYyyj1UO" role="3cqZAp" />
+            <node concept="3SKdUt" id="6SZYYyyj5hH" role="3cqZAp">
+              <node concept="1PaTwC" id="6SZYYyyj5Eg" role="1aUNEU">
+                <node concept="3oM_SD" id="6SZYYyyj5Eh" role="1PaTwD">
+                  <property role="3oM_SC" value="follow" />
+                </node>
+                <node concept="3oM_SD" id="6SZYYyyj60d" role="1PaTwD">
+                  <property role="3oM_SC" value="the" />
+                </node>
+                <node concept="3oM_SD" id="6SZYYyyj60o" role="1PaTwD">
+                  <property role="3oM_SC" value="reference" />
+                </node>
+                <node concept="3oM_SD" id="6SZYYyyj60s" role="1PaTwD">
+                  <property role="3oM_SC" value="and" />
+                </node>
+                <node concept="3oM_SD" id="6SZYYyyj60D" role="1PaTwD">
+                  <property role="3oM_SC" value="show" />
+                </node>
+                <node concept="3oM_SD" id="6SZYYyyj60J" role="1PaTwD">
+                  <property role="3oM_SC" value="the" />
+                </node>
+                <node concept="3oM_SD" id="6SZYYyyj60Y" role="1PaTwD">
+                  <property role="3oM_SC" value="documentation" />
+                </node>
+                <node concept="3oM_SD" id="6SZYYyyj61v" role="1PaTwD">
+                  <property role="3oM_SC" value="of" />
+                </node>
+                <node concept="3oM_SD" id="6SZYYyyj61L" role="1PaTwD">
+                  <property role="3oM_SC" value="the" />
+                </node>
+                <node concept="3oM_SD" id="6SZYYyyj624" role="1PaTwD">
+                  <property role="3oM_SC" value="target" />
+                </node>
+                <node concept="3oM_SD" id="6SZYYyyj61e" role="1PaTwD">
+                  <property role="3oM_SC" value="node" />
                 </node>
               </node>
             </node>

--- a/code/languages/com.mbeddr.doc.aspect/solutions/com.mbeddr.doc.aspect.runtime/models/com/mbeddr/doc/aspect/runtime.mps
+++ b/code/languages/com.mbeddr.doc.aspect/solutions/com.mbeddr.doc.aspect.runtime/models/com/mbeddr/doc/aspect/runtime.mps
@@ -67,6 +67,9 @@
       <concept id="1188208481402" name="jetbrains.mps.baseLanguage.structure.HasAnnotation" flags="ng" index="2AJDlI">
         <child id="1188208488637" name="annotation" index="2AJF6D" />
       </concept>
+      <concept id="2820489544401957797" name="jetbrains.mps.baseLanguage.structure.DefaultClassCreator" flags="nn" index="HV5vD">
+        <reference id="2820489544401957798" name="classifier" index="HV5vE" />
+      </concept>
       <concept id="1154032098014" name="jetbrains.mps.baseLanguage.structure.AbstractLoopStatement" flags="nn" index="2LF5Ji">
         <child id="1154032183016" name="body" index="2LFqv$" />
       </concept>
@@ -97,6 +100,9 @@
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <property id="1176718929932" name="isFinal" index="3TUv4t" />
         <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ng" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
       </concept>
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
@@ -349,6 +355,7 @@
       <concept id="1165525191778" name="jetbrains.mps.baseLanguage.collections.structure.GetFirstOperation" flags="nn" index="1uHKPH" />
       <concept id="1202128969694" name="jetbrains.mps.baseLanguage.collections.structure.SelectOperation" flags="nn" index="3$u5V9" />
       <concept id="1176501494711" name="jetbrains.mps.baseLanguage.collections.structure.IsNotEmptyOperation" flags="nn" index="3GX2aA" />
+      <concept id="31378964227347002" name="jetbrains.mps.baseLanguage.collections.structure.SelectNotNullOperation" flags="ng" index="1KnU$U" />
       <concept id="1180964022718" name="jetbrains.mps.baseLanguage.collections.structure.ConcatOperation" flags="nn" index="3QWeyG" />
     </language>
   </registry>
@@ -426,220 +433,408 @@
           </node>
         </node>
         <node concept="3clFbH" id="1XKxHZsUpiK" role="3cqZAp" />
-        <node concept="3cpWs8" id="1XKxHZsSGQz" role="3cqZAp">
-          <node concept="3cpWsn" id="1XKxHZsSGQA" role="3cpWs9">
-            <property role="TrG5h" value="n" />
-            <node concept="3Tqbb2" id="1XKxHZsSGQx" role="1tU5fm" />
-            <node concept="2OqwBi" id="1XKxHZsUs$K" role="33vP2m">
-              <node concept="37vLTw" id="1XKxHZsSHqA" role="2Oq$k0">
-                <ref role="3cqZAo" node="1XKxHZsSvB2" resolve="selectedNode" />
-              </node>
-              <node concept="1mfA1w" id="1XKxHZsUt1a" role="2OqNvi" />
-            </node>
-          </node>
-        </node>
-        <node concept="2$JKZl" id="1XKxHZsUn9_" role="3cqZAp">
-          <node concept="3clFbS" id="1XKxHZsUn9B" role="2LFqv$">
-            <node concept="3cpWs8" id="1GfgNpVITr1" role="3cqZAp">
-              <node concept="3cpWsn" id="1GfgNpVITr2" role="3cpWs9">
-                <property role="TrG5h" value="ancestorDocNode" />
-                <node concept="3Tqbb2" id="1GfgNpVQVTr" role="1tU5fm" />
-                <node concept="1rXfSq" id="1GfgNpVITr3" role="33vP2m">
-                  <ref role="37wK5l" node="2DFA9RLm5bh" resolve="getDocumentationForConcept" />
-                  <node concept="37vLTw" id="1GfgNpVITr4" role="37wK5m">
-                    <ref role="3cqZAo" node="1XKxHZsSvB0" resolve="repository" />
-                  </node>
-                  <node concept="2OqwBi" id="1GfgNpVITr5" role="37wK5m">
-                    <node concept="37vLTw" id="1GfgNpVITr6" role="2Oq$k0">
-                      <ref role="3cqZAo" node="1XKxHZsSGQA" resolve="n" />
-                    </node>
-                    <node concept="2yIwOk" id="1GfgNpVITr7" role="2OqNvi" />
-                  </node>
-                  <node concept="10Nm6u" id="1GfgNpVITr8" role="37wK5m" />
+        <node concept="3clFbJ" id="5ut4bh9pIaA" role="3cqZAp">
+          <node concept="3clFbS" id="5ut4bh9pIaC" role="3clFbx">
+            <node concept="3SKdUt" id="5ut4bh9pKgg" role="3cqZAp">
+              <node concept="1PaTwC" id="5ut4bh9pKgh" role="1aUNEU">
+                <node concept="3oM_SD" id="5ut4bh9pKzB" role="1PaTwD">
+                  <property role="3oM_SC" value="check" />
+                </node>
+                <node concept="3oM_SD" id="5ut4bh9pKzD" role="1PaTwD">
+                  <property role="3oM_SC" value="the" />
+                </node>
+                <node concept="3oM_SD" id="5ut4bh9pKzG" role="1PaTwD">
+                  <property role="3oM_SC" value="chain" />
+                </node>
+                <node concept="3oM_SD" id="5ut4bh9pKzK" role="1PaTwD">
+                  <property role="3oM_SC" value="of" />
+                </node>
+                <node concept="3oM_SD" id="5ut4bh9pKzP" role="1PaTwD">
+                  <property role="3oM_SC" value="ancestors" />
+                </node>
+                <node concept="3oM_SD" id="5ut4bh9pKzV" role="1PaTwD">
+                  <property role="3oM_SC" value="of" />
+                </node>
+                <node concept="3oM_SD" id="5ut4bh9pK$2" role="1PaTwD">
+                  <property role="3oM_SC" value="the" />
+                </node>
+                <node concept="3oM_SD" id="5ut4bh9pK$K" role="1PaTwD">
+                  <property role="3oM_SC" value="selected" />
+                </node>
+                <node concept="3oM_SD" id="5ut4bh9pK$T" role="1PaTwD">
+                  <property role="3oM_SC" value="node" />
+                </node>
+                <node concept="3oM_SD" id="5ut4bh9pK_3" role="1PaTwD">
+                  <property role="3oM_SC" value="if" />
+                </node>
+                <node concept="3oM_SD" id="5ut4bh9pK_e" role="1PaTwD">
+                  <property role="3oM_SC" value="there" />
+                </node>
+                <node concept="3oM_SD" id="5ut4bh9pK_q" role="1PaTwD">
+                  <property role="3oM_SC" value="is" />
+                </node>
+                <node concept="3oM_SD" id="5ut4bh9pK_B" role="1PaTwD">
+                  <property role="3oM_SC" value="one" />
+                </node>
+                <node concept="3oM_SD" id="5ut4bh9pK_P" role="1PaTwD">
+                  <property role="3oM_SC" value="with" />
+                </node>
+                <node concept="3oM_SD" id="5ut4bh9pKA4" role="1PaTwD">
+                  <property role="3oM_SC" value="" />
                 </node>
               </node>
             </node>
-            <node concept="3clFbJ" id="1GfgNpVISWi" role="3cqZAp">
-              <node concept="3clFbS" id="1GfgNpVISWk" role="3clFbx">
-                <node concept="3SKdUt" id="1XKxHZt0C8q" role="3cqZAp">
-                  <node concept="1PaTwC" id="1XKxHZt0C8r" role="1aUNEU">
-                    <node concept="3oM_SD" id="1XKxHZt0CxD" role="1PaTwD">
-                      <property role="3oM_SC" value="the" />
-                    </node>
-                    <node concept="3oM_SD" id="1XKxHZt0CxF" role="1PaTwD">
-                      <property role="3oM_SC" value="ancestor's" />
-                    </node>
-                    <node concept="3oM_SD" id="1XKxHZt0CUz" role="1PaTwD">
-                      <property role="3oM_SC" value="documentation" />
-                    </node>
-                    <node concept="3oM_SD" id="1XKxHZt0CUJ" role="1PaTwD">
-                      <property role="3oM_SC" value="node" />
-                    </node>
-                    <node concept="3oM_SD" id="1XKxHZt0CUO" role="1PaTwD">
-                      <property role="3oM_SC" value="should" />
-                    </node>
-                    <node concept="3oM_SD" id="1XKxHZt0CVa" role="1PaTwD">
-                      <property role="3oM_SC" value="have" />
-                    </node>
-                    <node concept="3oM_SD" id="1XKxHZt0CVh" role="1PaTwD">
-                      <property role="3oM_SC" value="an" />
-                    </node>
-                    <node concept="3oM_SD" id="1XKxHZt0CVp" role="1PaTwD">
-                      <property role="3oM_SC" value="annotation," />
-                    </node>
-                    <node concept="3oM_SD" id="1XKxHZt0CVy" role="1PaTwD">
-                      <property role="3oM_SC" value="retrieve" />
-                    </node>
-                    <node concept="3oM_SD" id="1XKxHZt0CVG" role="1PaTwD">
-                      <property role="3oM_SC" value="it" />
+            <node concept="3SKdUt" id="5ut4bh9pL43" role="3cqZAp">
+              <node concept="1PaTwC" id="5ut4bh9pL44" role="1aUNEU">
+                <node concept="3oM_SD" id="5ut4bh9pL5M" role="1PaTwD">
+                  <property role="3oM_SC" value="a" />
+                </node>
+                <node concept="3oM_SD" id="5ut4bh9pLnS" role="1PaTwD">
+                  <property role="3oM_SC" value="DocumentedConceptAnnotation" />
+                </node>
+                <node concept="3oM_SD" id="5ut4bh9pLo3" role="1PaTwD">
+                  <property role="3oM_SC" value="where" />
+                </node>
+                <node concept="3oM_SD" id="5ut4bh9pLof" role="1PaTwD">
+                  <property role="3oM_SC" value="the" />
+                </node>
+                <node concept="3oM_SD" id="5ut4bh9pLos" role="1PaTwD">
+                  <property role="3oM_SC" value="overrideChildren" />
+                </node>
+                <node concept="3oM_SD" id="5ut4bh9pLoM" role="1PaTwD">
+                  <property role="3oM_SC" value="flag" />
+                </node>
+                <node concept="3oM_SD" id="5ut4bh9pLp9" role="1PaTwD">
+                  <property role="3oM_SC" value="is" />
+                </node>
+                <node concept="3oM_SD" id="5ut4bh9pLph" role="1PaTwD">
+                  <property role="3oM_SC" value="set." />
+                </node>
+              </node>
+            </node>
+            <node concept="3SKdUt" id="5ut4bh9pNrO" role="3cqZAp">
+              <node concept="1PaTwC" id="5ut4bh9pNrP" role="1aUNEU">
+                <node concept="3oM_SD" id="5ut4bh9pNJF" role="1PaTwD">
+                  <property role="3oM_SC" value="this" />
+                </node>
+                <node concept="3oM_SD" id="5ut4bh9pNJH" role="1PaTwD">
+                  <property role="3oM_SC" value="might" />
+                </node>
+                <node concept="3oM_SD" id="5ut4bh9pNJK" role="1PaTwD">
+                  <property role="3oM_SC" value="have" />
+                </node>
+                <node concept="3oM_SD" id="5ut4bh9pNJO" role="1PaTwD">
+                  <property role="3oM_SC" value="an" />
+                </node>
+                <node concept="3oM_SD" id="5ut4bh9pNJT" role="1PaTwD">
+                  <property role="3oM_SC" value="impact" />
+                </node>
+                <node concept="3oM_SD" id="5ut4bh9pNKe" role="1PaTwD">
+                  <property role="3oM_SC" value="on" />
+                </node>
+                <node concept="3oM_SD" id="5ut4bh9pNKl" role="1PaTwD">
+                  <property role="3oM_SC" value="IDE" />
+                </node>
+                <node concept="3oM_SD" id="5ut4bh9pNKt" role="1PaTwD">
+                  <property role="3oM_SC" value="performance" />
+                </node>
+                <node concept="3oM_SD" id="5ut4bh9pNKA" role="1PaTwD">
+                  <property role="3oM_SC" value="when" />
+                </node>
+                <node concept="3oM_SD" id="5ut4bh9pNKK" role="1PaTwD">
+                  <property role="3oM_SC" value="the" />
+                </node>
+                <node concept="3oM_SD" id="5ut4bh9pNLk" role="1PaTwD">
+                  <property role="3oM_SC" value="documentation" />
+                </node>
+                <node concept="3oM_SD" id="5ut4bh9pNLw" role="1PaTwD">
+                  <property role="3oM_SC" value="view" />
+                </node>
+                <node concept="3oM_SD" id="5ut4bh9pNLH" role="1PaTwD">
+                  <property role="3oM_SC" value="is" />
+                </node>
+                <node concept="3oM_SD" id="5ut4bh9pNLV" role="1PaTwD">
+                  <property role="3oM_SC" value="opened" />
+                </node>
+              </node>
+            </node>
+            <node concept="3SKdUt" id="5ut4bh9pOgo" role="3cqZAp">
+              <node concept="1PaTwC" id="5ut4bh9pOgp" role="1aUNEU">
+                <node concept="3oM_SD" id="5ut4bh9pOiA" role="1PaTwD">
+                  <property role="3oM_SC" value="and" />
+                </node>
+                <node concept="3oM_SD" id="5ut4bh9pOAR" role="1PaTwD">
+                  <property role="3oM_SC" value="cache" />
+                </node>
+                <node concept="3oM_SD" id="5ut4bh9pOB2" role="1PaTwD">
+                  <property role="3oM_SC" value="misses" />
+                </node>
+                <node concept="3oM_SD" id="5ut4bh9pOBe" role="1PaTwD">
+                  <property role="3oM_SC" value="occur" />
+                </node>
+                <node concept="3oM_SD" id="5ut4bh9pOBr" role="1PaTwD">
+                  <property role="3oM_SC" value="(i.e.," />
+                </node>
+                <node concept="3oM_SD" id="5ut4bh9pOCY" role="1PaTwD">
+                  <property role="3oM_SC" value="the" />
+                </node>
+                <node concept="3oM_SD" id="5ut4bh9pODi" role="1PaTwD">
+                  <property role="3oM_SC" value="user" />
+                </node>
+                <node concept="3oM_SD" id="5ut4bh9pOBD" role="1PaTwD">
+                  <property role="3oM_SC" value="never" />
+                </node>
+                <node concept="3oM_SD" id="5ut4bh9pOBS" role="1PaTwD">
+                  <property role="3oM_SC" value="selected" />
+                </node>
+                <node concept="3oM_SD" id="5ut4bh9pOC8" role="1PaTwD">
+                  <property role="3oM_SC" value="the" />
+                </node>
+                <node concept="3oM_SD" id="5ut4bh9pOCp" role="1PaTwD">
+                  <property role="3oM_SC" value="node" />
+                </node>
+                <node concept="3oM_SD" id="5ut4bh9pOCz" role="1PaTwD">
+                  <property role="3oM_SC" value="before)." />
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs8" id="1XKxHZsSGQz" role="3cqZAp">
+              <node concept="3cpWsn" id="1XKxHZsSGQA" role="3cpWs9">
+                <property role="TrG5h" value="n" />
+                <node concept="3Tqbb2" id="1XKxHZsSGQx" role="1tU5fm" />
+                <node concept="2OqwBi" id="1XKxHZsUs$K" role="33vP2m">
+                  <node concept="37vLTw" id="1XKxHZsSHqA" role="2Oq$k0">
+                    <ref role="3cqZAo" node="1XKxHZsSvB2" resolve="selectedNode" />
+                  </node>
+                  <node concept="1mfA1w" id="1XKxHZsUt1a" role="2OqNvi" />
+                </node>
+              </node>
+            </node>
+            <node concept="2$JKZl" id="1XKxHZsUn9_" role="3cqZAp">
+              <node concept="3clFbS" id="1XKxHZsUn9B" role="2LFqv$">
+                <node concept="3cpWs8" id="1GfgNpVITr1" role="3cqZAp">
+                  <node concept="3cpWsn" id="1GfgNpVITr2" role="3cpWs9">
+                    <property role="TrG5h" value="ancestorDocNode" />
+                    <node concept="3Tqbb2" id="1GfgNpVQVTr" role="1tU5fm" />
+                    <node concept="1rXfSq" id="1GfgNpVITr3" role="33vP2m">
+                      <ref role="37wK5l" node="2DFA9RLm5bh" resolve="getDocForConceptCached" />
+                      <node concept="37vLTw" id="1GfgNpVITr4" role="37wK5m">
+                        <ref role="3cqZAo" node="1XKxHZsSvB0" resolve="repository" />
+                      </node>
+                      <node concept="2OqwBi" id="1GfgNpVITr5" role="37wK5m">
+                        <node concept="37vLTw" id="1GfgNpVITr6" role="2Oq$k0">
+                          <ref role="3cqZAo" node="1XKxHZsSGQA" resolve="n" />
+                        </node>
+                        <node concept="2yIwOk" id="1GfgNpVITr7" role="2OqNvi" />
+                      </node>
+                      <node concept="10Nm6u" id="1GfgNpVITr8" role="37wK5m" />
                     </node>
                   </node>
                 </node>
-                <node concept="3cpWs8" id="1GfgNpVMyDG" role="3cqZAp">
-                  <node concept="3cpWsn" id="1GfgNpVMyDH" role="3cpWs9">
-                    <property role="TrG5h" value="dca" />
-                    <node concept="3Tqbb2" id="1GfgNpVMx6B" role="1tU5fm">
-                      <ref role="ehGHo" to="748g:UK_oBp_UIu" resolve="DocumentedConceptAnnotation" />
-                    </node>
-                    <node concept="1rXfSq" id="1GfgNpVMyDI" role="33vP2m">
-                      <ref role="37wK5l" node="1GfgNpVL_IS" resolve="getAnnotation" />
-                      <node concept="37vLTw" id="1GfgNpVMyDJ" role="37wK5m">
-                        <ref role="3cqZAo" node="1GfgNpVITr2" resolve="ancestorDocNode" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="3clFbJ" id="1XKxHZsWmWJ" role="3cqZAp">
-                  <node concept="3clFbS" id="1XKxHZsWmWL" role="3clFbx">
-                    <node concept="3cpWs8" id="1XKxHZsWrqC" role="3cqZAp">
-                      <node concept="3cpWsn" id="1XKxHZsWrqD" role="3cpWs9">
-                        <property role="TrG5h" value="override" />
-                        <node concept="10P_77" id="1XKxHZsWr5Z" role="1tU5fm" />
-                        <node concept="2OqwBi" id="1XKxHZsWrqE" role="33vP2m">
-                          <node concept="37vLTw" id="1XKxHZsWrqG" role="2Oq$k0">
-                            <ref role="3cqZAo" node="1GfgNpVMyDH" resolve="dca" />
-                          </node>
-                          <node concept="3TrcHB" id="1XKxHZsWrqI" role="2OqNvi">
-                            <ref role="3TsBF5" to="748g:1XKxHZsTPvQ" resolve="overrideChildren" />
-                          </node>
+                <node concept="3clFbJ" id="1GfgNpVISWi" role="3cqZAp">
+                  <node concept="3clFbS" id="1GfgNpVISWk" role="3clFbx">
+                    <node concept="3SKdUt" id="1XKxHZt0C8q" role="3cqZAp">
+                      <node concept="1PaTwC" id="1XKxHZt0C8r" role="1aUNEU">
+                        <node concept="3oM_SD" id="1XKxHZt0CxD" role="1PaTwD">
+                          <property role="3oM_SC" value="the" />
+                        </node>
+                        <node concept="3oM_SD" id="1XKxHZt0CxF" role="1PaTwD">
+                          <property role="3oM_SC" value="ancestor's" />
+                        </node>
+                        <node concept="3oM_SD" id="1XKxHZt0CUz" role="1PaTwD">
+                          <property role="3oM_SC" value="documentation" />
+                        </node>
+                        <node concept="3oM_SD" id="1XKxHZt0CUJ" role="1PaTwD">
+                          <property role="3oM_SC" value="node" />
+                        </node>
+                        <node concept="3oM_SD" id="1XKxHZt0CUO" role="1PaTwD">
+                          <property role="3oM_SC" value="should" />
+                        </node>
+                        <node concept="3oM_SD" id="1XKxHZt0CVa" role="1PaTwD">
+                          <property role="3oM_SC" value="have" />
+                        </node>
+                        <node concept="3oM_SD" id="1XKxHZt0CVh" role="1PaTwD">
+                          <property role="3oM_SC" value="an" />
+                        </node>
+                        <node concept="3oM_SD" id="1XKxHZt0CVp" role="1PaTwD">
+                          <property role="3oM_SC" value="annotation," />
+                        </node>
+                        <node concept="3oM_SD" id="1XKxHZt0CVy" role="1PaTwD">
+                          <property role="3oM_SC" value="retrieve" />
+                        </node>
+                        <node concept="3oM_SD" id="1XKxHZt0CVG" role="1PaTwD">
+                          <property role="3oM_SC" value="it" />
                         </node>
                       </node>
                     </node>
-                    <node concept="3clFbJ" id="1XKxHZsWsph" role="3cqZAp">
-                      <node concept="3clFbS" id="1XKxHZsWspj" role="3clFbx">
-                        <node concept="3SKdUt" id="1XKxHZsWuY8" role="3cqZAp">
-                          <node concept="1PaTwC" id="1XKxHZsWuY9" role="1aUNEU">
-                            <node concept="3oM_SD" id="1XKxHZsWuYe" role="1PaTwD">
-                              <property role="3oM_SC" value="we" />
-                            </node>
-                            <node concept="3oM_SD" id="1XKxHZsWvmr" role="1PaTwD">
-                              <property role="3oM_SC" value="found" />
-                            </node>
-                            <node concept="3oM_SD" id="1XKxHZsWvmR" role="1PaTwD">
-                              <property role="3oM_SC" value="an" />
-                            </node>
-                            <node concept="3oM_SD" id="1XKxHZsWvmV" role="1PaTwD">
-                              <property role="3oM_SC" value="ancestor" />
-                            </node>
-                            <node concept="3oM_SD" id="1XKxHZsWvoR" role="1PaTwD">
-                              <property role="3oM_SC" value="whose" />
-                            </node>
-                            <node concept="3oM_SD" id="1XKxHZsWvp8" role="1PaTwD">
-                              <property role="3oM_SC" value="concept-documentation" />
-                            </node>
-                            <node concept="3oM_SD" id="1XKxHZsWvnH" role="1PaTwD">
-                              <property role="3oM_SC" value="has" />
-                            </node>
-                            <node concept="3oM_SD" id="1XKxHZsWvpU" role="1PaTwD">
-                              <property role="3oM_SC" value="its" />
-                            </node>
-                            <node concept="3oM_SD" id="1XKxHZsWvnX" role="1PaTwD">
-                              <property role="3oM_SC" value="overrideChild" />
-                            </node>
-                            <node concept="3oM_SD" id="1XKxHZsWvoe" role="1PaTwD">
-                              <property role="3oM_SC" value="flag" />
-                            </node>
-                            <node concept="3oM_SD" id="1XKxHZsWvqd" role="1PaTwD">
-                              <property role="3oM_SC" value="set" />
-                            </node>
-                          </node>
+                    <node concept="3cpWs8" id="1GfgNpVMyDG" role="3cqZAp">
+                      <node concept="3cpWsn" id="1GfgNpVMyDH" role="3cpWs9">
+                        <property role="TrG5h" value="dca" />
+                        <node concept="3Tqbb2" id="1GfgNpVMx6B" role="1tU5fm">
+                          <ref role="ehGHo" to="748g:UK_oBp_UIu" resolve="DocumentedConceptAnnotation" />
                         </node>
-                        <node concept="3SKdUt" id="1XKxHZsWvPw" role="3cqZAp">
-                          <node concept="1PaTwC" id="1XKxHZsWvPx" role="1aUNEU">
-                            <node concept="3oM_SD" id="1XKxHZsWwdY" role="1PaTwD">
-                              <property role="3oM_SC" value="show" />
-                            </node>
-                            <node concept="3oM_SD" id="1XKxHZsWwe0" role="1PaTwD">
-                              <property role="3oM_SC" value="the" />
-                            </node>
-                            <node concept="3oM_SD" id="1XKxHZsWwe3" role="1PaTwD">
-                              <property role="3oM_SC" value="ancestors" />
-                            </node>
-                            <node concept="3oM_SD" id="1XKxHZsWwei" role="1PaTwD">
-                              <property role="3oM_SC" value="concept-documentation" />
-                            </node>
-                            <node concept="3oM_SD" id="1XKxHZsWwen" role="1PaTwD">
-                              <property role="3oM_SC" value="instead" />
-                            </node>
-                            <node concept="3oM_SD" id="1XKxHZsWwet" role="1PaTwD">
-                              <property role="3oM_SC" value="of" />
-                            </node>
-                            <node concept="3oM_SD" id="1XKxHZsWwe$" role="1PaTwD">
-                              <property role="3oM_SC" value="the" />
-                            </node>
-                            <node concept="3oM_SD" id="1XKxHZsWweG" role="1PaTwD">
-                              <property role="3oM_SC" value="selectedNode's" />
-                            </node>
-                            <node concept="3oM_SD" id="1XKxHZsWweP" role="1PaTwD">
-                              <property role="3oM_SC" value="documentation" />
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="3cpWs6" id="1XKxHZsWwIx" role="3cqZAp">
-                          <node concept="37vLTw" id="1XKxHZsWxsY" role="3cqZAk">
+                        <node concept="1rXfSq" id="1GfgNpVMyDI" role="33vP2m">
+                          <ref role="37wK5l" node="1GfgNpVL_IS" resolve="getAnnotation" />
+                          <node concept="37vLTw" id="1GfgNpVMyDJ" role="37wK5m">
                             <ref role="3cqZAo" node="1GfgNpVITr2" resolve="ancestorDocNode" />
                           </node>
                         </node>
                       </node>
-                      <node concept="37vLTw" id="1XKxHZsWsUY" role="3clFbw">
-                        <ref role="3cqZAo" node="1XKxHZsWrqD" resolve="override" />
+                    </node>
+                    <node concept="3clFbJ" id="1XKxHZsWmWJ" role="3cqZAp">
+                      <node concept="3clFbS" id="1XKxHZsWmWL" role="3clFbx">
+                        <node concept="3SKdUt" id="5ut4bh9pLPA" role="3cqZAp">
+                          <node concept="1PaTwC" id="5ut4bh9pLPB" role="1aUNEU">
+                            <node concept="3oM_SD" id="5ut4bh9pMeQ" role="1PaTwD">
+                              <property role="3oM_SC" value="check" />
+                            </node>
+                            <node concept="3oM_SD" id="5ut4bh9pMeS" role="1PaTwD">
+                              <property role="3oM_SC" value="override" />
+                            </node>
+                            <node concept="3oM_SD" id="5ut4bh9pMeV" role="1PaTwD">
+                              <property role="3oM_SC" value="flag" />
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3cpWs8" id="1XKxHZsWrqC" role="3cqZAp">
+                          <node concept="3cpWsn" id="1XKxHZsWrqD" role="3cpWs9">
+                            <property role="TrG5h" value="override" />
+                            <node concept="10P_77" id="1XKxHZsWr5Z" role="1tU5fm" />
+                            <node concept="2OqwBi" id="1XKxHZsWrqE" role="33vP2m">
+                              <node concept="37vLTw" id="1XKxHZsWrqG" role="2Oq$k0">
+                                <ref role="3cqZAo" node="1GfgNpVMyDH" resolve="dca" />
+                              </node>
+                              <node concept="3TrcHB" id="1XKxHZsWrqI" role="2OqNvi">
+                                <ref role="3TsBF5" to="748g:1XKxHZsTPvQ" resolve="overrideChildren" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3clFbJ" id="1XKxHZsWsph" role="3cqZAp">
+                          <node concept="3clFbS" id="1XKxHZsWspj" role="3clFbx">
+                            <node concept="3SKdUt" id="1XKxHZsWuY8" role="3cqZAp">
+                              <node concept="1PaTwC" id="1XKxHZsWuY9" role="1aUNEU">
+                                <node concept="3oM_SD" id="1XKxHZsWuYe" role="1PaTwD">
+                                  <property role="3oM_SC" value="we" />
+                                </node>
+                                <node concept="3oM_SD" id="1XKxHZsWvmr" role="1PaTwD">
+                                  <property role="3oM_SC" value="found" />
+                                </node>
+                                <node concept="3oM_SD" id="1XKxHZsWvmR" role="1PaTwD">
+                                  <property role="3oM_SC" value="an" />
+                                </node>
+                                <node concept="3oM_SD" id="1XKxHZsWvmV" role="1PaTwD">
+                                  <property role="3oM_SC" value="ancestor" />
+                                </node>
+                                <node concept="3oM_SD" id="1XKxHZsWvoR" role="1PaTwD">
+                                  <property role="3oM_SC" value="whose" />
+                                </node>
+                                <node concept="3oM_SD" id="1XKxHZsWvp8" role="1PaTwD">
+                                  <property role="3oM_SC" value="concept-documentation" />
+                                </node>
+                                <node concept="3oM_SD" id="1XKxHZsWvnH" role="1PaTwD">
+                                  <property role="3oM_SC" value="has" />
+                                </node>
+                                <node concept="3oM_SD" id="1XKxHZsWvpU" role="1PaTwD">
+                                  <property role="3oM_SC" value="its" />
+                                </node>
+                                <node concept="3oM_SD" id="1XKxHZsWvnX" role="1PaTwD">
+                                  <property role="3oM_SC" value="overrideChild" />
+                                </node>
+                                <node concept="3oM_SD" id="1XKxHZsWvoe" role="1PaTwD">
+                                  <property role="3oM_SC" value="flag" />
+                                </node>
+                                <node concept="3oM_SD" id="1XKxHZsWvqd" role="1PaTwD">
+                                  <property role="3oM_SC" value="set" />
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="3SKdUt" id="1XKxHZsWvPw" role="3cqZAp">
+                              <node concept="1PaTwC" id="1XKxHZsWvPx" role="1aUNEU">
+                                <node concept="3oM_SD" id="1XKxHZsWwdY" role="1PaTwD">
+                                  <property role="3oM_SC" value="show" />
+                                </node>
+                                <node concept="3oM_SD" id="1XKxHZsWwe0" role="1PaTwD">
+                                  <property role="3oM_SC" value="the" />
+                                </node>
+                                <node concept="3oM_SD" id="1XKxHZsWwe3" role="1PaTwD">
+                                  <property role="3oM_SC" value="ancestors" />
+                                </node>
+                                <node concept="3oM_SD" id="1XKxHZsWwei" role="1PaTwD">
+                                  <property role="3oM_SC" value="concept-documentation" />
+                                </node>
+                                <node concept="3oM_SD" id="1XKxHZsWwen" role="1PaTwD">
+                                  <property role="3oM_SC" value="instead" />
+                                </node>
+                                <node concept="3oM_SD" id="1XKxHZsWwet" role="1PaTwD">
+                                  <property role="3oM_SC" value="of" />
+                                </node>
+                                <node concept="3oM_SD" id="1XKxHZsWwe$" role="1PaTwD">
+                                  <property role="3oM_SC" value="the" />
+                                </node>
+                                <node concept="3oM_SD" id="1XKxHZsWweG" role="1PaTwD">
+                                  <property role="3oM_SC" value="selectedNode's" />
+                                </node>
+                                <node concept="3oM_SD" id="1XKxHZsWweP" role="1PaTwD">
+                                  <property role="3oM_SC" value="documentation" />
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="3cpWs6" id="1XKxHZsWwIx" role="3cqZAp">
+                              <node concept="37vLTw" id="1XKxHZsWxsY" role="3cqZAk">
+                                <ref role="3cqZAo" node="1GfgNpVITr2" resolve="ancestorDocNode" />
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="37vLTw" id="1XKxHZsWsUY" role="3clFbw">
+                            <ref role="3cqZAo" node="1XKxHZsWrqD" resolve="override" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="2OqwBi" id="1GfgNpVMKgN" role="3clFbw">
+                        <node concept="37vLTw" id="1GfgNpVMJdD" role="2Oq$k0">
+                          <ref role="3cqZAo" node="1GfgNpVMyDH" resolve="dca" />
+                        </node>
+                        <node concept="3x8VRR" id="1GfgNpVMMIk" role="2OqNvi" />
                       </node>
                     </node>
                   </node>
-                  <node concept="2OqwBi" id="1GfgNpVMKgN" role="3clFbw">
-                    <node concept="37vLTw" id="1GfgNpVMJdD" role="2Oq$k0">
-                      <ref role="3cqZAo" node="1GfgNpVMyDH" resolve="dca" />
+                  <node concept="2OqwBi" id="1GfgNpVR1CF" role="3clFbw">
+                    <node concept="37vLTw" id="1GfgNpVIVI5" role="2Oq$k0">
+                      <ref role="3cqZAo" node="1GfgNpVITr2" resolve="ancestorDocNode" />
                     </node>
-                    <node concept="3x8VRR" id="1GfgNpVMMIk" role="2OqNvi" />
+                    <node concept="3x8VRR" id="1GfgNpVR3Vd" role="2OqNvi" />
+                  </node>
+                </node>
+                <node concept="3clFbF" id="1XKxHZsWtCF" role="3cqZAp">
+                  <node concept="37vLTI" id="1XKxHZsWu3C" role="3clFbG">
+                    <node concept="2OqwBi" id="1XKxHZsWukA" role="37vLTx">
+                      <node concept="37vLTw" id="1XKxHZsWu8d" role="2Oq$k0">
+                        <ref role="3cqZAo" node="1XKxHZsSGQA" resolve="n" />
+                      </node>
+                      <node concept="1mfA1w" id="1XKxHZsWuzj" role="2OqNvi" />
+                    </node>
+                    <node concept="37vLTw" id="1XKxHZsWtCD" role="37vLTJ">
+                      <ref role="3cqZAo" node="1XKxHZsSGQA" resolve="n" />
+                    </node>
                   </node>
                 </node>
               </node>
-              <node concept="2OqwBi" id="1GfgNpVR1CF" role="3clFbw">
-                <node concept="37vLTw" id="1GfgNpVIVI5" role="2Oq$k0">
-                  <ref role="3cqZAo" node="1GfgNpVITr2" resolve="docNode" />
-                </node>
-                <node concept="3x8VRR" id="1GfgNpVR3Vd" role="2OqNvi" />
-              </node>
-            </node>
-            <node concept="3clFbF" id="1XKxHZsWtCF" role="3cqZAp">
-              <node concept="37vLTI" id="1XKxHZsWu3C" role="3clFbG">
-                <node concept="2OqwBi" id="1XKxHZsWukA" role="37vLTx">
-                  <node concept="37vLTw" id="1XKxHZsWu8d" role="2Oq$k0">
-                    <ref role="3cqZAo" node="1XKxHZsSGQA" resolve="n" />
-                  </node>
-                  <node concept="1mfA1w" id="1XKxHZsWuzj" role="2OqNvi" />
-                </node>
-                <node concept="37vLTw" id="1XKxHZsWtCD" role="37vLTJ">
+              <node concept="2OqwBi" id="1XKxHZsUnCm" role="2$JKZa">
+                <node concept="37vLTw" id="1XKxHZsUnv6" role="2Oq$k0">
                   <ref role="3cqZAo" node="1XKxHZsSGQA" resolve="n" />
                 </node>
+                <node concept="3x8VRR" id="1XKxHZsUo9o" role="2OqNvi" />
               </node>
             </node>
           </node>
-          <node concept="2OqwBi" id="1XKxHZsUnCm" role="2$JKZa">
-            <node concept="37vLTw" id="1XKxHZsUnv6" role="2Oq$k0">
-              <ref role="3cqZAo" node="1XKxHZsSGQA" resolve="n" />
+          <node concept="2OqwBi" id="3qokpdXQIHO" role="3clFbw">
+            <node concept="1rXfSq" id="3qokpdXQKcA" role="2Oq$k0">
+              <ref role="37wK5l" node="5ut4bh9phV1" resolve="getConfig" />
             </node>
-            <node concept="3x8VRR" id="1XKxHZsUo9o" role="2OqNvi" />
+            <node concept="liA8E" id="3qokpdXQJgL" role="2OqNvi">
+              <ref role="37wK5l" to="pgte:5ut4bh9pm1v" resolve="allowOverrideChildren" />
+            </node>
           </node>
         </node>
         <node concept="3clFbH" id="1XKxHZsWxJh" role="3cqZAp" />
@@ -2676,23 +2871,6 @@
             </node>
           </node>
         </node>
-        <node concept="3cpWs8" id="1T8cMxCS4TB" role="3cqZAp">
-          <node concept="3cpWsn" id="1T8cMxCS4TC" role="3cpWs9">
-            <property role="TrG5h" value="configuration" />
-            <node concept="3uibUv" id="1T8cMxCS52W" role="1tU5fm">
-              <ref role="3uigEE" to="pgte:1T8cMxCROto" resolve="IDocumentationAspectConfiguration" />
-            </node>
-            <node concept="2OqwBi" id="1T8cMxCS4TD" role="33vP2m">
-              <node concept="2OqwBi" id="1T8cMxCS4TE" role="2Oq$k0">
-                <node concept="2O5UvJ" id="1T8cMxCS4TF" role="2Oq$k0">
-                  <ref role="2O5UnU" to="pgte:1T8cMxCROk6" resolve="documentationAspectConfiguration" />
-                </node>
-                <node concept="SfwO_" id="1T8cMxCS4TG" role="2OqNvi" />
-              </node>
-              <node concept="1uHKPH" id="1T8cMxCS4TH" role="2OqNvi" />
-            </node>
-          </node>
-        </node>
         <node concept="3clFbJ" id="qmep2m2liy" role="3cqZAp">
           <node concept="3clFbS" id="qmep2m2liz" role="3clFbx">
             <node concept="3cpWs8" id="68WEpgCynYz" role="3cqZAp">
@@ -2701,29 +2879,6 @@
                 <node concept="3Tqbb2" id="68WEpgCynYx" role="1tU5fm" />
                 <node concept="37vLTw" id="68WEpgCyoDE" role="33vP2m">
                   <ref role="3cqZAo" node="qmep2m2lin" resolve="cellNode" />
-                </node>
-              </node>
-            </node>
-            <node concept="3cpWs8" id="1T8cMxCSdU9" role="3cqZAp">
-              <node concept="3cpWsn" id="1T8cMxCSdUc" role="3cpWs9">
-                <property role="TrG5h" value="showReferenceConceptDocumentation" />
-                <node concept="10P_77" id="1T8cMxCSdU7" role="1tU5fm" />
-                <node concept="3K4zz7" id="1T8cMxCSeJU" role="33vP2m">
-                  <node concept="2OqwBi" id="1T8cMxCSf2K" role="3K4E3e">
-                    <node concept="37vLTw" id="1T8cMxCSeTm" role="2Oq$k0">
-                      <ref role="3cqZAo" node="1T8cMxCS4TC" resolve="configuration" />
-                    </node>
-                    <node concept="liA8E" id="1T8cMxCSfiw" role="2OqNvi">
-                      <ref role="37wK5l" to="pgte:1T8cMxCROxk" resolve="showReferenceConceptDocumentation" />
-                    </node>
-                  </node>
-                  <node concept="3clFbT" id="1T8cMxCSfsf" role="3K4GZi" />
-                  <node concept="3y3z36" id="1T8cMxCSe_$" role="3K4Cdx">
-                    <node concept="10Nm6u" id="1T8cMxCSeAA" role="3uHU7w" />
-                    <node concept="37vLTw" id="1T8cMxCSeka" role="3uHU7B">
-                      <ref role="3cqZAo" node="1T8cMxCS4TC" resolve="configuration" />
-                    </node>
-                  </node>
                 </node>
               </node>
             </node>
@@ -2785,8 +2940,13 @@
                   </node>
                 </node>
               </node>
-              <node concept="37vLTw" id="68WEpgCyWaa" role="3clFbw">
-                <ref role="3cqZAo" node="1T8cMxCSdUc" resolve="showReferenceConceptDocumentation" />
+              <node concept="2OqwBi" id="3qokpdXQLXn" role="3clFbw">
+                <node concept="1rXfSq" id="3qokpdXQLiQ" role="2Oq$k0">
+                  <ref role="37wK5l" node="5ut4bh9phV1" resolve="getConfig" />
+                </node>
+                <node concept="liA8E" id="3qokpdXQMvJ" role="2OqNvi">
+                  <ref role="37wK5l" to="pgte:1T8cMxCROxk" resolve="showReferenceConceptDocumentation" />
+                </node>
               </node>
             </node>
             <node concept="3cpWs8" id="qmep2m2li$" role="3cqZAp">
@@ -2862,6 +3022,117 @@
         </node>
       </node>
       <node concept="3Tm1VV" id="qmep2m2lii" role="1B3o_S" />
+    </node>
+    <node concept="2tJIrI" id="5ut4bh9p4ZU" role="jymVt" />
+    <node concept="2YIFZL" id="5ut4bh9phV1" role="jymVt">
+      <property role="TrG5h" value="config" />
+      <node concept="3clFbS" id="5ut4bh9pe2T" role="3clF47">
+        <node concept="3SKdUt" id="5ut4bh9qaqX" role="3cqZAp">
+          <node concept="1PaTwC" id="5ut4bh9qaqY" role="1aUNEU">
+            <node concept="3oM_SD" id="5ut4bh9qaMx" role="1PaTwD">
+              <property role="3oM_SC" value="one" />
+            </node>
+            <node concept="3oM_SD" id="5ut4bh9qaMz" role="1PaTwD">
+              <property role="3oM_SC" value="day," />
+            </node>
+            <node concept="3oM_SD" id="5ut4bh9qaMA" role="1PaTwD">
+              <property role="3oM_SC" value="we" />
+            </node>
+            <node concept="3oM_SD" id="5ut4bh9qaME" role="1PaTwD">
+              <property role="3oM_SC" value="might" />
+            </node>
+            <node concept="3oM_SD" id="5ut4bh9qaMJ" role="1PaTwD">
+              <property role="3oM_SC" value="implement" />
+            </node>
+            <node concept="3oM_SD" id="5ut4bh9qaMP" role="1PaTwD">
+              <property role="3oM_SC" value="a" />
+            </node>
+            <node concept="3oM_SD" id="5ut4bh9qaMW" role="1PaTwD">
+              <property role="3oM_SC" value="more" />
+            </node>
+            <node concept="3oM_SD" id="5ut4bh9qaN4" role="1PaTwD">
+              <property role="3oM_SC" value="elaborated" />
+            </node>
+            <node concept="3oM_SD" id="5ut4bh9qaNd" role="1PaTwD">
+              <property role="3oM_SC" value="scheme" />
+            </node>
+            <node concept="3oM_SD" id="5ut4bh9qaNn" role="1PaTwD">
+              <property role="3oM_SC" value="of" />
+            </node>
+            <node concept="3oM_SD" id="5ut4bh9qaNy" role="1PaTwD">
+              <property role="3oM_SC" value="choosing" />
+            </node>
+            <node concept="3oM_SD" id="5ut4bh9qaNI" role="1PaTwD">
+              <property role="3oM_SC" value="the" />
+            </node>
+            <node concept="3oM_SD" id="5ut4bh9qaNV" role="1PaTwD">
+              <property role="3oM_SC" value="proper" />
+            </node>
+            <node concept="3oM_SD" id="5ut4bh9qaO9" role="1PaTwD">
+              <property role="3oM_SC" value="extension" />
+            </node>
+            <node concept="3oM_SD" id="5ut4bh9qaOo" role="1PaTwD">
+              <property role="3oM_SC" value="point" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="2JMQ0Qq3aKr" role="3cqZAp">
+          <node concept="3cpWsn" id="2JMQ0Qq3aKs" role="3cpWs9">
+            <property role="TrG5h" value="extensions" />
+            <node concept="A3Dl8" id="2JMQ0Qq3aph" role="1tU5fm">
+              <node concept="3uibUv" id="2JMQ0Qq3apk" role="A3Ik2">
+                <ref role="3uigEE" to="pgte:1T8cMxCROto" resolve="IDocumentationAspectConfiguration" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="2JMQ0Qq3aKt" role="33vP2m">
+              <node concept="2OqwBi" id="2JMQ0Qq3aKu" role="2Oq$k0">
+                <node concept="2O5UvJ" id="2JMQ0Qq3aKv" role="2Oq$k0">
+                  <ref role="2O5UnU" to="pgte:1T8cMxCROk6" resolve="documentationAspectConfiguration" />
+                </node>
+                <node concept="SfwO_" id="2JMQ0Qq3aKw" role="2OqNvi" />
+              </node>
+              <node concept="1KnU$U" id="2JMQ0Qq3aKx" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="5R9SlUlNz7o" role="3cqZAp">
+          <node concept="3cpWsn" id="5R9SlUlNz7p" role="3cpWs9">
+            <property role="TrG5h" value="config" />
+            <node concept="3uibUv" id="5R9SlUlNlA4" role="1tU5fm">
+              <ref role="3uigEE" to="pgte:1T8cMxCROto" resolve="IDocumentationAspectConfiguration" />
+            </node>
+            <node concept="2OqwBi" id="5R9SlUlNz7q" role="33vP2m">
+              <node concept="37vLTw" id="2JMQ0Qq3aKy" role="2Oq$k0">
+                <ref role="3cqZAo" node="2JMQ0Qq3aKs" resolve="seq" />
+              </node>
+              <node concept="1uHKPH" id="5R9SlUlNz7u" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="66zcVGDcgKP" role="3cqZAp">
+          <node concept="3K4zz7" id="66zcVGDchB3" role="3clFbG">
+            <node concept="37vLTw" id="66zcVGDcjNK" role="3K4E3e">
+              <ref role="3cqZAo" node="5R9SlUlNz7p" resolve="config" />
+            </node>
+            <node concept="3y3z36" id="66zcVGDcjbX" role="3K4Cdx">
+              <node concept="37vLTw" id="66zcVGDcgKN" role="3uHU7B">
+                <ref role="3cqZAo" node="5R9SlUlNz7p" resolve="config" />
+              </node>
+              <node concept="10Nm6u" id="66zcVGDciub" role="3uHU7w" />
+            </node>
+            <node concept="2ShNRf" id="3qokpdXQprP" role="3K4GZi">
+              <node concept="HV5vD" id="3qokpdXQE31" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="HV5vE" to="pgte:3qokpdXQc0N" resolve="DefaultDocAspectConfiguration" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3uibUv" id="5ut4bh9pdQ7" role="3clF45">
+        <ref role="3uigEE" to="pgte:1T8cMxCROto" resolve="IDocumentationAspectConfiguration" />
+      </node>
+      <node concept="3Tm6S6" id="5ut4bh9pbJi" role="1B3o_S" />
     </node>
     <node concept="2tJIrI" id="qmep2m2kBx" role="jymVt" />
     <node concept="2YIFZL" id="qmep2m2vvj" role="jymVt">

--- a/code/languages/com.mbeddr.doc.aspect/solutions/com.mbeddr.doc.aspect.runtime/models/com/mbeddr/doc/aspect/runtime.mps
+++ b/code/languages/com.mbeddr.doc.aspect/solutions/com.mbeddr.doc.aspect.runtime/models/com/mbeddr/doc/aspect/runtime.mps
@@ -20,10 +20,13 @@
     <import index="f4zo" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.cells(MPS.Editor/)" />
     <import index="g51k" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor.cells(MPS.Editor/)" />
     <import index="pgte" ref="r:e361f9f2-2afa-4fbe-b895-bdd4fbfe44fa(com.mbeddr.doc.aspect.plugin)" />
-    <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
+    <import index="sgh3" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.google.common.cache(MPS.IDEA/)" />
+    <import index="5zyv" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util.concurrent(JDK/)" />
+    <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
     <import index="4gky" ref="r:e1dfab1d-c7a7-43e7-9f26-028afd483e82(com.mbeddr.doc.behavior)" implicit="true" />
     <import index="tpcn" ref="r:00000000-0000-4000-0000-011c8959028b(jetbrains.mps.lang.structure.behavior)" implicit="true" />
+    <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
   </imports>
   <registry>
     <language id="a247e09e-2435-45ba-b8d2-07e93feba96a" name="jetbrains.mps.baseLanguage.tuples">
@@ -44,6 +47,10 @@
       </concept>
     </language>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1080223426719" name="jetbrains.mps.baseLanguage.structure.OrExpression" flags="nn" index="22lmx$" />
+      <concept id="1082485599095" name="jetbrains.mps.baseLanguage.structure.BlockStatement" flags="nn" index="9aQIb">
+        <child id="1082485599096" name="statements" index="9aQI4" />
+      </concept>
       <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
         <child id="1068498886297" name="rValue" index="37vLTx" />
         <child id="1068498886295" name="lValue" index="37vLTJ" />
@@ -70,6 +77,7 @@
       <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
         <child id="1145553007750" name="creator" index="2ShVmc" />
       </concept>
+      <concept id="1070462154015" name="jetbrains.mps.baseLanguage.structure.StaticFieldDeclaration" flags="ig" index="Wx3nA" />
       <concept id="1081236700938" name="jetbrains.mps.baseLanguage.structure.StaticMethodDeclaration" flags="ig" index="2YIFZL" />
       <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
         <reference id="1144433194310" name="classConcept" index="1Pybhc" />
@@ -113,6 +121,7 @@
       </concept>
       <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
       <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
+        <child id="1082485599094" name="ifFalseStatement" index="9aQIa" />
         <child id="1068580123160" name="condition" index="3clFbw" />
         <child id="1068580123161" name="ifTrue" index="3clFbx" />
         <child id="1206060520071" name="elsifClauses" index="3eNLev" />
@@ -120,7 +129,9 @@
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
       </concept>
-      <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT" />
+      <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT">
+        <property id="1068580123138" name="value" index="3clFbU" />
+      </concept>
       <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
         <property id="1068580320021" name="value" index="3cmrfH" />
       </concept>
@@ -139,9 +150,13 @@
       <concept id="1079359253375" name="jetbrains.mps.baseLanguage.structure.ParenthesizedExpression" flags="nn" index="1eOMI4">
         <child id="1079359253376" name="expression" index="1eOMHV" />
       </concept>
+      <concept id="1081516740877" name="jetbrains.mps.baseLanguage.structure.NotExpression" flags="nn" index="3fqX7Q">
+        <child id="1081516765348" name="expression" index="3fr31v" />
+      </concept>
       <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
+        <child id="4972241301747169160" name="typeArgument" index="3PaCim" />
       </concept>
       <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
         <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
@@ -152,6 +167,7 @@
       <concept id="7812454656619025412" name="jetbrains.mps.baseLanguage.structure.LocalMethodCall" flags="nn" index="1rXfSq" />
       <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
         <reference id="1107535924139" name="classifier" index="3uigEE" />
+        <child id="1109201940907" name="parameter" index="11_B2D" />
       </concept>
       <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
         <child id="1081773367579" name="rightExpression" index="3uHU7w" />
@@ -192,11 +208,23 @@
       </concept>
     </language>
     <language id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc">
+      <concept id="5858074156537516430" name="jetbrains.mps.baseLanguage.javadoc.structure.ReturnBlockDocTag" flags="ng" index="x79VA">
+        <property id="5858074156537516431" name="text" index="x79VB" />
+      </concept>
+      <concept id="6832197706140896242" name="jetbrains.mps.baseLanguage.javadoc.structure.FieldDocComment" flags="ng" index="z59LJ" />
+      <concept id="6832197706140518104" name="jetbrains.mps.baseLanguage.javadoc.structure.DocMethodParameterReference" flags="ng" index="zr_55" />
+      <concept id="6832197706140518103" name="jetbrains.mps.baseLanguage.javadoc.structure.BaseParameterReference" flags="ng" index="zr_5a">
+        <reference id="6832197706140518108" name="param" index="zr_51" />
+      </concept>
       <concept id="5349172909345501395" name="jetbrains.mps.baseLanguage.javadoc.structure.BaseDocComment" flags="ng" index="P$AiS">
         <child id="8465538089690331502" name="body" index="TZ5H$" />
         <child id="5383422241790532083" name="tags" index="3nqlJM" />
       </concept>
       <concept id="5349172909345532724" name="jetbrains.mps.baseLanguage.javadoc.structure.MethodDocComment" flags="ng" index="P$JXv" />
+      <concept id="8465538089690881930" name="jetbrains.mps.baseLanguage.javadoc.structure.ParameterBlockDocTag" flags="ng" index="TUZQ0">
+        <property id="8465538089690881934" name="text" index="TUZQ4" />
+        <child id="6832197706140518123" name="parameter" index="zr_5Q" />
+      </concept>
       <concept id="8465538089690331500" name="jetbrains.mps.baseLanguage.javadoc.structure.CommentLine" flags="ng" index="TZ5HA">
         <child id="8970989240999019149" name="part" index="1dT_Ay" />
       </concept>
@@ -219,6 +247,7 @@
         <child id="4693937538533538124" name="requestedConcept" index="v3oSu" />
       </concept>
       <concept id="7453996997717780434" name="jetbrains.mps.lang.smodel.structure.Node_GetSConceptOperation" flags="nn" index="2yIwOk" />
+      <concept id="8866923313515890008" name="jetbrains.mps.lang.smodel.structure.AsNodeOperation" flags="nn" index="FGMqu" />
       <concept id="1143226024141" name="jetbrains.mps.lang.smodel.structure.SModelType" flags="in" index="H_c77" />
       <concept id="1143234257716" name="jetbrains.mps.lang.smodel.structure.Node_GetModelOperation" flags="nn" index="I4A8Y" />
       <concept id="1145404486709" name="jetbrains.mps.lang.smodel.structure.SemanticDowncastExpression" flags="nn" index="2JrnkZ">
@@ -378,9 +407,9 @@
         <node concept="3cpWs8" id="1XKxHZsUjEH" role="3cqZAp">
           <node concept="3cpWsn" id="1XKxHZsUjEI" role="3cpWs9">
             <property role="TrG5h" value="localDocNode" />
-            <node concept="3Tqbb2" id="1XKxHZsUjoY" role="1tU5fm" />
+            <node concept="3Tqbb2" id="1GfgNpVRbK$" role="1tU5fm" />
             <node concept="1rXfSq" id="1XKxHZsUjEJ" role="33vP2m">
-              <ref role="37wK5l" node="qh7UMGipbd" resolve="getDocumentationAux" />
+              <ref role="37wK5l" node="2DFA9RLm5bh" resolve="getDocumentationForConcept" />
               <node concept="37vLTw" id="1XKxHZsUjEK" role="37wK5m">
                 <ref role="3cqZAo" node="1XKxHZsSvB0" resolve="repository" />
               </node>
@@ -411,48 +440,71 @@
         </node>
         <node concept="2$JKZl" id="1XKxHZsUn9_" role="3cqZAp">
           <node concept="3clFbS" id="1XKxHZsUn9B" role="2LFqv$">
-            <node concept="3cpWs8" id="1XKxHZsUudA" role="3cqZAp">
-              <node concept="3cpWsn" id="1XKxHZsUudB" role="3cpWs9">
-                <property role="TrG5h" value="parentDocNode" />
-                <node concept="3Tqbb2" id="1XKxHZsUudC" role="1tU5fm" />
-                <node concept="1rXfSq" id="1XKxHZsUudD" role="33vP2m">
-                  <ref role="37wK5l" node="qh7UMGipbd" resolve="getDocumentationAux" />
-                  <node concept="37vLTw" id="1XKxHZsUudE" role="37wK5m">
+            <node concept="3cpWs8" id="1GfgNpVITr1" role="3cqZAp">
+              <node concept="3cpWsn" id="1GfgNpVITr2" role="3cpWs9">
+                <property role="TrG5h" value="ancestorDocNode" />
+                <node concept="3Tqbb2" id="1GfgNpVQVTr" role="1tU5fm" />
+                <node concept="1rXfSq" id="1GfgNpVITr3" role="33vP2m">
+                  <ref role="37wK5l" node="2DFA9RLm5bh" resolve="getDocumentationForConcept" />
+                  <node concept="37vLTw" id="1GfgNpVITr4" role="37wK5m">
                     <ref role="3cqZAo" node="1XKxHZsSvB0" resolve="repository" />
                   </node>
-                  <node concept="2OqwBi" id="1XKxHZsUudF" role="37wK5m">
-                    <node concept="37vLTw" id="1XKxHZsUudG" role="2Oq$k0">
+                  <node concept="2OqwBi" id="1GfgNpVITr5" role="37wK5m">
+                    <node concept="37vLTw" id="1GfgNpVITr6" role="2Oq$k0">
                       <ref role="3cqZAo" node="1XKxHZsSGQA" resolve="n" />
                     </node>
-                    <node concept="2yIwOk" id="1XKxHZsUudH" role="2OqNvi" />
+                    <node concept="2yIwOk" id="1GfgNpVITr7" role="2OqNvi" />
                   </node>
-                  <node concept="10Nm6u" id="1XKxHZsUxbz" role="37wK5m" />
+                  <node concept="10Nm6u" id="1GfgNpVITr8" role="37wK5m" />
                 </node>
               </node>
             </node>
-            <node concept="3clFbJ" id="1XKxHZsWd4O" role="3cqZAp">
-              <node concept="3clFbS" id="1XKxHZsWd4Q" role="3clFbx">
-                <node concept="3cpWs8" id="1XKxHZsWm1X" role="3cqZAp">
-                  <node concept="3cpWsn" id="1XKxHZsWm1Y" role="3cpWs9">
-                    <property role="TrG5h" value="annotations" />
-                    <node concept="A3Dl8" id="1XKxHZsWlJW" role="1tU5fm">
-                      <node concept="3Tqbb2" id="1XKxHZsWlJZ" role="A3Ik2">
-                        <ref role="ehGHo" to="748g:UK_oBp_UIu" resolve="DocumentedConceptAnnotation" />
-                      </node>
+            <node concept="3clFbJ" id="1GfgNpVISWi" role="3cqZAp">
+              <node concept="3clFbS" id="1GfgNpVISWk" role="3clFbx">
+                <node concept="3SKdUt" id="1XKxHZt0C8q" role="3cqZAp">
+                  <node concept="1PaTwC" id="1XKxHZt0C8r" role="1aUNEU">
+                    <node concept="3oM_SD" id="1XKxHZt0CxD" role="1PaTwD">
+                      <property role="3oM_SC" value="the" />
                     </node>
-                    <node concept="2OqwBi" id="1XKxHZsWm1Z" role="33vP2m">
-                      <node concept="2OqwBi" id="1XKxHZsWm20" role="2Oq$k0">
-                        <node concept="37vLTw" id="1XKxHZsWm21" role="2Oq$k0">
-                          <ref role="3cqZAo" node="1XKxHZsUudB" resolve="parentDocNode" />
-                        </node>
-                        <node concept="3Tsc0h" id="1XKxHZsWm22" role="2OqNvi">
-                          <ref role="3TtcxE" to="tpck:4uZwTti3__2" resolve="smodelAttribute" />
-                        </node>
-                      </node>
-                      <node concept="v3k3i" id="1XKxHZsWm23" role="2OqNvi">
-                        <node concept="chp4Y" id="1XKxHZsWm24" role="v3oSu">
-                          <ref role="cht4Q" to="748g:UK_oBp_UIu" resolve="DocumentedConceptAnnotation" />
-                        </node>
+                    <node concept="3oM_SD" id="1XKxHZt0CxF" role="1PaTwD">
+                      <property role="3oM_SC" value="ancestor's" />
+                    </node>
+                    <node concept="3oM_SD" id="1XKxHZt0CUz" role="1PaTwD">
+                      <property role="3oM_SC" value="documentation" />
+                    </node>
+                    <node concept="3oM_SD" id="1XKxHZt0CUJ" role="1PaTwD">
+                      <property role="3oM_SC" value="node" />
+                    </node>
+                    <node concept="3oM_SD" id="1XKxHZt0CUO" role="1PaTwD">
+                      <property role="3oM_SC" value="should" />
+                    </node>
+                    <node concept="3oM_SD" id="1XKxHZt0CVa" role="1PaTwD">
+                      <property role="3oM_SC" value="have" />
+                    </node>
+                    <node concept="3oM_SD" id="1XKxHZt0CVh" role="1PaTwD">
+                      <property role="3oM_SC" value="an" />
+                    </node>
+                    <node concept="3oM_SD" id="1XKxHZt0CVp" role="1PaTwD">
+                      <property role="3oM_SC" value="annotation," />
+                    </node>
+                    <node concept="3oM_SD" id="1XKxHZt0CVy" role="1PaTwD">
+                      <property role="3oM_SC" value="retrieve" />
+                    </node>
+                    <node concept="3oM_SD" id="1XKxHZt0CVG" role="1PaTwD">
+                      <property role="3oM_SC" value="it" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3cpWs8" id="1GfgNpVMyDG" role="3cqZAp">
+                  <node concept="3cpWsn" id="1GfgNpVMyDH" role="3cpWs9">
+                    <property role="TrG5h" value="dca" />
+                    <node concept="3Tqbb2" id="1GfgNpVMx6B" role="1tU5fm">
+                      <ref role="ehGHo" to="748g:UK_oBp_UIu" resolve="DocumentedConceptAnnotation" />
+                    </node>
+                    <node concept="1rXfSq" id="1GfgNpVMyDI" role="33vP2m">
+                      <ref role="37wK5l" node="1GfgNpVL_IS" resolve="getAnnotation" />
+                      <node concept="37vLTw" id="1GfgNpVMyDJ" role="37wK5m">
+                        <ref role="3cqZAo" node="1GfgNpVITr2" resolve="ancestorDocNode" />
                       </node>
                     </node>
                   </node>
@@ -464,11 +516,8 @@
                         <property role="TrG5h" value="override" />
                         <node concept="10P_77" id="1XKxHZsWr5Z" role="1tU5fm" />
                         <node concept="2OqwBi" id="1XKxHZsWrqE" role="33vP2m">
-                          <node concept="2OqwBi" id="1XKxHZsWrqF" role="2Oq$k0">
-                            <node concept="37vLTw" id="1XKxHZsWrqG" role="2Oq$k0">
-                              <ref role="3cqZAo" node="1XKxHZsWm1Y" resolve="annotations" />
-                            </node>
-                            <node concept="1uHKPH" id="1XKxHZsWrqH" role="2OqNvi" />
+                          <node concept="37vLTw" id="1XKxHZsWrqG" role="2Oq$k0">
+                            <ref role="3cqZAo" node="1GfgNpVMyDH" resolve="dca" />
                           </node>
                           <node concept="3TrcHB" id="1XKxHZsWrqI" role="2OqNvi">
                             <ref role="3TsBF5" to="748g:1XKxHZsTPvQ" resolve="overrideChildren" />
@@ -548,7 +597,7 @@
                         </node>
                         <node concept="3cpWs6" id="1XKxHZsWwIx" role="3cqZAp">
                           <node concept="37vLTw" id="1XKxHZsWxsY" role="3cqZAk">
-                            <ref role="3cqZAo" node="1XKxHZsUudB" resolve="parentDocNode" />
+                            <ref role="3cqZAo" node="1GfgNpVITr2" resolve="ancestorDocNode" />
                           </node>
                         </node>
                       </node>
@@ -557,19 +606,19 @@
                       </node>
                     </node>
                   </node>
-                  <node concept="2OqwBi" id="1XKxHZsWnKx" role="3clFbw">
-                    <node concept="37vLTw" id="1XKxHZsWncA" role="2Oq$k0">
-                      <ref role="3cqZAo" node="1XKxHZsWm1Y" resolve="annotations" />
+                  <node concept="2OqwBi" id="1GfgNpVMKgN" role="3clFbw">
+                    <node concept="37vLTw" id="1GfgNpVMJdD" role="2Oq$k0">
+                      <ref role="3cqZAo" node="1GfgNpVMyDH" resolve="dca" />
                     </node>
-                    <node concept="3GX2aA" id="1XKxHZsWosm" role="2OqNvi" />
+                    <node concept="3x8VRR" id="1GfgNpVMMIk" role="2OqNvi" />
                   </node>
                 </node>
               </node>
-              <node concept="2OqwBi" id="1XKxHZsWdO9" role="3clFbw">
-                <node concept="37vLTw" id="1XKxHZsWdrp" role="2Oq$k0">
-                  <ref role="3cqZAo" node="1XKxHZsUudB" resolve="parentDocNode" />
+              <node concept="2OqwBi" id="1GfgNpVR1CF" role="3clFbw">
+                <node concept="37vLTw" id="1GfgNpVIVI5" role="2Oq$k0">
+                  <ref role="3cqZAo" node="1GfgNpVITr2" resolve="docNode" />
                 </node>
-                <node concept="3x8VRR" id="1XKxHZsWedT" role="2OqNvi" />
+                <node concept="3x8VRR" id="1GfgNpVR3Vd" role="2OqNvi" />
               </node>
             </node>
             <node concept="3clFbF" id="1XKxHZsWtCF" role="3cqZAp">
@@ -631,16 +680,704 @@
             </node>
           </node>
         </node>
-        <node concept="3clFbF" id="1XKxHZsSCRO" role="3cqZAp">
-          <node concept="37vLTw" id="1XKxHZsUjEN" role="3clFbG">
-            <ref role="3cqZAo" node="1XKxHZsUjEI" resolve="documentation" />
+        <node concept="3cpWs6" id="1GfgNpVRCeH" role="3cqZAp">
+          <node concept="37vLTw" id="1GfgNpVRGdL" role="3cqZAk">
+            <ref role="3cqZAo" node="1XKxHZsUjEI" resolve="localDocNode" />
           </node>
         </node>
       </node>
       <node concept="3Tm1VV" id="1XKxHZsSqFL" role="1B3o_S" />
       <node concept="3Tqbb2" id="1XKxHZsSsoZ" role="3clF45" />
+      <node concept="P$JXv" id="1GfgNpVWOVT" role="lGtFl">
+        <node concept="TZ5HA" id="1GfgNpVWOVU" role="TZ5H$">
+          <node concept="1dT_AC" id="1GfgNpVWOVV" role="1dT_Ay">
+            <property role="1dT_AB" value="Get the documentation node for a given selected node/property." />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="1GfgNpVWPfG" role="TZ5H$">
+          <node concept="1dT_AC" id="1GfgNpVWPfH" role="1dT_Ay">
+            <property role="1dT_AB" value="" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="1GfgNpVWPAm" role="TZ5H$">
+          <node concept="1dT_AC" id="1GfgNpVWPAn" role="1dT_Ay">
+            <property role="1dT_AB" value="This will take into account the following settings of the documentation annotations:" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="1GfgNpVWPPE" role="TZ5H$">
+          <node concept="1dT_AC" id="1GfgNpVWPPF" role="1dT_Ay">
+            <property role="1dT_AB" value="- priority: if there is more than one documentation annotation for the given node," />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="1GfgNpVWQco" role="TZ5H$">
+          <node concept="1dT_AC" id="1GfgNpVWQcp" role="1dT_Ay">
+            <property role="1dT_AB" value="  the one with the higher priority will be returned" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="1GfgNpVWQz8" role="TZ5H$">
+          <node concept="1dT_AC" id="1GfgNpVWQz9" role="1dT_Ay">
+            <property role="1dT_AB" value="- overrideChildren: the documentation node for the given selected node will only be " />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="1GfgNpVWRgI" role="TZ5H$">
+          <node concept="1dT_AC" id="1GfgNpVWRgJ" role="1dT_Ay">
+            <property role="1dT_AB" value="  returned if there is no ancestor of the selected node which has a documentation node" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="1GfgNpVWRB$" role="TZ5H$">
+          <node concept="1dT_AC" id="1GfgNpVWRB_" role="1dT_Ay">
+            <property role="1dT_AB" value="  with the override-flag set. If there is such an ancestor, its documentation will be shown" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="1GfgNpVWRYs" role="TZ5H$">
+          <node concept="1dT_AC" id="1GfgNpVWRYt" role="1dT_Ay">
+            <property role="1dT_AB" value="  instead of the selected node's documentation." />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="1GfgNpVWSGd" role="TZ5H$">
+          <node concept="1dT_AC" id="1GfgNpVWSGe" role="1dT_Ay">
+            <property role="1dT_AB" value="" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="1GfgNpVWSVJ" role="TZ5H$">
+          <node concept="1dT_AC" id="1GfgNpVWSVK" role="1dT_Ay">
+            <property role="1dT_AB" value="Note that the retrieval of documentation nodes uses caching, as searching through the " />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="1GfgNpVWTiF" role="TZ5H$">
+          <node concept="1dT_AC" id="1GfgNpVWTiG" role="1dT_Ay">
+            <property role="1dT_AB" value="ancestors might be expensive." />
+          </node>
+        </node>
+        <node concept="TUZQ0" id="1GfgNpVWOVW" role="3nqlJM">
+          <property role="TUZQ4" value="the current repository (opened with IDE)" />
+          <node concept="zr_55" id="1GfgNpVWOVY" role="zr_5Q">
+            <ref role="zr_51" node="1XKxHZsSvB0" resolve="repository" />
+          </node>
+        </node>
+        <node concept="TUZQ0" id="1GfgNpVWOVZ" role="3nqlJM">
+          <property role="TUZQ4" value="the node at the cursor" />
+          <node concept="zr_55" id="1GfgNpVWOW1" role="zr_5Q">
+            <ref role="zr_51" node="1XKxHZsSvB2" resolve="selectedNode" />
+          </node>
+        </node>
+        <node concept="TUZQ0" id="1GfgNpVWOW2" role="3nqlJM">
+          <property role="TUZQ4" value="the property at the cursor (or null)" />
+          <node concept="zr_55" id="1GfgNpVWOW4" role="zr_5Q">
+            <ref role="zr_51" node="1XKxHZsSvB4" resolve="property" />
+          </node>
+        </node>
+        <node concept="x79VA" id="1GfgNpVWOW5" role="3nqlJM">
+          <property role="x79VB" value="a documentation node, if any" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="1GfgNpVLtKR" role="jymVt" />
+    <node concept="Wx3nA" id="2DFA9RLkOfY" role="jymVt">
+      <property role="TrG5h" value="cache" />
+      <node concept="3Tm6S6" id="2DFA9RLl1cR" role="1B3o_S" />
+      <node concept="3uibUv" id="2DFA9RLkRkP" role="1tU5fm">
+        <ref role="3uigEE" to="sgh3:~Cache" resolve="Cache" />
+        <node concept="1LlUBW" id="2DFA9RLkRLr" role="11_B2D">
+          <node concept="3bZ5Sz" id="2DFA9RLkSej" role="1Lm7xW" />
+          <node concept="3uibUv" id="2DFA9RLkSFc" role="1Lm7xW">
+            <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
+          </node>
+        </node>
+        <node concept="3uibUv" id="1GfgNpVSE1t" role="11_B2D">
+          <ref role="3uigEE" to="33ny:~Optional" resolve="Optional" />
+          <node concept="3Tqbb2" id="1GfgNpVSGmN" role="11_B2D" />
+        </node>
+      </node>
+      <node concept="2OqwBi" id="2DFA9RLkXKB" role="33vP2m">
+        <node concept="2OqwBi" id="2DFA9RLkVrI" role="2Oq$k0">
+          <node concept="2YIFZM" id="2DFA9RLkV2x" role="2Oq$k0">
+            <ref role="37wK5l" to="sgh3:~CacheBuilder.newBuilder()" resolve="newBuilder" />
+            <ref role="1Pybhc" to="sgh3:~CacheBuilder" resolve="CacheBuilder" />
+          </node>
+          <node concept="liA8E" id="2DFA9RLkWu4" role="2OqNvi">
+            <ref role="37wK5l" to="sgh3:~CacheBuilder.maximumSize(long)" resolve="maximumSize" />
+            <node concept="3cmrfG" id="2DFA9RLkWMO" role="37wK5m">
+              <property role="3cmrfH" value="5000" />
+            </node>
+          </node>
+        </node>
+        <node concept="liA8E" id="2DFA9RLkYWI" role="2OqNvi">
+          <ref role="37wK5l" to="sgh3:~CacheBuilder.build()" resolve="build" />
+          <node concept="1LlUBW" id="2DFA9RLl0fN" role="3PaCim">
+            <node concept="3bZ5Sz" id="2DFA9RLl0fO" role="1Lm7xW" />
+            <node concept="3uibUv" id="2DFA9RLl0fP" role="1Lm7xW">
+              <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
+            </node>
+          </node>
+          <node concept="3uibUv" id="1GfgNpVSIDz" role="3PaCim">
+            <ref role="3uigEE" to="33ny:~Optional" resolve="Optional" />
+            <node concept="3Tqbb2" id="1GfgNpVSID$" role="11_B2D" />
+          </node>
+        </node>
+      </node>
+      <node concept="z59LJ" id="1GfgNpVVt$C" role="lGtFl">
+        <node concept="TZ5HA" id="1GfgNpVVt$D" role="TZ5H$">
+          <node concept="1dT_AC" id="1GfgNpVVt$E" role="1dT_Ay">
+            <property role="1dT_AB" value="Cache for concept/property to corresponding node in documentation." />
+          </node>
+        </node>
+      </node>
     </node>
     <node concept="2tJIrI" id="1XKxHZsSu63" role="jymVt" />
+    <node concept="2YIFZL" id="2DFA9RLm5bh" role="jymVt">
+      <property role="TrG5h" value="getDocForConceptCached" />
+      <node concept="3clFbS" id="2DFA9RLl5jQ" role="3clF47">
+        <node concept="3SKdUt" id="1GfgNpVL205" role="3cqZAp">
+          <node concept="1PaTwC" id="1GfgNpVL206" role="1aUNEU">
+            <node concept="3oM_SD" id="1GfgNpVL4aN" role="1PaTwD">
+              <property role="3oM_SC" value="get" />
+            </node>
+            <node concept="3oM_SD" id="1GfgNpVL4aP" role="1PaTwD">
+              <property role="3oM_SC" value="documentation" />
+            </node>
+            <node concept="3oM_SD" id="1GfgNpVL4aS" role="1PaTwD">
+              <property role="3oM_SC" value="node" />
+            </node>
+            <node concept="3oM_SD" id="1GfgNpVL4aW" role="1PaTwD">
+              <property role="3oM_SC" value="from" />
+            </node>
+            <node concept="3oM_SD" id="1GfgNpVL4b1" role="1PaTwD">
+              <property role="3oM_SC" value="cache" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="1GfgNpVOWOS" role="3cqZAp">
+          <node concept="3cpWsn" id="1GfgNpVOWOT" role="3cpWs9">
+            <property role="TrG5h" value="key" />
+            <node concept="1LlUBW" id="1GfgNpVOVuY" role="1tU5fm">
+              <node concept="3bZ5Sz" id="1GfgNpVOVv3" role="1Lm7xW" />
+              <node concept="3uibUv" id="1GfgNpVOVv4" role="1Lm7xW">
+                <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
+              </node>
+            </node>
+            <node concept="1Ls8ON" id="1GfgNpVOWOU" role="33vP2m">
+              <node concept="37vLTw" id="1GfgNpVOWOV" role="1Lso8e">
+                <ref role="3cqZAo" node="2DFA9RLl8eY" resolve="concept" />
+              </node>
+              <node concept="37vLTw" id="1GfgNpVOWOW" role="1Lso8e">
+                <ref role="3cqZAo" node="2DFA9RLl8f0" resolve="property" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="1GfgNpVOgQi" role="3cqZAp">
+          <node concept="3cpWsn" id="1GfgNpVOgQj" role="3cpWs9">
+            <property role="TrG5h" value="result" />
+            <node concept="2OqwBi" id="1GfgNpVOgQk" role="33vP2m">
+              <node concept="37vLTw" id="1GfgNpVOgQl" role="2Oq$k0">
+                <ref role="3cqZAo" node="2DFA9RLkOfY" resolve="cache" />
+              </node>
+              <node concept="liA8E" id="1GfgNpVOgQm" role="2OqNvi">
+                <ref role="37wK5l" to="sgh3:~Cache.getIfPresent(java.lang.Object)" resolve="getIfPresent" />
+                <node concept="37vLTw" id="1GfgNpVOWOX" role="37wK5m">
+                  <ref role="3cqZAo" node="1GfgNpVOWOT" resolve="key" />
+                </node>
+              </node>
+            </node>
+            <node concept="3uibUv" id="1GfgNpVSKVd" role="1tU5fm">
+              <ref role="3uigEE" to="33ny:~Optional" resolve="Optional" />
+              <node concept="3Tqbb2" id="1GfgNpVSKVe" role="11_B2D" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="1GfgNpVOo9E" role="3cqZAp">
+          <node concept="3clFbS" id="1GfgNpVOo9G" role="3clFbx">
+            <node concept="3SKdUt" id="1GfgNpVO$w1" role="3cqZAp">
+              <node concept="1PaTwC" id="1GfgNpVO$w2" role="1aUNEU">
+                <node concept="3oM_SD" id="1GfgNpVOAuM" role="1PaTwD">
+                  <property role="3oM_SC" value="not" />
+                </node>
+                <node concept="3oM_SD" id="1GfgNpVOAuO" role="1PaTwD">
+                  <property role="3oM_SC" value="in" />
+                </node>
+                <node concept="3oM_SD" id="1GfgNpVOAuR" role="1PaTwD">
+                  <property role="3oM_SC" value="cache" />
+                </node>
+                <node concept="3oM_SD" id="1GfgNpVPLWi" role="1PaTwD">
+                  <property role="3oM_SC" value="or" />
+                </node>
+                <node concept="3oM_SD" id="1GfgNpVPM6o" role="1PaTwD">
+                  <property role="3oM_SC" value="outdated," />
+                </node>
+                <node concept="3oM_SD" id="1GfgNpVPMbo" role="1PaTwD">
+                  <property role="3oM_SC" value="compute" />
+                </node>
+                <node concept="3oM_SD" id="1GfgNpVPMlj" role="1PaTwD">
+                  <property role="3oM_SC" value="it" />
+                </node>
+                <node concept="3oM_SD" id="1GfgNpVPMlr" role="1PaTwD">
+                  <property role="3oM_SC" value="and" />
+                </node>
+                <node concept="3oM_SD" id="1GfgNpVPMqu" role="1PaTwD">
+                  <property role="3oM_SC" value="put" />
+                </node>
+                <node concept="3oM_SD" id="1GfgNpVPMvy" role="1PaTwD">
+                  <property role="3oM_SC" value="in" />
+                </node>
+                <node concept="3oM_SD" id="1GfgNpVPMvH" role="1PaTwD">
+                  <property role="3oM_SC" value="cache" />
+                </node>
+              </node>
+            </node>
+            <node concept="3SKdUt" id="1GfgNpVWUnQ" role="3cqZAp">
+              <node concept="1PaTwC" id="1GfgNpVWUnR" role="1aUNEU">
+                <node concept="3oM_SD" id="1GfgNpVWV3e" role="1PaTwD">
+                  <property role="3oM_SC" value="Note" />
+                </node>
+                <node concept="3oM_SD" id="1GfgNpVWV3n" role="1PaTwD">
+                  <property role="3oM_SC" value="that" />
+                </node>
+                <node concept="3oM_SD" id="1GfgNpVWV3q" role="1PaTwD">
+                  <property role="3oM_SC" value="this" />
+                </node>
+                <node concept="3oM_SD" id="1GfgNpVWV3u" role="1PaTwD">
+                  <property role="3oM_SC" value="is" />
+                </node>
+                <node concept="3oM_SD" id="1GfgNpVWV3z" role="1PaTwD">
+                  <property role="3oM_SC" value="the" />
+                </node>
+                <node concept="3oM_SD" id="1GfgNpVWV3D" role="1PaTwD">
+                  <property role="3oM_SC" value="only" />
+                </node>
+                <node concept="3oM_SD" id="1GfgNpVWV3K" role="1PaTwD">
+                  <property role="3oM_SC" value="call" />
+                </node>
+                <node concept="3oM_SD" id="1GfgNpVWV5c" role="1PaTwD">
+                  <property role="3oM_SC" value="site" />
+                </node>
+                <node concept="3oM_SD" id="1GfgNpVWV4y" role="1PaTwD">
+                  <property role="3oM_SC" value="of" />
+                </node>
+                <node concept="3oM_SD" id="1GfgNpVWV4J" role="1PaTwD">
+                  <property role="3oM_SC" value="getDocumentationAux" />
+                </node>
+                <node concept="3oM_SD" id="1GfgNpVWV4X" role="1PaTwD">
+                  <property role="3oM_SC" value="which" />
+                </node>
+                <node concept="3oM_SD" id="1GfgNpVWV41" role="1PaTwD">
+                  <property role="3oM_SC" value="is" />
+                </node>
+                <node concept="3oM_SD" id="1GfgNpVWV4b" role="1PaTwD">
+                  <property role="3oM_SC" value="intended." />
+                </node>
+              </node>
+            </node>
+            <node concept="3SKdUt" id="1GfgNpVWVPf" role="3cqZAp">
+              <node concept="1PaTwC" id="1GfgNpVWVPg" role="1aUNEU">
+                <node concept="3oM_SD" id="1GfgNpVWWwQ" role="1PaTwD">
+                  <property role="3oM_SC" value="After" />
+                </node>
+                <node concept="3oM_SD" id="1GfgNpVWWwS" role="1PaTwD">
+                  <property role="3oM_SC" value="getDocumentationAux" />
+                </node>
+                <node concept="3oM_SD" id="1GfgNpVWWwV" role="1PaTwD">
+                  <property role="3oM_SC" value="is" />
+                </node>
+                <node concept="3oM_SD" id="1GfgNpVWWwZ" role="1PaTwD">
+                  <property role="3oM_SC" value="set" />
+                </node>
+                <node concept="3oM_SD" id="1GfgNpVWWx4" role="1PaTwD">
+                  <property role="3oM_SC" value="to" />
+                </node>
+                <node concept="3oM_SD" id="1GfgNpVWWxa" role="1PaTwD">
+                  <property role="3oM_SC" value="private" />
+                </node>
+                <node concept="3oM_SD" id="1GfgNpVWWxh" role="1PaTwD">
+                  <property role="3oM_SC" value="visibility," />
+                </node>
+                <node concept="3oM_SD" id="1GfgNpVWWxp" role="1PaTwD">
+                  <property role="3oM_SC" value="the" />
+                </node>
+                <node concept="3oM_SD" id="1GfgNpVWWxy" role="1PaTwD">
+                  <property role="3oM_SC" value="deprecation" />
+                </node>
+                <node concept="3oM_SD" id="1GfgNpVWWxG" role="1PaTwD">
+                  <property role="3oM_SC" value="can" />
+                </node>
+                <node concept="3oM_SD" id="1GfgNpVWWxR" role="1PaTwD">
+                  <property role="3oM_SC" value="be" />
+                </node>
+                <node concept="3oM_SD" id="1GfgNpVWWy3" role="1PaTwD">
+                  <property role="3oM_SC" value="removed." />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="1GfgNpVTHe8" role="3cqZAp">
+              <node concept="37vLTI" id="1GfgNpVTJiZ" role="3clFbG">
+                <node concept="2YIFZM" id="1GfgNpVTMtU" role="37vLTx">
+                  <ref role="37wK5l" to="33ny:~Optional.ofNullable(java.lang.Object)" resolve="ofNullable" />
+                  <ref role="1Pybhc" to="33ny:~Optional" resolve="Optional" />
+                  <node concept="1rXfSq" id="1GfgNpVJAd4" role="37wK5m">
+                    <ref role="37wK5l" node="qh7UMGipbd" resolve="getDocumentationAux" />
+                    <node concept="37vLTw" id="1GfgNpVJAd5" role="37wK5m">
+                      <ref role="3cqZAo" node="2DFA9RLl8eW" resolve="repository" />
+                    </node>
+                    <node concept="37vLTw" id="1GfgNpVJAd6" role="37wK5m">
+                      <ref role="3cqZAo" node="2DFA9RLl8eY" resolve="concept" />
+                    </node>
+                    <node concept="37vLTw" id="1GfgNpVJAd7" role="37wK5m">
+                      <ref role="3cqZAo" node="2DFA9RLl8f0" resolve="property" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="37vLTw" id="1GfgNpVTHe6" role="37vLTJ">
+                  <ref role="3cqZAo" node="1GfgNpVOgQj" resolve="result" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="1GfgNpVQkXj" role="3cqZAp">
+              <node concept="2OqwBi" id="1GfgNpVQlWR" role="3clFbG">
+                <node concept="37vLTw" id="1GfgNpVQkXh" role="2Oq$k0">
+                  <ref role="3cqZAo" node="2DFA9RLkOfY" resolve="cache" />
+                </node>
+                <node concept="liA8E" id="1GfgNpVQoOd" role="2OqNvi">
+                  <ref role="37wK5l" to="sgh3:~Cache.put(java.lang.Object,java.lang.Object)" resolve="put" />
+                  <node concept="37vLTw" id="1GfgNpVQrcc" role="37wK5m">
+                    <ref role="3cqZAo" node="1GfgNpVOWOT" resolve="key" />
+                  </node>
+                  <node concept="37vLTw" id="1GfgNpVQus6" role="37wK5m">
+                    <ref role="3cqZAo" node="1GfgNpVOgQj" resolve="result" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="22lmx$" id="1GfgNpVPzFC" role="3clFbw">
+            <node concept="3fqX7Q" id="1GfgNpVPEOh" role="3uHU7w">
+              <node concept="1rXfSq" id="1GfgNpVPEOj" role="3fr31v">
+                <ref role="37wK5l" node="1GfgNpVOJDd" resolve="isValidCacheEntry" />
+                <node concept="37vLTw" id="1GfgNpVPEOk" role="37wK5m">
+                  <ref role="3cqZAo" node="1GfgNpVOgQj" resolve="result" />
+                </node>
+                <node concept="37vLTw" id="1GfgNpVPJH2" role="37wK5m">
+                  <ref role="3cqZAo" node="2DFA9RLl8eY" resolve="concept" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbC" id="1GfgNpVOvzR" role="3uHU7B">
+              <node concept="37vLTw" id="1GfgNpVOogB" role="3uHU7B">
+                <ref role="3cqZAo" node="1GfgNpVOgQj" resolve="result" />
+              </node>
+              <node concept="10Nm6u" id="1GfgNpVOy4V" role="3uHU7w" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="2DFA9RLm80f" role="3cqZAp">
+          <node concept="3K4zz7" id="1GfgNpVU38f" role="3cqZAk">
+            <node concept="10Nm6u" id="1GfgNpVU5lp" role="3K4E3e" />
+            <node concept="2OqwBi" id="1GfgNpVU855" role="3K4GZi">
+              <node concept="37vLTw" id="1GfgNpVU7bL" role="2Oq$k0">
+                <ref role="3cqZAo" node="1GfgNpVOgQj" resolve="result" />
+              </node>
+              <node concept="liA8E" id="1GfgNpVUaFu" role="2OqNvi">
+                <ref role="37wK5l" to="33ny:~Optional.get()" resolve="get" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="1GfgNpVTYqb" role="3K4Cdx">
+              <node concept="37vLTw" id="2DFA9RLopLZ" role="2Oq$k0">
+                <ref role="3cqZAo" node="1GfgNpVOgQj" resolve="result" />
+              </node>
+              <node concept="liA8E" id="1GfgNpVU10l" role="2OqNvi">
+                <ref role="37wK5l" to="33ny:~Optional.isEmpty()" resolve="isEmpty" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="2DFA9RLl8eW" role="3clF46">
+        <property role="TrG5h" value="repository" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3uibUv" id="2DFA9RLl8eX" role="1tU5fm">
+          <ref role="3uigEE" to="lui2:~SRepository" resolve="SRepository" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="2DFA9RLl8eY" role="3clF46">
+        <property role="TrG5h" value="concept" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3bZ5Sz" id="2DFA9RLl8eZ" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="2DFA9RLl8f0" role="3clF46">
+        <property role="TrG5h" value="property" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3uibUv" id="2DFA9RLl8f1" role="1tU5fm">
+          <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
+        </node>
+      </node>
+      <node concept="3Tqbb2" id="1GfgNpVQCUH" role="3clF45" />
+      <node concept="3Tm6S6" id="2DFA9RLl3tL" role="1B3o_S" />
+    </node>
+    <node concept="2tJIrI" id="1GfgNpVOAuV" role="jymVt" />
+    <node concept="2YIFZL" id="1GfgNpVOJDd" role="jymVt">
+      <property role="TrG5h" value="isValidCacheEntry" />
+      <node concept="3clFbS" id="1GfgNpVOJDg" role="3clF47">
+        <node concept="3clFbJ" id="1GfgNpVSW9M" role="3cqZAp">
+          <node concept="3clFbS" id="1GfgNpVSW9O" role="3clFbx">
+            <node concept="3SKdUt" id="1GfgNpVT6j_" role="3cqZAp">
+              <node concept="1PaTwC" id="1GfgNpVT6jA" role="1aUNEU">
+                <node concept="3oM_SD" id="1GfgNpVT6jF" role="1PaTwD">
+                  <property role="3oM_SC" value="the" />
+                </node>
+                <node concept="3oM_SD" id="1GfgNpVT6jH" role="1PaTwD">
+                  <property role="3oM_SC" value="cache" />
+                </node>
+                <node concept="3oM_SD" id="1GfgNpVT8xX" role="1PaTwD">
+                  <property role="3oM_SC" value="entry" />
+                </node>
+                <node concept="3oM_SD" id="1GfgNpVT8y1" role="1PaTwD">
+                  <property role="3oM_SC" value="is" />
+                </node>
+                <node concept="3oM_SD" id="1GfgNpVT8ym" role="1PaTwD">
+                  <property role="3oM_SC" value="&quot;no" />
+                </node>
+                <node concept="3oM_SD" id="1GfgNpVT8y$" role="1PaTwD">
+                  <property role="3oM_SC" value="documentation" />
+                </node>
+                <node concept="3oM_SD" id="1GfgNpVT8z3" role="1PaTwD">
+                  <property role="3oM_SC" value="node&quot;," />
+                </node>
+                <node concept="3oM_SD" id="1GfgNpVT8zr" role="1PaTwD">
+                  <property role="3oM_SC" value="we" />
+                </node>
+                <node concept="3oM_SD" id="1GfgNpVT8z$" role="1PaTwD">
+                  <property role="3oM_SC" value="cannot" />
+                </node>
+                <node concept="3oM_SD" id="1GfgNpVT8zI" role="1PaTwD">
+                  <property role="3oM_SC" value="check" />
+                </node>
+                <node concept="3oM_SD" id="1GfgNpVT8zT" role="1PaTwD">
+                  <property role="3oM_SC" value="if" />
+                </node>
+                <node concept="3oM_SD" id="1GfgNpVT8$5" role="1PaTwD">
+                  <property role="3oM_SC" value="this" />
+                </node>
+                <node concept="3oM_SD" id="1GfgNpVT8$q" role="1PaTwD">
+                  <property role="3oM_SC" value="is" />
+                </node>
+                <node concept="3oM_SD" id="1GfgNpVT8$C" role="1PaTwD">
+                  <property role="3oM_SC" value="still" />
+                </node>
+                <node concept="3oM_SD" id="1GfgNpVT8$Z" role="1PaTwD">
+                  <property role="3oM_SC" value="valid" />
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs6" id="1GfgNpVTi9V" role="3cqZAp">
+              <node concept="3clFbT" id="1GfgNpVTkrG" role="3cqZAk">
+                <property role="3clFbU" value="true" />
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="1GfgNpVT0NV" role="3clFbw">
+            <node concept="37vLTw" id="1GfgNpVSYpO" role="2Oq$k0">
+              <ref role="3cqZAo" node="1GfgNpVP5_n" resolve="docNode" />
+            </node>
+            <node concept="liA8E" id="1GfgNpVT42U" role="2OqNvi">
+              <ref role="37wK5l" to="33ny:~Optional.isEmpty()" resolve="isEmpty" />
+            </node>
+          </node>
+          <node concept="9aQIb" id="1GfgNpVTmEL" role="9aQIa">
+            <node concept="3clFbS" id="1GfgNpVTmEM" role="9aQI4">
+              <node concept="3SKdUt" id="1GfgNpVVApW" role="3cqZAp">
+                <node concept="1PaTwC" id="1GfgNpVVApX" role="1aUNEU">
+                  <node concept="3oM_SD" id="1GfgNpVVBae" role="1PaTwD">
+                    <property role="3oM_SC" value="this" />
+                  </node>
+                  <node concept="3oM_SD" id="1GfgNpVVBag" role="1PaTwD">
+                    <property role="3oM_SC" value="will" />
+                  </node>
+                  <node concept="3oM_SD" id="1GfgNpVVBaj" role="1PaTwD">
+                    <property role="3oM_SC" value="check" />
+                  </node>
+                  <node concept="3oM_SD" id="1GfgNpVVBan" role="1PaTwD">
+                    <property role="3oM_SC" value="two" />
+                  </node>
+                  <node concept="3oM_SD" id="1GfgNpVVBas" role="1PaTwD">
+                    <property role="3oM_SC" value="properties:" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3SKdUt" id="1GfgNpVVBW8" role="3cqZAp">
+                <node concept="1PaTwC" id="1GfgNpVVBW9" role="1aUNEU">
+                  <node concept="3oM_SD" id="1GfgNpVVCG1" role="1PaTwD">
+                    <property role="3oM_SC" value="1." />
+                  </node>
+                  <node concept="3oM_SD" id="1GfgNpVVCG3" role="1PaTwD">
+                    <property role="3oM_SC" value="the" />
+                  </node>
+                  <node concept="3oM_SD" id="1GfgNpVVCG6" role="1PaTwD">
+                    <property role="3oM_SC" value="docNode" />
+                  </node>
+                  <node concept="3oM_SD" id="1GfgNpVVCGa" role="1PaTwD">
+                    <property role="3oM_SC" value="must" />
+                  </node>
+                  <node concept="3oM_SD" id="1GfgNpVVCGf" role="1PaTwD">
+                    <property role="3oM_SC" value="have" />
+                  </node>
+                  <node concept="3oM_SD" id="1GfgNpVVCGl" role="1PaTwD">
+                    <property role="3oM_SC" value="a" />
+                  </node>
+                  <node concept="3oM_SD" id="1GfgNpVVCGs" role="1PaTwD">
+                    <property role="3oM_SC" value="documentation" />
+                  </node>
+                  <node concept="3oM_SD" id="1GfgNpVVCG$" role="1PaTwD">
+                    <property role="3oM_SC" value="annotation" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3SKdUt" id="1GfgNpVVDv1" role="3cqZAp">
+                <node concept="1PaTwC" id="1GfgNpVVDv2" role="1aUNEU">
+                  <node concept="3oM_SD" id="1GfgNpVVEah" role="1PaTwD">
+                    <property role="3oM_SC" value="2." />
+                  </node>
+                  <node concept="3oM_SD" id="1GfgNpVVEaj" role="1PaTwD">
+                    <property role="3oM_SC" value="the" />
+                  </node>
+                  <node concept="3oM_SD" id="1GfgNpVVEam" role="1PaTwD">
+                    <property role="3oM_SC" value="annotation" />
+                  </node>
+                  <node concept="3oM_SD" id="1GfgNpVVEaq" role="1PaTwD">
+                    <property role="3oM_SC" value="must" />
+                  </node>
+                  <node concept="3oM_SD" id="1GfgNpVVEaG" role="1PaTwD">
+                    <property role="3oM_SC" value="match" />
+                  </node>
+                  <node concept="3oM_SD" id="1GfgNpVVEaM" role="1PaTwD">
+                    <property role="3oM_SC" value="the" />
+                  </node>
+                  <node concept="3oM_SD" id="1GfgNpVVELI" role="1PaTwD">
+                    <property role="3oM_SC" value="concept" />
+                  </node>
+                  <node concept="3oM_SD" id="1GfgNpVVELQ" role="1PaTwD">
+                    <property role="3oM_SC" value="we" />
+                  </node>
+                  <node concept="3oM_SD" id="1GfgNpVVELZ" role="1PaTwD">
+                    <property role="3oM_SC" value="are" />
+                  </node>
+                  <node concept="3oM_SD" id="1GfgNpVVEM9" role="1PaTwD">
+                    <property role="3oM_SC" value="looking" />
+                  </node>
+                  <node concept="3oM_SD" id="1GfgNpVVEMk" role="1PaTwD">
+                    <property role="3oM_SC" value="for" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3cpWs8" id="1GfgNpVP7E7" role="3cqZAp">
+                <node concept="3cpWsn" id="1GfgNpVP7E8" role="3cpWs9">
+                  <property role="TrG5h" value="dca" />
+                  <node concept="3Tqbb2" id="1GfgNpVP7E9" role="1tU5fm">
+                    <ref role="ehGHo" to="748g:UK_oBp_UIu" resolve="DocumentedConceptAnnotation" />
+                  </node>
+                  <node concept="1rXfSq" id="1GfgNpVP7Ea" role="33vP2m">
+                    <ref role="37wK5l" node="1GfgNpVL_IS" resolve="getAnnotation" />
+                    <node concept="2OqwBi" id="1GfgNpVTsAN" role="37wK5m">
+                      <node concept="37vLTw" id="1GfgNpVP7Ec" role="2Oq$k0">
+                        <ref role="3cqZAo" node="1GfgNpVP5_n" resolve="docNode" />
+                      </node>
+                      <node concept="liA8E" id="1GfgNpVTvnR" role="2OqNvi">
+                        <ref role="37wK5l" to="33ny:~Optional.get()" resolve="get" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3cpWs6" id="1GfgNpVTCIa" role="3cqZAp">
+                <node concept="1Wc70l" id="1GfgNpVTCIc" role="3cqZAk">
+                  <node concept="2OqwBi" id="1GfgNpVTCId" role="3uHU7B">
+                    <node concept="37vLTw" id="1GfgNpVTCIe" role="2Oq$k0">
+                      <ref role="3cqZAo" node="1GfgNpVP7E8" resolve="dca" />
+                    </node>
+                    <node concept="3x8VRR" id="1GfgNpVTCIf" role="2OqNvi" />
+                  </node>
+                  <node concept="17R0WA" id="1GfgNpVTCIg" role="3uHU7w">
+                    <node concept="2OqwBi" id="1GfgNpVTCIh" role="3uHU7B">
+                      <node concept="37vLTw" id="1GfgNpVTCIi" role="2Oq$k0">
+                        <ref role="3cqZAo" node="1GfgNpVP7E8" resolve="dca" />
+                      </node>
+                      <node concept="3TrEf2" id="1GfgNpVTCIj" role="2OqNvi">
+                        <ref role="3Tt5mk" to="748g:UK_oBpA4EG" resolve="concept" />
+                      </node>
+                    </node>
+                    <node concept="2OqwBi" id="1GfgNpVTCIk" role="3uHU7w">
+                      <node concept="37vLTw" id="1GfgNpVTCIl" role="2Oq$k0">
+                        <ref role="3cqZAo" node="1GfgNpVPv6W" resolve="concept" />
+                      </node>
+                      <node concept="FGMqu" id="1GfgNpVTCIm" role="2OqNvi" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm6S6" id="1GfgNpVOFQc" role="1B3o_S" />
+      <node concept="10P_77" id="1GfgNpVOJoR" role="3clF45" />
+      <node concept="37vLTG" id="1GfgNpVP5_n" role="3clF46">
+        <property role="TrG5h" value="docNode" />
+        <node concept="3uibUv" id="1GfgNpVSPqZ" role="1tU5fm">
+          <ref role="3uigEE" to="33ny:~Optional" resolve="Optional" />
+          <node concept="3Tqbb2" id="1GfgNpVSRGV" role="11_B2D" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="1GfgNpVPv6W" role="3clF46">
+        <property role="TrG5h" value="concept" />
+        <node concept="3bZ5Sz" id="1GfgNpVPvy4" role="1tU5fm" />
+      </node>
+      <node concept="P$JXv" id="1GfgNpVVulo" role="lGtFl">
+        <node concept="TZ5HA" id="1GfgNpVVulp" role="TZ5H$">
+          <node concept="1dT_AC" id="1GfgNpVVulq" role="1dT_Ay">
+            <property role="1dT_AB" value="Check if a given cache entry (i.e., a documentation node) is still valid." />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="1GfgNpVVv__" role="TZ5H$">
+          <node concept="1dT_AC" id="1GfgNpVVv_A" role="1dT_Ay">
+            <property role="1dT_AB" value="" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="1GfgNpVVwkw" role="TZ5H$">
+          <node concept="1dT_AC" id="1GfgNpVVwkx" role="1dT_Ay">
+            <property role="1dT_AB" value="If the documentation annotation has been moved to a different location or " />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="1GfgNpVVwNB" role="TZ5H$">
+          <node concept="1dT_AC" id="1GfgNpVVwNC" role="1dT_Ay">
+            <property role="1dT_AB" value="the documented concept has been changed, this will be detected here." />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="1GfgNpVVxxJ" role="TZ5H$">
+          <node concept="1dT_AC" id="1GfgNpVVxxK" role="1dT_Ay">
+            <property role="1dT_AB" value="" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="1GfgNpVVyfT" role="TZ5H$">
+          <node concept="1dT_AC" id="1GfgNpVVyfU" role="1dT_Ay">
+            <property role="1dT_AB" value="Note: If the cache stores the information that there is no documentation node" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="1GfgNpVVyY5" role="TZ5H$">
+          <node concept="1dT_AC" id="1GfgNpVVyY6" role="1dT_Ay">
+            <property role="1dT_AB" value="for a given concept, this cannot be checked here. Thus, if a documentation annotation" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="1GfgNpVVzGj" role="TZ5H$">
+          <node concept="1dT_AC" id="1GfgNpVVzGk" role="1dT_Ay">
+            <property role="1dT_AB" value="is being added after this null-entry has been stored in the cache, only reloading all" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="1GfgNpVV$qz" role="TZ5H$">
+          <node concept="1dT_AC" id="1GfgNpVV$q$" role="1dT_Ay">
+            <property role="1dT_AB" value="classes or restarting MPS will fix this." />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="2DFA9RLm9pV" role="jymVt" />
     <node concept="2YIFZL" id="qh7UMGipbd" role="jymVt">
       <property role="od$2w" value="false" />
       <property role="DiZV1" value="false" />
@@ -2010,26 +2747,25 @@
                     <property role="3TUv4t" value="true" />
                     <property role="TrG5h" value="conceptDoc" />
                     <node concept="3Tqbb2" id="11K_5nNfog1" role="1tU5fm" />
-                    <node concept="2YIFZM" id="11K_5nNfog2" role="33vP2m">
-                      <ref role="1Pybhc" node="qh7UMGioaa" resolve="DocumentationAspectHelper" />
-                      <ref role="37wK5l" node="qh7UMGipbd" resolve="getDocumentation" />
-                      <node concept="2OqwBi" id="68WEpgC$SOA" role="37wK5m">
-                        <node concept="2JrnkZ" id="68WEpgC$SzH" role="2Oq$k0">
-                          <node concept="2OqwBi" id="68WEpgC$R2J" role="2JrQYb">
-                            <node concept="37vLTw" id="68WEpgC$QPo" role="2Oq$k0">
+                    <node concept="1rXfSq" id="1GfgNpVXlZA" role="33vP2m">
+                      <ref role="37wK5l" node="2DFA9RLm5bh" resolve="getDocForConceptCached" />
+                      <node concept="2OqwBi" id="1GfgNpVXlsH" role="37wK5m">
+                        <node concept="2JrnkZ" id="1GfgNpVXlsI" role="2Oq$k0">
+                          <node concept="2OqwBi" id="1GfgNpVXlsJ" role="2JrQYb">
+                            <node concept="37vLTw" id="1GfgNpVXlsK" role="2Oq$k0">
                               <ref role="3cqZAo" node="68WEpgCynYA" resolve="n" />
                             </node>
-                            <node concept="I4A8Y" id="68WEpgC$Rpw" role="2OqNvi" />
+                            <node concept="I4A8Y" id="1GfgNpVXlsL" role="2OqNvi" />
                           </node>
                         </node>
-                        <node concept="liA8E" id="68WEpgC$Tbc" role="2OqNvi">
+                        <node concept="liA8E" id="1GfgNpVXlsM" role="2OqNvi">
                           <ref role="37wK5l" to="mhbf:~SModel.getRepository()" resolve="getRepository" />
                         </node>
                       </node>
-                      <node concept="37vLTw" id="11K_5nNfog8" role="37wK5m">
+                      <node concept="37vLTw" id="1GfgNpVXlsN" role="37wK5m">
                         <ref role="3cqZAo" node="11K_5nNfofr" resolve="concept" />
                       </node>
-                      <node concept="10Nm6u" id="68WEpgC$TpF" role="37wK5m" />
+                      <node concept="10Nm6u" id="1GfgNpVXlsO" role="37wK5m" />
                     </node>
                   </node>
                 </node>
@@ -2273,6 +3009,47 @@
       <node concept="3Tm1VV" id="qmep2m2viH" role="1B3o_S" />
     </node>
     <node concept="2tJIrI" id="qmep2m2jLR" role="jymVt" />
+    <node concept="2YIFZL" id="1GfgNpVL_IS" role="jymVt">
+      <property role="TrG5h" value="getAnnotation" />
+      <node concept="3clFbS" id="1GfgNpVL_IV" role="3clF47">
+        <node concept="3clFbF" id="1GfgNpVMpKm" role="3cqZAp">
+          <node concept="2OqwBi" id="1GfgNpVMnEu" role="3clFbG">
+            <node concept="2OqwBi" id="1GfgNpVMi82" role="2Oq$k0">
+              <node concept="2OqwBi" id="1GfgNpVMi83" role="2Oq$k0">
+                <node concept="37vLTw" id="1GfgNpVMi84" role="2Oq$k0">
+                  <ref role="3cqZAo" node="1GfgNpVMjPb" resolve="documentationNode" />
+                </node>
+                <node concept="3Tsc0h" id="1GfgNpVMi85" role="2OqNvi">
+                  <ref role="3TtcxE" to="tpck:4uZwTti3__2" resolve="smodelAttribute" />
+                </node>
+              </node>
+              <node concept="v3k3i" id="1GfgNpVMi86" role="2OqNvi">
+                <node concept="chp4Y" id="1GfgNpVMi87" role="v3oSu">
+                  <ref role="cht4Q" to="748g:UK_oBp_UIu" resolve="DocumentedConceptAnnotation" />
+                </node>
+              </node>
+            </node>
+            <node concept="1uHKPH" id="1GfgNpVMoHw" role="2OqNvi" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm6S6" id="1GfgNpVLy5A" role="1B3o_S" />
+      <node concept="3Tqbb2" id="1GfgNpVMr4y" role="3clF45">
+        <ref role="ehGHo" to="748g:UK_oBp_UIu" resolve="DocumentedConceptAnnotation" />
+      </node>
+      <node concept="37vLTG" id="1GfgNpVMjPb" role="3clF46">
+        <property role="TrG5h" value="documentationNode" />
+        <node concept="3Tqbb2" id="1GfgNpVMjPa" role="1tU5fm" />
+      </node>
+      <node concept="P$JXv" id="1GfgNpVVZTd" role="lGtFl">
+        <node concept="TZ5HA" id="1GfgNpVVZTe" role="TZ5H$">
+          <node concept="1dT_AC" id="1GfgNpVVZTf" role="1dT_Ay">
+            <property role="1dT_AB" value="Retrieve annotation for a given documentationNode (e.g., a section or an item)." />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="2DFA9RLkKeE" role="jymVt" />
   </node>
 </model>
 

--- a/code/languages/com.mbeddr.doc.aspect/solutions/com.mbeddr.doc.aspect.ui/com.mbeddr.doc.aspect.ui.msd
+++ b/code/languages/com.mbeddr.doc.aspect/solutions/com.mbeddr.doc.aspect.ui/com.mbeddr.doc.aspect.ui.msd
@@ -34,7 +34,6 @@
     <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
     <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
     <language slang="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" version="2" />
-    <language slang="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" version="0" />
     <language slang="l:63650c59-16c8-498a-99c8-005c7ee9515d:jetbrains.mps.lang.access" version="0" />
     <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
     <language slang="l:18bc6592-03a6-4e29-a83a-7ff23bde13ba:jetbrains.mps.lang.editor" version="14" />

--- a/code/languages/com.mbeddr.doc.aspect/solutions/com.mbeddr.doc.aspect.ui/models/com/mbeddr/doc/aspect/ui/plugin.mps
+++ b/code/languages/com.mbeddr.doc.aspect/solutions/com.mbeddr.doc.aspect.ui/models/com/mbeddr/doc/aspect/ui/plugin.mps
@@ -15,7 +15,6 @@
     <use id="63650c59-16c8-498a-99c8-005c7ee9515d" name="jetbrains.mps.lang.access" version="-1" />
     <use id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc" version="-1" />
     <use id="774bf8a0-62e5-41e1-af63-f4812e60e48b" name="jetbrains.mps.baseLanguage.checkedDots" version="0" />
-    <use id="760a0a8c-eabb-4521-8bfd-65db761a9ba3" name="jetbrains.mps.baseLanguage.logging" version="0" />
   </languages>
   <imports>
     <import index="exr9" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor(MPS.Editor/)" />

--- a/code/languages/com.mbeddr.doc.aspect/solutions/com.mbeddr.doc.aspect.ui/models/com/mbeddr/doc/aspect/ui/plugin.mps
+++ b/code/languages/com.mbeddr.doc.aspect/solutions/com.mbeddr.doc.aspect.ui/models/com/mbeddr/doc/aspect/ui/plugin.mps
@@ -2730,29 +2730,20 @@
       <property role="TrG5h" value="hasDoc" />
       <node concept="10P_77" id="1CsE99tCSgo" role="3clF45" />
       <node concept="3clFbS" id="1CsE99tCReh" role="3clF47">
-        <node concept="3cpWs8" id="1XKxHZsRYBA" role="3cqZAp">
-          <node concept="3cpWsn" id="1XKxHZsRYBB" role="3cpWs9">
-            <property role="TrG5h" value="b" />
-            <node concept="10P_77" id="1XKxHZsRWqC" role="1tU5fm" />
-            <node concept="3y3z36" id="1XKxHZsRYBC" role="33vP2m">
-              <node concept="10Nm6u" id="1XKxHZsRYBD" role="3uHU7w" />
-              <node concept="2YIFZM" id="1XKxHZsXFqa" role="3uHU7B">
-                <ref role="37wK5l" to="ttl0:1XKxHZsSs$9" resolve="getDocumentation" />
-                <ref role="1Pybhc" to="ttl0:qh7UMGioaa" resolve="DocumentationAspectHelper" />
-                <node concept="37vLTw" id="1XKxHZsXFqb" role="37wK5m">
-                  <ref role="3cqZAo" node="1CsE99tCStE" resolve="repository" />
-                </node>
-                <node concept="37vLTw" id="1XKxHZsXFqc" role="37wK5m">
-                  <ref role="3cqZAo" node="1CsE99tCSE2" resolve="selectedNode" />
-                </node>
-                <node concept="10Nm6u" id="1XKxHZsXFqd" role="37wK5m" />
+        <node concept="3clFbF" id="1GfgNpVWE9m" role="3cqZAp">
+          <node concept="3y3z36" id="1XKxHZsRYBC" role="3clFbG">
+            <node concept="10Nm6u" id="1XKxHZsRYBD" role="3uHU7w" />
+            <node concept="2YIFZM" id="1XKxHZsXFqa" role="3uHU7B">
+              <ref role="1Pybhc" to="ttl0:qh7UMGioaa" resolve="DocumentationAspectHelper" />
+              <ref role="37wK5l" to="ttl0:1XKxHZsSs$9" resolve="getDocumentation" />
+              <node concept="37vLTw" id="1XKxHZsXFqb" role="37wK5m">
+                <ref role="3cqZAo" node="1CsE99tCStE" resolve="repository" />
               </node>
+              <node concept="37vLTw" id="1XKxHZsXFqc" role="37wK5m">
+                <ref role="3cqZAo" node="1CsE99tCSE2" resolve="selectedNode" />
+              </node>
+              <node concept="10Nm6u" id="1XKxHZsXFqd" role="37wK5m" />
             </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="1XKxHZsSdGi" role="3cqZAp">
-          <node concept="37vLTw" id="1XKxHZsSdGg" role="3clFbG">
-            <ref role="3cqZAo" node="1XKxHZsRYBB" resolve="b" />
           </node>
         </node>
       </node>

--- a/code/languages/com.mbeddr.doc.aspect/solutions/com.mbeddr.doc.aspect.ui/models/com/mbeddr/doc/aspect/ui/plugin.mps
+++ b/code/languages/com.mbeddr.doc.aspect/solutions/com.mbeddr.doc.aspect.ui/models/com/mbeddr/doc/aspect/ui/plugin.mps
@@ -1121,11 +1121,8 @@
                 <node concept="2WthIp" id="18EYPZeyOxo" role="2Oq$k0" />
                 <node concept="2XshWL" id="18EYPZeyOxq" role="2OqNvi">
                   <ref role="2WH_rO" node="1CsE99tCRef" resolve="hasDoc" />
-                  <node concept="2OqwBi" id="18EYPZeyPth" role="2XxRq1">
-                    <node concept="37vLTw" id="18EYPZeyPmb" role="2Oq$k0">
-                      <ref role="3cqZAo" node="18EYPZeyMBy" resolve="selectedNode" />
-                    </node>
-                    <node concept="2yIwOk" id="18EYPZeyPEQ" role="2OqNvi" />
+                  <node concept="37vLTw" id="18EYPZeyPmb" role="2XxRq1">
+                    <ref role="3cqZAo" node="18EYPZeyMBy" resolve="selectedNode" />
                   </node>
                   <node concept="2EnYce" id="2MiGV0HSqeg" role="2XxRq1">
                     <node concept="2OqwBi" id="18EYPZeyQX4" role="2Oq$k0">
@@ -2733,28 +2730,37 @@
       <property role="TrG5h" value="hasDoc" />
       <node concept="10P_77" id="1CsE99tCSgo" role="3clF45" />
       <node concept="3clFbS" id="1CsE99tCReh" role="3clF47">
-        <node concept="3clFbF" id="1CsE99tCSkn" role="3cqZAp">
-          <node concept="3y3z36" id="1CsE99tCTcg" role="3clFbG">
-            <node concept="10Nm6u" id="1CsE99tCTjo" role="3uHU7w" />
-            <node concept="2YIFZM" id="1CsE99tCSmY" role="3uHU7B">
-              <ref role="37wK5l" to="ttl0:qh7UMGipbd" resolve="getDocumentation" />
-              <ref role="1Pybhc" to="ttl0:qh7UMGioaa" resolve="DocumentationAspectHelper" />
-              <node concept="37vLTw" id="1CsE99tCSZI" role="37wK5m">
-                <ref role="3cqZAo" node="1CsE99tCStE" resolve="repository" />
+        <node concept="3cpWs8" id="1XKxHZsRYBA" role="3cqZAp">
+          <node concept="3cpWsn" id="1XKxHZsRYBB" role="3cpWs9">
+            <property role="TrG5h" value="b" />
+            <node concept="10P_77" id="1XKxHZsRWqC" role="1tU5fm" />
+            <node concept="3y3z36" id="1XKxHZsRYBC" role="33vP2m">
+              <node concept="10Nm6u" id="1XKxHZsRYBD" role="3uHU7w" />
+              <node concept="2YIFZM" id="1XKxHZsXFqa" role="3uHU7B">
+                <ref role="37wK5l" to="ttl0:1XKxHZsSs$9" resolve="getDocumentation" />
+                <ref role="1Pybhc" to="ttl0:qh7UMGioaa" resolve="DocumentationAspectHelper" />
+                <node concept="37vLTw" id="1XKxHZsXFqb" role="37wK5m">
+                  <ref role="3cqZAo" node="1CsE99tCStE" resolve="repository" />
+                </node>
+                <node concept="37vLTw" id="1XKxHZsXFqc" role="37wK5m">
+                  <ref role="3cqZAo" node="1CsE99tCSE2" resolve="selectedNode" />
+                </node>
+                <node concept="10Nm6u" id="1XKxHZsXFqd" role="37wK5m" />
               </node>
-              <node concept="37vLTw" id="1CsE99tCT2W" role="37wK5m">
-                <ref role="3cqZAo" node="1CsE99tCSE2" resolve="concept" />
-              </node>
-              <node concept="10Nm6u" id="1CsE99tCT5T" role="37wK5m" />
             </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="1XKxHZsSdGi" role="3cqZAp">
+          <node concept="37vLTw" id="1XKxHZsSdGg" role="3clFbG">
+            <ref role="3cqZAo" node="1XKxHZsRYBB" resolve="b" />
           </node>
         </node>
       </node>
       <node concept="3Tm6S6" id="1CsE99tCScR" role="1B3o_S" />
       <node concept="37vLTG" id="1CsE99tCSE2" role="3clF46">
         <property role="3TUv4t" value="true" />
-        <property role="TrG5h" value="concept" />
-        <node concept="3bZ5Sz" id="1CsE99tCSQu" role="1tU5fm" />
+        <property role="TrG5h" value="selectedNode" />
+        <node concept="3Tqbb2" id="1XKxHZsXpPf" role="1tU5fm" />
       </node>
       <node concept="37vLTG" id="1CsE99tCStE" role="3clF46">
         <property role="3TUv4t" value="true" />
@@ -3086,16 +3092,15 @@
                   </node>
                 </node>
               </node>
-              <node concept="3cpWs8" id="11K_5nNfofq" role="3cqZAp">
-                <node concept="3cpWsn" id="11K_5nNfofr" role="3cpWs9">
-                  <property role="TrG5h" value="concept" />
-                  <property role="3TUv4t" value="true" />
-                  <node concept="3bZ5Sz" id="11K_5nNfofs" role="1tU5fm" />
-                  <node concept="2OqwBi" id="11K_5nNfoft" role="33vP2m">
-                    <node concept="37vLTw" id="11K_5nNfofu" role="2Oq$k0">
+              <node concept="3cpWs8" id="1XKxHZsX96M" role="3cqZAp">
+                <node concept="3cpWsn" id="1XKxHZsX96N" role="3cpWs9">
+                  <property role="TrG5h" value="selectedConcept" />
+                  <node concept="3bZ5Sz" id="1XKxHZsX8GR" role="1tU5fm" />
+                  <node concept="2OqwBi" id="1XKxHZsX96O" role="33vP2m">
+                    <node concept="37vLTw" id="1XKxHZsX96P" role="2Oq$k0">
                       <ref role="3cqZAo" node="11K_5nNeQYb" resolve="selectedNode" />
                     </node>
-                    <node concept="2yIwOk" id="11K_5nNfofv" role="2OqNvi" />
+                    <node concept="2yIwOk" id="1XKxHZsX96Q" role="2OqNvi" />
                   </node>
                 </node>
               </node>
@@ -3104,24 +3109,24 @@
                   <property role="3TUv4t" value="true" />
                   <property role="TrG5h" value="conceptDoc" />
                   <node concept="3Tqbb2" id="11K_5nNfog1" role="1tU5fm" />
-                  <node concept="2YIFZM" id="11K_5nNfog2" role="33vP2m">
-                    <ref role="37wK5l" to="ttl0:qh7UMGipbd" resolve="getDocumentation" />
+                  <node concept="2YIFZM" id="1XKxHZsWWjn" role="33vP2m">
+                    <ref role="37wK5l" to="ttl0:1XKxHZsSs$9" resolve="getDocumentation" />
                     <ref role="1Pybhc" to="ttl0:qh7UMGioaa" resolve="DocumentationAspectHelper" />
-                    <node concept="2OqwBi" id="11K_5nNfog3" role="37wK5m">
-                      <node concept="2OqwBi" id="11K_5nNfog4" role="2Oq$k0">
-                        <node concept="2WthIp" id="11K_5nNfog5" role="2Oq$k0" />
-                        <node concept="2BZ7hE" id="11K_5nNfog6" role="2OqNvi">
+                    <node concept="2OqwBi" id="1XKxHZsWWjo" role="37wK5m">
+                      <node concept="2OqwBi" id="1XKxHZsWWjp" role="2Oq$k0">
+                        <node concept="2WthIp" id="1XKxHZsWWjq" role="2Oq$k0" />
+                        <node concept="2BZ7hE" id="1XKxHZsWWjr" role="2OqNvi">
                           <ref role="2WH_rO" node="1IUlN8Q4hs1" resolve="currentProject" />
                         </node>
                       </node>
-                      <node concept="liA8E" id="11K_5nNfog7" role="2OqNvi">
+                      <node concept="liA8E" id="1XKxHZsWWjs" role="2OqNvi">
                         <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
                       </node>
                     </node>
-                    <node concept="37vLTw" id="11K_5nNfog8" role="37wK5m">
-                      <ref role="3cqZAo" node="11K_5nNfofr" resolve="concept" />
+                    <node concept="37vLTw" id="1XKxHZsWWjt" role="37wK5m">
+                      <ref role="3cqZAo" node="11K_5nNeQYb" resolve="selectedNode" />
                     </node>
-                    <node concept="37vLTw" id="11K_5nNfog9" role="37wK5m">
+                    <node concept="37vLTw" id="1XKxHZsWWju" role="37wK5m">
                       <ref role="3cqZAo" node="11K_5nNeQYd" resolve="property" />
                     </node>
                   </node>
@@ -3210,7 +3215,7 @@
                             <ref role="37wK5l" to="xnls:~BaseIconManager.getIconFor(org.jetbrains.mps.openapi.model.SNode)" resolve="getIconFor" />
                             <node concept="2OqwBi" id="11K_5nNfofV" role="37wK5m">
                               <node concept="37vLTw" id="11K_5nNfofW" role="2Oq$k0">
-                                <ref role="3cqZAo" node="11K_5nNfofr" resolve="concept" />
+                                <ref role="3cqZAo" node="1XKxHZsX96N" resolve="selectedConcept" />
                               </node>
                               <node concept="FGMqu" id="11K_5nNfofX" role="2OqNvi" />
                             </node>
@@ -3367,7 +3372,7 @@
                     <property role="3oM_SC" value="StackOverflow" />
                   </node>
                   <node concept="3oM_SD" id="4PCyu9RTWz_" role="1PaTwD">
-                    <property role="3oM_SC" value="happend." />
+                    <property role="3oM_SC" value="happened." />
                   </node>
                 </node>
               </node>


### PR DESCRIPTION
This PR introduces a new flag `overrideChildren` for `DocumentedConceptAnnotation` nodes. Setting this flag will force the document for this concept be shown even if the cursor is not directly on a node of this concept, but on some child node (transitively). So the documentation for the child node will not be shown if there is an ancestor with the `overrideChildren` flag switched on. 

In addition to the feature, there are some more additions related to the feature:
- The configuration extension point `documentationAspectConfiguration` has been extended by the API call `allowOverrideChildren()` and documented. The `override`-logic is switched off by default, in order to use it, an extension has to be provided which returns true for `allowOverrideChildren()`.
- Example language:
  - A concept `CostAttribute` has been added to the example language in order to allow testing the new feature. An example node with an override-flag can be found here: [node URL](http://127.0.0.1:63320/node?ref=r%3A9f051296-ca8b-43ff-8d91-e0b7ca63b52a%28com.mbeddr.doc.lang.exampleLanguage.sandbox%29%2F2265458908607261733).
  - How to test? Open the example node. Open the documentation view Click on the expression nodes behind "cost: .." in the example, still the concept documentation for `CostAttribute` will be shown (see screenshot below).
  - An extension has been implemented for the default language to switch on `allowOverrideChildren()`.
- A cache for concept-specific documentation has been implemented. This improves the current performance (without the override-feature), but is really necessary when the override-feature is switched on.
- Introduce a blacklist for baselanguage root nodes. This avoids that the performance-heavy override-logic will be implied for any baselanguage code. Without this, the first click (with a cache miss) into some base language code node might take about 500-1000 milliseconds (from the second click on, there is no more performance penalty).
- The CHANGELOG has been updated.
 
Performance remark: I tested the override-feature in a big customer project. For an average root node for some arbitrary customer DSL, the first click with opened documentation view could take 50-300 milliseconds. After that, the cache is armed and the penalty is below 1 millisecond.

This PR solves #2309.


<img width="620" alt="image" src="https://github.com/mbeddr/mbeddr.core/assets/1193045/62cb8c83-8d17-48c2-90c5-94a9eb8c4647">


