### PR TITLE
Small documentation language improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ Semantic Versioning and the changes are simply documented in reverse chronologic
 
 # December 2023
 
+## com.mbeddr.doc
+
+### Fixed
+
+- The escaping of the new line character works again.
+
 ## com.mbeddr.mpsutils
 
 ### Changed
@@ -18,6 +24,11 @@ Semantic Versioning and the changes are simply documented in reverse chronologic
 ### Changed
 
 - Assessement result entries with invalid references are now automatically removed.
+- The cell editor screenshooter doesn't trim the offset of the editor component anymore.
+
+### Fixed
+
+- The cell editor screenshooter now supports editor extensions and the rendering quality was slightly improved.
 
 ## com.mbeddr.core.base.intentions
 

--- a/code/languages/com.mbeddr.core/languages/com.mbeddr.core.base/solutions/pluginSolution/models/com/mbeddr/core/base/pluginSolution/plugin.mps
+++ b/code/languages/com.mbeddr.core/languages/com.mbeddr.core.base/solutions/pluginSolution/models/com/mbeddr/core/base/pluginSolution/plugin.mps
@@ -301,6 +301,7 @@
       <concept id="1197029447546" name="jetbrains.mps.baseLanguage.structure.FieldReferenceOperation" flags="nn" index="2OwXpG">
         <reference id="1197029500499" name="fieldDeclaration" index="2Oxat5" />
       </concept>
+      <concept id="5763944538902644732" name="jetbrains.mps.baseLanguage.structure.StaticMethodCallOperation" flags="ng" index="2PDubS" />
       <concept id="1201370618622" name="jetbrains.mps.baseLanguage.structure.Property" flags="ig" index="2RhdJD">
         <property id="1201371481316" name="propertyName" index="2RkwnN" />
         <child id="1201371521209" name="type" index="2RkE6I" />
@@ -22235,74 +22236,15 @@
             </node>
           </node>
         </node>
-        <node concept="3clFbF" id="7SQqK0Fdk2j" role="3cqZAp">
-          <node concept="2OqwBi" id="7SQqK0Fdk2k" role="3clFbG">
-            <node concept="37vLTw" id="7SQqK0Fdk2l" role="2Oq$k0">
-              <ref role="3cqZAo" node="7SQqK0Fdk2e" resolve="g" />
+        <node concept="3clFbF" id="2pjWqF4TQ$n" role="3cqZAp">
+          <node concept="2OqwBi" id="2pjWqF4TQ$v" role="3clFbG">
+            <node concept="37vLTw" id="2pjWqF4SG2u" role="2Oq$k0">
+              <ref role="3cqZAo" node="7SQqK0FdFYc" resolve="editorComp" />
             </node>
-            <node concept="liA8E" id="7SQqK0Fdk2m" role="2OqNvi">
-              <ref role="37wK5l" to="z60i:~Graphics2D.setRenderingHint(java.awt.RenderingHints$Key,java.lang.Object)" resolve="setRenderingHint" />
-              <node concept="10M0yZ" id="7SQqK0Fdk2n" role="37wK5m">
-                <ref role="3cqZAo" to="z60i:~RenderingHints.KEY_TEXT_ANTIALIASING" resolve="KEY_TEXT_ANTIALIASING" />
-                <ref role="1PxDUh" to="z60i:~RenderingHints" resolve="RenderingHints" />
-              </node>
-              <node concept="10M0yZ" id="7SQqK0Fdk2o" role="37wK5m">
-                <ref role="3cqZAo" to="z60i:~RenderingHints.VALUE_TEXT_ANTIALIAS_LCD_VBGR" resolve="VALUE_TEXT_ANTIALIAS_LCD_VBGR" />
-                <ref role="1PxDUh" to="z60i:~RenderingHints" resolve="RenderingHints" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="7SQqK0Fdk2H" role="3cqZAp">
-          <node concept="2OqwBi" id="7SQqK0Fdk2I" role="3clFbG">
-            <node concept="37vLTw" id="7SQqK0Fdk2J" role="2Oq$k0">
-              <ref role="3cqZAo" node="7SQqK0Fdk2e" resolve="g" />
-            </node>
-            <node concept="liA8E" id="7SQqK0Fdk2K" role="2OqNvi">
-              <ref role="37wK5l" to="z60i:~Graphics2D.setRenderingHint(java.awt.RenderingHints$Key,java.lang.Object)" resolve="setRenderingHint" />
-              <node concept="10M0yZ" id="7SQqK0Fdk2L" role="37wK5m">
-                <ref role="1PxDUh" to="z60i:~RenderingHints" resolve="RenderingHints" />
-                <ref role="3cqZAo" to="z60i:~RenderingHints.KEY_ANTIALIASING" resolve="KEY_ANTIALIASING" />
-              </node>
-              <node concept="10M0yZ" id="7SQqK0Fdk2M" role="37wK5m">
-                <ref role="3cqZAo" to="z60i:~RenderingHints.VALUE_ANTIALIAS_ON" resolve="VALUE_ANTIALIAS_ON" />
-                <ref role="1PxDUh" to="z60i:~RenderingHints" resolve="RenderingHints" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="7SQqK0Fdk37" role="3cqZAp">
-          <node concept="2OqwBi" id="7SQqK0Fdk38" role="3clFbG">
-            <node concept="37vLTw" id="7SQqK0Fdk39" role="2Oq$k0">
-              <ref role="3cqZAo" node="7SQqK0Fdk2e" resolve="g" />
-            </node>
-            <node concept="liA8E" id="7SQqK0Fdk3a" role="2OqNvi">
-              <ref role="37wK5l" to="z60i:~Graphics2D.setRenderingHint(java.awt.RenderingHints$Key,java.lang.Object)" resolve="setRenderingHint" />
-              <node concept="10M0yZ" id="7SQqK0Fdk3b" role="37wK5m">
-                <ref role="1PxDUh" to="z60i:~RenderingHints" resolve="RenderingHints" />
-                <ref role="3cqZAo" to="z60i:~RenderingHints.KEY_RENDERING" resolve="KEY_RENDERING" />
-              </node>
-              <node concept="10M0yZ" id="7SQqK0Fdk3c" role="37wK5m">
-                <ref role="1PxDUh" to="z60i:~RenderingHints" resolve="RenderingHints" />
-                <ref role="3cqZAo" to="z60i:~RenderingHints.VALUE_RENDER_QUALITY" resolve="VALUE_RENDER_QUALITY" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="7SQqK0Fdk3x" role="3cqZAp">
-          <node concept="2OqwBi" id="7SQqK0Fdk3y" role="3clFbG">
-            <node concept="37vLTw" id="7SQqK0Fdk3z" role="2Oq$k0">
-              <ref role="3cqZAo" node="7SQqK0Fdk2e" resolve="g" />
-            </node>
-            <node concept="liA8E" id="7SQqK0Fdk3$" role="2OqNvi">
-              <ref role="37wK5l" to="z60i:~Graphics2D.setRenderingHint(java.awt.RenderingHints$Key,java.lang.Object)" resolve="setRenderingHint" />
-              <node concept="10M0yZ" id="7SQqK0Fdk3_" role="37wK5m">
-                <ref role="3cqZAo" to="z60i:~RenderingHints.KEY_DITHERING" resolve="KEY_DITHERING" />
-                <ref role="1PxDUh" to="z60i:~RenderingHints" resolve="RenderingHints" />
-              </node>
-              <node concept="10M0yZ" id="7SQqK0Fdk3A" role="37wK5m">
-                <ref role="3cqZAo" to="z60i:~RenderingHints.VALUE_DITHER_ENABLE" resolve="VALUE_DITHER_ENABLE" />
-                <ref role="1PxDUh" to="z60i:~RenderingHints" resolve="RenderingHints" />
+            <node concept="2PDubS" id="2pjWqF4SMHq" role="2OqNvi">
+              <ref role="37wK5l" to="exr9:~EditorComponent.turnOnAliasingIfPossible(java.awt.Graphics2D)" resolve="turnOnAliasingIfPossible" />
+              <node concept="37vLTw" id="2pjWqF4SOq7" role="37wK5m">
+                <ref role="3cqZAo" node="7SQqK0Fdk2e" resolve="g" />
               </node>
             </node>
           </node>

--- a/code/languages/com.mbeddr.core/languages/com.mbeddr.core.base/solutions/pluginSolution/models/com/mbeddr/core/base/pluginSolution/plugin.mps
+++ b/code/languages/com.mbeddr.core/languages/com.mbeddr.core.base/solutions/pluginSolution/models/com/mbeddr/core/base/pluginSolution/plugin.mps
@@ -122,6 +122,7 @@
     <import index="3a50" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.ide(MPS.Platform/)" />
     <import index="o2jy" ref="r:5a764b6f-e05f-4050-b22c-cbcad1577f1b(jetbrains.mps.ide.refactoring)" />
     <import index="pdwk" ref="8e98f4e2-decf-4e97-bf80-9109e8b759ee/java:jetbrains.mps.core.aspects.constraints.rules.kinds(jetbrains.mps.lang.constraints.rules.runtime/)" />
+    <import index="wvnl" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.extensions(MPS.Editor/)" />
     <import index="68mc" ref="r:2a10821d-612f-4a73-b7b0-ed6b57106321(com.mbeddr.mpsutil.filepicker.structure)" implicit="true" />
   </imports>
   <registry>
@@ -21796,7 +21797,44 @@
                 </node>
               </node>
             </node>
-            <node concept="3clFbH" id="2hPErkZEm_e" role="3cqZAp" />
+            <node concept="3cpWs8" id="3bTIKVD_mWq" role="3cqZAp">
+              <node concept="3cpWsn" id="3bTIKVD_mWr" role="3cpWs9">
+                <property role="TrG5h" value="project" />
+                <node concept="3uibUv" id="3bTIKVD_m_R" role="1tU5fm">
+                  <ref role="3uigEE" to="z1c3:~Project" resolve="Project" />
+                </node>
+                <node concept="2YIFZM" id="3bTIKVD_mWs" role="33vP2m">
+                  <ref role="37wK5l" to="alof:~ProjectHelper.getProject(org.jetbrains.mps.openapi.module.SRepository)" resolve="getProject" />
+                  <ref role="1Pybhc" to="alof:~ProjectHelper" resolve="ProjectHelper" />
+                  <node concept="37vLTw" id="3bTIKVD_mWt" role="37wK5m">
+                    <ref role="3cqZAo" node="2hPErkZBlEx" resolve="repository" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbJ" id="3bTIKVD_oTH" role="3cqZAp">
+              <node concept="3clFbS" id="3bTIKVD_oTJ" role="3clFbx">
+                <node concept="3clFbF" id="3bTIKVD_fAl" role="3cqZAp">
+                  <node concept="2YIFZM" id="3bTIKVD_h9t" role="3clFbG">
+                    <ref role="37wK5l" to="wvnl:~EditorExtensionUtil.extendUsingProject(jetbrains.mps.openapi.editor.EditorComponent,jetbrains.mps.project.IProject)" resolve="extendUsingProject" />
+                    <ref role="1Pybhc" to="wvnl:~EditorExtensionUtil" resolve="EditorExtensionUtil" />
+                    <node concept="37vLTw" id="3bTIKVD_iPU" role="37wK5m">
+                      <ref role="3cqZAo" node="2hPErkZAv65" resolve="editorComp" />
+                    </node>
+                    <node concept="37vLTw" id="3bTIKVD_mWu" role="37wK5m">
+                      <ref role="3cqZAo" node="3bTIKVD_mWr" resolve="project" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3y3z36" id="3bTIKVD_roA" role="3clFbw">
+                <node concept="10Nm6u" id="3bTIKVD_sxP" role="3uHU7w" />
+                <node concept="37vLTw" id="3bTIKVD_pHU" role="3uHU7B">
+                  <ref role="3cqZAo" node="3bTIKVD_mWr" resolve="project" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbH" id="3bTIKVD_dTN" role="3cqZAp" />
             <node concept="3clFbJ" id="2hPErkZAv6D" role="3cqZAp">
               <node concept="3clFbS" id="2hPErkZAv6E" role="3clFbx">
                 <node concept="3cpWs8" id="2hPErkZAv6F" role="3cqZAp">

--- a/code/languages/com.mbeddr.core/languages/com.mbeddr.core.base/solutions/pluginSolution/models/com/mbeddr/core/base/pluginSolution/plugin.mps
+++ b/code/languages/com.mbeddr.core/languages/com.mbeddr.core.base/solutions/pluginSolution/models/com/mbeddr/core/base/pluginSolution/plugin.mps
@@ -22212,8 +22212,8 @@
                 <node concept="37vLTw" id="7SQqK0Fdk21" role="37wK5m">
                   <ref role="3cqZAo" node="7SQqK0Fdk1N" resolve="height" />
                 </node>
-                <node concept="10M0yZ" id="7SQqK0Fdk22" role="37wK5m">
-                  <ref role="3cqZAo" to="jan3:~BufferedImage.TYPE_INT_RGB" resolve="TYPE_INT_RGB" />
+                <node concept="10M0yZ" id="2pjWqF5dKmN" role="37wK5m">
+                  <ref role="3cqZAo" to="jan3:~BufferedImage.TYPE_INT_ARGB" resolve="TYPE_INT_ARGB" />
                   <ref role="1PxDUh" to="jan3:~BufferedImage" resolve="BufferedImage" />
                 </node>
               </node>

--- a/code/languages/com.mbeddr.core/languages/com.mbeddr.core.base/solutions/pluginSolution/models/com/mbeddr/core/base/pluginSolution/plugin.mps
+++ b/code/languages/com.mbeddr.core/languages/com.mbeddr.core.base/solutions/pluginSolution/models/com/mbeddr/core/base/pluginSolution/plugin.mps
@@ -22562,47 +22562,12 @@
             </node>
           </node>
         </node>
-        <node concept="3cpWs8" id="7SQqK0Fdk58" role="3cqZAp">
-          <node concept="3cpWsn" id="7SQqK0Fdk59" role="3cpWs9">
-            <property role="TrG5h" value="t" />
-            <node concept="3uibUv" id="7SQqK0Fdk5a" role="1tU5fm">
-              <ref role="3uigEE" to="hwgx:1yFmGPnLcNP" resolve="ImageTrimmer" />
-            </node>
-            <node concept="2ShNRf" id="7SQqK0Fdk5b" role="33vP2m">
-              <node concept="HV5vD" id="7SQqK0Fdk5c" role="2ShVmc">
-                <ref role="HV5vE" to="hwgx:1yFmGPnLcNP" resolve="ImageTrimmer" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3cpWs8" id="xCk$O6nIr8" role="3cqZAp">
-          <node concept="3cpWsn" id="xCk$O6nIr9" role="3cpWs9">
-            <property role="TrG5h" value="croppedImage" />
-            <node concept="3uibUv" id="xCk$O6nHON" role="1tU5fm">
-              <ref role="3uigEE" to="jan3:~BufferedImage" resolve="BufferedImage" />
-            </node>
-            <node concept="2OqwBi" id="xCk$O6nIra" role="33vP2m">
-              <node concept="37vLTw" id="xCk$O6nIrb" role="2Oq$k0">
-                <ref role="3cqZAo" node="7SQqK0Fdk59" resolve="t" />
-              </node>
-              <node concept="liA8E" id="xCk$O6nIrc" role="2OqNvi">
-                <ref role="37wK5l" to="hwgx:1yFmGPnLcNR" resolve="getCroppedImage" />
-                <node concept="37vLTw" id="xCk$O6nIrd" role="37wK5m">
-                  <ref role="3cqZAo" node="7SQqK0Fdk1W" resolve="image" />
-                </node>
-                <node concept="3cmrfG" id="xCk$O6nIre" role="37wK5m">
-                  <property role="3cmrfH" value="0" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
         <node concept="3clFbF" id="7SQqK0Fdk5d" role="3cqZAp">
           <node concept="2YIFZM" id="7SQqK0Fdk5e" role="3clFbG">
             <ref role="37wK5l" to="oqcp:~ImageIO.write(java.awt.image.RenderedImage,java.lang.String,java.io.File)" resolve="write" />
             <ref role="1Pybhc" to="oqcp:~ImageIO" resolve="ImageIO" />
             <node concept="37vLTw" id="xCk$O6nIrf" role="37wK5m">
-              <ref role="3cqZAo" node="xCk$O6nIr9" resolve="croppedImage" />
+              <ref role="3cqZAo" node="7SQqK0Fdk1W" resolve="image" />
             </node>
             <node concept="Xl_RD" id="7SQqK0Fdk5k" role="37wK5m">
               <property role="Xl_RC" value="png" />
@@ -22619,7 +22584,7 @@
         </node>
         <node concept="3cpWs6" id="xCk$O6nKov" role="3cqZAp">
           <node concept="37vLTw" id="xCk$O6nM1b" role="3cqZAk">
-            <ref role="3cqZAo" node="xCk$O6nIr9" resolve="croppedImage" />
+            <ref role="3cqZAo" node="7SQqK0Fdk1W" resolve="image" />
           </node>
         </node>
       </node>

--- a/code/languages/com.mbeddr.core/languages/com.mbeddr.core.base/solutions/pluginSolution/models/com/mbeddr/core/base/pluginSolution/plugin.mps
+++ b/code/languages/com.mbeddr.core/languages/com.mbeddr.core.base/solutions/pluginSolution/models/com/mbeddr/core/base/pluginSolution/plugin.mps
@@ -22256,9 +22256,13 @@
             </node>
             <node concept="liA8E" id="7SQqK0Fdk3Y" role="2OqNvi">
               <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
-              <node concept="10M0yZ" id="7SQqK0Fdk3Z" role="37wK5m">
-                <ref role="3cqZAo" to="z60i:~Color.WHITE" resolve="WHITE" />
-                <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+              <node concept="2OqwBi" id="2pjWqF4WE5X" role="37wK5m">
+                <node concept="37vLTw" id="2pjWqF4WC6x" role="2Oq$k0">
+                  <ref role="3cqZAo" node="7SQqK0FdFYc" resolve="editorComp" />
+                </node>
+                <node concept="liA8E" id="2pjWqF4WG6i" role="2OqNvi">
+                  <ref role="37wK5l" to="z60i:~Component.getBackground()" resolve="getBackground" />
+                </node>
               </node>
             </node>
           </node>

--- a/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc.gen_xhtml/generator/template/com/mbeddr/doc/gen_xhtml/generator/template/main@generator.mps
+++ b/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc.gen_xhtml/generator/template/com/mbeddr/doc/gen_xhtml/generator/template/main@generator.mps
@@ -50,6 +50,13 @@
       <concept id="1076505808687" name="jetbrains.mps.baseLanguage.structure.WhileStatement" flags="nn" index="2$JKZl">
         <child id="1076505808688" name="condition" index="2$JKZa" />
       </concept>
+      <concept id="1239714755177" name="jetbrains.mps.baseLanguage.structure.AbstractUnaryNumberOperation" flags="nn" index="2$Kvd9">
+        <child id="1239714902950" name="expression" index="2$L3a6" />
+      </concept>
+      <concept id="1173175405605" name="jetbrains.mps.baseLanguage.structure.ArrayAccessExpression" flags="nn" index="AH0OO">
+        <child id="1173175577737" name="index" index="AHEQo" />
+        <child id="1173175590490" name="array" index="AHHXb" />
+      </concept>
       <concept id="1154032098014" name="jetbrains.mps.baseLanguage.structure.AbstractLoopStatement" flags="nn" index="2LF5Ji">
         <child id="1154032183016" name="body" index="2LFqv$" />
       </concept>
@@ -71,6 +78,9 @@
       </concept>
       <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
       <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
+      <concept id="1070534760951" name="jetbrains.mps.baseLanguage.structure.ArrayType" flags="in" index="10Q1$e">
+        <child id="1070534760952" name="componentType" index="10Q1$1" />
+      </concept>
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <child id="1068431790190" name="initializer" index="33vP2m" />
       </concept>
@@ -134,7 +144,15 @@
         <child id="1081773367579" name="rightExpression" index="3uHU7w" />
         <child id="1081773367580" name="leftExpression" index="3uHU7B" />
       </concept>
+      <concept id="1214918800624" name="jetbrains.mps.baseLanguage.structure.PostfixIncrementExpression" flags="nn" index="3uNrnE" />
       <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
+      <concept id="1144230876926" name="jetbrains.mps.baseLanguage.structure.AbstractForStatement" flags="nn" index="1DupvO">
+        <child id="1144230900587" name="variable" index="1Duv9x" />
+      </concept>
+      <concept id="1144231330558" name="jetbrains.mps.baseLanguage.structure.ForStatement" flags="nn" index="1Dw8fO">
+        <child id="1144231399730" name="condition" index="1Dwp0S" />
+        <child id="1144231408325" name="iteration" index="1Dwrff" />
+      </concept>
       <concept id="1163668896201" name="jetbrains.mps.baseLanguage.structure.TernaryOperatorExpression" flags="nn" index="3K4zz7">
         <child id="1163668914799" name="condition" index="3K4Cdx" />
         <child id="1163668922816" name="ifTrue" index="3K4E3e" />
@@ -143,13 +161,11 @@
       <concept id="5497648299878491908" name="jetbrains.mps.baseLanguage.structure.BaseVariableReference" flags="nn" index="1M0zk4">
         <reference id="5497648299878491909" name="baseVariableDeclaration" index="1M0zk5" />
       </concept>
+      <concept id="1208890769693" name="jetbrains.mps.baseLanguage.structure.ArrayLengthOperation" flags="nn" index="1Rwk04" />
       <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="nn" index="3SKdUt">
         <child id="8356039341262087992" name="line" index="1aUNEU" />
       </concept>
       <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
-    </language>
-    <language id="774bf8a0-62e5-41e1-af63-f4812e60e48b" name="jetbrains.mps.baseLanguage.checkedDots">
-      <concept id="4079382982702596667" name="jetbrains.mps.baseLanguage.checkedDots.structure.CheckedDotExpression" flags="nn" index="2EnYce" />
     </language>
     <language id="479c7a8c-02f9-43b5-9139-d910cb22f298" name="jetbrains.mps.core.xml">
       <concept id="6666499814681515200" name="jetbrains.mps.core.xml.structure.XmlFile" flags="ng" index="2pMbU2">
@@ -271,6 +287,25 @@
     <language id="d7706f63-9be2-479c-a3da-ae92af1e64d5" name="jetbrains.mps.lang.generator.generationContext">
       <concept id="1216860049635" name="jetbrains.mps.lang.generator.generationContext.structure.TemplateFunctionParameter_generationContext" flags="nn" index="1iwH7S" />
     </language>
+    <language id="3a13115c-633c-4c5c-bbcc-75c4219e9555" name="jetbrains.mps.lang.quotation">
+      <concept id="1196350785113" name="jetbrains.mps.lang.quotation.structure.Quotation" flags="nn" index="2c44tf">
+        <child id="1196350785114" name="quotedNode" index="2c44tc" />
+      </concept>
+      <concept id="5455284157993911077" name="jetbrains.mps.lang.quotation.structure.NodeBuilderInitProperty" flags="ng" index="2pJxcG">
+        <reference id="5455284157993911078" name="property" index="2pJxcJ" />
+        <child id="1595412875168045201" name="initValue" index="28ntcv" />
+      </concept>
+      <concept id="5455284157993863837" name="jetbrains.mps.lang.quotation.structure.NodeBuilder" flags="nn" index="2pJPEk">
+        <child id="5455284157993863838" name="quotedNode" index="2pJPEn" />
+      </concept>
+      <concept id="5455284157993863840" name="jetbrains.mps.lang.quotation.structure.NodeBuilderNode" flags="nn" index="2pJPED">
+        <reference id="5455284157993910961" name="concept" index="2pJxaS" />
+        <child id="5455284157993911099" name="values" index="2pJxcM" />
+      </concept>
+      <concept id="6985522012210254362" name="jetbrains.mps.lang.quotation.structure.NodeBuilderPropertyExpression" flags="nn" index="WxPPo">
+        <child id="6985522012210254363" name="expression" index="WxPPp" />
+      </concept>
+    </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
       <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
         <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
@@ -285,6 +320,9 @@
       <concept id="2396822768958367367" name="jetbrains.mps.lang.smodel.structure.AbstractTypeCastExpression" flags="nn" index="$5XWr">
         <child id="6733348108486823193" name="leftExpression" index="1m5AlR" />
         <child id="3906496115198199033" name="conceptArgument" index="3oSUPX" />
+      </concept>
+      <concept id="1143224066846" name="jetbrains.mps.lang.smodel.structure.Node_InsertNextSiblingOperation" flags="nn" index="HtI8k">
+        <child id="1143224066849" name="insertedNode" index="HtI8F" />
       </concept>
       <concept id="1145383075378" name="jetbrains.mps.lang.smodel.structure.SNodeListType" flags="in" index="2I9FWS">
         <reference id="1145383142433" name="elementConcept" index="2I9WkF" />
@@ -5884,58 +5922,222 @@
     <property role="TrG5h" value="escapeXmlText" />
     <node concept="1pplIY" id="QRmqzL5ttV" role="1pqMTA">
       <node concept="3clFbS" id="QRmqzL5ttW" role="2VODD2">
-        <node concept="3clFbF" id="QRmqzL5ttY" role="3cqZAp">
-          <node concept="2OqwBi" id="QRmqzL5ugO" role="3clFbG">
-            <node concept="2OqwBi" id="QRmqzL5tus" role="2Oq$k0">
-              <node concept="1Q6Npb" id="QRmqzL5ttX" role="2Oq$k0" />
-              <node concept="2SmgA7" id="QRmqzL5tA0" role="2OqNvi">
-                <node concept="chp4Y" id="12zeRDvnbgZ" role="1dBWTz">
+        <node concept="3clFbF" id="2pjWqF4zseE" role="3cqZAp">
+          <node concept="2OqwBi" id="2pjWqF4zuVz" role="3clFbG">
+            <node concept="2OqwBi" id="2pjWqF4zsoi" role="2Oq$k0">
+              <node concept="1Q6Npb" id="2pjWqF4zseD" role="2Oq$k0" />
+              <node concept="2SmgA7" id="2pjWqF4zswp" role="2OqNvi">
+                <node concept="chp4Y" id="2pjWqF4zswO" role="1dBWTz">
                   <ref role="cht4Q" to="iuxj:1q3yNZeAEkj" resolve="XmlText" />
                 </node>
               </node>
             </node>
-            <node concept="2es0OD" id="QRmqzL5z80" role="2OqNvi">
-              <node concept="1bVj0M" id="QRmqzL5z82" role="23t8la">
-                <node concept="3clFbS" id="QRmqzL5z83" role="1bW5cS">
-                  <node concept="3clFbF" id="QRmqzL5z9T" role="3cqZAp">
-                    <node concept="37vLTI" id="QRmqzL5$rC" role="3clFbG">
-                      <node concept="2EnYce" id="QRmqzLaz7T" role="37vLTx">
-                        <node concept="2YIFZM" id="QRmqzL5$wV" role="2Oq$k0">
-                          <ref role="37wK5l" to="btm1:~StringEscapeUtils.escapeXml10(java.lang.String)" resolve="escapeXml10" />
-                          <ref role="1Pybhc" to="btm1:~StringEscapeUtils" resolve="StringEscapeUtils" />
-                          <node concept="2OqwBi" id="QRmqzL5$C0" role="37wK5m">
-                            <node concept="37vLTw" id="QRmqzL5$zv" role="2Oq$k0">
-                              <ref role="3cqZAo" node="QRmqzL5z84" resolve="it" />
-                            </node>
-                            <node concept="3TrcHB" id="QRmqzL5$SG" role="2OqNvi">
-                              <ref role="3TsBF5" to="iuxj:1q3yNZeAEDC" resolve="value" />
-                            </node>
-                          </node>
+            <node concept="2es0OD" id="2pjWqF4zxnX" role="2OqNvi">
+              <node concept="1bVj0M" id="2pjWqF4zxnZ" role="23t8la">
+                <node concept="3clFbS" id="2pjWqF4zxo0" role="1bW5cS">
+                  <node concept="3clFbJ" id="2pjWqF4$o7I" role="3cqZAp">
+                    <node concept="3clFbS" id="2pjWqF4$o7K" role="3clFbx">
+                      <node concept="3cpWs6" id="2pjWqF4$sYF" role="3cqZAp" />
+                    </node>
+                    <node concept="3clFbC" id="2pjWqF4$qIK" role="3clFbw">
+                      <node concept="10Nm6u" id="2pjWqF4$sMf" role="3uHU7w" />
+                      <node concept="2OqwBi" id="2pjWqF4$o$c" role="3uHU7B">
+                        <node concept="37vLTw" id="2pjWqF4$oaf" role="2Oq$k0">
+                          <ref role="3cqZAo" node="2pjWqF4zxo1" resolve="it" />
                         </node>
-                        <node concept="liA8E" id="QRmqzL7_Y8" role="2OqNvi">
-                          <ref role="37wK5l" to="wyt6:~String.replace(java.lang.CharSequence,java.lang.CharSequence)" resolve="replace" />
-                          <node concept="Xl_RD" id="QRmqzL7A1o" role="37wK5m">
-                            <property role="Xl_RC" value="\n" />
-                          </node>
-                          <node concept="Xl_RD" id="QRmqzL7A1p" role="37wK5m">
-                            <property role="Xl_RC" value="&lt;br/&gt;\n" />
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="2OqwBi" id="QRmqzL5zdo" role="37vLTJ">
-                        <node concept="37vLTw" id="QRmqzL5z9S" role="2Oq$k0">
-                          <ref role="3cqZAo" node="QRmqzL5z84" resolve="it" />
-                        </node>
-                        <node concept="3TrcHB" id="QRmqzL5zF_" role="2OqNvi">
+                        <node concept="3TrcHB" id="2pjWqF4$p3v" role="2OqNvi">
                           <ref role="3TsBF5" to="iuxj:1q3yNZeAEDC" resolve="value" />
                         </node>
                       </node>
                     </node>
                   </node>
+                  <node concept="3cpWs8" id="2pjWqF4zzl8" role="3cqZAp">
+                    <node concept="3cpWsn" id="2pjWqF4zzl9" role="3cpWs9">
+                      <property role="TrG5h" value="split" />
+                      <node concept="10Q1$e" id="2pjWqF4zzjQ" role="1tU5fm">
+                        <node concept="17QB3L" id="2pjWqF4EKVd" role="10Q1$1" />
+                      </node>
+                      <node concept="2OqwBi" id="2pjWqF4zzla" role="33vP2m">
+                        <node concept="2OqwBi" id="2pjWqF4zzlb" role="2Oq$k0">
+                          <node concept="37vLTw" id="2pjWqF4zzlc" role="2Oq$k0">
+                            <ref role="3cqZAo" node="2pjWqF4zxo1" resolve="it" />
+                          </node>
+                          <node concept="3TrcHB" id="2pjWqF4zzld" role="2OqNvi">
+                            <ref role="3TsBF5" to="iuxj:1q3yNZeAEDC" resolve="value" />
+                          </node>
+                        </node>
+                        <node concept="liA8E" id="2pjWqF4zzle" role="2OqNvi">
+                          <ref role="37wK5l" to="wyt6:~String.split(java.lang.String)" resolve="split" />
+                          <node concept="Xl_RD" id="2pjWqF4zzlf" role="37wK5m">
+                            <property role="Xl_RC" value="\\\\n" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3cpWs8" id="2pjWqF4zFTI" role="3cqZAp">
+                    <node concept="3cpWsn" id="2pjWqF4zFTL" role="3cpWs9">
+                      <property role="TrG5h" value="currentNode" />
+                      <node concept="3Tqbb2" id="2pjWqF4zFTG" role="1tU5fm" />
+                      <node concept="37vLTw" id="2pjWqF4zGqn" role="33vP2m">
+                        <ref role="3cqZAo" node="2pjWqF4zxo1" resolve="it" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbF" id="2pjWqF4zzzf" role="3cqZAp">
+                    <node concept="2OqwBi" id="2pjWqF4zz_Z" role="3clFbG">
+                      <node concept="37vLTw" id="2pjWqF4zzzd" role="2Oq$k0">
+                        <ref role="3cqZAo" node="2pjWqF4zFTL" resolve="currentNode" />
+                      </node>
+                      <node concept="1P9Npp" id="2pjWqF4zzHj" role="2OqNvi">
+                        <node concept="2pJPEk" id="2pjWqF4z$m4" role="1P9ThW">
+                          <node concept="2pJPED" id="2pjWqF4z$m6" role="2pJPEn">
+                            <ref role="2pJxaS" to="iuxj:1q3yNZeAEkj" resolve="XmlText" />
+                            <node concept="2pJxcG" id="2pjWqF4z$ug" role="2pJxcM">
+                              <ref role="2pJxcJ" to="iuxj:1q3yNZeAEDC" resolve="value" />
+                              <node concept="WxPPo" id="2pjWqF4EJ8x" role="28ntcv">
+                                <node concept="2YIFZM" id="2pjWqF4EJmb" role="WxPPp">
+                                  <ref role="37wK5l" to="btm1:~StringEscapeUtils.escapeXml10(java.lang.String)" resolve="escapeXml10" />
+                                  <ref role="1Pybhc" to="btm1:~StringEscapeUtils" resolve="StringEscapeUtils" />
+                                  <node concept="AH0OO" id="2pjWqF4EKt_" role="37wK5m">
+                                    <node concept="3cmrfG" id="2pjWqF4EKGu" role="AHEQo">
+                                      <property role="3cmrfH" value="0" />
+                                    </node>
+                                    <node concept="37vLTw" id="2pjWqF4EKeW" role="AHHXb">
+                                      <ref role="3cqZAo" node="2pjWqF4zzl9" resolve="split" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbJ" id="2pjWqF4z_fi" role="3cqZAp">
+                    <node concept="3clFbS" id="2pjWqF4z_fk" role="3clFbx">
+                      <node concept="3cpWs6" id="2pjWqF4zBE3" role="3cqZAp" />
+                    </node>
+                    <node concept="3clFbC" id="2pjWqF4zB0Y" role="3clFbw">
+                      <node concept="3cmrfG" id="2pjWqF4zB_n" role="3uHU7w">
+                        <property role="3cmrfH" value="1" />
+                      </node>
+                      <node concept="2OqwBi" id="2pjWqF4z_wu" role="3uHU7B">
+                        <node concept="37vLTw" id="2pjWqF4z_kT" role="2Oq$k0">
+                          <ref role="3cqZAo" node="2pjWqF4zzl9" resolve="split" />
+                        </node>
+                        <node concept="1Rwk04" id="2pjWqF4zBT_" role="2OqNvi" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="1Dw8fO" id="2pjWqF4z$VW" role="3cqZAp">
+                    <node concept="3clFbS" id="2pjWqF4z$VY" role="2LFqv$">
+                      <node concept="3cpWs8" id="2pjWqF4zHGs" role="3cqZAp">
+                        <node concept="3cpWsn" id="2pjWqF4zHGv" role="3cpWs9">
+                          <property role="TrG5h" value="breakElement" />
+                          <node concept="3Tqbb2" id="2pjWqF4zHGq" role="1tU5fm">
+                            <ref role="ehGHo" to="iuxj:5M4a$b5iL2M" resolve="XmlElement" />
+                          </node>
+                          <node concept="2c44tf" id="2pjWqF4zKIp" role="33vP2m">
+                            <node concept="2pNNFK" id="2pjWqF4zLA_" role="2c44tc">
+                              <property role="2pNNFO" value="br" />
+                              <property role="qg3DV" value="true" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbF" id="2pjWqF4zGJ8" role="3cqZAp">
+                        <node concept="2OqwBi" id="2pjWqF4zH2j" role="3clFbG">
+                          <node concept="37vLTw" id="2pjWqF4zGJ7" role="2Oq$k0">
+                            <ref role="3cqZAo" node="2pjWqF4zFTL" resolve="currentNode" />
+                          </node>
+                          <node concept="HtI8k" id="2pjWqF4zHmP" role="2OqNvi">
+                            <node concept="37vLTw" id="2pjWqF4zMWx" role="HtI8F">
+                              <ref role="3cqZAo" node="2pjWqF4zHGv" resolve="breakElement" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3cpWs8" id="2pjWqF4zObZ" role="3cqZAp">
+                        <node concept="3cpWsn" id="2pjWqF4zOc2" role="3cpWs9">
+                          <property role="TrG5h" value="nextText" />
+                          <node concept="3Tqbb2" id="2pjWqF4zObX" role="1tU5fm">
+                            <ref role="ehGHo" to="iuxj:1q3yNZeAEkj" resolve="XmlText" />
+                          </node>
+                          <node concept="2pJPEk" id="2pjWqF4zP$L" role="33vP2m">
+                            <node concept="2pJPED" id="2pjWqF4zP$N" role="2pJPEn">
+                              <ref role="2pJxaS" to="iuxj:1q3yNZeAEkj" resolve="XmlText" />
+                              <node concept="2pJxcG" id="2pjWqF4zPY_" role="2pJxcM">
+                                <ref role="2pJxcJ" to="iuxj:1q3yNZeAEDC" resolve="value" />
+                                <node concept="2YIFZM" id="2pjWqF4EGTa" role="28ntcv">
+                                  <ref role="37wK5l" to="btm1:~StringEscapeUtils.escapeXml10(java.lang.String)" resolve="escapeXml10" />
+                                  <ref role="1Pybhc" to="btm1:~StringEscapeUtils" resolve="StringEscapeUtils" />
+                                  <node concept="AH0OO" id="2pjWqF4EHTY" role="37wK5m">
+                                    <node concept="37vLTw" id="2pjWqF4EI7x" role="AHEQo">
+                                      <ref role="3cqZAo" node="2pjWqF4z$VZ" resolve="i" />
+                                    </node>
+                                    <node concept="37vLTw" id="2pjWqF4EHva" role="AHHXb">
+                                      <ref role="3cqZAo" node="2pjWqF4zzl9" resolve="split" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbF" id="2pjWqF4zRei" role="3cqZAp">
+                        <node concept="2OqwBi" id="2pjWqF4zRAv" role="3clFbG">
+                          <node concept="37vLTw" id="2pjWqF4zReg" role="2Oq$k0">
+                            <ref role="3cqZAo" node="2pjWqF4zHGv" resolve="breakElement" />
+                          </node>
+                          <node concept="HtI8k" id="2pjWqF4zS5h" role="2OqNvi">
+                            <node concept="37vLTw" id="2pjWqF4zShP" role="HtI8F">
+                              <ref role="3cqZAo" node="2pjWqF4zOc2" resolve="nextText" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbF" id="2pjWqF4zS$S" role="3cqZAp">
+                        <node concept="37vLTI" id="2pjWqF4zSLB" role="3clFbG">
+                          <node concept="37vLTw" id="2pjWqF4zT5Q" role="37vLTx">
+                            <ref role="3cqZAo" node="2pjWqF4zOc2" resolve="nextText" />
+                          </node>
+                          <node concept="37vLTw" id="2pjWqF4zS$Q" role="37vLTJ">
+                            <ref role="3cqZAo" node="2pjWqF4zFTL" resolve="currentNode" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3cpWsn" id="2pjWqF4z$VZ" role="1Duv9x">
+                      <property role="TrG5h" value="i" />
+                      <node concept="10Oyi0" id="2pjWqF4z_1C" role="1tU5fm" />
+                      <node concept="3cmrfG" id="2pjWqF4zCYD" role="33vP2m">
+                        <property role="3cmrfH" value="1" />
+                      </node>
+                    </node>
+                    <node concept="3eOVzh" id="2pjWqF4zDB1" role="1Dwp0S">
+                      <node concept="2OqwBi" id="2pjWqF4zEbG" role="3uHU7w">
+                        <node concept="37vLTw" id="2pjWqF4zDKM" role="2Oq$k0">
+                          <ref role="3cqZAo" node="2pjWqF4zzl9" resolve="split" />
+                        </node>
+                        <node concept="1Rwk04" id="2pjWqF4zEss" role="2OqNvi" />
+                      </node>
+                      <node concept="37vLTw" id="2pjWqF4zD8g" role="3uHU7B">
+                        <ref role="3cqZAo" node="2pjWqF4z$VZ" resolve="i" />
+                      </node>
+                    </node>
+                    <node concept="3uNrnE" id="2pjWqF4zESw" role="1Dwrff">
+                      <node concept="37vLTw" id="2pjWqF4zESy" role="2$L3a6">
+                        <ref role="3cqZAo" node="2pjWqF4z$VZ" resolve="i" />
+                      </node>
+                    </node>
+                  </node>
                 </node>
-                <node concept="Rh6nW" id="QRmqzL5z84" role="1bW2Oz">
+                <node concept="Rh6nW" id="2pjWqF4zxo1" role="1bW2Oz">
                   <property role="TrG5h" value="it" />
-                  <node concept="2jxLKc" id="QRmqzL5z85" role="1tU5fm" />
+                  <node concept="2jxLKc" id="2pjWqF4zxo2" role="1tU5fm" />
                 </node>
               </node>
             </node>

--- a/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/languageModels/plugin.mps
+++ b/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/languageModels/plugin.mps
@@ -3513,14 +3513,27 @@
                             </node>
                             <node concept="liA8E" id="oUcJT$luJd" role="2OqNvi">
                               <ref role="37wK5l" to="yyf4:~ProgressMonitor.step(java.lang.String)" resolve="step" />
-                              <node concept="3cpWs3" id="3jAiNlltCax" role="37wK5m">
-                                <node concept="3uNrnE" id="3jAiNlltER$" role="3uHU7w">
-                                  <node concept="37vLTw" id="3jAiNlltERA" role="2$L3a6">
-                                    <ref role="3cqZAo" node="3jAiNlltD3e" resolve="index" />
+                              <node concept="3cpWs3" id="3OTy9gWa97V" role="37wK5m">
+                                <node concept="3cpWs3" id="3OTy9gWa89m" role="3uHU7B">
+                                  <node concept="3cpWs3" id="3jAiNlltCax" role="3uHU7B">
+                                    <node concept="Xl_RD" id="3jAiNlltB_L" role="3uHU7B">
+                                      <property role="Xl_RC" value="Creating screenshot step " />
+                                    </node>
+                                    <node concept="3uNrnE" id="3jAiNlltER$" role="3uHU7w">
+                                      <node concept="37vLTw" id="3jAiNlltERA" role="2$L3a6">
+                                        <ref role="3cqZAo" node="3jAiNlltD3e" resolve="index" />
+                                      </node>
+                                    </node>
+                                  </node>
+                                  <node concept="Xl_RD" id="3OTy9gWa89_" role="3uHU7w">
+                                    <property role="Xl_RC" value=" of " />
                                   </node>
                                 </node>
-                                <node concept="Xl_RD" id="3jAiNlltB_L" role="3uHU7B">
-                                  <property role="Xl_RC" value="Creating screenshot step " />
+                                <node concept="2OqwBi" id="3OTy9gWa5$_" role="3uHU7w">
+                                  <node concept="37vLTw" id="3OTy9gWa4oc" role="2Oq$k0">
+                                    <ref role="3cqZAo" node="C1ce8Wei$9" resolve="runnables" />
+                                  </node>
+                                  <node concept="34oBXx" id="3OTy9gWa6CH" role="2OqNvi" />
                                 </node>
                               </node>
                             </node>

--- a/code/languages/com.mbeddr.doc/solutions/com.mbeddr.doc.doc/models/main.mps
+++ b/code/languages/com.mbeddr.doc/solutions/com.mbeddr.doc.doc/models/main.mps
@@ -262,7 +262,7 @@
       <node concept="1_0LV8" id="1ZiHc0gKJBC" role="1_0VJ0">
         <node concept="19SGf9" id="1ZiHc0gKJBD" role="1_0LWR">
           <node concept="19SUe$" id="1ZiHc0gKJBE" role="19SJt6">
-            <property role="19SUeA" value="The mbeddr documentation language provdides a better alternative. It supports writing prose inside of MPS, supporting a tight integration between the prose and the code. In this document we explain how this works. Of course, this document is itself written in the documentation language." />
+            <property role="19SUeA" value="The mbeddr documentation language provides a better alternative. It supports writing prose inside of MPS, supporting a tight integration between the prose and the code. In this document we explain how this works. Of course, this document is itself written in the documentation language." />
           </node>
         </node>
       </node>
@@ -276,7 +276,7 @@
       <node concept="1_0LV8" id="1ZiHc0gKJBK" role="1_0VJ0">
         <node concept="19SGf9" id="1ZiHc0gKJBL" role="1_0LWR">
           <node concept="19SUe$" id="1ZiHc0gKJBM" role="19SJt6">
-            <property role="19SUeA" value="The documentation language supports several different extensions, each supporting the integration with differnet code artifacts. We will explain all of this in this document. The languages that support these features are all named " />
+            <property role="19SUeA" value="The documentation language supports several different extensions, each supporting the integration with different code artifacts. We will explain all of this in this document. The languages that support these features are all named " />
           </node>
           <node concept="1jUjqm" id="1ZiHc0gKJBN" role="19SJt6">
             <node concept="19SGf9" id="1ZiHc0gKJBO" role="$DsGW">
@@ -1002,7 +1002,7 @@
       <node concept="1_0LV8" id="7$DvC4gRxXS" role="1_0VJ0">
         <node concept="19SGf9" id="7$DvC4gRxXT" role="1_0LWR">
           <node concept="19SUe$" id="7$DvC4gRxXU" role="19SJt6">
-            <property role="19SUeA" value="A more interesting use case is the ability to work with mbeddr code. In fact, \nthe ability to tightly integrate with mebddr code was the reason for building\nthis documentation language, as we have said in " />
+            <property role="19SUeA" value="A more interesting use case is the ability to work with mbeddr code. In fact, the ability to tightly integrate with mebddr code was the reason for building\nthis documentation language, as we have said in " />
           </node>
           <node concept="1_0GAv" id="7$DvC4gRxY1" role="19SJt6">
             <ref role="1_0GAl" node="1ZiHc0gKJBz" resolve="introduction" />


### PR DESCRIPTION
- The cell editor screenshooter doesn't trim the offset of the editor component anymore.
- The escaping of the new line character works again in the HTML generator.
- The cell editor screenshooter now supports editor extensions and the rendering quality was slightly improved.	

Unfortunately, I couldn't figure out why the quality of the generated png files is still worse than in the editor. There is no compression going on, all rendering hints are set and the size of the generated image also looks right to me.