### PR TITLE
Fix 'error when saving settings' caused by actionsfilter plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ Semantic Versioning and the changes are simply documented in reverse chronologic
 
 - The language will no longer attempt to generate screenshots when run from an `MpsEnvironment` (i.e. the `<generate>` Ant task) but will instead output a warning. Use [mps-gradle-plugin](https://github.com/mbeddr/mps-gradle-plugin), [mps-build-backends](https://github.com/mbeddr/mps-build-backends), MPS tests, or other means to run the MPS make process in an IDEA environment.
 
+## com.mbeddr.mpsutil
+
+### Fixed
+
+- When actionsfilter was enabled, MPS will no longer display an error saying that settings could not be saved.
+
 # October 2023
 
 ## com.mbeddr.mpsutils

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is _loosely_ based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). The project does _not_ follow
 Semantic Versioning and the changes are simply documented in reverse chronological order, grouped by calendar month.
 
+# November 2023
+
+## com.mbeddr.doc
+
+### Changed
+
+- The language will no longer attempt to generate screenshots when run from an `MpsEnvironment` (i.e. the `<generate>` Ant task) but will instead output a warning. Use [mps-gradle-plugin](https://github.com/mbeddr/mps-gradle-plugin), [mps-build-backends](https://github.com/mbeddr/mps-build-backends), MPS tests, or other means to run the MPS make process in an IDEA environment.
+
 # October 2023
 
 ## com.mbeddr.mpsutils
 
 ### Changed
 
-Added possiblity to update the ToolWindow contents of context action 2 evenif the Window is not visible.
+- Added possiblity to update the ToolWindow contents of context action 2 evenif the Window is not visible.
 
 # September 2023
 
@@ -19,7 +27,7 @@ Added possiblity to update the ToolWindow contents of context action 2 evenif th
 
 ### Changed
 
-* The aspect documentation now can handle solution-level documentation as well and is not limited to extending languages.
+- The aspect documentation now can handle solution-level documentation as well and is not limited to extending languages.
 
 ## com.mbeddr.core
 

--- a/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/languageModels/plugin.mps
+++ b/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/languageModels/plugin.mps
@@ -2320,7 +2320,7 @@
                     <property role="Xl_RC" value="Screenshots cannot be taken in MpsEnvironment (Ant &lt;generate&gt; task). " />
                   </node>
                   <node concept="Xl_RD" id="5Ulr5FUQLH_" role="3uHU7w">
-                    <property role="Xl_RC" value="Use mps-gradle-plugins or mps-build-backends or other means to run the build in an IDEA environment." />
+                    <property role="Xl_RC" value="Use mps-gradle-plugin, mps-build-backends, MPS tests, or other means to run the MPS make process in an IDEA environment." />
                   </node>
                 </node>
               </node>

--- a/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/languageModels/plugin.mps
+++ b/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/languageModels/plugin.mps
@@ -51,6 +51,7 @@
     <import index="i9so" ref="r:9e5578e0-37f0-4c9b-a301-771bcb453678(jetbrains.mps.make.script)" />
     <import index="ap4t" ref="215c4c45-ba99-49f5-9ab7-4b6901a63cfd/java:jetbrains.mps.generator(MPS.Generator/)" />
     <import index="ao3" ref="7124e466-fc92-4803-a656-d7a6b7eb3910/java:jetbrains.mps.text(MPS.TextGen/)" />
+    <import index="v9gs" ref="r:a139668a-5a0e-46e2-a802-102190e497e5(jetbrains.mps.core.tool.environment.util)" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
     <import index="hfuk" ref="r:b25dd364-bc3f-4a66-97d1-262009610c5e(jetbrains.mps.make)" implicit="true" />
   </imports>
@@ -275,6 +276,7 @@
         <child id="8276990574909234106" name="finallyBody" index="1wplMD" />
       </concept>
       <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
+      <concept id="1081855346303" name="jetbrains.mps.baseLanguage.structure.BreakStatement" flags="nn" index="3zACq4" />
       <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
       </concept>
@@ -2232,6 +2234,107 @@
       <node concept="2aLE7I" id="oUcJT$humY" role="ElM8M">
         <node concept="ElOhj" id="oUcJT$humZ" role="2aLE7H">
           <node concept="3clFbS" id="oUcJT$hun0" role="2VODD2">
+            <node concept="3SKdUt" id="5Ulr5FUPTkl" role="3cqZAp">
+              <node concept="1PaTwC" id="5Ulr5FUPTkm" role="1aUNEU">
+                <node concept="3oM_SD" id="5Ulr5FUPUFQ" role="1PaTwD">
+                  <property role="3oM_SC" value="Make" />
+                </node>
+                <node concept="3oM_SD" id="5Ulr5FUPUMe" role="1PaTwD">
+                  <property role="3oM_SC" value="sure" />
+                </node>
+                <node concept="3oM_SD" id="5Ulr5FUPUFV" role="1PaTwD">
+                  <property role="3oM_SC" value="we" />
+                </node>
+                <node concept="3oM_SD" id="5Ulr5FUPUGh" role="1PaTwD">
+                  <property role="3oM_SC" value="only" />
+                </node>
+                <node concept="3oM_SD" id="5Ulr5FUPWSl" role="1PaTwD">
+                  <property role="3oM_SC" value="warn" />
+                </node>
+                <node concept="3oM_SD" id="5Ulr5FUPUHY" role="1PaTwD">
+                  <property role="3oM_SC" value="about" />
+                </node>
+                <node concept="3oM_SD" id="5Ulr5FUPUGo" role="1PaTwD">
+                  <property role="3oM_SC" value="MPS" />
+                </node>
+                <node concept="3oM_SD" id="5Ulr5FUPUH0" role="1PaTwD">
+                  <property role="3oM_SC" value="Environment" />
+                </node>
+                <node concept="3oM_SD" id="5Ulr5FUPUH9" role="1PaTwD">
+                  <property role="3oM_SC" value="if" />
+                </node>
+                <node concept="3oM_SD" id="5Ulr5FUPUIU" role="1PaTwD">
+                  <property role="3oM_SC" value="screenshots" />
+                </node>
+                <node concept="3oM_SD" id="5Ulr5FUPUJB" role="1PaTwD">
+                  <property role="3oM_SC" value="are" />
+                </node>
+                <node concept="3oM_SD" id="5Ulr5FUPWTB" role="1PaTwD">
+                  <property role="3oM_SC" value="actually" />
+                </node>
+                <node concept="3oM_SD" id="5Ulr5FUPUJP" role="1PaTwD">
+                  <property role="3oM_SC" value="used," />
+                </node>
+                <node concept="3oM_SD" id="5Ulr5FUPUK4" role="1PaTwD">
+                  <property role="3oM_SC" value="and" />
+                </node>
+                <node concept="3oM_SD" id="5Ulr5FUPUKk" role="1PaTwD">
+                  <property role="3oM_SC" value="only" />
+                </node>
+                <node concept="3oM_SD" id="5Ulr5FUPUK_" role="1PaTwD">
+                  <property role="3oM_SC" value="do" />
+                </node>
+                <node concept="3oM_SD" id="5Ulr5FUPUKR" role="1PaTwD">
+                  <property role="3oM_SC" value="it" />
+                </node>
+                <node concept="3oM_SD" id="5Ulr5FUPULa" role="1PaTwD">
+                  <property role="3oM_SC" value="once." />
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs8" id="5Ulr5FUPOua" role="3cqZAp">
+              <node concept="3cpWsn" id="5Ulr5FUPOud" role="3cpWs9">
+                <property role="TrG5h" value="isMpsEnvironment" />
+                <property role="3TUv4t" value="true" />
+                <node concept="10P_77" id="5Ulr5FUQ6KF" role="1tU5fm" />
+                <node concept="2ZW3vV" id="5Ulr5FUPUNy" role="33vP2m">
+                  <node concept="3uibUv" id="5Ulr5FUPUNz" role="2ZW6by">
+                    <ref role="3uigEE" to="v9gs:2doG_VG59Hc" resolve="FileMPSProject" />
+                  </node>
+                  <node concept="2OqwBi" id="5Ulr5FUPUN$" role="2ZW6bz">
+                    <node concept="2_BwXt" id="5Ulr5FUPUN_" role="2Oq$k0" />
+                    <node concept="liA8E" id="5Ulr5FUPUNA" role="2OqNvi">
+                      <ref role="37wK5l" to="hfuk:2BjwmTxTf34" resolve="getProject" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs8" id="5Ulr5FUQJNQ" role="3cqZAp">
+              <node concept="3cpWsn" id="5Ulr5FUQJNO" role="3cpWs9">
+                <property role="3TUv4t" value="true" />
+                <property role="TrG5h" value="mpsEnvironmentWarning" />
+                <node concept="17QB3L" id="5Ulr5FUQKky" role="1tU5fm" />
+                <node concept="3cpWs3" id="5Ulr5FUQLHz" role="33vP2m">
+                  <node concept="Xl_RD" id="5Ulr5FUQLH$" role="3uHU7B">
+                    <property role="Xl_RC" value="Screenshots cannot be taken in MpsEnvironment (Ant &lt;generate&gt; task). " />
+                  </node>
+                  <node concept="Xl_RD" id="5Ulr5FUQLH_" role="3uHU7w">
+                    <property role="Xl_RC" value="Use mps-gradle-plugins or mps-build-backends or other means to run the build in an IDEA environment." />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs8" id="5Ulr5FUQ$al" role="3cqZAp">
+              <node concept="3cpWsn" id="5Ulr5FUQ$ao" role="3cpWs9">
+                <property role="TrG5h" value="reportMpsEnvironment" />
+                <node concept="10P_77" id="5Ulr5FUQ$aj" role="1tU5fm" />
+                <node concept="3clFbT" id="5Ulr5FUQ_zi" role="33vP2m">
+                  <property role="3clFbU" value="true" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbH" id="5Ulr5FUPPPH" role="3cqZAp" />
             <node concept="3clFbF" id="3hEqlZ1qKCA" role="3cqZAp">
               <node concept="2OqwBi" id="3hEqlZ1qKCW" role="3clFbG">
                 <node concept="EWnkA" id="3hEqlZ1qKCB" role="2Oq$k0" />
@@ -2272,7 +2375,7 @@
                 <node concept="3clFbH" id="33dz4spT2qO" role="3cqZAp" />
                 <node concept="3cpWs8" id="3kcKtVhKdAp" role="3cqZAp">
                   <node concept="3cpWsn" id="3kcKtVhKdAs" role="3cpWs9">
-                    <property role="TrG5h" value="MakeModelFolder2Runnables" />
+                    <property role="TrG5h" value="runnablesByFolder" />
                     <node concept="3rvAFt" id="3kcKtVhKdAj" role="1tU5fm">
                       <node concept="_YKpA" id="3kcKtVhKf5L" role="3rvSg0">
                         <node concept="3uibUv" id="1cBwqeL36X_" role="_ZDj9">
@@ -2696,6 +2799,36 @@
                               <property role="TrG5h" value="modelContent" />
                             </node>
                             <node concept="3clFbS" id="oUcJT$i_d2" role="2LFqv$">
+                              <node concept="3clFbJ" id="6D39xFaCpK0" role="3cqZAp">
+                                <node concept="3clFbS" id="6D39xFaCpK2" role="3clFbx">
+                                  <node concept="3clFbJ" id="5Ulr5FUQAJB" role="3cqZAp">
+                                    <node concept="3clFbS" id="5Ulr5FUQAJD" role="3clFbx">
+                                      <node concept="1daRAt" id="6D39xFaCR1u" role="3cqZAp">
+                                        <property role="1daRAr" value="3bEKrlZKrwG/WARNING" />
+                                        <node concept="37vLTw" id="5Ulr5FUQMHU" role="1daK9t">
+                                          <ref role="3cqZAo" node="5Ulr5FUQJNO" resolve="mpsEnvironmentWarning" />
+                                        </node>
+                                      </node>
+                                      <node concept="3clFbF" id="5Ulr5FUQETA" role="3cqZAp">
+                                        <node concept="37vLTI" id="5Ulr5FUQFWz" role="3clFbG">
+                                          <node concept="3clFbT" id="5Ulr5FUQG_5" role="37vLTx" />
+                                          <node concept="37vLTw" id="5Ulr5FUQET$" role="37vLTJ">
+                                            <ref role="3cqZAo" node="5Ulr5FUQ$ao" resolve="reportMpsEnvironment" />
+                                          </node>
+                                        </node>
+                                      </node>
+                                    </node>
+                                    <node concept="37vLTw" id="5Ulr5FUQBmn" role="3clFbw">
+                                      <ref role="3cqZAo" node="5Ulr5FUQ$ao" resolve="reportMpsEnvironment" />
+                                    </node>
+                                  </node>
+                                  <node concept="3zACq4" id="5Ulr5FUQ9rW" role="3cqZAp" />
+                                </node>
+                                <node concept="37vLTw" id="5Ulr5FUPY0h" role="3clFbw">
+                                  <ref role="3cqZAo" node="5Ulr5FUPOud" resolve="shouldReportMpsEnvironment" />
+                                </node>
+                              </node>
+                              <node concept="3clFbH" id="5Ulr5FUPGhu" role="3cqZAp" />
                               <node concept="3cpWs8" id="5XfUTkOUJIA" role="3cqZAp">
                                 <node concept="3cpWsn" id="5XfUTkOUJIB" role="3cpWs9">
                                   <property role="TrG5h" value="node" />
@@ -2999,6 +3132,36 @@
                               <property role="TrG5h" value="sectionAsImage" />
                             </node>
                             <node concept="3clFbS" id="5XfUTkOqstl" role="2LFqv$">
+                              <node concept="3clFbJ" id="5Ulr5FUQH9V" role="3cqZAp">
+                                <node concept="3clFbS" id="5Ulr5FUQH9W" role="3clFbx">
+                                  <node concept="3clFbJ" id="5Ulr5FUQH9X" role="3cqZAp">
+                                    <node concept="3clFbS" id="5Ulr5FUQH9Y" role="3clFbx">
+                                      <node concept="1daRAt" id="5Ulr5FUQH9Z" role="3cqZAp">
+                                        <property role="1daRAr" value="3bEKrlZKrwG/WARNING" />
+                                        <node concept="37vLTw" id="5Ulr5FUQOrG" role="1daK9t">
+                                          <ref role="3cqZAo" node="5Ulr5FUQJNO" resolve="mpsEnvironmentWarning" />
+                                        </node>
+                                      </node>
+                                      <node concept="3clFbF" id="5Ulr5FUQHa3" role="3cqZAp">
+                                        <node concept="37vLTI" id="5Ulr5FUQHa4" role="3clFbG">
+                                          <node concept="3clFbT" id="5Ulr5FUQHa5" role="37vLTx" />
+                                          <node concept="37vLTw" id="5Ulr5FUQHa6" role="37vLTJ">
+                                            <ref role="3cqZAo" node="5Ulr5FUQ$ao" resolve="reportMpsEnvironment" />
+                                          </node>
+                                        </node>
+                                      </node>
+                                    </node>
+                                    <node concept="37vLTw" id="5Ulr5FUQHa7" role="3clFbw">
+                                      <ref role="3cqZAo" node="5Ulr5FUQ$ao" resolve="reportMpsEnvironment" />
+                                    </node>
+                                  </node>
+                                  <node concept="3zACq4" id="5Ulr5FUQHa8" role="3cqZAp" />
+                                </node>
+                                <node concept="37vLTw" id="5Ulr5FUQHa9" role="3clFbw">
+                                  <ref role="3cqZAo" node="5Ulr5FUPOud" resolve="shouldReportMpsEnvironment" />
+                                </node>
+                              </node>
+                              <node concept="3clFbH" id="5Ulr5FUQgvP" role="3cqZAp" />
                               <node concept="3cpWs8" id="223OxQl_y91" role="3cqZAp">
                                 <node concept="3cpWsn" id="223OxQl_y92" role="3cpWs9">
                                   <property role="TrG5h" value="node" />

--- a/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.actionsfilter.runtime/models/com/mbeddr/mpsutil/actionsfilter/runtime.mps
+++ b/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.actionsfilter.runtime/models/com/mbeddr/mpsutil/actionsfilter/runtime.mps
@@ -13674,10 +13674,35 @@
         </node>
         <node concept="3clFbF" id="fi1uEpw4Fd" role="3cqZAp">
           <node concept="2OqwBi" id="fi1uEpw5NW" role="3clFbG">
-            <node concept="2OqwBi" id="fi1uEpw4Rk" role="2Oq$k0">
-              <node concept="Xjq3P" id="fi1uEpw4Fc" role="2Oq$k0" />
-              <node concept="2OwXpG" id="fi1uEpw4YM" role="2OqNvi">
-                <ref role="2Oxat5" node="2D4mVfzuSON" resolve="entries" />
+            <node concept="2OqwBi" id="5s3J1p6p6pi" role="2Oq$k0">
+              <node concept="2OqwBi" id="fi1uEpw4Rk" role="2Oq$k0">
+                <node concept="Xjq3P" id="fi1uEpw4Fc" role="2Oq$k0" />
+                <node concept="2OwXpG" id="fi1uEpw4YM" role="2OqNvi">
+                  <ref role="2Oxat5" node="2D4mVfzuSON" resolve="entries" />
+                </node>
+              </node>
+              <node concept="3zZkjj" id="5s3J1p6p8f8" role="2OqNvi">
+                <node concept="1bVj0M" id="5s3J1p6p8fa" role="23t8la">
+                  <node concept="3clFbS" id="5s3J1p6p8fb" role="1bW5cS">
+                    <node concept="3clFbF" id="5s3J1p6p9Jg" role="3cqZAp">
+                      <node concept="2OqwBi" id="5s3J1p6pd8z" role="3clFbG">
+                        <node concept="2OqwBi" id="5s3J1p6pamO" role="2Oq$k0">
+                          <node concept="37vLTw" id="5s3J1p6p9Jf" role="2Oq$k0">
+                            <ref role="3cqZAo" node="5s3J1p6p8fc" resolve="it" />
+                          </node>
+                          <node concept="liA8E" id="1Y41B6dwtts" role="2OqNvi">
+                            <ref role="37wK5l" node="3m_GngirHOj" resolve="getId" />
+                          </node>
+                        </node>
+                        <node concept="17RvpY" id="5s3J1p6pepp" role="2OqNvi" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="Rh6nW" id="5s3J1p6p8fc" role="1bW2Oz">
+                    <property role="TrG5h" value="it" />
+                    <node concept="2jxLKc" id="5s3J1p6p8fd" role="1tU5fm" />
+                  </node>
+                </node>
               </node>
             </node>
             <node concept="2es0OD" id="fi1uEpw6$v" role="2OqNvi">


### PR DESCRIPTION
Includes #2316 (to avoid conflict in the changelog), please review that one first.

Passing `null` as action ID to IDEA's `CustomActionsSchema#addIconCustomization()` causes it to break later when persisting the settings. This didn't happen on 2021.3 so the fix is only needed for 2022.2 onwards.