### PR TITLE
mpsutil.interpreter: Add a dummy computation trace when the computation trace is not available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is _loosely_ based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). The project does _not_ follow
 Semantic Versioning and the changes are simply documented in reverse chronological order, grouped by calendar month.
 
+# January 2024
+
+## com.mbeddr.mpsutils
+
+- A dummy computation trace is now used when the computation trace is not available in the interpreter to prevent NullPointerExceptions.
+
 # December 2023
 
 ## com.mbeddr.mpsutils

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.interpreter/generator/template/main@generator.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.interpreter/generator/template/main@generator.mps
@@ -108,6 +108,9 @@
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <child id="1068431790190" name="initializer" index="33vP2m" />
       </concept>
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ng" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
+      </concept>
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
@@ -133,6 +136,7 @@
       </concept>
       <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
       <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
+        <child id="1082485599094" name="ifFalseStatement" index="9aQIa" />
         <child id="1068580123160" name="condition" index="3clFbw" />
         <child id="1068580123161" name="ifTrue" index="3clFbx" />
         <child id="1206060520071" name="elsifClauses" index="3eNLev" />
@@ -321,6 +325,9 @@
       </concept>
     </language>
     <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
+      <concept id="1235746970280" name="jetbrains.mps.baseLanguage.closures.structure.CompactInvokeFunctionExpression" flags="nn" index="2Sg_IR">
+        <child id="1235746996653" name="function" index="2SgG2M" />
+      </concept>
       <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
         <child id="1199569906740" name="parameter" index="1bW2Oz" />
         <child id="1199569916463" name="body" index="1bW5cS" />
@@ -2781,22 +2788,81 @@
                 <node concept="3uibUv" id="5d4VabuMRjA" role="1tU5fm">
                   <ref role="3uigEE" to="2ahs:7cNsFS_gTK8" resolve="ComputationTrace" />
                 </node>
-                <node concept="37vLTw" id="5d4VabuMHon" role="33vP2m">
-                  <ref role="3cqZAo" node="5d4VabuMHou" resolve="trace" />
-                  <node concept="raruj" id="5d4VabuMHoo" role="lGtFl" />
-                  <node concept="1ZhdrF" id="5d4VabuMHop" role="lGtFl">
-                    <property role="2qtEX8" value="variableDeclaration" />
-                    <property role="P3scX" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068498886296/1068581517664" />
-                    <node concept="3$xsQk" id="5d4VabuMHoq" role="3$ytzL">
-                      <node concept="3clFbS" id="5d4VabuMHor" role="2VODD2">
-                        <node concept="3clFbF" id="5d4VabuMHos" role="3cqZAp">
-                          <node concept="Xl_RD" id="5d4VabuMHot" role="3clFbG">
-                            <property role="Xl_RC" value="trace" />
+                <node concept="2Sg_IR" id="1nsRmdN9mg1" role="33vP2m">
+                  <node concept="1bVj0M" id="1nsRmdN9mg2" role="2SgG2M">
+                    <node concept="3clFbS" id="1nsRmdN9mg3" role="1bW5cS">
+                      <node concept="3clFbJ" id="1nsRmdN9mio" role="3cqZAp">
+                        <node concept="3clFbS" id="1nsRmdN9miq" role="3clFbx">
+                          <node concept="3cpWs6" id="1nsRmdN9mIx" role="3cqZAp">
+                            <node concept="37vLTw" id="1nsRmdN9mKk" role="3cqZAk">
+                              <ref role="3cqZAo" node="5d4VabuMHou" resolve="trace" />
+                              <node concept="1ZhdrF" id="1nsRmdN9mKl" role="lGtFl">
+                                <property role="2qtEX8" value="variableDeclaration" />
+                                <property role="P3scX" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068498886296/1068581517664" />
+                                <node concept="3$xsQk" id="1nsRmdN9mKm" role="3$ytzL">
+                                  <node concept="3clFbS" id="1nsRmdN9mKn" role="2VODD2">
+                                    <node concept="3clFbF" id="1nsRmdN9mKo" role="3cqZAp">
+                                      <node concept="Xl_RD" id="1nsRmdN9mKp" role="3clFbG">
+                                        <property role="Xl_RC" value="trace" />
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3y3z36" id="1nsRmdN9mzX" role="3clFbw">
+                          <node concept="10Nm6u" id="1nsRmdN9mGa" role="3uHU7w" />
+                          <node concept="37vLTw" id="5d4VabuMHon" role="3uHU7B">
+                            <ref role="3cqZAo" node="5d4VabuMHou" resolve="trace" />
+                            <node concept="1ZhdrF" id="5d4VabuMHop" role="lGtFl">
+                              <property role="2qtEX8" value="variableDeclaration" />
+                              <property role="P3scX" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068498886296/1068581517664" />
+                              <node concept="3$xsQk" id="5d4VabuMHoq" role="3$ytzL">
+                                <node concept="3clFbS" id="5d4VabuMHor" role="2VODD2">
+                                  <node concept="3clFbF" id="5d4VabuMHos" role="3cqZAp">
+                                    <node concept="Xl_RD" id="5d4VabuMHot" role="3clFbG">
+                                      <property role="Xl_RC" value="trace" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="9aQIb" id="1nsRmdN9mML" role="9aQIa">
+                          <node concept="3clFbS" id="1nsRmdN9mMM" role="9aQI4">
+                            <node concept="3cpWs6" id="1nsRmdN9mQu" role="3cqZAp">
+                              <node concept="2ShNRf" id="1nsRmdN9n76" role="3cqZAk">
+                                <node concept="1pGfFk" id="1nsRmdN9omV" role="2ShVmc">
+                                  <property role="373rjd" value="true" />
+                                  <ref role="37wK5l" to="2ahs:1nsRmdNe_zj" resolve="DummyComputationTrace" />
+                                  <node concept="37vLTw" id="1nsRmdNh_g9" role="37wK5m">
+                                    <ref role="3cqZAo" node="1nsRmdNh_eI" resolve="node" />
+                                    <node concept="1ZhdrF" id="1nsRmdNh_ga" role="lGtFl">
+                                      <property role="2qtEX8" value="variableDeclaration" />
+                                      <property role="P3scX" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068498886296/1068581517664" />
+                                      <node concept="3$xsQk" id="1nsRmdNh_gb" role="3$ytzL">
+                                        <node concept="3clFbS" id="1nsRmdNh_gc" role="2VODD2">
+                                          <node concept="3clFbF" id="1nsRmdNh_gd" role="3cqZAp">
+                                            <node concept="Xl_RD" id="1nsRmdNh_ge" role="3clFbG">
+                                              <property role="Xl_RC" value="node" />
+                                            </node>
+                                          </node>
+                                        </node>
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
                           </node>
                         </node>
                       </node>
                     </node>
                   </node>
+                  <node concept="raruj" id="1nsRmdNj8p7" role="lGtFl" />
                 </node>
               </node>
             </node>
@@ -2806,6 +2872,10 @@
             <node concept="3uibUv" id="5d4VabuMR9O" role="1tU5fm">
               <ref role="3uigEE" to="2ahs:7cNsFS_gTK8" resolve="ComputationTrace" />
             </node>
+          </node>
+          <node concept="37vLTG" id="1nsRmdNh_eI" role="3clF46">
+            <property role="TrG5h" value="node" />
+            <node concept="3Tqbb2" id="1nsRmdNh_fM" role="1tU5fm" />
           </node>
         </node>
       </node>

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.interpreter/runtime/models/com/mbeddr/mpsutil/interpreter/rt.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.interpreter/runtime/models/com/mbeddr/mpsutil/interpreter/rt.mps
@@ -18197,5 +18197,278 @@
       </node>
     </node>
   </node>
+  <node concept="312cEu" id="1nsRmdN9tD9">
+    <property role="3GE5qa" value="context" />
+    <property role="TrG5h" value="DummyComputationTrace" />
+    <node concept="2tJIrI" id="1nsRmdN9v$l" role="jymVt" />
+    <node concept="3clFbW" id="1nsRmdNe_zj" role="jymVt">
+      <node concept="3cqZAl" id="1nsRmdNe_zk" role="3clF45" />
+      <node concept="3clFbS" id="1nsRmdNe_zm" role="3clF47">
+        <node concept="XkiVB" id="1nsRmdNeEIf" role="3cqZAp">
+          <ref role="37wK5l" node="7cNsFS_gVK7" resolve="ComputationTrace" />
+          <node concept="37vLTw" id="1nsRmdNeIPP" role="37wK5m">
+            <ref role="3cqZAo" node="1nsRmdNeCbG" resolve="node" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="1nsRmdNe_zn" role="1B3o_S" />
+      <node concept="37vLTG" id="1nsRmdNeCbG" role="3clF46">
+        <property role="TrG5h" value="node" />
+        <node concept="3Tqbb2" id="1nsRmdNeCbF" role="1tU5fm" />
+      </node>
+    </node>
+    <node concept="3Tm1VV" id="1nsRmdN9tDa" role="1B3o_S" />
+    <node concept="3uibUv" id="1nsRmdN9tRS" role="1zkMxy">
+      <ref role="3uigEE" node="7cNsFS_gTK8" resolve="ComputationTrace" />
+    </node>
+    <node concept="2tJIrI" id="1nsRmdNbbB5" role="jymVt" />
+    <node concept="3clFb_" id="1nsRmdN9vGG" role="jymVt">
+      <property role="TrG5h" value="addChild" />
+      <property role="od$2w" value="false" />
+      <property role="DiZV1" value="false" />
+      <property role="2aFKle" value="false" />
+      <node concept="3uibUv" id="1nsRmdN9vHw" role="3clF45">
+        <ref role="3uigEE" node="7cNsFS_gTK8" resolve="ComputationTrace" />
+      </node>
+      <node concept="3Tm1VV" id="1nsRmdN9vHx" role="1B3o_S" />
+      <node concept="37vLTG" id="1nsRmdN9vHy" role="3clF46">
+        <property role="TrG5h" value="t" />
+        <node concept="3uibUv" id="1nsRmdN9vHz" role="1tU5fm">
+          <ref role="3uigEE" node="7cNsFS_gTK8" resolve="ComputationTrace" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="1nsRmdN9vH$" role="3clF47">
+        <node concept="3clFbF" id="1nsRmdNbh0a" role="3cqZAp">
+          <node concept="Xjq3P" id="1nsRmdNbh09" role="3clFbG" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="1nsRmdN9vH_" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="1nsRmdNbjg4" role="jymVt" />
+    <node concept="3clFb_" id="1nsRmdN9vHD" role="jymVt">
+      <property role="TrG5h" value="addChild" />
+      <property role="od$2w" value="false" />
+      <property role="DiZV1" value="false" />
+      <property role="2aFKle" value="false" />
+      <node concept="3uibUv" id="1nsRmdN9vIF" role="3clF45">
+        <ref role="3uigEE" node="7cNsFS_gTK8" resolve="ComputationTrace" />
+      </node>
+      <node concept="3Tm1VV" id="1nsRmdN9vIG" role="1B3o_S" />
+      <node concept="37vLTG" id="1nsRmdN9vIH" role="3clF46">
+        <property role="TrG5h" value="t" />
+        <node concept="3uibUv" id="1nsRmdN9vII" role="1tU5fm">
+          <ref role="3uigEE" node="7cNsFS_gTK8" resolve="ComputationTrace" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="1nsRmdN9vIJ" role="3clF46">
+        <property role="TrG5h" value="showInAnyCase" />
+        <node concept="10P_77" id="1nsRmdN9vIK" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="1nsRmdN9vIL" role="3clF46">
+        <property role="TrG5h" value="label" />
+        <node concept="17QB3L" id="1nsRmdN9vIM" role="1tU5fm" />
+      </node>
+      <node concept="3clFbS" id="1nsRmdN9vIN" role="3clF47">
+        <node concept="3clFbF" id="1nsRmdNboCn" role="3cqZAp">
+          <node concept="Xjq3P" id="1nsRmdNboCm" role="3clFbG" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="1nsRmdN9vIO" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="1nsRmdNh$7h" role="jymVt" />
+    <node concept="3clFb_" id="1nsRmdN9vIU" role="jymVt">
+      <property role="TrG5h" value="newChild" />
+      <property role="od$2w" value="false" />
+      <property role="DiZV1" value="false" />
+      <property role="2aFKle" value="false" />
+      <node concept="3uibUv" id="1nsRmdN9vJb" role="3clF45">
+        <ref role="3uigEE" node="7cNsFS_gTK8" resolve="ComputationTrace" />
+      </node>
+      <node concept="3Tm1VV" id="1nsRmdN9vJc" role="1B3o_S" />
+      <node concept="37vLTG" id="1nsRmdN9vJd" role="3clF46">
+        <property role="TrG5h" value="n" />
+        <node concept="3Tqbb2" id="1nsRmdN9vJe" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="1nsRmdN9vJf" role="3clF46">
+        <property role="TrG5h" value="showInAnyCase" />
+        <node concept="10P_77" id="1nsRmdN9vJg" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="1nsRmdN9vJh" role="3clF46">
+        <property role="TrG5h" value="label" />
+        <node concept="17QB3L" id="1nsRmdN9vJi" role="1tU5fm" />
+      </node>
+      <node concept="3clFbS" id="1nsRmdN9vJj" role="3clF47">
+        <node concept="3clFbF" id="1nsRmdNbtDc" role="3cqZAp">
+          <node concept="Xjq3P" id="1nsRmdNbtDb" role="3clFbG" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="1nsRmdN9vJk" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="1nsRmdNhzEn" role="jymVt" />
+    <node concept="3clFb_" id="1nsRmdN9vJq" role="jymVt">
+      <property role="TrG5h" value="newChild" />
+      <property role="od$2w" value="false" />
+      <property role="DiZV1" value="false" />
+      <property role="2aFKle" value="false" />
+      <node concept="3uibUv" id="1nsRmdN9vJE" role="3clF45">
+        <ref role="3uigEE" node="7cNsFS_gTK8" resolve="ComputationTrace" />
+      </node>
+      <node concept="3Tm1VV" id="1nsRmdN9vJF" role="1B3o_S" />
+      <node concept="37vLTG" id="1nsRmdN9vJG" role="3clF46">
+        <property role="TrG5h" value="n" />
+        <node concept="3Tqbb2" id="1nsRmdN9vJH" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="1nsRmdN9vJI" role="3clF46">
+        <property role="TrG5h" value="showInAnyCase" />
+        <node concept="10P_77" id="1nsRmdN9vJJ" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="1nsRmdN9vJK" role="3clF46">
+        <property role="TrG5h" value="label" />
+        <node concept="17QB3L" id="1nsRmdN9vJL" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="1nsRmdN9vJM" role="3clF46">
+        <property role="TrG5h" value="value" />
+        <node concept="3uibUv" id="1nsRmdN9vJN" role="1tU5fm">
+          <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="1nsRmdN9vJO" role="3clF47">
+        <node concept="3clFbF" id="1nsRmdNbyDl" role="3cqZAp">
+          <node concept="Xjq3P" id="1nsRmdNbyDk" role="3clFbG" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="1nsRmdN9vJP" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="1nsRmdNcg6f" role="jymVt" />
+    <node concept="3clFb_" id="1nsRmdN9vKO" role="jymVt">
+      <property role="TrG5h" value="descendantForNode" />
+      <node concept="3uibUv" id="1nsRmdN9vKP" role="3clF45">
+        <ref role="3uigEE" node="7cNsFS_gTK8" resolve="ComputationTrace" />
+      </node>
+      <node concept="3Tm1VV" id="1nsRmdN9vKQ" role="1B3o_S" />
+      <node concept="37vLTG" id="1nsRmdN9vLw" role="3clF46">
+        <property role="TrG5h" value="n" />
+        <node concept="3Tqbb2" id="1nsRmdN9vLx" role="1tU5fm" />
+      </node>
+      <node concept="3clFbS" id="1nsRmdN9vLy" role="3clF47">
+        <node concept="3clFbF" id="1nsRmdNcl7J" role="3cqZAp">
+          <node concept="10Nm6u" id="1nsRmdNcl7I" role="3clFbG" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="1nsRmdN9vLz" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="1nsRmdNcwHx" role="jymVt" />
+    <node concept="3clFb_" id="1nsRmdN9vMR" role="jymVt">
+      <property role="2aFKle" value="false" />
+      <property role="TrG5h" value="getName" />
+      <node concept="3Tm1VV" id="1nsRmdN9vMS" role="1B3o_S" />
+      <node concept="17QB3L" id="1nsRmdN9vMT" role="3clF45" />
+      <node concept="2AHcQZ" id="1nsRmdN9vMU" role="2AJF6D">
+        <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+      </node>
+      <node concept="2AHcQZ" id="1nsRmdN9vN6" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+      <node concept="3clFbS" id="1nsRmdN9vN7" role="3clF47">
+        <node concept="3clFbF" id="1nsRmdNhjX_" role="3cqZAp">
+          <node concept="Xl_RD" id="1nsRmdNhjX$" role="3clFbG">
+            <property role="Xl_RC" value="" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="1nsRmdNec5V" role="jymVt" />
+    <node concept="3clFb_" id="1nsRmdN9vO9" role="jymVt">
+      <property role="TrG5h" value="findNextLevelFiltered" />
+      <node concept="3Tm1VV" id="1nsRmdN9vOa" role="1B3o_S" />
+      <node concept="37vLTG" id="1nsRmdN9vOH" role="3clF46">
+        <property role="TrG5h" value="t" />
+        <node concept="3uibUv" id="1nsRmdN9vOI" role="1tU5fm">
+          <ref role="3uigEE" node="7cNsFS_gTK8" resolve="ComputationTrace" />
+        </node>
+      </node>
+      <node concept="A3Dl8" id="1nsRmdN9vOJ" role="3clF45">
+        <node concept="3uibUv" id="1nsRmdN9vOK" role="A3Ik2">
+          <ref role="3uigEE" node="7cNsFS_gTK8" resolve="ComputationTrace" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="1nsRmdN9vOL" role="3clF47">
+        <node concept="3clFbF" id="1nsRmdNeext" role="3cqZAp">
+          <node concept="2ShNRf" id="1nsRmdNeexv" role="3clFbG">
+            <node concept="Tc6Ow" id="1nsRmdNeexw" role="2ShVmc">
+              <node concept="3uibUv" id="1nsRmdNeexx" role="HW$YZ">
+                <ref role="3uigEE" node="7cNsFS_gTK8" resolve="ComputationTrace" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="1nsRmdN9vOM" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="1nsRmdNegH5" role="jymVt" />
+    <node concept="3clFb_" id="1nsRmdN9vU6" role="jymVt">
+      <property role="TrG5h" value="createStackTraceToThisOne" />
+      <node concept="_YKpA" id="1nsRmdN9vU7" role="3clF45">
+        <node concept="3uibUv" id="1nsRmdN9vU8" role="_ZDj9">
+          <ref role="3uigEE" node="7cNsFS_gTK8" resolve="ComputationTrace" />
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="1nsRmdN9vU9" role="1B3o_S" />
+      <node concept="37vLTG" id="1nsRmdN9vUV" role="3clF46">
+        <property role="TrG5h" value="filtered" />
+        <node concept="10P_77" id="1nsRmdN9vUW" role="1tU5fm" />
+      </node>
+      <node concept="3clFbS" id="1nsRmdN9vUX" role="3clF47">
+        <node concept="3clFbF" id="1nsRmdNhvRh" role="3cqZAp">
+          <node concept="2ShNRf" id="1nsRmdNhvRi" role="3clFbG">
+            <node concept="Tc6Ow" id="1nsRmdNhvRj" role="2ShVmc">
+              <node concept="3uibUv" id="1nsRmdNhvRk" role="HW$YZ">
+                <ref role="3uigEE" node="7cNsFS_gTK8" resolve="ComputationTrace" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="1nsRmdN9vUY" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="1nsRmdNhwiE" role="jymVt" />
+    <node concept="3clFb_" id="1nsRmdN9vV2" role="jymVt">
+      <property role="TrG5h" value="createStackTraceToThisOneAsString" />
+      <node concept="17QB3L" id="1nsRmdN9vV3" role="3clF45" />
+      <node concept="3Tm1VV" id="1nsRmdN9vV4" role="1B3o_S" />
+      <node concept="37vLTG" id="1nsRmdN9vVU" role="3clF46">
+        <property role="TrG5h" value="filtered" />
+        <node concept="10P_77" id="1nsRmdN9vVV" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="1nsRmdN9vVW" role="3clF46">
+        <property role="TrG5h" value="indent" />
+        <node concept="10Oyi0" id="1nsRmdN9vVX" role="1tU5fm" />
+      </node>
+      <node concept="3clFbS" id="1nsRmdN9vVY" role="3clF47">
+        <node concept="3clFbF" id="1nsRmdNhzg5" role="3cqZAp">
+          <node concept="Xl_RD" id="1nsRmdNhzg4" role="3clFbG">
+            <property role="Xl_RC" value="" />
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="1nsRmdN9vVZ" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" />
+      </node>
+    </node>
+  </node>
 </model>
 


### PR DESCRIPTION
A dummy computation trace is now used when the computation trace is not available in the interpreter to prevent NullPointerExceptions. This can happen when the interpreter is called with tracing disabled and the `trace` expression is used.