### PR TITLE
doc.generator: fix deprecation warning

### DIFF
--- a/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/generator/template/com/mbeddr/doc/generator/template/main@generator.mps
+++ b/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/generator/template/com/mbeddr/doc/generator/template/main@generator.mps
@@ -1367,7 +1367,10 @@
                 <ref role="cht4Q" to="2c95:2fGuOSYbvYU" resolve="Visualization" />
               </node>
             </node>
-            <node concept="1Q6Npb" id="2fGuOSYbJKB" role="2Oq$k0" />
+            <node concept="2OqwBi" id="2ZoaAPJ7Avo" role="2Oq$k0">
+              <node concept="1iwH7S" id="2ZoaAPJ7Afl" role="2Oq$k0" />
+              <node concept="1st3f0" id="2ZoaAPJ7B3W" role="2OqNvi" />
+            </node>
           </node>
         </node>
       </node>

--- a/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/languageModels/plugin.mps
+++ b/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/languageModels/plugin.mps
@@ -936,7 +936,6 @@
                               </node>
                               <node concept="3clFbS" id="2DWJLXXAF8k" role="3eOfB_">
                                 <node concept="RRSsy" id="2DWJLXXAHTs" role="3cqZAp">
-                                  <property role="RRSoG" value="h1akgim/info" />
                                   <node concept="Xl_RD" id="2DWJLXXAHTu" role="RRSoy">
                                     <property role="Xl_RC" value="doc_gen folder doesn't exist nothing to clean" />
                                   </node>


### PR DESCRIPTION
This fixes the warning: `SModelRepository.getModelDescriptor(String) is ineffective, please refactor to use SModelReference` for the documentation language.