### PR TITLE
Backport PlantUML EPL version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ Semantic Versioning and the changes are simply documented in reverse chronologic
 
 - When embedding a documentation section or model content as image, the inspector can now be rendered instead of the editor.
 
+### Fixed
+
+- PlantUML was updated to PlantUML to v1.2023.13 EPL version (regression bug).
+
 # January 2024
 
 ## com.mbeddr.mpsutils

--- a/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/generator/template/com/mbeddr/doc/generator/template/main@generator.mps
+++ b/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/generator/template/com/mbeddr/doc/generator/template/main@generator.mps
@@ -1353,12 +1353,12 @@
             </node>
           </node>
           <node concept="2OqwBi" id="2fGuOSYbJKA" role="2GsD0m">
-            <node concept="1Q6Npb" id="2fGuOSYbJKB" role="2Oq$k0" />
             <node concept="2SmgA7" id="2fGuOSYbJKC" role="2OqNvi">
               <node concept="chp4Y" id="12zeRDvnbhv" role="1dBWTz">
                 <ref role="cht4Q" to="2c95:2fGuOSYbvYU" resolve="Visualization" />
               </node>
             </node>
+            <node concept="1Q6Npb" id="2fGuOSYbJKB" role="2Oq$k0" />
           </node>
         </node>
       </node>

--- a/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/generator/template/com/mbeddr/doc/generator/template/main@generator.mps
+++ b/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/generator/template/com/mbeddr/doc/generator/template/main@generator.mps
@@ -99,6 +99,9 @@
         <property id="1176718929932" name="isFinal" index="3TUv4t" />
         <child id="1068431790190" name="initializer" index="33vP2m" />
       </concept>
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ng" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
+      </concept>
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
@@ -1311,9 +1314,15 @@
                           <ref role="3cqZAo" node="5pyBnOIETAw" resolve="reader" />
                         </node>
                         <node concept="liA8E" id="5pyBnOIEUyU" role="2OqNvi">
-                          <ref role="37wK5l" to="81o:~SourceStringReader.generateImage(java.io.File)" resolve="generateImage" />
-                          <node concept="37vLTw" id="4t$H79$kPgE" role="37wK5m">
-                            <ref role="3cqZAo" node="4t$H79$kPgx" resolve="outputFile" />
+                          <ref role="37wK5l" to="81o:~SourceStringReader.generateImage(java.io.OutputStream)" resolve="generateImage" />
+                          <node concept="2ShNRf" id="7ymv7GF2fIm" role="37wK5m">
+                            <node concept="1pGfFk" id="7ymv7GF2fYv" role="2ShVmc">
+                              <property role="373rjd" value="true" />
+                              <ref role="37wK5l" to="guwi:~FileOutputStream.&lt;init&gt;(java.io.File)" resolve="FileOutputStream" />
+                              <node concept="37vLTw" id="7ymv7GF2g2Q" role="37wK5m">
+                                <ref role="3cqZAo" node="4t$H79$kPgx" resolve="outputFile" />
+                              </node>
+                            </node>
                           </node>
                         </node>
                       </node>

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.filepicker/models/behavior.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.filepicker/models/behavior.mps
@@ -68,6 +68,12 @@
         <child id="1173175577737" name="index" index="AHEQo" />
         <child id="1173175590490" name="array" index="AHHXb" />
       </concept>
+      <concept id="1188207840427" name="jetbrains.mps.baseLanguage.structure.AnnotationInstance" flags="nn" index="2AHcQZ">
+        <reference id="1188208074048" name="annotation" index="2AI5Lk" />
+      </concept>
+      <concept id="1188208481402" name="jetbrains.mps.baseLanguage.structure.HasAnnotation" flags="ng" index="2AJDlI">
+        <child id="1188208488637" name="annotation" index="2AJF6D" />
+      </concept>
       <concept id="1154032098014" name="jetbrains.mps.baseLanguage.structure.AbstractLoopStatement" flags="nn" index="2LF5Ji">
         <child id="1154032183016" name="body" index="2LFqv$" />
       </concept>
@@ -207,6 +213,16 @@
       <concept id="1146644641414" name="jetbrains.mps.baseLanguage.structure.ProtectedVisibility" flags="nn" index="3Tmbuc" />
       <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
     </language>
+    <language id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc">
+      <concept id="5349172909345501395" name="jetbrains.mps.baseLanguage.javadoc.structure.BaseDocComment" flags="ng" index="P$AiS">
+        <child id="5383422241790532083" name="tags" index="3nqlJM" />
+      </concept>
+      <concept id="5349172909345532724" name="jetbrains.mps.baseLanguage.javadoc.structure.MethodDocComment" flags="ng" index="P$JXv" />
+      <concept id="8465538089690331500" name="jetbrains.mps.baseLanguage.javadoc.structure.CommentLine" flags="ng" index="TZ5HA" />
+      <concept id="8465538089690331492" name="jetbrains.mps.baseLanguage.javadoc.structure.DeprecatedBlockDocTag" flags="ng" index="TZ5HI">
+        <child id="2667874559098216723" name="text" index="3HnX3l" />
+      </concept>
+    </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
       <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
         <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
@@ -250,6 +266,7 @@
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
         <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
       </concept>
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
@@ -1122,6 +1139,14 @@
       <node concept="37vLTG" id="5lKnBeAuGqW" role="3clF46">
         <property role="TrG5h" value="path" />
         <node concept="17QB3L" id="5lKnBeAuGqV" role="1tU5fm" />
+      </node>
+      <node concept="P$JXv" id="3uIy_akxeuo" role="lGtFl">
+        <node concept="TZ5HI" id="3uIy_akxeup" role="3nqlJM">
+          <node concept="TZ5HA" id="3uIy_akxeuq" role="3HnX3l" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="3uIy_akxeur" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" />
       </node>
     </node>
     <node concept="13i0hz" id="35YirduUNg0" role="13h7CS">


### PR DESCRIPTION
We need this also in MPS 2021.3 so that the cascading merged don't overwrite the version.