### PR TITLE
Fix NPE in BlockExpression constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is _loosely_ based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). The project does _not_ follow
 Semantic Versioning and the changes are simply documented in reverse chronological order, grouped by calendar month.
 
+# November 2023
+
+## com.mbeddr.core
+
+- Fixed a NullPointerException in BlockExpression_Constraints that was preventing completion menu from appearing in mbeddr code.
+
 # July 2023
 
 The following languages/plugins were removed:

--- a/code/languages/com.mbeddr.core/languages/com.mbeddr.core.util/languageModels/constraints.mps
+++ b/code/languages/com.mbeddr.core/languages/com.mbeddr.core.util/languageModels/constraints.mps
@@ -805,23 +805,6 @@
   <node concept="1M2fIO" id="7moCclreYpX">
     <property role="3GE5qa" value="blockexpr" />
     <ref role="1M2myG" to="k146:4VEDcE28so4" resolve="BlockExpression" />
-    <node concept="9S07l" id="79i$vAY60tW" role="9Vyp8">
-      <node concept="3clFbS" id="79i$vAY60tX" role="2VODD2">
-        <node concept="3clFbF" id="79i$vAY60tY" role="3cqZAp">
-          <node concept="2OqwBi" id="79i$vAY60tZ" role="3clFbG">
-            <node concept="nLn13" id="79i$vAY60u0" role="2Oq$k0" />
-            <node concept="2qgKlT" id="79i$vAY60u1" role="2OqNvi">
-              <ref role="37wK5l" to="tpcu:hEwIMij" resolve="isInTemplates" />
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="79i$vAY60u2" role="3cqZAp">
-          <node concept="3clFbT" id="79i$vAY60u3" role="3clFbG">
-            <property role="3clFbU" value="true" />
-          </node>
-        </node>
-      </node>
-    </node>
   </node>
   <node concept="1M2fIO" id="gaSsNU986_">
     <property role="3GE5qa" value="stack" />


### PR DESCRIPTION
Remove from BlockExpression_Constraints the call to `parentNode.isInTemplates()` whose return value was ignored but which caused a NPE if the parent node was null.