### PR TITLE
Add two memoizing supplier implementations

### DIFF
--- a/code/languages/com.mbeddr.build/solutions/com.mbeddr.platform/models/com/mbeddr/platform/build.mps
+++ b/code/languages/com.mbeddr.build/solutions/com.mbeddr.platform/models/com/mbeddr/platform/build.mps
@@ -22847,6 +22847,7 @@
         <property role="BnDLt" value="true" />
         <property role="TrG5h" value="test.com.mbeddr.mpsutil.compare" />
         <property role="3LESm3" value="f1331acb-f5b8-487b-9d42-6ffd5fcde7e3" />
+        <property role="aoJFB" value="eYcmk9QOlj/sources_and_tests" />
         <node concept="398BVA" id="4_9e_MLhXgG" role="3LF7KH">
           <ref role="398BVh" node="7hVsScEQJ6E" resolve="mbeddr.mpsutil" />
           <node concept="2Ry0Ak" id="4_9e_MLhXgH" role="iGT6I">

--- a/code/languages/com.mbeddr.build/solutions/com.mbeddr.platform/models/com/mbeddr/platform/build.mps
+++ b/code/languages/com.mbeddr.build/solutions/com.mbeddr.platform/models/com/mbeddr/platform/build.mps
@@ -6449,6 +6449,11 @@
             </node>
           </node>
         </node>
+        <node concept="1SiIV0" id="9jWrhFmzzW" role="3bR37C">
+          <node concept="3bR9La" id="9jWrhFmzzX" role="1SiIV1">
+            <ref role="3bR37D" to="90a9:PE3B26QCrP" resolve="org.apache.commons" />
+          </node>
+        </node>
       </node>
     </node>
     <node concept="2G$12M" id="3quoVcnRjZi" role="3989C9">

--- a/code/languages/com.mbeddr.build/solutions/com.mbeddr.platform/models/com/mbeddr/platform/build.mps
+++ b/code/languages/com.mbeddr.build/solutions/com.mbeddr.platform/models/com/mbeddr/platform/build.mps
@@ -6396,19 +6396,9 @@
             <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
           </node>
         </node>
-        <node concept="1SiIV0" id="5fGcQI947Ch" role="3bR37C">
-          <node concept="3bR9La" id="5fGcQI947Ci" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:1TaHNgiIbJb" resolve="MPS.Platform" />
-          </node>
-        </node>
         <node concept="1SiIV0" id="5fGcQI947Cj" role="3bR37C">
           <node concept="3bR9La" id="5fGcQI947Ck" role="1SiIV1">
             <ref role="3bR37D" to="ffeo:1H905DlDUSw" resolve="MPS.OpenAPI" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="5fGcQI947Cl" role="3bR37C">
-          <node concept="3bR9La" id="5fGcQI947Cm" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:7Kfy9QB6L8Y" resolve="jetbrains.mps.lang.project" />
           </node>
         </node>
         <node concept="1SiIV0" id="5fGcQI947Cn" role="3bR37C">
@@ -6449,9 +6439,9 @@
             </node>
           </node>
         </node>
-        <node concept="1SiIV0" id="9jWrhFmzzW" role="3bR37C">
-          <node concept="3bR9La" id="9jWrhFmzzX" role="1SiIV1">
-            <ref role="3bR37D" to="90a9:PE3B26QCrP" resolve="org.apache.commons" />
+        <node concept="1SiIV0" id="9jWrhFq1E0" role="3bR37C">
+          <node concept="3bR9La" id="9jWrhFq1E1" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:7Kfy9QB6KXW" resolve="jetbrains.mps.lang.core" />
           </node>
         </node>
       </node>

--- a/code/languages/com.mbeddr.build/solutions/com.mbeddr.platform/models/com/mbeddr/platform/build.mps
+++ b/code/languages/com.mbeddr.build/solutions/com.mbeddr.platform/models/com/mbeddr/platform/build.mps
@@ -21518,6 +21518,9 @@
       <node concept="L2wRC" id="7eUZPevvU80" role="39821P">
         <ref role="L2wRA" node="Um6saBVXnk" resolve="com.mbeddr.mpsutil.compare.pattern.test" />
       </node>
+      <node concept="L2wRC" id="9jWrhFpWP3" role="39821P">
+        <ref role="L2wRA" node="9jWrhFpWZO" resolve="test.com.mbeddr.mpsutil.common" />
+      </node>
       <node concept="L2wRC" id="4_9e_MLi3i0" role="39821P">
         <ref role="L2wRA" node="4_9e_MLhX80" resolve="test.com.mbeddr.mpsutil.compare" />
       </node>
@@ -22779,6 +22782,77 @@
           </node>
         </node>
       </node>
+      <node concept="1E1JtA" id="9jWrhFpWZO" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="test.com.mbeddr.mpsutil.common" />
+        <property role="3LESm3" value="fceddec6-7184-49a0-9009-0da4dbdc8b95" />
+        <property role="aoJFB" value="eYcmk9QOlj/sources_and_tests" />
+        <node concept="398BVA" id="9jWrhFpXbi" role="3LF7KH">
+          <ref role="398BVh" node="7hVsScEQJ6E" resolve="mbeddr.mpsutil" />
+          <node concept="2Ry0Ak" id="9jWrhFpXc0" role="iGT6I">
+            <property role="2Ry0Am" value="tests" />
+            <node concept="2Ry0Ak" id="9jWrhFpXfn" role="2Ry0An">
+              <property role="2Ry0Am" value="test.com.mbeddr.mpsutil.common" />
+              <node concept="2Ry0Ak" id="9jWrhFpXgK" role="2Ry0An">
+                <property role="2Ry0Am" value="test.com.mbeddr.mpsutil.common.msd" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3rtmxn" id="9jWrhFpXjq" role="3bR31x">
+          <node concept="3LXTmp" id="9jWrhFpXjr" role="3rtmxm">
+            <node concept="398BVA" id="9jWrhFpXjs" role="3LXTmr">
+              <ref role="398BVh" node="7hVsScEQJ6E" resolve="mbeddr.mpsutil" />
+              <node concept="2Ry0Ak" id="9jWrhFpXjt" role="iGT6I">
+                <property role="2Ry0Am" value="tests" />
+                <node concept="2Ry0Ak" id="9jWrhFpXju" role="2Ry0An">
+                  <property role="2Ry0Am" value="test.com.mbeddr.mpsutil.common" />
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="9jWrhFpXjw" role="3LXTna">
+              <property role="3qWCbO" value="icons/**" />
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="9jWrhFpXqt" role="3bR37C">
+          <node concept="3bR9La" id="9jWrhFpXqu" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="9jWrhFpXqv" role="3bR37C">
+          <node concept="3bR9La" id="9jWrhFpXqw" role="1SiIV1">
+            <ref role="3bR37D" node="5fGcQI947Ca" resolve="com.mbeddr.mpsutil.common" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="9jWrhFpXqx" role="3bR37C">
+          <node concept="3bR9La" id="9jWrhFpXqy" role="1SiIV1">
+            <ref role="3bR37D" to="90a9:PE3B26QCrP" resolve="org.apache.commons" />
+          </node>
+        </node>
+        <node concept="1BupzO" id="9jWrhFpXqP" role="3bR31x">
+          <property role="3ZfqAx" value="models" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="9jWrhFpXqQ" role="1HemKq">
+            <node concept="398BVA" id="9jWrhFpXqz" role="3LXTmr">
+              <ref role="398BVh" node="7hVsScEQJ6E" resolve="mbeddr.mpsutil" />
+              <node concept="2Ry0Ak" id="9jWrhFpXq$" role="iGT6I">
+                <property role="2Ry0Am" value="tests" />
+                <node concept="2Ry0Ak" id="9jWrhFpXq_" role="2Ry0An">
+                  <property role="2Ry0Am" value="test.com.mbeddr.mpsutil.common" />
+                  <node concept="2Ry0Ak" id="9jWrhFpXqA" role="2Ry0An">
+                    <property role="2Ry0Am" value="models" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="9jWrhFpXqR" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+      </node>
       <node concept="1E1JtA" id="4_9e_MLhX80" role="2G$12L">
         <property role="BnDLt" value="true" />
         <property role="TrG5h" value="test.com.mbeddr.mpsutil.compare" />
@@ -22798,11 +22872,6 @@
         <node concept="1SiIV0" id="4_9e_MLhXnY" role="3bR37C">
           <node concept="3bR9La" id="4_9e_MLhXnZ" role="1SiIV1">
             <ref role="3bR37D" node="776vT$mQZbf" resolve="com.mbeddr.mpsutil.comparator" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="4_9e_MLhXo0" role="3bR37C">
-          <node concept="3bR9La" id="4_9e_MLhXo1" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
           </node>
         </node>
         <node concept="1BupzO" id="4_9e_MLhXok" role="3bR31x">
@@ -23395,6 +23464,9 @@
       </node>
       <node concept="22LTRM" id="7eUZPevvUva" role="22LTRK">
         <ref role="22LTRN" node="Um6saBVXnk" resolve="com.mbeddr.mpsutil.compare.pattern.test" />
+      </node>
+      <node concept="22LTRM" id="9jWrhFpXuU" role="22LTRK">
+        <ref role="22LTRN" node="9jWrhFpWZO" resolve="test.com.mbeddr.mpsutil.common" />
       </node>
       <node concept="22LTRM" id="4_9e_MLi41E" role="22LTRK">
         <ref role="22LTRN" node="4_9e_MLhX80" resolve="test.com.mbeddr.mpsutil.compare" />

--- a/code/languages/com.mbeddr.mpsutil/.mps/modules.xml
+++ b/code/languages/com.mbeddr.mpsutil/.mps/modules.xml
@@ -112,7 +112,7 @@
       <modulePath path="$PROJECT_DIR$/solutions/com.mbeddr.mpsutil.ccmenu.reftarget.runtime/com.mbeddr.mpsutil.ccmenu.reftarget.runtime.msd" folder="rest.ccmenu" />
       <modulePath path="$PROJECT_DIR$/solutions/com.mbeddr.mpsutil.ccmenu.runtime/com.mbeddr.mpsutil.ccmenu.runtime.msd" folder="rest.ccmenu" />
       <modulePath path="$PROJECT_DIR$/solutions/com.mbeddr.mpsutil.ccmenu.sandbox/com.mbeddr.mpsutil.ccmenu.sandbox.msd" folder="rest.ccmenu" />
-      <modulePath path="$PROJECT_DIR$/solutions/com.mbeddr.mpsutil.common/com.mbeddr.mpsutil.common.msd" folder="staging" />
+      <modulePath path="$PROJECT_DIR$/solutions/com.mbeddr.mpsutil.common/com.mbeddr.mpsutil.common.msd" folder="staging.common" />
       <modulePath path="$PROJECT_DIR$/solutions/com.mbeddr.mpsutil.comparator.diff.demo.genplan/com.mbeddr.mpsutil.comparator.diff.demo.genplan.msd" folder="staging.comparator.demo" />
       <modulePath path="$PROJECT_DIR$/solutions/com.mbeddr.mpsutil.comparator.diff.demo.tests/com.mbeddr.mpsutil.comparator.diff.demo.tests.msd" folder="staging.comparator.demo" />
       <modulePath path="$PROJECT_DIR$/solutions/com.mbeddr.mpsutil.comparator/comparator.msd" folder="staging.comparator" />
@@ -194,6 +194,7 @@
       <modulePath path="$PROJECT_DIR$/tests/com.mbeddr.mpsutil.javainterpreter.test/com.mbeddr.mpsutil.javainterpreter.test.mpl" folder="staging.javainterpreter" />
       <modulePath path="$PROJECT_DIR$/tests/test.com.mbeddr.mpsutil.asynccell/test.com.mbeddr.mpsutil.asynccell.msd" folder="asynccell" />
       <modulePath path="$PROJECT_DIR$/tests/test.com.mbeddr.mpsutil.blutil.test.waitfor/test.com.mbeddr.mpsutil.blutil.test.waitfor.msd" folder="waitfor" />
+      <modulePath path="$PROJECT_DIR$/tests/test.com.mbeddr.mpsutil.common/test.com.mbeddr.mpsutil.common.msd" folder="staging.common" />
       <modulePath path="$PROJECT_DIR$/tests/test.com.mbeddr.mpsutil.compare.testlang/test.com.mbeddr.mpsutil.compare.testlang.mpl" folder="staging.comparator" />
       <modulePath path="$PROJECT_DIR$/tests/test.com.mbeddr.mpsutil.compare/test.com.mbeddr.mpsutil.compare.msd" folder="staging.comparator" />
       <modulePath path="$PROJECT_DIR$/tests/test.com.mbeddr.mpsutil.contextactions/tests.com.mbeddr.mpsutil.contextactions.msd" folder="rest.contextActions" />

--- a/code/languages/com.mbeddr.mpsutil/.mps/modules.xml
+++ b/code/languages/com.mbeddr.mpsutil/.mps/modules.xml
@@ -200,6 +200,12 @@
       <modulePath path="$PROJECT_DIR$/tests/test.com.mbeddr.mpsutil.contextactions/tests.com.mbeddr.mpsutil.contextactions.msd" folder="rest.contextActions" />
       <modulePath path="$PROJECT_DIR$/tests/test.com.mbeddr.mpsutil.ecore.modelImportExport/test.com.mbeddr.mpsutil.ecore.modelImportExport.msd" folder="rest.ecore.tests" />
       <modulePath path="$PROJECT_DIR$/tests/test.com.mbeddr.mpsutil.ecoreimporter.runtime/test.com.mbeddr.mpsutil.ecore.metaModelImport.msd" folder="rest.ecore.tests" />
+      <modulePath path="$PROJECT_DIR$/tests/test.com.mbeddr.mpsutil.ecoretransformation.modelImportExport.testLanguage1/test.com.mbeddr.mpsutil.ecoretransformation.modelImportExport.testLanguage1.mpl" folder="rest.ecore.tests.modelImporterExporterLanguages" />
+      <modulePath path="$PROJECT_DIR$/tests/test.com.mbeddr.mpsutil.ecoretransformation.modelImportExport.testLanguage2/test.com.mbeddr.mpsutil.ecoretransformation.modelImportExport.testLanguage2.mpl" folder="rest.ecore.tests.modelImporterExporterLanguages" />
+      <modulePath path="$PROJECT_DIR$/tests/test.com.mbeddr.mpsutil.ecoretransformation.modelImportExport.testLanguage3/test.com.mbeddr.mpsutil.ecoretransformation.modelImportExport.testLanguage3.mpl" folder="rest.ecore.tests.modelImporterExporterLanguages" />
+      <modulePath path="$PROJECT_DIR$/tests/test.com.mbeddr.mpsutil.ecoretransformation.modelImportExport.testLanguage4/test.com.mbeddr.mpsutil.ecoretransformation.modelImportExport.testLanguage4.mpl" folder="rest.ecore.tests.modelImporterExporterLanguages" />
+      <modulePath path="$PROJECT_DIR$/tests/test.com.mbeddr.mpsutil.ecoretransformation.modelImportExport.testLanguage5/test.com.mbeddr.mpsutil.ecoretransformation.modelImportExport.testLanguage5.mpl" folder="rest.ecore.tests.modelImporterExporterLanguages" />
+      <modulePath path="$PROJECT_DIR$/tests/test.com.mbeddr.mpsutil.ecoretransformation.modelImportExport.testLanguage6/test.com.mbeddr.mpsutil.ecoretransformation.modelImportExport.testLanguage6.mpl" folder="rest.ecore.tests.modelImporterExporterLanguages" />
       <modulePath path="$PROJECT_DIR$/tests/test.com.mbeddr.mpsutil.extensionclass/test.com.mbeddr.mpsutil.extensionclass.msd" folder="staging.extensionclass" />
       <modulePath path="$PROJECT_DIR$/tests/test.com.mbeddr.mpsutil.iconchar.test/test.com.mbeddr.mpsutil.iconchar.test.msd" folder="stable.iconchar" />
       <modulePath path="$PROJECT_DIR$/tests/test.com.mbeddr.mpsutil.iconchar/test.com.mbeddr.mpsutil.iconchar.mpl" folder="stable.iconchar" />

--- a/code/languages/com.mbeddr.mpsutil/.mps/modules.xml
+++ b/code/languages/com.mbeddr.mpsutil/.mps/modules.xml
@@ -200,12 +200,6 @@
       <modulePath path="$PROJECT_DIR$/tests/test.com.mbeddr.mpsutil.contextactions/tests.com.mbeddr.mpsutil.contextactions.msd" folder="rest.contextActions" />
       <modulePath path="$PROJECT_DIR$/tests/test.com.mbeddr.mpsutil.ecore.modelImportExport/test.com.mbeddr.mpsutil.ecore.modelImportExport.msd" folder="rest.ecore.tests" />
       <modulePath path="$PROJECT_DIR$/tests/test.com.mbeddr.mpsutil.ecoreimporter.runtime/test.com.mbeddr.mpsutil.ecore.metaModelImport.msd" folder="rest.ecore.tests" />
-      <modulePath path="$PROJECT_DIR$/tests/test.com.mbeddr.mpsutil.ecoretransformation.modelImportExport.testLanguage1/test.com.mbeddr.mpsutil.ecoretransformation.modelImportExport.testLanguage1.mpl" folder="rest.ecore.tests.modelImporterExporterLanguages" />
-      <modulePath path="$PROJECT_DIR$/tests/test.com.mbeddr.mpsutil.ecoretransformation.modelImportExport.testLanguage2/test.com.mbeddr.mpsutil.ecoretransformation.modelImportExport.testLanguage2.mpl" folder="rest.ecore.tests.modelImporterExporterLanguages" />
-      <modulePath path="$PROJECT_DIR$/tests/test.com.mbeddr.mpsutil.ecoretransformation.modelImportExport.testLanguage3/test.com.mbeddr.mpsutil.ecoretransformation.modelImportExport.testLanguage3.mpl" folder="rest.ecore.tests.modelImporterExporterLanguages" />
-      <modulePath path="$PROJECT_DIR$/tests/test.com.mbeddr.mpsutil.ecoretransformation.modelImportExport.testLanguage4/test.com.mbeddr.mpsutil.ecoretransformation.modelImportExport.testLanguage4.mpl" folder="rest.ecore.tests.modelImporterExporterLanguages" />
-      <modulePath path="$PROJECT_DIR$/tests/test.com.mbeddr.mpsutil.ecoretransformation.modelImportExport.testLanguage5/test.com.mbeddr.mpsutil.ecoretransformation.modelImportExport.testLanguage5.mpl" folder="rest.ecore.tests.modelImporterExporterLanguages" />
-      <modulePath path="$PROJECT_DIR$/tests/test.com.mbeddr.mpsutil.ecoretransformation.modelImportExport.testLanguage6/test.com.mbeddr.mpsutil.ecoretransformation.modelImportExport.testLanguage6.mpl" folder="rest.ecore.tests.modelImporterExporterLanguages" />
       <modulePath path="$PROJECT_DIR$/tests/test.com.mbeddr.mpsutil.extensionclass/test.com.mbeddr.mpsutil.extensionclass.msd" folder="staging.extensionclass" />
       <modulePath path="$PROJECT_DIR$/tests/test.com.mbeddr.mpsutil.iconchar.test/test.com.mbeddr.mpsutil.iconchar.test.msd" folder="stable.iconchar" />
       <modulePath path="$PROJECT_DIR$/tests/test.com.mbeddr.mpsutil.iconchar/test.com.mbeddr.mpsutil.iconchar.mpl" folder="stable.iconchar" />

--- a/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.common/com.mbeddr.mpsutil.common.msd
+++ b/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.common/com.mbeddr.mpsutil.common.msd
@@ -16,11 +16,9 @@
     <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
     <dependency reexport="true">6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)</dependency>
     <dependency reexport="false">8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)</dependency>
-    <dependency reexport="false">742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)</dependency>
-    <dependency reexport="false">86ef8290-12bb-4ca7-947f-093788f263a9(jetbrains.mps.lang.project)</dependency>
     <dependency reexport="false">3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)</dependency>
     <dependency reexport="false">498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)</dependency>
-    <dependency reexport="false">b0f8641f-bd77-4421-8425-30d9088a82f7(org.apache.commons)</dependency>
+    <dependency reexport="false">ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
@@ -44,14 +42,10 @@
     <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
     <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
     <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
-    <module reference="1ed103c3-3aa6-49b7-9c21-6765ee11f224(MPS.Editor)" version="0" />
     <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
-    <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
     <module reference="c7a315e6-1d93-4186-85bc-2dfafd1ccc21(com.mbeddr.mpsutil.common)" version="0" />
     <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
-    <module reference="86ef8290-12bb-4ca7-947f-093788f263a9(jetbrains.mps.lang.project)" version="0" />
-    <module reference="b0f8641f-bd77-4421-8425-30d9088a82f7(org.apache.commons)" version="0" />
   </dependencyVersions>
 </solution>
 

--- a/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.common/com.mbeddr.mpsutil.common.msd
+++ b/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.common/com.mbeddr.mpsutil.common.msd
@@ -20,6 +20,7 @@
     <dependency reexport="false">86ef8290-12bb-4ca7-947f-093788f263a9(jetbrains.mps.lang.project)</dependency>
     <dependency reexport="false">3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)</dependency>
     <dependency reexport="false">498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)</dependency>
+    <dependency reexport="false">b0f8641f-bd77-4421-8425-30d9088a82f7(org.apache.commons)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
@@ -50,6 +51,7 @@
     <module reference="c7a315e6-1d93-4186-85bc-2dfafd1ccc21(com.mbeddr.mpsutil.common)" version="0" />
     <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
     <module reference="86ef8290-12bb-4ca7-947f-093788f263a9(jetbrains.mps.lang.project)" version="0" />
+    <module reference="b0f8641f-bd77-4421-8425-30d9088a82f7(org.apache.commons)" version="0" />
   </dependencyVersions>
 </solution>
 

--- a/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.common/models/com.mbeddr.mpsutil.common.util@tests.mps
+++ b/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.common/models/com.mbeddr.mpsutil.common.util@tests.mps
@@ -1,0 +1,913 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:2ab3ddbe-8637-491d-bebd-21897939eb53(com.mbeddr.mpsutil.common.util@tests)">
+  <persistence version="9" />
+  <languages>
+    <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="6" />
+    <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="1" />
+    <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="12" />
+    <use id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures" version="0" />
+  </languages>
+  <imports>
+    <import index="7wpd" ref="c7a315e6-1d93-4186-85bc-2dfafd1ccc21/r:fb1c47d7-a72e-4e01-92dc-1e9f2ba4a118(com.mbeddr.mpsutil.common/com.mbeddr.mpsutil.common.util)" />
+    <import index="qhup" ref="b0f8641f-bd77-4421-8425-30d9088a82f7/java:org.apache.commons.lang3.mutable(org.apache.commons/)" />
+    <import index="82uw" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util.function(JDK/)" />
+    <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
+    <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
+      <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
+        <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
+      </concept>
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
+        <child id="1145553007750" name="creator" index="2ShVmc" />
+      </concept>
+      <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
+        <reference id="1144433194310" name="classConcept" index="1Pybhc" />
+      </concept>
+      <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
+      <concept id="1070534934090" name="jetbrains.mps.baseLanguage.structure.CastExpression" flags="nn" index="10QFUN">
+        <child id="1070534934091" name="type" index="10QFUM" />
+        <child id="1070534934092" name="expression" index="10QFUP" />
+      </concept>
+      <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
+        <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
+        <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
+      </concept>
+      <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
+      <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
+        <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
+      <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
+        <child id="1068580123133" name="returnType" index="3clF45" />
+        <child id="1068580123135" name="body" index="3clF47" />
+      </concept>
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
+        <property id="1068580320021" name="value" index="3cmrfH" />
+      </concept>
+      <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
+        <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
+      </concept>
+      <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
+      <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
+      </concept>
+      <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk" />
+      <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
+        <reference id="1107535924139" name="classifier" index="3uigEE" />
+        <child id="1109201940907" name="parameter" index="11_B2D" />
+      </concept>
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
+        <child id="1178549979242" name="visibility" index="1B3o_S" />
+      </concept>
+      <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="nn" index="3SKdUt">
+        <child id="8356039341262087992" name="line" index="1aUNEU" />
+      </concept>
+      <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
+    </language>
+    <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
+      <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
+        <child id="1199569906740" name="parameter" index="1bW2Oz" />
+        <child id="1199569916463" name="body" index="1bW5cS" />
+      </concept>
+    </language>
+    <language id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest">
+      <concept id="1171931690126" name="jetbrains.mps.baseLanguage.unitTest.structure.TestMethod" flags="ig" index="3s$Bmu">
+        <property id="1171931690128" name="methodName" index="3s$Bm0" />
+      </concept>
+      <concept id="1171931851043" name="jetbrains.mps.baseLanguage.unitTest.structure.BTestCase" flags="ig" index="3s_ewN">
+        <property id="1171931851045" name="testCaseName" index="3s_ewP" />
+        <child id="1171931851044" name="testMethodList" index="3s_ewO" />
+      </concept>
+      <concept id="1171931858461" name="jetbrains.mps.baseLanguage.unitTest.structure.TestMethodList" flags="ng" index="3s_gsd">
+        <child id="1171931858462" name="testMethod" index="3s_gse" />
+      </concept>
+      <concept id="8427750732757990717" name="jetbrains.mps.baseLanguage.unitTest.structure.BinaryAssert" flags="nn" index="3tpDYu">
+        <child id="8427750732757990725" name="actual" index="3tpDZA" />
+        <child id="8427750732757990724" name="expected" index="3tpDZB" />
+      </concept>
+      <concept id="1171978097730" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertEquals" flags="nn" index="3vlDli" />
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+    <language id="c7fb639f-be78-4307-89b0-b5959c3fa8c8" name="jetbrains.mps.lang.text">
+      <concept id="155656958578482948" name="jetbrains.mps.lang.text.structure.Word" flags="nn" index="3oM_SD">
+        <property id="155656958578482949" name="value" index="3oM_SC" />
+      </concept>
+      <concept id="2535923850359271782" name="jetbrains.mps.lang.text.structure.Line" flags="nn" index="1PaTwC">
+        <child id="2535923850359271783" name="elements" index="1PaTwD" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="2XOHcx" id="3RjqiP9ZZRO">
+    <property role="2XOHcw" value="${mbeddr.github.core.home}/code/languages/com.mbeddr.mpsutil" />
+  </node>
+  <node concept="3s_ewN" id="9jWrhFjvu4">
+    <property role="3s_ewP" value="LazyInit" />
+    <node concept="3Tm1VV" id="9jWrhFjvu5" role="1B3o_S" />
+    <node concept="3s_gsd" id="9jWrhFjvu6" role="3s_ewO">
+      <node concept="3s$Bmu" id="9jWrhFjvuD" role="3s_gse">
+        <property role="3s$Bm0" value="lazyInit" />
+        <node concept="3cqZAl" id="9jWrhFjvuE" role="3clF45" />
+        <node concept="3Tm1VV" id="9jWrhFjvuF" role="1B3o_S" />
+        <node concept="3clFbS" id="9jWrhFjvuG" role="3clF47">
+          <node concept="3cpWs8" id="9jWrhFjvIZ" role="3cqZAp">
+            <node concept="3cpWsn" id="9jWrhFjvJ0" role="3cpWs9">
+              <property role="TrG5h" value="expensiveCount" />
+              <node concept="3uibUv" id="9jWrhFjvJ1" role="1tU5fm">
+                <ref role="3uigEE" to="qhup:~MutableInt" resolve="MutableInt" />
+              </node>
+              <node concept="2ShNRf" id="9jWrhFjvK6" role="33vP2m">
+                <node concept="1pGfFk" id="9jWrhFjvJX" role="2ShVmc">
+                  <ref role="37wK5l" to="qhup:~MutableInt.&lt;init&gt;(int)" resolve="MutableInt" />
+                  <node concept="3cmrfG" id="9jWrhFjvKE" role="37wK5m">
+                    <property role="3cmrfH" value="0" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs8" id="9jWrhFjvMl" role="3cqZAp">
+            <node concept="3cpWsn" id="9jWrhFjvMm" role="3cpWs9">
+              <property role="TrG5h" value="supplier" />
+              <node concept="3uibUv" id="9jWrhFjvMn" role="1tU5fm">
+                <ref role="3uigEE" to="82uw:~Supplier" resolve="Supplier" />
+                <node concept="3uibUv" id="9jWrhFkQHn" role="11_B2D">
+                  <ref role="3uigEE" to="wyt6:~Integer" resolve="Integer" />
+                </node>
+              </node>
+              <node concept="2YIFZM" id="9jWrhFjvOe" role="33vP2m">
+                <ref role="37wK5l" to="7wpd:9jWrhFiKyu" resolve="lazy" />
+                <ref role="1Pybhc" to="7wpd:9jWrhFizRs" resolve="LazyInit" />
+                <node concept="1bVj0M" id="9jWrhFjTQa" role="37wK5m">
+                  <node concept="3clFbS" id="9jWrhFjTQb" role="1bW5cS">
+                    <node concept="3SKdUt" id="9jWrhFl3wH" role="3cqZAp">
+                      <node concept="1PaTwC" id="9jWrhFl3wI" role="1aUNEU">
+                        <node concept="3oM_SD" id="9jWrhFl3Bv" role="1PaTwD">
+                          <property role="3oM_SC" value="this" />
+                        </node>
+                        <node concept="3oM_SD" id="9jWrhFl3Bx" role="1PaTwD">
+                          <property role="3oM_SC" value="is" />
+                        </node>
+                        <node concept="3oM_SD" id="9jWrhFl3B$" role="1PaTwD">
+                          <property role="3oM_SC" value="the" />
+                        </node>
+                        <node concept="3oM_SD" id="9jWrhFl3I0" role="1PaTwD">
+                          <property role="3oM_SC" value="expensive" />
+                        </node>
+                        <node concept="3oM_SD" id="9jWrhFl3Ot" role="1PaTwD">
+                          <property role="3oM_SC" value="code" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbF" id="9jWrhFjTWz" role="3cqZAp">
+                      <node concept="2OqwBi" id="9jWrhFjUoi" role="3clFbG">
+                        <node concept="37vLTw" id="9jWrhFjTWy" role="2Oq$k0">
+                          <ref role="3cqZAo" node="9jWrhFjvJ0" resolve="expensiveCount" />
+                        </node>
+                        <node concept="liA8E" id="9jWrhFjUDf" role="2OqNvi">
+                          <ref role="37wK5l" to="qhup:~MutableInt.increment()" resolve="increment" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbF" id="9jWrhFjUJd" role="3cqZAp">
+                      <node concept="3cmrfG" id="9jWrhFkReg" role="3clFbG">
+                        <property role="3cmrfH" value="777" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbH" id="9jWrhFkUGB" role="3cqZAp" />
+          <node concept="3SKdUt" id="9jWrhFkUZI" role="3cqZAp">
+            <node concept="1PaTwC" id="9jWrhFkUZJ" role="1aUNEU">
+              <node concept="3oM_SD" id="9jWrhFkV9e" role="1PaTwD">
+                <property role="3oM_SC" value="execute" />
+              </node>
+              <node concept="3oM_SD" id="9jWrhFkV9g" role="1PaTwD">
+                <property role="3oM_SC" value="first" />
+              </node>
+              <node concept="3oM_SD" id="9jWrhFkV9j" role="1PaTwD">
+                <property role="3oM_SC" value="get()," />
+              </node>
+              <node concept="3oM_SD" id="9jWrhFkV9n" role="1PaTwD">
+                <property role="3oM_SC" value="should" />
+              </node>
+              <node concept="3oM_SD" id="9jWrhFkV9s" role="1PaTwD">
+                <property role="3oM_SC" value="return" />
+              </node>
+              <node concept="3oM_SD" id="9jWrhFkV9y" role="1PaTwD">
+                <property role="3oM_SC" value="777," />
+              </node>
+              <node concept="3oM_SD" id="9jWrhFkV9D" role="1PaTwD">
+                <property role="3oM_SC" value="and" />
+              </node>
+              <node concept="3oM_SD" id="9jWrhFkV9L" role="1PaTwD">
+                <property role="3oM_SC" value="expensive" />
+              </node>
+              <node concept="3oM_SD" id="9jWrhFkV9U" role="1PaTwD">
+                <property role="3oM_SC" value="code" />
+              </node>
+              <node concept="3oM_SD" id="9jWrhFkVa4" role="1PaTwD">
+                <property role="3oM_SC" value="should" />
+              </node>
+              <node concept="3oM_SD" id="9jWrhFkVaf" role="1PaTwD">
+                <property role="3oM_SC" value="be" />
+              </node>
+              <node concept="3oM_SD" id="9jWrhFkVar" role="1PaTwD">
+                <property role="3oM_SC" value="executed" />
+              </node>
+              <node concept="3oM_SD" id="9jWrhFkVaC" role="1PaTwD">
+                <property role="3oM_SC" value="exactly" />
+              </node>
+              <node concept="3oM_SD" id="9jWrhFkVaQ" role="1PaTwD">
+                <property role="3oM_SC" value="once" />
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs8" id="9jWrhFkRCA" role="3cqZAp">
+            <node concept="3cpWsn" id="9jWrhFkRCB" role="3cpWs9">
+              <property role="TrG5h" value="v1" />
+              <node concept="10Oyi0" id="9jWrhFkU19" role="1tU5fm" />
+              <node concept="2OqwBi" id="9jWrhFkRCC" role="33vP2m">
+                <node concept="37vLTw" id="9jWrhFkRCD" role="2Oq$k0">
+                  <ref role="3cqZAo" node="9jWrhFjvMm" resolve="init" />
+                </node>
+                <node concept="liA8E" id="9jWrhFkRCE" role="2OqNvi">
+                  <ref role="37wK5l" to="82uw:~Supplier.get()" resolve="get" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3vlDli" id="9jWrhFkW6g" role="3cqZAp">
+            <node concept="37vLTw" id="9jWrhFkWA1" role="3tpDZA">
+              <ref role="3cqZAo" node="9jWrhFkRCB" resolve="v1" />
+            </node>
+            <node concept="3cmrfG" id="9jWrhFkWus" role="3tpDZB">
+              <property role="3cmrfH" value="777" />
+            </node>
+          </node>
+          <node concept="3vlDli" id="9jWrhFl2m$" role="3cqZAp">
+            <node concept="3cmrfG" id="9jWrhFl2m_" role="3tpDZB">
+              <property role="3cmrfH" value="1" />
+            </node>
+            <node concept="10QFUN" id="9jWrhFl2mA" role="3tpDZA">
+              <node concept="10Oyi0" id="9jWrhFl2mB" role="10QFUM" />
+              <node concept="2OqwBi" id="9jWrhFl2mC" role="10QFUP">
+                <node concept="37vLTw" id="9jWrhFl2mD" role="2Oq$k0">
+                  <ref role="3cqZAo" node="9jWrhFjvJ0" resolve="expensiveCount" />
+                </node>
+                <node concept="liA8E" id="9jWrhFl2mE" role="2OqNvi">
+                  <ref role="37wK5l" to="qhup:~MutableInt.getValue()" resolve="getValue" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbH" id="9jWrhFkVb5" role="3cqZAp" />
+          <node concept="3SKdUt" id="9jWrhFkVz0" role="3cqZAp">
+            <node concept="1PaTwC" id="9jWrhFkVz1" role="1aUNEU">
+              <node concept="3oM_SD" id="9jWrhFkVGL" role="1PaTwD">
+                <property role="3oM_SC" value="when" />
+              </node>
+              <node concept="3oM_SD" id="9jWrhFkVGN" role="1PaTwD">
+                <property role="3oM_SC" value="executing" />
+              </node>
+              <node concept="3oM_SD" id="9jWrhFkVGQ" role="1PaTwD">
+                <property role="3oM_SC" value="get()" />
+              </node>
+              <node concept="3oM_SD" id="9jWrhFkVGU" role="1PaTwD">
+                <property role="3oM_SC" value="again," />
+              </node>
+              <node concept="3oM_SD" id="9jWrhFkVGZ" role="1PaTwD">
+                <property role="3oM_SC" value="it" />
+              </node>
+              <node concept="3oM_SD" id="9jWrhFkVH5" role="1PaTwD">
+                <property role="3oM_SC" value="still" />
+              </node>
+              <node concept="3oM_SD" id="9jWrhFkVHc" role="1PaTwD">
+                <property role="3oM_SC" value="should" />
+              </node>
+              <node concept="3oM_SD" id="9jWrhFkVHk" role="1PaTwD">
+                <property role="3oM_SC" value="return" />
+              </node>
+              <node concept="3oM_SD" id="9jWrhFkVHt" role="1PaTwD">
+                <property role="3oM_SC" value="777," />
+              </node>
+              <node concept="3oM_SD" id="9jWrhFkVHB" role="1PaTwD">
+                <property role="3oM_SC" value="but" />
+              </node>
+              <node concept="3oM_SD" id="9jWrhFkVHM" role="1PaTwD">
+                <property role="3oM_SC" value="without" />
+              </node>
+              <node concept="3oM_SD" id="9jWrhFkVHY" role="1PaTwD">
+                <property role="3oM_SC" value="executing" />
+              </node>
+              <node concept="3oM_SD" id="9jWrhFkVIb" role="1PaTwD">
+                <property role="3oM_SC" value="expensive" />
+              </node>
+              <node concept="3oM_SD" id="9jWrhFkVIp" role="1PaTwD">
+                <property role="3oM_SC" value="code" />
+              </node>
+              <node concept="3oM_SD" id="9jWrhFkVIC" role="1PaTwD">
+                <property role="3oM_SC" value="again" />
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs8" id="9jWrhFkTCj" role="3cqZAp">
+            <node concept="3cpWsn" id="9jWrhFkTCk" role="3cpWs9">
+              <property role="TrG5h" value="v2" />
+              <node concept="10Oyi0" id="9jWrhFkTTI" role="1tU5fm" />
+              <node concept="2OqwBi" id="9jWrhFkTCm" role="33vP2m">
+                <node concept="37vLTw" id="9jWrhFkTCn" role="2Oq$k0">
+                  <ref role="3cqZAo" node="9jWrhFjvMm" resolve="init" />
+                </node>
+                <node concept="liA8E" id="9jWrhFkTCo" role="2OqNvi">
+                  <ref role="37wK5l" to="82uw:~Supplier.get()" resolve="get" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3vlDli" id="9jWrhFkXqI" role="3cqZAp">
+            <node concept="37vLTw" id="9jWrhFkXqJ" role="3tpDZA">
+              <ref role="3cqZAo" node="9jWrhFkTCk" resolve="v2" />
+            </node>
+            <node concept="3cmrfG" id="9jWrhFkXqK" role="3tpDZB">
+              <property role="3cmrfH" value="777" />
+            </node>
+          </node>
+          <node concept="3vlDli" id="9jWrhFkZlx" role="3cqZAp">
+            <node concept="3cmrfG" id="9jWrhFl0Es" role="3tpDZB">
+              <property role="3cmrfH" value="1" />
+            </node>
+            <node concept="10QFUN" id="9jWrhFl0NK" role="3tpDZA">
+              <node concept="10Oyi0" id="9jWrhFl15G" role="10QFUM" />
+              <node concept="2OqwBi" id="9jWrhFkOYG" role="10QFUP">
+                <node concept="37vLTw" id="9jWrhFkOYH" role="2Oq$k0">
+                  <ref role="3cqZAo" node="9jWrhFjvJ0" resolve="expensiveCount" />
+                </node>
+                <node concept="liA8E" id="9jWrhFkOYI" role="2OqNvi">
+                  <ref role="37wK5l" to="qhup:~MutableInt.getValue()" resolve="getValue" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="3s_ewN" id="9jWrhFl41j">
+    <property role="3s_ewP" value="LazyInitWithCheck" />
+    <node concept="3Tm1VV" id="9jWrhFl41k" role="1B3o_S" />
+    <node concept="3s_gsd" id="9jWrhFl41l" role="3s_ewO">
+      <node concept="3s$Bmu" id="9jWrhFl41m" role="3s_gse">
+        <property role="3s$Bm0" value="lazyInitCheck" />
+        <node concept="3cqZAl" id="9jWrhFl41n" role="3clF45" />
+        <node concept="3Tm1VV" id="9jWrhFl41o" role="1B3o_S" />
+        <node concept="3clFbS" id="9jWrhFl41p" role="3clF47">
+          <node concept="3cpWs8" id="9jWrhFl41q" role="3cqZAp">
+            <node concept="3cpWsn" id="9jWrhFl41r" role="3cpWs9">
+              <property role="TrG5h" value="expensiveCount" />
+              <node concept="3uibUv" id="9jWrhFl41s" role="1tU5fm">
+                <ref role="3uigEE" to="qhup:~MutableInt" resolve="MutableInt" />
+              </node>
+              <node concept="2ShNRf" id="9jWrhFl41t" role="33vP2m">
+                <node concept="1pGfFk" id="9jWrhFl41u" role="2ShVmc">
+                  <ref role="37wK5l" to="qhup:~MutableInt.&lt;init&gt;(int)" resolve="MutableInt" />
+                  <node concept="3cmrfG" id="9jWrhFl41v" role="37wK5m">
+                    <property role="3cmrfH" value="0" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs8" id="9jWrhFl5iG" role="3cqZAp">
+            <node concept="3cpWsn" id="9jWrhFl5iH" role="3cpWs9">
+              <property role="TrG5h" value="m" />
+              <node concept="3uibUv" id="9jWrhFl5iI" role="1tU5fm">
+                <ref role="3uigEE" to="qhup:~MutableInt" resolve="MutableInt" />
+              </node>
+              <node concept="2ShNRf" id="9jWrhFl5Ea" role="33vP2m">
+                <node concept="1pGfFk" id="9jWrhFl5E1" role="2ShVmc">
+                  <ref role="37wK5l" to="qhup:~MutableInt.&lt;init&gt;(int)" resolve="MutableInt" />
+                  <node concept="3cmrfG" id="9jWrhFla4D" role="37wK5m">
+                    <property role="3cmrfH" value="77" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs8" id="9jWrhFl41w" role="3cqZAp">
+            <node concept="3cpWsn" id="9jWrhFl41x" role="3cpWs9">
+              <property role="TrG5h" value="supplier" />
+              <node concept="3uibUv" id="9jWrhFl41y" role="1tU5fm">
+                <ref role="3uigEE" to="82uw:~Supplier" resolve="Supplier" />
+                <node concept="3uibUv" id="9jWrhFl41z" role="11_B2D">
+                  <ref role="3uigEE" to="wyt6:~Integer" resolve="Integer" />
+                </node>
+              </node>
+              <node concept="2YIFZM" id="9jWrhFl41$" role="33vP2m">
+                <ref role="37wK5l" to="7wpd:9jWrhFiXuJ" resolve="lazy" />
+                <ref role="1Pybhc" to="7wpd:9jWrhFiXtZ" resolve="LazyInitCheck" />
+                <node concept="1bVj0M" id="9jWrhFl41_" role="37wK5m">
+                  <node concept="3clFbS" id="9jWrhFl41A" role="1bW5cS">
+                    <node concept="3SKdUt" id="9jWrhFl41B" role="3cqZAp">
+                      <node concept="1PaTwC" id="9jWrhFl41C" role="1aUNEU">
+                        <node concept="3oM_SD" id="9jWrhFl41D" role="1PaTwD">
+                          <property role="3oM_SC" value="this" />
+                        </node>
+                        <node concept="3oM_SD" id="9jWrhFl41E" role="1PaTwD">
+                          <property role="3oM_SC" value="is" />
+                        </node>
+                        <node concept="3oM_SD" id="9jWrhFl41F" role="1PaTwD">
+                          <property role="3oM_SC" value="the" />
+                        </node>
+                        <node concept="3oM_SD" id="9jWrhFl41G" role="1PaTwD">
+                          <property role="3oM_SC" value="expensive" />
+                        </node>
+                        <node concept="3oM_SD" id="9jWrhFl41H" role="1PaTwD">
+                          <property role="3oM_SC" value="code" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbF" id="9jWrhFl41I" role="3cqZAp">
+                      <node concept="2OqwBi" id="9jWrhFl41J" role="3clFbG">
+                        <node concept="37vLTw" id="9jWrhFl41K" role="2Oq$k0">
+                          <ref role="3cqZAo" node="9jWrhFl41r" resolve="expensiveCount" />
+                        </node>
+                        <node concept="liA8E" id="9jWrhFl41L" role="2OqNvi">
+                          <ref role="37wK5l" to="qhup:~MutableInt.increment()" resolve="increment" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbF" id="9jWrhFl41M" role="3cqZAp">
+                      <node concept="37vLTw" id="9jWrhFl6Mp" role="3clFbG">
+                        <ref role="3cqZAo" node="9jWrhFl5iH" resolve="m" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="1bVj0M" id="9jWrhFl73e" role="37wK5m">
+                  <node concept="37vLTG" id="9jWrhFl79Q" role="1bW2Oz">
+                    <property role="TrG5h" value="m" />
+                    <node concept="3uibUv" id="9jWrhFl7A$" role="1tU5fm">
+                      <ref role="3uigEE" to="qhup:~MutableInt" resolve="MutableInt" />
+                    </node>
+                  </node>
+                  <node concept="3clFbS" id="9jWrhFl73g" role="1bW5cS">
+                    <node concept="3SKdUt" id="9jWrhFlVa5" role="3cqZAp">
+                      <node concept="1PaTwC" id="9jWrhFlVa6" role="1aUNEU">
+                        <node concept="3oM_SD" id="9jWrhFlVi$" role="1PaTwD">
+                          <property role="3oM_SC" value="cheap" />
+                        </node>
+                        <node concept="3oM_SD" id="9jWrhFlVsB" role="1PaTwD">
+                          <property role="3oM_SC" value="computation" />
+                        </node>
+                        <node concept="3oM_SD" id="9jWrhFlVAl" role="1PaTwD">
+                          <property role="3oM_SC" value="of" />
+                        </node>
+                        <node concept="3oM_SD" id="9jWrhFlVAp" role="1PaTwD">
+                          <property role="3oM_SC" value="a" />
+                        </node>
+                        <node concept="3oM_SD" id="9jWrhFlVK9" role="1PaTwD">
+                          <property role="3oM_SC" value="hash" />
+                        </node>
+                        <node concept="3oM_SD" id="9jWrhFlVTU" role="1PaTwD">
+                          <property role="3oM_SC" value="value" />
+                        </node>
+                        <node concept="3oM_SD" id="9jWrhFlW3G" role="1PaTwD">
+                          <property role="3oM_SC" value="based" />
+                        </node>
+                        <node concept="3oM_SD" id="9jWrhFlWdv" role="1PaTwD">
+                          <property role="3oM_SC" value="on" />
+                        </node>
+                        <node concept="3oM_SD" id="9jWrhFlWnj" role="1PaTwD">
+                          <property role="3oM_SC" value="the" />
+                        </node>
+                        <node concept="3oM_SD" id="9jWrhFlWx8" role="1PaTwD">
+                          <property role="3oM_SC" value="expensive" />
+                        </node>
+                        <node concept="3oM_SD" id="9jWrhFlXfZ" role="1PaTwD">
+                          <property role="3oM_SC" value="result" />
+                        </node>
+                        <node concept="3oM_SD" id="9jWrhFlXgb" role="1PaTwD">
+                          <property role="3oM_SC" value="m" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbF" id="9jWrhFl7Sa" role="3cqZAp">
+                      <node concept="2YIFZM" id="9jWrhFl8dX" role="3clFbG">
+                        <ref role="37wK5l" to="33ny:~Objects.hash(java.lang.Object...)" resolve="hash" />
+                        <ref role="1Pybhc" to="33ny:~Objects" resolve="Objects" />
+                        <node concept="2OqwBi" id="9jWrhFl92Q" role="37wK5m">
+                          <node concept="37vLTw" id="9jWrhFl8z2" role="2Oq$k0">
+                            <ref role="3cqZAo" node="9jWrhFl79Q" resolve="m" />
+                          </node>
+                          <node concept="liA8E" id="9jWrhFl9tj" role="2OqNvi">
+                            <ref role="37wK5l" to="qhup:~MutableInt.getValue()" resolve="getValue" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbH" id="9jWrhFl41O" role="3cqZAp" />
+          <node concept="3SKdUt" id="9jWrhFl41P" role="3cqZAp">
+            <node concept="1PaTwC" id="9jWrhFl41Q" role="1aUNEU">
+              <node concept="3oM_SD" id="9jWrhFl41R" role="1PaTwD">
+                <property role="3oM_SC" value="execute" />
+              </node>
+              <node concept="3oM_SD" id="9jWrhFl41S" role="1PaTwD">
+                <property role="3oM_SC" value="first" />
+              </node>
+              <node concept="3oM_SD" id="9jWrhFl41T" role="1PaTwD">
+                <property role="3oM_SC" value="get()," />
+              </node>
+              <node concept="3oM_SD" id="9jWrhFl41U" role="1PaTwD">
+                <property role="3oM_SC" value="should" />
+              </node>
+              <node concept="3oM_SD" id="9jWrhFl41V" role="1PaTwD">
+                <property role="3oM_SC" value="return" />
+              </node>
+              <node concept="3oM_SD" id="9jWrhFl41W" role="1PaTwD">
+                <property role="3oM_SC" value="777," />
+              </node>
+              <node concept="3oM_SD" id="9jWrhFl41X" role="1PaTwD">
+                <property role="3oM_SC" value="and" />
+              </node>
+              <node concept="3oM_SD" id="9jWrhFl41Y" role="1PaTwD">
+                <property role="3oM_SC" value="expensive" />
+              </node>
+              <node concept="3oM_SD" id="9jWrhFl41Z" role="1PaTwD">
+                <property role="3oM_SC" value="code" />
+              </node>
+              <node concept="3oM_SD" id="9jWrhFl420" role="1PaTwD">
+                <property role="3oM_SC" value="should" />
+              </node>
+              <node concept="3oM_SD" id="9jWrhFl421" role="1PaTwD">
+                <property role="3oM_SC" value="be" />
+              </node>
+              <node concept="3oM_SD" id="9jWrhFl422" role="1PaTwD">
+                <property role="3oM_SC" value="executed" />
+              </node>
+              <node concept="3oM_SD" id="9jWrhFl423" role="1PaTwD">
+                <property role="3oM_SC" value="exactly" />
+              </node>
+              <node concept="3oM_SD" id="9jWrhFl424" role="1PaTwD">
+                <property role="3oM_SC" value="once" />
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs8" id="9jWrhFl425" role="3cqZAp">
+            <node concept="3cpWsn" id="9jWrhFl426" role="3cpWs9">
+              <property role="TrG5h" value="v1" />
+              <node concept="10Oyi0" id="9jWrhFl427" role="1tU5fm" />
+              <node concept="2OqwBi" id="9jWrhFl428" role="33vP2m">
+                <node concept="37vLTw" id="9jWrhFl429" role="2Oq$k0">
+                  <ref role="3cqZAo" node="9jWrhFl41x" resolve="init" />
+                </node>
+                <node concept="liA8E" id="9jWrhFl42a" role="2OqNvi">
+                  <ref role="37wK5l" to="82uw:~Supplier.get()" resolve="get" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3vlDli" id="9jWrhFl42b" role="3cqZAp">
+            <node concept="37vLTw" id="9jWrhFl42c" role="3tpDZA">
+              <ref role="3cqZAo" node="9jWrhFl426" resolve="v1" />
+            </node>
+            <node concept="2YIFZM" id="9jWrhFlZ0V" role="3tpDZB">
+              <ref role="37wK5l" to="33ny:~Objects.hash(java.lang.Object...)" resolve="hash" />
+              <ref role="1Pybhc" to="33ny:~Objects" resolve="Objects" />
+              <node concept="3cmrfG" id="9jWrhFlZcY" role="37wK5m">
+                <property role="3cmrfH" value="77" />
+              </node>
+            </node>
+          </node>
+          <node concept="3vlDli" id="9jWrhFl42e" role="3cqZAp">
+            <node concept="3cmrfG" id="9jWrhFl42f" role="3tpDZB">
+              <property role="3cmrfH" value="1" />
+            </node>
+            <node concept="10QFUN" id="9jWrhFl42g" role="3tpDZA">
+              <node concept="10Oyi0" id="9jWrhFl42h" role="10QFUM" />
+              <node concept="2OqwBi" id="9jWrhFl42i" role="10QFUP">
+                <node concept="37vLTw" id="9jWrhFl42j" role="2Oq$k0">
+                  <ref role="3cqZAo" node="9jWrhFl41r" resolve="expensiveCount" />
+                </node>
+                <node concept="liA8E" id="9jWrhFl42k" role="2OqNvi">
+                  <ref role="37wK5l" to="qhup:~MutableInt.getValue()" resolve="getValue" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbH" id="9jWrhFl42l" role="3cqZAp" />
+          <node concept="3SKdUt" id="9jWrhFl42m" role="3cqZAp">
+            <node concept="1PaTwC" id="9jWrhFl42n" role="1aUNEU">
+              <node concept="3oM_SD" id="9jWrhFl42o" role="1PaTwD">
+                <property role="3oM_SC" value="when" />
+              </node>
+              <node concept="3oM_SD" id="9jWrhFl42p" role="1PaTwD">
+                <property role="3oM_SC" value="executing" />
+              </node>
+              <node concept="3oM_SD" id="9jWrhFl42q" role="1PaTwD">
+                <property role="3oM_SC" value="get()" />
+              </node>
+              <node concept="3oM_SD" id="9jWrhFl42r" role="1PaTwD">
+                <property role="3oM_SC" value="again," />
+              </node>
+              <node concept="3oM_SD" id="9jWrhFl42s" role="1PaTwD">
+                <property role="3oM_SC" value="it" />
+              </node>
+              <node concept="3oM_SD" id="9jWrhFl42t" role="1PaTwD">
+                <property role="3oM_SC" value="still" />
+              </node>
+              <node concept="3oM_SD" id="9jWrhFl42u" role="1PaTwD">
+                <property role="3oM_SC" value="should" />
+              </node>
+              <node concept="3oM_SD" id="9jWrhFl42v" role="1PaTwD">
+                <property role="3oM_SC" value="return" />
+              </node>
+              <node concept="3oM_SD" id="9jWrhFl42w" role="1PaTwD">
+                <property role="3oM_SC" value="777," />
+              </node>
+              <node concept="3oM_SD" id="9jWrhFl42x" role="1PaTwD">
+                <property role="3oM_SC" value="but" />
+              </node>
+              <node concept="3oM_SD" id="9jWrhFl42y" role="1PaTwD">
+                <property role="3oM_SC" value="without" />
+              </node>
+              <node concept="3oM_SD" id="9jWrhFl42z" role="1PaTwD">
+                <property role="3oM_SC" value="executing" />
+              </node>
+              <node concept="3oM_SD" id="9jWrhFl42$" role="1PaTwD">
+                <property role="3oM_SC" value="expensive" />
+              </node>
+              <node concept="3oM_SD" id="9jWrhFl42_" role="1PaTwD">
+                <property role="3oM_SC" value="code" />
+              </node>
+              <node concept="3oM_SD" id="9jWrhFl42A" role="1PaTwD">
+                <property role="3oM_SC" value="again" />
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs8" id="9jWrhFl42B" role="3cqZAp">
+            <node concept="3cpWsn" id="9jWrhFl42C" role="3cpWs9">
+              <property role="TrG5h" value="v2" />
+              <node concept="10Oyi0" id="9jWrhFl42D" role="1tU5fm" />
+              <node concept="2OqwBi" id="9jWrhFl42E" role="33vP2m">
+                <node concept="37vLTw" id="9jWrhFl42F" role="2Oq$k0">
+                  <ref role="3cqZAo" node="9jWrhFl41x" resolve="init" />
+                </node>
+                <node concept="liA8E" id="9jWrhFl42G" role="2OqNvi">
+                  <ref role="37wK5l" to="82uw:~Supplier.get()" resolve="get" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3vlDli" id="9jWrhFl42H" role="3cqZAp">
+            <node concept="37vLTw" id="9jWrhFl42I" role="3tpDZA">
+              <ref role="3cqZAo" node="9jWrhFl42C" resolve="v2" />
+            </node>
+            <node concept="2YIFZM" id="9jWrhFlZxg" role="3tpDZB">
+              <ref role="37wK5l" to="33ny:~Objects.hash(java.lang.Object...)" resolve="hash" />
+              <ref role="1Pybhc" to="33ny:~Objects" resolve="Objects" />
+              <node concept="3cmrfG" id="9jWrhFlZxh" role="37wK5m">
+                <property role="3cmrfH" value="77" />
+              </node>
+            </node>
+          </node>
+          <node concept="3vlDli" id="9jWrhFl42K" role="3cqZAp">
+            <node concept="3cmrfG" id="9jWrhFl42L" role="3tpDZB">
+              <property role="3cmrfH" value="1" />
+            </node>
+            <node concept="10QFUN" id="9jWrhFl42M" role="3tpDZA">
+              <node concept="10Oyi0" id="9jWrhFl42N" role="10QFUM" />
+              <node concept="2OqwBi" id="9jWrhFl42O" role="10QFUP">
+                <node concept="37vLTw" id="9jWrhFl42P" role="2Oq$k0">
+                  <ref role="3cqZAo" node="9jWrhFl41r" resolve="expensiveCount" />
+                </node>
+                <node concept="liA8E" id="9jWrhFl42Q" role="2OqNvi">
+                  <ref role="37wK5l" to="qhup:~MutableInt.getValue()" resolve="getValue" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbH" id="9jWrhFlafy" role="3cqZAp" />
+          <node concept="3SKdUt" id="9jWrhFm2dE" role="3cqZAp">
+            <node concept="1PaTwC" id="9jWrhFm2dF" role="1aUNEU">
+              <node concept="3oM_SD" id="9jWrhFm2xe" role="1PaTwD">
+                <property role="3oM_SC" value="let's" />
+              </node>
+              <node concept="3oM_SD" id="9jWrhFm2xg" role="1PaTwD">
+                <property role="3oM_SC" value="change" />
+              </node>
+              <node concept="3oM_SD" id="9jWrhFm2xj" role="1PaTwD">
+                <property role="3oM_SC" value="the" />
+              </node>
+              <node concept="3oM_SD" id="9jWrhFm2xn" role="1PaTwD">
+                <property role="3oM_SC" value="expensive" />
+              </node>
+              <node concept="3oM_SD" id="9jWrhFm2xs" role="1PaTwD">
+                <property role="3oM_SC" value="value," />
+              </node>
+              <node concept="3oM_SD" id="9jWrhFm2xy" role="1PaTwD">
+                <property role="3oM_SC" value="will" />
+              </node>
+              <node concept="3oM_SD" id="9jWrhFm2xD" role="1PaTwD">
+                <property role="3oM_SC" value="lead" />
+              </node>
+              <node concept="3oM_SD" id="9jWrhFm2xL" role="1PaTwD">
+                <property role="3oM_SC" value="to" />
+              </node>
+              <node concept="3oM_SD" id="9jWrhFm2xU" role="1PaTwD">
+                <property role="3oM_SC" value="a" />
+              </node>
+              <node concept="3oM_SD" id="9jWrhFm2y4" role="1PaTwD">
+                <property role="3oM_SC" value="re-computation" />
+              </node>
+              <node concept="3oM_SD" id="9jWrhFm2yC" role="1PaTwD">
+                <property role="3oM_SC" value="because" />
+              </node>
+              <node concept="3oM_SD" id="9jWrhFm2yO" role="1PaTwD">
+                <property role="3oM_SC" value="the" />
+              </node>
+              <node concept="3oM_SD" id="9jWrhFm2z1" role="1PaTwD">
+                <property role="3oM_SC" value="hashcode" />
+              </node>
+              <node concept="3oM_SD" id="9jWrhFm2zf" role="1PaTwD">
+                <property role="3oM_SC" value="doesn't" />
+              </node>
+              <node concept="3oM_SD" id="9jWrhFm2zu" role="1PaTwD">
+                <property role="3oM_SC" value="match" />
+              </node>
+              <node concept="3oM_SD" id="9jWrhFm2zI" role="1PaTwD">
+                <property role="3oM_SC" value="anymore" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="9jWrhFlaEh" role="3cqZAp">
+            <node concept="2OqwBi" id="9jWrhFlb7a" role="3clFbG">
+              <node concept="37vLTw" id="9jWrhFlaEf" role="2Oq$k0">
+                <ref role="3cqZAo" node="9jWrhFl5iH" resolve="m" />
+              </node>
+              <node concept="liA8E" id="9jWrhFlbnC" role="2OqNvi">
+                <ref role="37wK5l" to="qhup:~MutableInt.increment()" resolve="increment" />
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs8" id="9jWrhFlbJJ" role="3cqZAp">
+            <node concept="3cpWsn" id="9jWrhFlbJK" role="3cpWs9">
+              <property role="TrG5h" value="v3" />
+              <node concept="10Oyi0" id="9jWrhFlbJL" role="1tU5fm" />
+              <node concept="2OqwBi" id="9jWrhFlbJM" role="33vP2m">
+                <node concept="37vLTw" id="9jWrhFlbJN" role="2Oq$k0">
+                  <ref role="3cqZAo" node="9jWrhFl41x" resolve="init" />
+                </node>
+                <node concept="liA8E" id="9jWrhFlbJO" role="2OqNvi">
+                  <ref role="37wK5l" to="82uw:~Supplier.get()" resolve="get" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3vlDli" id="9jWrhFlbJP" role="3cqZAp">
+            <node concept="37vLTw" id="9jWrhFlbJQ" role="3tpDZA">
+              <ref role="3cqZAo" node="9jWrhFlbJK" resolve="v2" />
+            </node>
+            <node concept="2YIFZM" id="9jWrhFlZGJ" role="3tpDZB">
+              <ref role="37wK5l" to="33ny:~Objects.hash(java.lang.Object...)" resolve="hash" />
+              <ref role="1Pybhc" to="33ny:~Objects" resolve="Objects" />
+              <node concept="3cmrfG" id="9jWrhFlZGK" role="37wK5m">
+                <property role="3cmrfH" value="78" />
+              </node>
+            </node>
+          </node>
+          <node concept="3vlDli" id="9jWrhFlbJS" role="3cqZAp">
+            <node concept="10QFUN" id="9jWrhFlbJU" role="3tpDZA">
+              <node concept="10Oyi0" id="9jWrhFlbJV" role="10QFUM" />
+              <node concept="2OqwBi" id="9jWrhFlbJW" role="10QFUP">
+                <node concept="37vLTw" id="9jWrhFlbJX" role="2Oq$k0">
+                  <ref role="3cqZAo" node="9jWrhFl41r" resolve="expensiveCount" />
+                </node>
+                <node concept="liA8E" id="9jWrhFlbJY" role="2OqNvi">
+                  <ref role="37wK5l" to="qhup:~MutableInt.getValue()" resolve="getValue" />
+                </node>
+              </node>
+            </node>
+            <node concept="3cmrfG" id="9jWrhFlcXQ" role="3tpDZB">
+              <property role="3cmrfH" value="2" />
+            </node>
+          </node>
+          <node concept="3clFbH" id="9jWrhFlbxX" role="3cqZAp" />
+          <node concept="3SKdUt" id="9jWrhFm3D6" role="3cqZAp">
+            <node concept="1PaTwC" id="9jWrhFm3D7" role="1aUNEU">
+              <node concept="3oM_SD" id="9jWrhFm3WW" role="1PaTwD">
+                <property role="3oM_SC" value="when" />
+              </node>
+              <node concept="3oM_SD" id="9jWrhFm3WY" role="1PaTwD">
+                <property role="3oM_SC" value="getting" />
+              </node>
+              <node concept="3oM_SD" id="9jWrhFm3X1" role="1PaTwD">
+                <property role="3oM_SC" value="the" />
+              </node>
+              <node concept="3oM_SD" id="9jWrhFm3X5" role="1PaTwD">
+                <property role="3oM_SC" value="value" />
+              </node>
+              <node concept="3oM_SD" id="9jWrhFm3Xa" role="1PaTwD">
+                <property role="3oM_SC" value="again" />
+              </node>
+              <node concept="3oM_SD" id="9jWrhFm3Xg" role="1PaTwD">
+                <property role="3oM_SC" value="it" />
+              </node>
+              <node concept="3oM_SD" id="9jWrhFm3Xn" role="1PaTwD">
+                <property role="3oM_SC" value="is" />
+              </node>
+              <node concept="3oM_SD" id="9jWrhFm3Xv" role="1PaTwD">
+                <property role="3oM_SC" value="provided" />
+              </node>
+              <node concept="3oM_SD" id="9jWrhFm3XC" role="1PaTwD">
+                <property role="3oM_SC" value="without" />
+              </node>
+              <node concept="3oM_SD" id="9jWrhFm3XM" role="1PaTwD">
+                <property role="3oM_SC" value="another" />
+              </node>
+              <node concept="3oM_SD" id="9jWrhFm3XX" role="1PaTwD">
+                <property role="3oM_SC" value="expensive" />
+              </node>
+              <node concept="3oM_SD" id="9jWrhFm3Y9" role="1PaTwD">
+                <property role="3oM_SC" value="re-computation" />
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs8" id="9jWrhFldaV" role="3cqZAp">
+            <node concept="3cpWsn" id="9jWrhFldaW" role="3cpWs9">
+              <property role="TrG5h" value="v4" />
+              <node concept="10Oyi0" id="9jWrhFldaX" role="1tU5fm" />
+              <node concept="2OqwBi" id="9jWrhFldaY" role="33vP2m">
+                <node concept="37vLTw" id="9jWrhFldaZ" role="2Oq$k0">
+                  <ref role="3cqZAo" node="9jWrhFl41x" resolve="init" />
+                </node>
+                <node concept="liA8E" id="9jWrhFldb0" role="2OqNvi">
+                  <ref role="37wK5l" to="82uw:~Supplier.get()" resolve="get" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3vlDli" id="9jWrhFldb1" role="3cqZAp">
+            <node concept="37vLTw" id="9jWrhFldb2" role="3tpDZA">
+              <ref role="3cqZAo" node="9jWrhFldaW" resolve="v3" />
+            </node>
+            <node concept="2YIFZM" id="9jWrhFm059" role="3tpDZB">
+              <ref role="37wK5l" to="33ny:~Objects.hash(java.lang.Object...)" resolve="hash" />
+              <ref role="1Pybhc" to="33ny:~Objects" resolve="Objects" />
+              <node concept="3cmrfG" id="9jWrhFm05a" role="37wK5m">
+                <property role="3cmrfH" value="78" />
+              </node>
+            </node>
+          </node>
+          <node concept="3vlDli" id="9jWrhFldb4" role="3cqZAp">
+            <node concept="10QFUN" id="9jWrhFldb5" role="3tpDZA">
+              <node concept="10Oyi0" id="9jWrhFldb6" role="10QFUM" />
+              <node concept="2OqwBi" id="9jWrhFldb7" role="10QFUP">
+                <node concept="37vLTw" id="9jWrhFldb8" role="2Oq$k0">
+                  <ref role="3cqZAo" node="9jWrhFl41r" resolve="expensiveCount" />
+                </node>
+                <node concept="liA8E" id="9jWrhFldb9" role="2OqNvi">
+                  <ref role="37wK5l" to="qhup:~MutableInt.getValue()" resolve="getValue" />
+                </node>
+              </node>
+            </node>
+            <node concept="3cmrfG" id="9jWrhFldba" role="3tpDZB">
+              <property role="3cmrfH" value="2" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.common/models/com/mbeddr/mpsutil/common/model.mps
+++ b/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.common/models/com/mbeddr/mpsutil/common/model.mps
@@ -9,13 +9,10 @@
   <imports>
     <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" />
     <import index="w1kc" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel(MPS.Core/)" />
-    <import index="fyhk" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps(MPS.Platform/)" />
     <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
     <import index="vndm" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel.language(MPS.Core/)" />
     <import index="mhbf" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.model(MPS.OpenAPI/)" />
     <import index="lui2" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.module(MPS.OpenAPI/)" />
-    <import index="bd8o" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.application(MPS.IDEA/)" />
-    <import index="3a50" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.ide(MPS.Platform/)" />
     <import index="z1c3" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.project(MPS.Core/)" />
     <import index="tqvn" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel.tempmodel(MPS.Core/)" />
     <import index="18ew" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.util(MPS.Core/)" />

--- a/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.common/models/com/mbeddr/mpsutil/common/util.mps
+++ b/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.common/models/com/mbeddr/mpsutil/common/util.mps
@@ -21,6 +21,7 @@
     <import index="4nm9" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.project(MPS.IDEA/)" />
     <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" />
     <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
+    <import index="82uw" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util.function(JDK/)" />
     <import index="bd8o" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.application(MPS.IDEA/)" implicit="true" />
   </imports>
   <registry>
@@ -98,11 +99,15 @@
       <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu">
         <property id="1075300953594" name="abstractClass" index="1sVAO0" />
         <property id="1221565133444" name="isFinal" index="1EXbeo" />
+        <child id="1095933932569" name="implementedInterface" index="EKbjA" />
         <child id="1165602531693" name="superclass" index="1zkMxy" />
       </concept>
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <property id="1176718929932" name="isFinal" index="3TUv4t" />
         <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ng" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
       </concept>
       <concept id="1109279763828" name="jetbrains.mps.baseLanguage.structure.TypeVariableDeclaration" flags="ng" index="16euLQ">
         <child id="1214996921760" name="bound" index="3ztrMU" />
@@ -175,7 +180,9 @@
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
       <concept id="1073063089578" name="jetbrains.mps.baseLanguage.structure.SuperMethodCall" flags="nn" index="3nyPlj" />
-      <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk" />
+      <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk">
+        <child id="1212687122400" name="typeParameter" index="1pMfVU" />
+      </concept>
       <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
         <property id="521412098689998745" name="nonStatic" index="2bfB8j" />
         <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
@@ -186,6 +193,7 @@
       <concept id="7812454656619025412" name="jetbrains.mps.baseLanguage.structure.LocalMethodCall" flags="nn" index="1rXfSq" />
       <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
         <reference id="1107535924139" name="classifier" index="3uigEE" />
+        <child id="1109201940907" name="parameter" index="11_B2D" />
       </concept>
       <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
         <child id="1081773367579" name="rightExpression" index="3uHU7w" />
@@ -232,15 +240,37 @@
       <concept id="4079382982702596667" name="jetbrains.mps.baseLanguage.checkedDots.structure.CheckedDotExpression" flags="nn" index="2EnYce" />
     </language>
     <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
+      <concept id="1235746970280" name="jetbrains.mps.baseLanguage.closures.structure.CompactInvokeFunctionExpression" flags="nn" index="2Sg_IR">
+        <child id="1235746996653" name="function" index="2SgG2M" />
+        <child id="1235747002942" name="parameter" index="2SgHGx" />
+      </concept>
+      <concept id="1199542442495" name="jetbrains.mps.baseLanguage.closures.structure.FunctionType" flags="in" index="1ajhzC">
+        <child id="1199542457201" name="resultType" index="1ajl9A" />
+        <child id="1199542501692" name="parameterType" index="1ajw0F" />
+      </concept>
       <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
         <child id="1199569906740" name="parameter" index="1bW2Oz" />
         <child id="1199569916463" name="body" index="1bW5cS" />
       </concept>
     </language>
     <language id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc">
+      <concept id="5858074156537516430" name="jetbrains.mps.baseLanguage.javadoc.structure.ReturnBlockDocTag" flags="ng" index="x79VA">
+        <property id="5858074156537516431" name="text" index="x79VB" />
+      </concept>
       <concept id="6832197706140896242" name="jetbrains.mps.baseLanguage.javadoc.structure.FieldDocComment" flags="ng" index="z59LJ" />
+      <concept id="6832197706140518104" name="jetbrains.mps.baseLanguage.javadoc.structure.DocMethodParameterReference" flags="ng" index="zr_55" />
+      <concept id="6832197706140518107" name="jetbrains.mps.baseLanguage.javadoc.structure.DocTypeParameterReference" flags="ng" index="zr_56" />
+      <concept id="6832197706140518103" name="jetbrains.mps.baseLanguage.javadoc.structure.BaseParameterReference" flags="ng" index="zr_5a">
+        <reference id="6832197706140518108" name="param" index="zr_51" />
+      </concept>
       <concept id="5349172909345501395" name="jetbrains.mps.baseLanguage.javadoc.structure.BaseDocComment" flags="ng" index="P$AiS">
         <child id="8465538089690331502" name="body" index="TZ5H$" />
+        <child id="5383422241790532083" name="tags" index="3nqlJM" />
+      </concept>
+      <concept id="5349172909345532724" name="jetbrains.mps.baseLanguage.javadoc.structure.MethodDocComment" flags="ng" index="P$JXv" />
+      <concept id="8465538089690881930" name="jetbrains.mps.baseLanguage.javadoc.structure.ParameterBlockDocTag" flags="ng" index="TUZQ0">
+        <property id="8465538089690881934" name="text" index="TUZQ4" />
+        <child id="6832197706140518123" name="parameter" index="zr_5Q" />
       </concept>
       <concept id="8465538089690331500" name="jetbrains.mps.baseLanguage.javadoc.structure.CommentLine" flags="ng" index="TZ5HA">
         <child id="8970989240999019149" name="part" index="1dT_Ay" />
@@ -248,6 +278,7 @@
       <concept id="8970989240999019143" name="jetbrains.mps.baseLanguage.javadoc.structure.TextCommentLinePart" flags="ng" index="1dT_AC">
         <property id="8970989240999019144" name="text" index="1dT_AB" />
       </concept>
+      <concept id="2068944020170241612" name="jetbrains.mps.baseLanguage.javadoc.structure.ClassifierDocComment" flags="ng" index="3UR2Jj" />
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
       <concept id="1960721196051541146" name="jetbrains.mps.lang.smodel.structure.Node_GetContainingRoleOperation" flags="nn" index="13GOg" />
@@ -3528,6 +3559,628 @@
     </node>
     <node concept="2tJIrI" id="4biM00Jg0Ng" role="jymVt" />
     <node concept="3Tm1VV" id="4biM00Jg0oR" role="1B3o_S" />
+  </node>
+  <node concept="312cEu" id="9jWrhFizRs">
+    <property role="TrG5h" value="LazyInit" />
+    <node concept="2tJIrI" id="9jWrhFmbfw" role="jymVt" />
+    <node concept="2YIFZL" id="9jWrhFiKyu" role="jymVt">
+      <property role="TrG5h" value="lazy" />
+      <node concept="3clFbS" id="9jWrhFiKyx" role="3clF47">
+        <node concept="3clFbF" id="9jWrhFiLxP" role="3cqZAp">
+          <node concept="2ShNRf" id="9jWrhFiLxN" role="3clFbG">
+            <node concept="1pGfFk" id="9jWrhFiWJj" role="2ShVmc">
+              <property role="373rjd" value="true" />
+              <ref role="37wK5l" node="9jWrhFiBTG" resolve="LazyInit" />
+              <node concept="16syzq" id="9jWrhFiWR5" role="1pMfVU">
+                <ref role="16sUi3" node="9jWrhFiKWP" resolve="T" />
+              </node>
+              <node concept="37vLTw" id="9jWrhFiXnX" role="37wK5m">
+                <ref role="3cqZAo" node="9jWrhFiKIM" resolve="expensive" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="9jWrhFiK0f" role="1B3o_S" />
+      <node concept="3uibUv" id="9jWrhFiKws" role="3clF45">
+        <ref role="3uigEE" to="82uw:~Supplier" resolve="Supplier" />
+        <node concept="16syzq" id="9jWrhFiL7f" role="11_B2D">
+          <ref role="16sUi3" node="9jWrhFiKWP" resolve="T" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="9jWrhFiKIM" role="3clF46">
+        <property role="TrG5h" value="expensive" />
+        <node concept="1ajhzC" id="9jWrhFiKIK" role="1tU5fm">
+          <node concept="16syzq" id="9jWrhFiLbc" role="1ajl9A">
+            <ref role="16sUi3" node="9jWrhFiKWP" resolve="T" />
+          </node>
+        </node>
+      </node>
+      <node concept="16euLQ" id="9jWrhFiKWP" role="16eVyc">
+        <property role="TrG5h" value="T" />
+      </node>
+      <node concept="P$JXv" id="9jWrhFmbGN" role="lGtFl">
+        <node concept="TZ5HA" id="9jWrhFmbGO" role="TZ5H$">
+          <node concept="1dT_AC" id="9jWrhFmbGP" role="1dT_Ay">
+            <property role="1dT_AB" value="Static factory method to construct a memorizing supplier." />
+          </node>
+        </node>
+        <node concept="TUZQ0" id="9jWrhFmbGQ" role="3nqlJM">
+          <property role="TUZQ4" value="the code which should only be executed once and on first demand" />
+          <node concept="zr_55" id="9jWrhFmbGS" role="zr_5Q">
+            <ref role="zr_51" node="9jWrhFiKIM" resolve="expensive" />
+          </node>
+        </node>
+        <node concept="TUZQ0" id="9jWrhFmbGT" role="3nqlJM">
+          <property role="TUZQ4" value="type of supplied values" />
+          <node concept="zr_56" id="9jWrhFmbGV" role="zr_5Q">
+            <ref role="zr_51" node="9jWrhFiKWP" resolve="T" />
+          </node>
+        </node>
+        <node concept="x79VA" id="9jWrhFmbGW" role="3nqlJM">
+          <property role="x79VB" value="the memorizing supplier" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="9jWrhFmb5e" role="jymVt" />
+    <node concept="312cEg" id="9jWrhFiBB7" role="jymVt">
+      <property role="TrG5h" value="innerSupplier" />
+      <node concept="3Tm6S6" id="9jWrhFiBpx" role="1B3o_S" />
+      <node concept="1ajhzC" id="9jWrhFiBvU" role="1tU5fm">
+        <node concept="16syzq" id="9jWrhFiB_U" role="1ajl9A">
+          <ref role="16sUi3" node="9jWrhFizRP" resolve="T" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="9jWrhFiBCQ" role="jymVt" />
+    <node concept="3clFbW" id="9jWrhFiBTG" role="jymVt">
+      <node concept="3cqZAl" id="9jWrhFiBTI" role="3clF45" />
+      <node concept="3Tm6S6" id="9jWrhFmb$4" role="1B3o_S" />
+      <node concept="3clFbS" id="9jWrhFiBTK" role="3clF47">
+        <node concept="3clFbF" id="9jWrhFiCJ1" role="3cqZAp">
+          <node concept="37vLTI" id="9jWrhFiDEB" role="3clFbG">
+            <node concept="1bVj0M" id="9jWrhFiDWf" role="37vLTx">
+              <node concept="3clFbS" id="9jWrhFiDWh" role="1bW5cS">
+                <node concept="3cpWs8" id="9jWrhFiEfY" role="3cqZAp">
+                  <node concept="3cpWsn" id="9jWrhFiEg1" role="3cpWs9">
+                    <property role="TrG5h" value="t" />
+                    <property role="3TUv4t" value="true" />
+                    <node concept="16syzq" id="9jWrhFiEfX" role="1tU5fm">
+                      <ref role="16sUi3" node="9jWrhFizRP" resolve="T" />
+                    </node>
+                    <node concept="2Sg_IR" id="9jWrhFiFMB" role="33vP2m">
+                      <node concept="37vLTw" id="9jWrhFiFMC" role="2SgG2M">
+                        <ref role="3cqZAo" node="9jWrhFiC1S" resolve="expensive" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbF" id="9jWrhFiGOt" role="3cqZAp">
+                  <node concept="37vLTI" id="9jWrhFiH0_" role="3clFbG">
+                    <node concept="1bVj0M" id="9jWrhFiHjS" role="37vLTx">
+                      <node concept="3clFbS" id="9jWrhFiHjU" role="1bW5cS">
+                        <node concept="3clFbF" id="9jWrhFiHC2" role="3cqZAp">
+                          <node concept="37vLTw" id="9jWrhFiHC1" role="3clFbG">
+                            <ref role="3cqZAo" node="9jWrhFiEg1" resolve="t" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="37vLTw" id="9jWrhFiGOr" role="37vLTJ">
+                      <ref role="3cqZAo" node="9jWrhFiBB7" resolve="supplier" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbF" id="9jWrhFiI8Y" role="3cqZAp">
+                  <node concept="37vLTw" id="9jWrhFiI8W" role="3clFbG">
+                    <ref role="3cqZAo" node="9jWrhFiEg1" resolve="t" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="2OqwBi" id="9jWrhFiD1Z" role="37vLTJ">
+              <node concept="Xjq3P" id="9jWrhFiCJ0" role="2Oq$k0" />
+              <node concept="2OwXpG" id="9jWrhFiD_8" role="2OqNvi">
+                <ref role="2Oxat5" node="9jWrhFiBB7" resolve="supplier" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="9jWrhFiC1S" role="3clF46">
+        <property role="TrG5h" value="expensive" />
+        <node concept="1ajhzC" id="9jWrhFiC1Q" role="1tU5fm">
+          <node concept="16syzq" id="9jWrhFiC8h" role="1ajl9A">
+            <ref role="16sUi3" node="9jWrhFizRP" resolve="T" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="9jWrhFiFrS" role="jymVt" />
+    <node concept="3Tm1VV" id="9jWrhFizRt" role="1B3o_S" />
+    <node concept="16euLQ" id="9jWrhFizRP" role="16eVyc">
+      <property role="TrG5h" value="T" />
+    </node>
+    <node concept="3uibUv" id="9jWrhFiAZd" role="EKbjA">
+      <ref role="3uigEE" to="82uw:~Supplier" resolve="Supplier" />
+      <node concept="16syzq" id="9jWrhFiAZS" role="11_B2D">
+        <ref role="16sUi3" node="9jWrhFizRP" resolve="T" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="9jWrhFiB0U" role="jymVt">
+      <property role="TrG5h" value="get" />
+      <node concept="3Tm1VV" id="9jWrhFiB0V" role="1B3o_S" />
+      <node concept="16syzq" id="9jWrhFiB0Y" role="3clF45">
+        <ref role="16sUi3" node="9jWrhFizRP" resolve="T" />
+      </node>
+      <node concept="3clFbS" id="9jWrhFiB0Z" role="3clF47">
+        <node concept="3clFbF" id="9jWrhFiJg9" role="3cqZAp">
+          <node concept="2Sg_IR" id="9jWrhFiJtA" role="3clFbG">
+            <node concept="37vLTw" id="9jWrhFiJtB" role="2SgG2M">
+              <ref role="3cqZAo" node="9jWrhFiBB7" resolve="supplier" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="9jWrhFiB10" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" />
+      </node>
+    </node>
+    <node concept="3UR2Jj" id="9jWrhFm7uv" role="lGtFl">
+      <node concept="TZ5HA" id="9jWrhFm7uw" role="TZ5H$">
+        <node concept="1dT_AC" id="9jWrhFm7ux" role="1dT_Ay">
+          <property role="1dT_AB" value="Supplier which memorizes its value after first call to get()." />
+        </node>
+      </node>
+      <node concept="TZ5HA" id="9jWrhFma9Y" role="TZ5H$">
+        <node concept="1dT_AC" id="9jWrhFma9Z" role="1dT_Ay">
+          <property role="1dT_AB" value="The implementation is very efficient as it does not need null-checks." />
+        </node>
+      </node>
+      <node concept="TZ5HA" id="9jWrhFm96w" role="TZ5H$">
+        <node concept="1dT_AC" id="9jWrhFm96x" role="1dT_Ay">
+          <property role="1dT_AB" value="" />
+        </node>
+      </node>
+      <node concept="TZ5HA" id="9jWrhFm9fo" role="TZ5H$">
+        <node concept="1dT_AC" id="9jWrhFm9fp" role="1dT_Ay">
+          <property role="1dT_AB" value="NOTE: This class is not thread-safe." />
+        </node>
+      </node>
+      <node concept="TUZQ0" id="9jWrhFm7uy" role="3nqlJM">
+        <property role="TUZQ4" value="generic type of supplied values" />
+        <node concept="zr_56" id="9jWrhFm7u$" role="zr_5Q">
+          <ref role="zr_51" node="9jWrhFizRP" resolve="T" />
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="312cEu" id="9jWrhFiXtZ">
+    <property role="TrG5h" value="LazyInitWithCheck" />
+    <node concept="2tJIrI" id="9jWrhFmoFy" role="jymVt" />
+    <node concept="2YIFZL" id="9jWrhFiXuJ" role="jymVt">
+      <property role="TrG5h" value="lazy" />
+      <node concept="3clFbS" id="9jWrhFiXuK" role="3clF47">
+        <node concept="3clFbF" id="9jWrhFiXuL" role="3cqZAp">
+          <node concept="2ShNRf" id="9jWrhFiXuM" role="3clFbG">
+            <node concept="1pGfFk" id="9jWrhFiXuN" role="2ShVmc">
+              <property role="373rjd" value="true" />
+              <ref role="37wK5l" node="9jWrhFiXu5" resolve="LazyInitWithCheck" />
+              <node concept="16syzq" id="9jWrhFiXuO" role="1pMfVU">
+                <ref role="16sUi3" node="9jWrhFiXuW" resolve="T" />
+              </node>
+              <node concept="16syzq" id="9jWrhFjlvp" role="1pMfVU">
+                <ref role="16sUi3" node="9jWrhFjkmA" resolve="M" />
+              </node>
+              <node concept="37vLTw" id="9jWrhFiXuP" role="37wK5m">
+                <ref role="3cqZAo" node="9jWrhFiXuT" resolve="expensive" />
+              </node>
+              <node concept="37vLTw" id="9jWrhFjmd4" role="37wK5m">
+                <ref role="3cqZAo" node="9jWrhFjkCI" resolve="cheap" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="9jWrhFiXuQ" role="1B3o_S" />
+      <node concept="3uibUv" id="9jWrhFiXuR" role="3clF45">
+        <ref role="3uigEE" to="82uw:~Supplier" resolve="Supplier" />
+        <node concept="16syzq" id="9jWrhFiXuS" role="11_B2D">
+          <ref role="16sUi3" node="9jWrhFiXuW" resolve="T" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="9jWrhFiXuT" role="3clF46">
+        <property role="TrG5h" value="expensive" />
+        <property role="3TUv4t" value="true" />
+        <node concept="1ajhzC" id="9jWrhFiXuU" role="1tU5fm">
+          <node concept="16syzq" id="9jWrhFiXuV" role="1ajl9A">
+            <ref role="16sUi3" node="9jWrhFjkmA" resolve="M" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="9jWrhFjkCI" role="3clF46">
+        <property role="TrG5h" value="cheap" />
+        <node concept="1ajhzC" id="9jWrhFjkKQ" role="1tU5fm">
+          <node concept="16syzq" id="9jWrhFjkQD" role="1ajl9A">
+            <ref role="16sUi3" node="9jWrhFiXuW" resolve="T" />
+          </node>
+          <node concept="16syzq" id="9jWrhFjl59" role="1ajw0F">
+            <ref role="16sUi3" node="9jWrhFjkmA" resolve="M" />
+          </node>
+        </node>
+      </node>
+      <node concept="16euLQ" id="9jWrhFiXuW" role="16eVyc">
+        <property role="TrG5h" value="T" />
+      </node>
+      <node concept="16euLQ" id="9jWrhFjkmA" role="16eVyc">
+        <property role="TrG5h" value="M" />
+      </node>
+      <node concept="P$JXv" id="9jWrhFmpqX" role="lGtFl">
+        <node concept="TZ5HA" id="9jWrhFmpqY" role="TZ5H$">
+          <node concept="1dT_AC" id="9jWrhFmpqZ" role="1dT_Ay">
+            <property role="1dT_AB" value="Static factory method to construct the memorizing, re-executable supplier" />
+          </node>
+        </node>
+        <node concept="TUZQ0" id="9jWrhFmpr0" role="3nqlJM">
+          <property role="TUZQ4" value="the expensive computation" />
+          <node concept="zr_55" id="9jWrhFmpr2" role="zr_5Q">
+            <ref role="zr_51" node="9jWrhFiXuT" resolve="expensive" />
+          </node>
+        </node>
+        <node concept="TUZQ0" id="9jWrhFmpr3" role="3nqlJM">
+          <property role="TUZQ4" value="the additional, cheap computation" />
+          <node concept="zr_55" id="9jWrhFmpr5" role="zr_5Q">
+            <ref role="zr_51" node="9jWrhFjkCI" resolve="cheap" />
+          </node>
+        </node>
+        <node concept="TUZQ0" id="9jWrhFmpDb" role="3nqlJM">
+          <property role="TUZQ4" value="generic type of supplied value (e.g., a hashcode type like Integer)" />
+          <node concept="zr_56" id="9jWrhFmpDc" role="zr_5Q">
+            <ref role="zr_51" node="9jWrhFiXuW" resolve="T" />
+          </node>
+        </node>
+        <node concept="TUZQ0" id="9jWrhFmpDd" role="3nqlJM">
+          <property role="TUZQ4" value="result type for the expensive computation" />
+          <node concept="zr_56" id="9jWrhFmpDe" role="zr_5Q">
+            <ref role="zr_51" node="9jWrhFjkmA" resolve="M" />
+          </node>
+        </node>
+        <node concept="x79VA" id="9jWrhFmprc" role="3nqlJM">
+          <property role="x79VB" value="the memorizing, re-executable supplier" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="9jWrhFmoo4" role="jymVt" />
+    <node concept="312cEg" id="9jWrhFiXu0" role="jymVt">
+      <property role="TrG5h" value="innerSupplier" />
+      <node concept="3Tm6S6" id="9jWrhFiXu1" role="1B3o_S" />
+      <node concept="1ajhzC" id="9jWrhFiXu2" role="1tU5fm">
+        <node concept="16syzq" id="9jWrhFiXu3" role="1ajl9A">
+          <ref role="16sUi3" node="9jWrhFiXuz" resolve="T" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="9jWrhFiXu4" role="jymVt" />
+    <node concept="3clFbW" id="9jWrhFiXu5" role="jymVt">
+      <node concept="3cqZAl" id="9jWrhFiXu6" role="3clF45" />
+      <node concept="3Tm6S6" id="9jWrhFmnDv" role="1B3o_S" />
+      <node concept="3clFbS" id="9jWrhFiXu8" role="3clF47">
+        <node concept="3clFbF" id="9jWrhFiXu9" role="3cqZAp">
+          <node concept="37vLTI" id="9jWrhFiXua" role="3clFbG">
+            <node concept="1rXfSq" id="9jWrhFj1z7" role="37vLTx">
+              <ref role="37wK5l" node="9jWrhFiZPP" resolve="inner" />
+              <node concept="37vLTw" id="9jWrhFj2ec" role="37wK5m">
+                <ref role="3cqZAo" node="9jWrhFiXuu" resolve="expensive" />
+              </node>
+              <node concept="37vLTw" id="9jWrhFj2YD" role="37wK5m">
+                <ref role="3cqZAo" node="9jWrhFiYyK" resolve="cheap" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="9jWrhFiXur" role="37vLTJ">
+              <node concept="Xjq3P" id="9jWrhFiXus" role="2Oq$k0" />
+              <node concept="2OwXpG" id="9jWrhFiXut" role="2OqNvi">
+                <ref role="2Oxat5" node="9jWrhFiXu0" resolve="supplier" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="9jWrhFiXuu" role="3clF46">
+        <property role="TrG5h" value="expensive" />
+        <node concept="1ajhzC" id="9jWrhFiXuv" role="1tU5fm">
+          <node concept="16syzq" id="9jWrhFiXuw" role="1ajl9A">
+            <ref role="16sUi3" node="9jWrhFiXLI" resolve="M" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="9jWrhFiYyK" role="3clF46">
+        <property role="TrG5h" value="cheap" />
+        <node concept="1ajhzC" id="9jWrhFiYIY" role="1tU5fm">
+          <node concept="16syzq" id="9jWrhFiYQH" role="1ajl9A">
+            <ref role="16sUi3" node="9jWrhFiXuz" resolve="T" />
+          </node>
+          <node concept="16syzq" id="9jWrhFiZ3q" role="1ajw0F">
+            <ref role="16sUi3" node="9jWrhFiXLI" resolve="M" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="9jWrhFiZ6p" role="jymVt" />
+    <node concept="3clFb_" id="9jWrhFiZPP" role="jymVt">
+      <property role="TrG5h" value="inner" />
+      <node concept="37vLTG" id="9jWrhFj0w4" role="3clF46">
+        <property role="TrG5h" value="expensive" />
+        <property role="3TUv4t" value="true" />
+        <node concept="1ajhzC" id="9jWrhFj0w5" role="1tU5fm">
+          <node concept="16syzq" id="9jWrhFj0w6" role="1ajl9A">
+            <ref role="16sUi3" node="9jWrhFiXLI" resolve="M" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="9jWrhFj0w7" role="3clF46">
+        <property role="TrG5h" value="cheap" />
+        <property role="3TUv4t" value="true" />
+        <node concept="1ajhzC" id="9jWrhFj0w8" role="1tU5fm">
+          <node concept="16syzq" id="9jWrhFj0w9" role="1ajl9A">
+            <ref role="16sUi3" node="9jWrhFiXuz" resolve="T" />
+          </node>
+          <node concept="16syzq" id="9jWrhFj0wa" role="1ajw0F">
+            <ref role="16sUi3" node="9jWrhFiXLI" resolve="M" />
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbS" id="9jWrhFiZPS" role="3clF47">
+        <node concept="3clFbF" id="9jWrhFj3j7" role="3cqZAp">
+          <node concept="1bVj0M" id="9jWrhFj3j5" role="3clFbG">
+            <node concept="3clFbS" id="9jWrhFj3j6" role="1bW5cS">
+              <node concept="3SKdUt" id="9jWrhFlfDR" role="3cqZAp">
+                <node concept="1PaTwC" id="9jWrhFlfDS" role="1aUNEU">
+                  <node concept="3oM_SD" id="9jWrhFlg_F" role="1PaTwD">
+                    <property role="3oM_SC" value="execute" />
+                  </node>
+                  <node concept="3oM_SD" id="9jWrhFlfTs" role="1PaTwD">
+                    <property role="3oM_SC" value="expensive" />
+                  </node>
+                  <node concept="3oM_SD" id="9jWrhFlg7p" role="1PaTwD">
+                    <property role="3oM_SC" value="code" />
+                  </node>
+                  <node concept="3oM_SD" id="9jWrhFlgND" role="1PaTwD">
+                    <property role="3oM_SC" value="and" />
+                  </node>
+                  <node concept="3oM_SD" id="9jWrhFlh1C" role="1PaTwD">
+                    <property role="3oM_SC" value="based" />
+                  </node>
+                  <node concept="3oM_SD" id="9jWrhFlhfC" role="1PaTwD">
+                    <property role="3oM_SC" value="on" />
+                  </node>
+                  <node concept="3oM_SD" id="9jWrhFlhfJ" role="1PaTwD">
+                    <property role="3oM_SC" value="its" />
+                  </node>
+                  <node concept="3oM_SD" id="9jWrhFlhFF" role="1PaTwD">
+                    <property role="3oM_SC" value="result" />
+                  </node>
+                  <node concept="3oM_SD" id="9jWrhFlhTI" role="1PaTwD">
+                    <property role="3oM_SC" value="also" />
+                  </node>
+                  <node concept="3oM_SD" id="9jWrhFli7M" role="1PaTwD">
+                    <property role="3oM_SC" value="the" />
+                  </node>
+                  <node concept="3oM_SD" id="9jWrhFlilR" role="1PaTwD">
+                    <property role="3oM_SC" value="cheap" />
+                  </node>
+                  <node concept="3oM_SD" id="9jWrhFlizX" role="1PaTwD">
+                    <property role="3oM_SC" value="check" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3cpWs8" id="9jWrhFj3Gz" role="3cqZAp">
+                <node concept="3cpWsn" id="9jWrhFj3GA" role="3cpWs9">
+                  <property role="TrG5h" value="m" />
+                  <property role="3TUv4t" value="true" />
+                  <node concept="16syzq" id="9jWrhFj3Gy" role="1tU5fm">
+                    <ref role="16sUi3" node="9jWrhFiXLI" resolve="M" />
+                  </node>
+                  <node concept="2Sg_IR" id="9jWrhFj4FC" role="33vP2m">
+                    <node concept="37vLTw" id="9jWrhFj4FD" role="2SgG2M">
+                      <ref role="3cqZAo" node="9jWrhFj0w4" resolve="expensive" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3cpWs8" id="9jWrhFj5Op" role="3cqZAp">
+                <node concept="3cpWsn" id="9jWrhFj5On" role="3cpWs9">
+                  <property role="3TUv4t" value="true" />
+                  <property role="TrG5h" value="t" />
+                  <node concept="16syzq" id="9jWrhFj61d" role="1tU5fm">
+                    <ref role="16sUi3" node="9jWrhFiXuz" resolve="T" />
+                  </node>
+                  <node concept="2Sg_IR" id="9jWrhFj7qG" role="33vP2m">
+                    <node concept="37vLTw" id="9jWrhFj7qH" role="2SgG2M">
+                      <ref role="3cqZAo" node="9jWrhFj0w7" resolve="cheap" />
+                    </node>
+                    <node concept="37vLTw" id="9jWrhFj7M0" role="2SgHGx">
+                      <ref role="3cqZAo" node="9jWrhFj3GA" resolve="m" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbF" id="9jWrhFj8RY" role="3cqZAp">
+                <node concept="37vLTI" id="9jWrhFj998" role="3clFbG">
+                  <node concept="1bVj0M" id="9jWrhFj9EU" role="37vLTx">
+                    <node concept="3clFbS" id="9jWrhFj9EW" role="1bW5cS">
+                      <node concept="3clFbJ" id="9jWrhFjado" role="3cqZAp">
+                        <node concept="2OqwBi" id="9jWrhFjchW" role="3clFbw">
+                          <node concept="2Sg_IR" id="9jWrhFjbev" role="2Oq$k0">
+                            <node concept="37vLTw" id="9jWrhFjbew" role="2SgG2M">
+                              <ref role="3cqZAo" node="9jWrhFj0w7" resolve="cheap" />
+                            </node>
+                            <node concept="37vLTw" id="9jWrhFjbXY" role="2SgHGx">
+                              <ref role="3cqZAo" node="9jWrhFj3GA" resolve="m" />
+                            </node>
+                          </node>
+                          <node concept="liA8E" id="9jWrhFjcAz" role="2OqNvi">
+                            <ref role="37wK5l" to="wyt6:~Object.equals(java.lang.Object)" resolve="equals" />
+                            <node concept="37vLTw" id="9jWrhFjd11" role="37wK5m">
+                              <ref role="3cqZAo" node="9jWrhFj5On" resolve="t" />
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3clFbS" id="9jWrhFjadq" role="3clFbx">
+                          <node concept="3cpWs6" id="9jWrhFjdUA" role="3cqZAp">
+                            <node concept="37vLTw" id="9jWrhFjevZ" role="3cqZAk">
+                              <ref role="3cqZAo" node="9jWrhFj5On" resolve="t" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbF" id="9jWrhFjfkT" role="3cqZAp">
+                        <node concept="37vLTI" id="9jWrhFjfEV" role="3clFbG">
+                          <node concept="1rXfSq" id="9jWrhFjgtL" role="37vLTx">
+                            <ref role="37wK5l" node="9jWrhFiZPP" resolve="inner" />
+                            <node concept="37vLTw" id="9jWrhFjh8R" role="37wK5m">
+                              <ref role="3cqZAo" node="9jWrhFj0w4" resolve="expensive" />
+                            </node>
+                            <node concept="37vLTw" id="9jWrhFji2Q" role="37wK5m">
+                              <ref role="3cqZAo" node="9jWrhFj0w7" resolve="cheap" />
+                            </node>
+                          </node>
+                          <node concept="37vLTw" id="9jWrhFjfkR" role="37vLTJ">
+                            <ref role="3cqZAo" node="9jWrhFiXu0" resolve="innerSupplier" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbF" id="9jWrhFjiXD" role="3cqZAp">
+                        <node concept="2Sg_IR" id="9jWrhFjjkP" role="3clFbG">
+                          <node concept="37vLTw" id="9jWrhFjjkQ" role="2SgG2M">
+                            <ref role="3cqZAo" node="9jWrhFiXu0" resolve="innerSupplier" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="37vLTw" id="9jWrhFj8RW" role="37vLTJ">
+                    <ref role="3cqZAo" node="9jWrhFiXu0" resolve="innerSupplier" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbF" id="9jWrhFjk4E" role="3cqZAp">
+                <node concept="37vLTw" id="9jWrhFjk4C" role="3clFbG">
+                  <ref role="3cqZAo" node="9jWrhFj5On" resolve="t" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm6S6" id="9jWrhFiZu4" role="1B3o_S" />
+      <node concept="1ajhzC" id="9jWrhFj04t" role="3clF45">
+        <node concept="16syzq" id="9jWrhFj0h5" role="1ajl9A">
+          <ref role="16sUi3" node="9jWrhFiXuz" resolve="T" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="9jWrhFiXux" role="jymVt" />
+    <node concept="3Tm1VV" id="9jWrhFiXuy" role="1B3o_S" />
+    <node concept="16euLQ" id="9jWrhFiXuz" role="16eVyc">
+      <property role="TrG5h" value="T" />
+    </node>
+    <node concept="16euLQ" id="9jWrhFiXLI" role="16eVyc">
+      <property role="TrG5h" value="M" />
+    </node>
+    <node concept="3uibUv" id="9jWrhFiXu$" role="EKbjA">
+      <ref role="3uigEE" to="82uw:~Supplier" resolve="Supplier" />
+      <node concept="16syzq" id="9jWrhFiXu_" role="11_B2D">
+        <ref role="16sUi3" node="9jWrhFiXuz" resolve="T" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="9jWrhFiXuA" role="jymVt">
+      <property role="TrG5h" value="get" />
+      <node concept="3Tm1VV" id="9jWrhFiXuB" role="1B3o_S" />
+      <node concept="16syzq" id="9jWrhFiXuC" role="3clF45">
+        <ref role="16sUi3" node="9jWrhFiXuz" resolve="T" />
+      </node>
+      <node concept="3clFbS" id="9jWrhFiXuD" role="3clF47">
+        <node concept="3clFbF" id="9jWrhFiXuE" role="3cqZAp">
+          <node concept="2Sg_IR" id="9jWrhFiXuF" role="3clFbG">
+            <node concept="37vLTw" id="9jWrhFiXuG" role="2SgG2M">
+              <ref role="3cqZAo" node="9jWrhFiXu0" resolve="supplier" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="9jWrhFiXuH" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" />
+      </node>
+    </node>
+    <node concept="3UR2Jj" id="9jWrhFm84N" role="lGtFl">
+      <node concept="TZ5HA" id="9jWrhFm84O" role="TZ5H$">
+        <node concept="1dT_AC" id="9jWrhFm84P" role="1dT_Ay">
+          <property role="1dT_AB" value="Supplier which memorizes its value after first call to get(), but is able to" />
+        </node>
+      </node>
+      <node concept="TZ5HA" id="9jWrhFml58" role="TZ5H$">
+        <node concept="1dT_AC" id="9jWrhFml59" role="1dT_Ay">
+          <property role="1dT_AB" value="trigger a re-computation of the expensive computation if some cheap computation" />
+        </node>
+      </node>
+      <node concept="TZ5HA" id="9jWrhFmlnG" role="TZ5H$">
+        <node concept="1dT_AC" id="9jWrhFmlnH" role="1dT_Ay">
+          <property role="1dT_AB" value="returns a different value." />
+        </node>
+      </node>
+      <node concept="TZ5HA" id="9jWrhFmlBu" role="TZ5H$">
+        <node concept="1dT_AC" id="9jWrhFmlBv" role="1dT_Ay">
+          <property role="1dT_AB" value="" />
+        </node>
+      </node>
+      <node concept="TZ5HA" id="9jWrhFmn7x" role="TZ5H$">
+        <node concept="1dT_AC" id="9jWrhFmn7y" role="1dT_Ay">
+          <property role="1dT_AB" value="The implementation is very efficient as it does not need null-checks." />
+        </node>
+      </node>
+      <node concept="TZ5HA" id="9jWrhFmno5" role="TZ5H$">
+        <node concept="1dT_AC" id="9jWrhFmno6" role="1dT_Ay">
+          <property role="1dT_AB" value="" />
+        </node>
+      </node>
+      <node concept="TZ5HA" id="9jWrhFmlBG" role="TZ5H$">
+        <node concept="1dT_AC" id="9jWrhFmlBH" role="1dT_Ay">
+          <property role="1dT_AB" value="Typical usage: Expensive computation collects some data, and the cheap computation " />
+        </node>
+      </node>
+      <node concept="TZ5HA" id="9jWrhFmlRy" role="TZ5H$">
+        <node concept="1dT_AC" id="9jWrhFmlRz" role="1dT_Ay">
+          <property role="1dT_AB" value="computes a hashcode based on this data. If a different hashcode is computed later," />
+        </node>
+      </node>
+      <node concept="TZ5HA" id="9jWrhFmmbE" role="TZ5H$">
+        <node concept="1dT_AC" id="9jWrhFmmbF" role="1dT_Ay">
+          <property role="1dT_AB" value="the expensive data collection has to be executed again." />
+        </node>
+      </node>
+      <node concept="TZ5HA" id="9jWrhFm9qk" role="TZ5H$">
+        <node concept="1dT_AC" id="9jWrhFm9ql" role="1dT_Ay">
+          <property role="1dT_AB" value="" />
+        </node>
+      </node>
+      <node concept="TZ5HA" id="9jWrhFm9DT" role="TZ5H$">
+        <node concept="1dT_AC" id="9jWrhFm9DU" role="1dT_Ay">
+          <property role="1dT_AB" value="NOTE: This class is not thread-safe." />
+        </node>
+      </node>
+      <node concept="TUZQ0" id="9jWrhFm8mM" role="3nqlJM">
+        <property role="TUZQ4" value="generic type of supplied value (e.g., a hashcode type like Integer)" />
+        <node concept="zr_56" id="9jWrhFm8mN" role="zr_5Q">
+          <ref role="zr_51" node="9jWrhFiXuz" resolve="T" />
+        </node>
+      </node>
+      <node concept="TUZQ0" id="9jWrhFm84Q" role="3nqlJM">
+        <property role="TUZQ4" value="result type for the expensive computation" />
+        <node concept="zr_56" id="9jWrhFm84S" role="zr_5Q">
+          <ref role="zr_51" node="9jWrhFiXLI" resolve="M" />
+        </node>
+      </node>
+    </node>
   </node>
 </model>
 

--- a/code/languages/com.mbeddr.mpsutil/tests/test.com.mbeddr.mpsutil.common/models/test.com.mbeddr.mpsutil.common.util@tests.mps
+++ b/code/languages/com.mbeddr.mpsutil/tests/test.com.mbeddr.mpsutil.common/models/test.com.mbeddr.mpsutil.common.util@tests.mps
@@ -9,9 +9,9 @@
   </languages>
   <imports>
     <import index="7wpd" ref="c7a315e6-1d93-4186-85bc-2dfafd1ccc21/r:fb1c47d7-a72e-4e01-92dc-1e9f2ba4a118(com.mbeddr.mpsutil.common/com.mbeddr.mpsutil.common.util)" />
+    <import index="qhup" ref="b0f8641f-bd77-4421-8425-30d9088a82f7/java:org.apache.commons.lang3.mutable(org.apache.commons/)" />
     <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
     <import index="82uw" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util.function(JDK/)" />
-    <import index="cfsy" ref="822a7acd-f487-45f5-bbb9-1ce595a1705f/java:org.apache.commons.lang.mutable(com.mbeddr.mpsutil.ecore.stubs/)" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
   </imports>
   <registry>
@@ -133,11 +133,11 @@
             <node concept="3cpWsn" id="9jWrhFjvJ0" role="3cpWs9">
               <property role="TrG5h" value="expensiveCount" />
               <node concept="3uibUv" id="9jWrhFjvJ1" role="1tU5fm">
-                <ref role="3uigEE" to="cfsy:~MutableInt" resolve="MutableInt" />
+                <ref role="3uigEE" to="qhup:~MutableInt" resolve="MutableInt" />
               </node>
               <node concept="2ShNRf" id="9jWrhFjvK6" role="33vP2m">
                 <node concept="1pGfFk" id="9jWrhFjvJX" role="2ShVmc">
-                  <ref role="37wK5l" to="cfsy:~MutableInt.&lt;init&gt;(int)" resolve="MutableInt" />
+                  <ref role="37wK5l" to="qhup:~MutableInt.&lt;init&gt;(int)" resolve="MutableInt" />
                   <node concept="3cmrfG" id="9jWrhFjvKE" role="37wK5m">
                     <property role="3cmrfH" value="0" />
                   </node>
@@ -184,7 +184,7 @@
                           <ref role="3cqZAo" node="9jWrhFjvJ0" resolve="expensiveCount" />
                         </node>
                         <node concept="liA8E" id="9jWrhFjUDf" role="2OqNvi">
-                          <ref role="37wK5l" to="cfsy:~MutableInt.increment()" resolve="increment" />
+                          <ref role="37wK5l" to="qhup:~MutableInt.increment()" resolve="increment" />
                         </node>
                       </node>
                     </node>
@@ -278,7 +278,7 @@
                   <ref role="3cqZAo" node="9jWrhFjvJ0" resolve="expensiveCount" />
                 </node>
                 <node concept="liA8E" id="9jWrhFl2mE" role="2OqNvi">
-                  <ref role="37wK5l" to="cfsy:~MutableInt.getValue()" resolve="getValue" />
+                  <ref role="37wK5l" to="qhup:~MutableInt.getValue()" resolve="getValue" />
                 </node>
               </node>
             </node>
@@ -366,7 +366,7 @@
                   <ref role="3cqZAo" node="9jWrhFjvJ0" resolve="expensiveCount" />
                 </node>
                 <node concept="liA8E" id="9jWrhFkOYI" role="2OqNvi">
-                  <ref role="37wK5l" to="cfsy:~MutableInt.getValue()" resolve="getValue" />
+                  <ref role="37wK5l" to="qhup:~MutableInt.getValue()" resolve="getValue" />
                 </node>
               </node>
             </node>
@@ -388,11 +388,11 @@
             <node concept="3cpWsn" id="9jWrhFl41r" role="3cpWs9">
               <property role="TrG5h" value="expensiveCount" />
               <node concept="3uibUv" id="9jWrhFl41s" role="1tU5fm">
-                <ref role="3uigEE" to="cfsy:~MutableInt" resolve="MutableInt" />
+                <ref role="3uigEE" to="qhup:~MutableInt" resolve="MutableInt" />
               </node>
               <node concept="2ShNRf" id="9jWrhFl41t" role="33vP2m">
                 <node concept="1pGfFk" id="9jWrhFl41u" role="2ShVmc">
-                  <ref role="37wK5l" to="cfsy:~MutableInt.&lt;init&gt;(int)" resolve="MutableInt" />
+                  <ref role="37wK5l" to="qhup:~MutableInt.&lt;init&gt;(int)" resolve="MutableInt" />
                   <node concept="3cmrfG" id="9jWrhFl41v" role="37wK5m">
                     <property role="3cmrfH" value="0" />
                   </node>
@@ -404,11 +404,11 @@
             <node concept="3cpWsn" id="9jWrhFl5iH" role="3cpWs9">
               <property role="TrG5h" value="m" />
               <node concept="3uibUv" id="9jWrhFl5iI" role="1tU5fm">
-                <ref role="3uigEE" to="cfsy:~MutableInt" resolve="MutableInt" />
+                <ref role="3uigEE" to="qhup:~MutableInt" resolve="MutableInt" />
               </node>
               <node concept="2ShNRf" id="9jWrhFl5Ea" role="33vP2m">
                 <node concept="1pGfFk" id="9jWrhFl5E1" role="2ShVmc">
-                  <ref role="37wK5l" to="cfsy:~MutableInt.&lt;init&gt;(int)" resolve="MutableInt" />
+                  <ref role="37wK5l" to="qhup:~MutableInt.&lt;init&gt;(int)" resolve="MutableInt" />
                   <node concept="3cmrfG" id="9jWrhFla4D" role="37wK5m">
                     <property role="3cmrfH" value="77" />
                   </node>
@@ -455,7 +455,7 @@
                           <ref role="3cqZAo" node="9jWrhFl41r" resolve="expensiveCount" />
                         </node>
                         <node concept="liA8E" id="9jWrhFl41L" role="2OqNvi">
-                          <ref role="37wK5l" to="cfsy:~MutableInt.increment()" resolve="increment" />
+                          <ref role="37wK5l" to="qhup:~MutableInt.increment()" resolve="increment" />
                         </node>
                       </node>
                     </node>
@@ -470,7 +470,7 @@
                   <node concept="37vLTG" id="9jWrhFl79Q" role="1bW2Oz">
                     <property role="TrG5h" value="m" />
                     <node concept="3uibUv" id="9jWrhFl7A$" role="1tU5fm">
-                      <ref role="3uigEE" to="cfsy:~MutableInt" resolve="MutableInt" />
+                      <ref role="3uigEE" to="qhup:~MutableInt" resolve="MutableInt" />
                     </node>
                   </node>
                   <node concept="3clFbS" id="9jWrhFl73g" role="1bW5cS">
@@ -523,7 +523,7 @@
                             <ref role="3cqZAo" node="9jWrhFl79Q" resolve="m" />
                           </node>
                           <node concept="liA8E" id="9jWrhFl9tj" role="2OqNvi">
-                            <ref role="37wK5l" to="cfsy:~MutableInt.getValue()" resolve="getValue" />
+                            <ref role="37wK5l" to="qhup:~MutableInt.getValue()" resolve="getValue" />
                           </node>
                         </node>
                       </node>
@@ -617,7 +617,7 @@
                   <ref role="3cqZAo" node="9jWrhFl41r" resolve="expensiveCount" />
                 </node>
                 <node concept="liA8E" id="9jWrhFl42k" role="2OqNvi">
-                  <ref role="37wK5l" to="cfsy:~MutableInt.getValue()" resolve="getValue" />
+                  <ref role="37wK5l" to="qhup:~MutableInt.getValue()" resolve="getValue" />
                 </node>
               </node>
             </node>
@@ -709,7 +709,7 @@
                   <ref role="3cqZAo" node="9jWrhFl41r" resolve="expensiveCount" />
                 </node>
                 <node concept="liA8E" id="9jWrhFl42Q" role="2OqNvi">
-                  <ref role="37wK5l" to="cfsy:~MutableInt.getValue()" resolve="getValue" />
+                  <ref role="37wK5l" to="qhup:~MutableInt.getValue()" resolve="getValue" />
                 </node>
               </node>
             </node>
@@ -773,7 +773,7 @@
                 <ref role="3cqZAo" node="9jWrhFl5iH" resolve="m" />
               </node>
               <node concept="liA8E" id="9jWrhFlbnC" role="2OqNvi">
-                <ref role="37wK5l" to="cfsy:~MutableInt.increment()" resolve="increment" />
+                <ref role="37wK5l" to="qhup:~MutableInt.increment()" resolve="increment" />
               </node>
             </node>
           </node>
@@ -811,7 +811,7 @@
                   <ref role="3cqZAo" node="9jWrhFl41r" resolve="expensiveCount" />
                 </node>
                 <node concept="liA8E" id="9jWrhFlbJY" role="2OqNvi">
-                  <ref role="37wK5l" to="cfsy:~MutableInt.getValue()" resolve="getValue" />
+                  <ref role="37wK5l" to="qhup:~MutableInt.getValue()" resolve="getValue" />
                 </node>
               </node>
             </node>
@@ -894,7 +894,7 @@
                   <ref role="3cqZAo" node="9jWrhFl41r" resolve="expensiveCount" />
                 </node>
                 <node concept="liA8E" id="9jWrhFldb9" role="2OqNvi">
-                  <ref role="37wK5l" to="cfsy:~MutableInt.getValue()" resolve="getValue" />
+                  <ref role="37wK5l" to="qhup:~MutableInt.getValue()" resolve="getValue" />
                 </node>
               </node>
             </node>

--- a/code/languages/com.mbeddr.mpsutil/tests/test.com.mbeddr.mpsutil.common/models/test.com.mbeddr.mpsutil.common.util@tests.mps
+++ b/code/languages/com.mbeddr.mpsutil/tests/test.com.mbeddr.mpsutil.common/models/test.com.mbeddr.mpsutil.common.util@tests.mps
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<model ref="r:2ab3ddbe-8637-491d-bebd-21897939eb53(com.mbeddr.mpsutil.common.util@tests)">
+<model ref="r:4edb27ca-b2e0-4133-881e-47d5e6977f2d(test.com.mbeddr.mpsutil.common.util@tests)">
   <persistence version="9" />
   <languages>
     <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="6" />
@@ -10,8 +10,8 @@
   <imports>
     <import index="7wpd" ref="c7a315e6-1d93-4186-85bc-2dfafd1ccc21/r:fb1c47d7-a72e-4e01-92dc-1e9f2ba4a118(com.mbeddr.mpsutil.common/com.mbeddr.mpsutil.common.util)" />
     <import index="qhup" ref="b0f8641f-bd77-4421-8425-30d9088a82f7/java:org.apache.commons.lang3.mutable(org.apache.commons/)" />
-    <import index="82uw" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util.function(JDK/)" />
     <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
+    <import index="82uw" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util.function(JDK/)" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
   </imports>
   <registry>
@@ -120,9 +120,6 @@
       </concept>
     </language>
   </registry>
-  <node concept="2XOHcx" id="3RjqiP9ZZRO">
-    <property role="2XOHcw" value="${mbeddr.github.core.home}/code/languages/com.mbeddr.mpsutil" />
-  </node>
   <node concept="3s_ewN" id="9jWrhFjvu4">
     <property role="3s_ewP" value="LazyInit" />
     <node concept="3Tm1VV" id="9jWrhFjvu5" role="1B3o_S" />
@@ -254,7 +251,7 @@
               <node concept="10Oyi0" id="9jWrhFkU19" role="1tU5fm" />
               <node concept="2OqwBi" id="9jWrhFkRCC" role="33vP2m">
                 <node concept="37vLTw" id="9jWrhFkRCD" role="2Oq$k0">
-                  <ref role="3cqZAo" node="9jWrhFjvMm" resolve="init" />
+                  <ref role="3cqZAo" node="9jWrhFjvMm" resolve="supplier" />
                 </node>
                 <node concept="liA8E" id="9jWrhFkRCE" role="2OqNvi">
                   <ref role="37wK5l" to="82uw:~Supplier.get()" resolve="get" />
@@ -342,7 +339,7 @@
               <node concept="10Oyi0" id="9jWrhFkTTI" role="1tU5fm" />
               <node concept="2OqwBi" id="9jWrhFkTCm" role="33vP2m">
                 <node concept="37vLTw" id="9jWrhFkTCn" role="2Oq$k0">
-                  <ref role="3cqZAo" node="9jWrhFjvMm" resolve="init" />
+                  <ref role="3cqZAo" node="9jWrhFjvMm" resolve="supplier" />
                 </node>
                 <node concept="liA8E" id="9jWrhFkTCo" role="2OqNvi">
                   <ref role="37wK5l" to="82uw:~Supplier.get()" resolve="get" />
@@ -589,7 +586,7 @@
               <node concept="10Oyi0" id="9jWrhFl427" role="1tU5fm" />
               <node concept="2OqwBi" id="9jWrhFl428" role="33vP2m">
                 <node concept="37vLTw" id="9jWrhFl429" role="2Oq$k0">
-                  <ref role="3cqZAo" node="9jWrhFl41x" resolve="init" />
+                  <ref role="3cqZAo" node="9jWrhFl41x" resolve="supplier" />
                 </node>
                 <node concept="liA8E" id="9jWrhFl42a" role="2OqNvi">
                   <ref role="37wK5l" to="82uw:~Supplier.get()" resolve="get" />
@@ -681,7 +678,7 @@
               <node concept="10Oyi0" id="9jWrhFl42D" role="1tU5fm" />
               <node concept="2OqwBi" id="9jWrhFl42E" role="33vP2m">
                 <node concept="37vLTw" id="9jWrhFl42F" role="2Oq$k0">
-                  <ref role="3cqZAo" node="9jWrhFl41x" resolve="init" />
+                  <ref role="3cqZAo" node="9jWrhFl41x" resolve="supplier" />
                 </node>
                 <node concept="liA8E" id="9jWrhFl42G" role="2OqNvi">
                   <ref role="37wK5l" to="82uw:~Supplier.get()" resolve="get" />
@@ -786,7 +783,7 @@
               <node concept="10Oyi0" id="9jWrhFlbJL" role="1tU5fm" />
               <node concept="2OqwBi" id="9jWrhFlbJM" role="33vP2m">
                 <node concept="37vLTw" id="9jWrhFlbJN" role="2Oq$k0">
-                  <ref role="3cqZAo" node="9jWrhFl41x" resolve="init" />
+                  <ref role="3cqZAo" node="9jWrhFl41x" resolve="supplier" />
                 </node>
                 <node concept="liA8E" id="9jWrhFlbJO" role="2OqNvi">
                   <ref role="37wK5l" to="82uw:~Supplier.get()" resolve="get" />
@@ -796,7 +793,7 @@
           </node>
           <node concept="3vlDli" id="9jWrhFlbJP" role="3cqZAp">
             <node concept="37vLTw" id="9jWrhFlbJQ" role="3tpDZA">
-              <ref role="3cqZAo" node="9jWrhFlbJK" resolve="v2" />
+              <ref role="3cqZAo" node="9jWrhFlbJK" resolve="v3" />
             </node>
             <node concept="2YIFZM" id="9jWrhFlZGJ" role="3tpDZB">
               <ref role="37wK5l" to="33ny:~Objects.hash(java.lang.Object...)" resolve="hash" />
@@ -869,7 +866,7 @@
               <node concept="10Oyi0" id="9jWrhFldaX" role="1tU5fm" />
               <node concept="2OqwBi" id="9jWrhFldaY" role="33vP2m">
                 <node concept="37vLTw" id="9jWrhFldaZ" role="2Oq$k0">
-                  <ref role="3cqZAo" node="9jWrhFl41x" resolve="init" />
+                  <ref role="3cqZAo" node="9jWrhFl41x" resolve="supplier" />
                 </node>
                 <node concept="liA8E" id="9jWrhFldb0" role="2OqNvi">
                   <ref role="37wK5l" to="82uw:~Supplier.get()" resolve="get" />
@@ -879,7 +876,7 @@
           </node>
           <node concept="3vlDli" id="9jWrhFldb1" role="3cqZAp">
             <node concept="37vLTw" id="9jWrhFldb2" role="3tpDZA">
-              <ref role="3cqZAo" node="9jWrhFldaW" resolve="v3" />
+              <ref role="3cqZAo" node="9jWrhFldaW" resolve="v4" />
             </node>
             <node concept="2YIFZM" id="9jWrhFm059" role="3tpDZB">
               <ref role="37wK5l" to="33ny:~Objects.hash(java.lang.Object...)" resolve="hash" />
@@ -908,6 +905,9 @@
         </node>
       </node>
     </node>
+  </node>
+  <node concept="2XOHcx" id="3RjqiP9ZZRO">
+    <property role="2XOHcw" value="${mbeddr.github.core.home}/code/languages/com.mbeddr.mpsutil" />
   </node>
 </model>
 

--- a/code/languages/com.mbeddr.mpsutil/tests/test.com.mbeddr.mpsutil.common/models/test.com.mbeddr.mpsutil.common.util@tests.mps
+++ b/code/languages/com.mbeddr.mpsutil/tests/test.com.mbeddr.mpsutil.common/models/test.com.mbeddr.mpsutil.common.util@tests.mps
@@ -9,9 +9,9 @@
   </languages>
   <imports>
     <import index="7wpd" ref="c7a315e6-1d93-4186-85bc-2dfafd1ccc21/r:fb1c47d7-a72e-4e01-92dc-1e9f2ba4a118(com.mbeddr.mpsutil.common/com.mbeddr.mpsutil.common.util)" />
-    <import index="qhup" ref="b0f8641f-bd77-4421-8425-30d9088a82f7/java:org.apache.commons.lang3.mutable(org.apache.commons/)" />
     <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
     <import index="82uw" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util.function(JDK/)" />
+    <import index="cfsy" ref="822a7acd-f487-45f5-bbb9-1ce595a1705f/java:org.apache.commons.lang.mutable(com.mbeddr.mpsutil.ecore.stubs/)" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
   </imports>
   <registry>
@@ -133,11 +133,11 @@
             <node concept="3cpWsn" id="9jWrhFjvJ0" role="3cpWs9">
               <property role="TrG5h" value="expensiveCount" />
               <node concept="3uibUv" id="9jWrhFjvJ1" role="1tU5fm">
-                <ref role="3uigEE" to="qhup:~MutableInt" resolve="MutableInt" />
+                <ref role="3uigEE" to="cfsy:~MutableInt" resolve="MutableInt" />
               </node>
               <node concept="2ShNRf" id="9jWrhFjvK6" role="33vP2m">
                 <node concept="1pGfFk" id="9jWrhFjvJX" role="2ShVmc">
-                  <ref role="37wK5l" to="qhup:~MutableInt.&lt;init&gt;(int)" resolve="MutableInt" />
+                  <ref role="37wK5l" to="cfsy:~MutableInt.&lt;init&gt;(int)" resolve="MutableInt" />
                   <node concept="3cmrfG" id="9jWrhFjvKE" role="37wK5m">
                     <property role="3cmrfH" value="0" />
                   </node>
@@ -184,7 +184,7 @@
                           <ref role="3cqZAo" node="9jWrhFjvJ0" resolve="expensiveCount" />
                         </node>
                         <node concept="liA8E" id="9jWrhFjUDf" role="2OqNvi">
-                          <ref role="37wK5l" to="qhup:~MutableInt.increment()" resolve="increment" />
+                          <ref role="37wK5l" to="cfsy:~MutableInt.increment()" resolve="increment" />
                         </node>
                       </node>
                     </node>
@@ -278,7 +278,7 @@
                   <ref role="3cqZAo" node="9jWrhFjvJ0" resolve="expensiveCount" />
                 </node>
                 <node concept="liA8E" id="9jWrhFl2mE" role="2OqNvi">
-                  <ref role="37wK5l" to="qhup:~MutableInt.getValue()" resolve="getValue" />
+                  <ref role="37wK5l" to="cfsy:~MutableInt.getValue()" resolve="getValue" />
                 </node>
               </node>
             </node>
@@ -366,7 +366,7 @@
                   <ref role="3cqZAo" node="9jWrhFjvJ0" resolve="expensiveCount" />
                 </node>
                 <node concept="liA8E" id="9jWrhFkOYI" role="2OqNvi">
-                  <ref role="37wK5l" to="qhup:~MutableInt.getValue()" resolve="getValue" />
+                  <ref role="37wK5l" to="cfsy:~MutableInt.getValue()" resolve="getValue" />
                 </node>
               </node>
             </node>
@@ -388,11 +388,11 @@
             <node concept="3cpWsn" id="9jWrhFl41r" role="3cpWs9">
               <property role="TrG5h" value="expensiveCount" />
               <node concept="3uibUv" id="9jWrhFl41s" role="1tU5fm">
-                <ref role="3uigEE" to="qhup:~MutableInt" resolve="MutableInt" />
+                <ref role="3uigEE" to="cfsy:~MutableInt" resolve="MutableInt" />
               </node>
               <node concept="2ShNRf" id="9jWrhFl41t" role="33vP2m">
                 <node concept="1pGfFk" id="9jWrhFl41u" role="2ShVmc">
-                  <ref role="37wK5l" to="qhup:~MutableInt.&lt;init&gt;(int)" resolve="MutableInt" />
+                  <ref role="37wK5l" to="cfsy:~MutableInt.&lt;init&gt;(int)" resolve="MutableInt" />
                   <node concept="3cmrfG" id="9jWrhFl41v" role="37wK5m">
                     <property role="3cmrfH" value="0" />
                   </node>
@@ -404,11 +404,11 @@
             <node concept="3cpWsn" id="9jWrhFl5iH" role="3cpWs9">
               <property role="TrG5h" value="m" />
               <node concept="3uibUv" id="9jWrhFl5iI" role="1tU5fm">
-                <ref role="3uigEE" to="qhup:~MutableInt" resolve="MutableInt" />
+                <ref role="3uigEE" to="cfsy:~MutableInt" resolve="MutableInt" />
               </node>
               <node concept="2ShNRf" id="9jWrhFl5Ea" role="33vP2m">
                 <node concept="1pGfFk" id="9jWrhFl5E1" role="2ShVmc">
-                  <ref role="37wK5l" to="qhup:~MutableInt.&lt;init&gt;(int)" resolve="MutableInt" />
+                  <ref role="37wK5l" to="cfsy:~MutableInt.&lt;init&gt;(int)" resolve="MutableInt" />
                   <node concept="3cmrfG" id="9jWrhFla4D" role="37wK5m">
                     <property role="3cmrfH" value="77" />
                   </node>
@@ -455,7 +455,7 @@
                           <ref role="3cqZAo" node="9jWrhFl41r" resolve="expensiveCount" />
                         </node>
                         <node concept="liA8E" id="9jWrhFl41L" role="2OqNvi">
-                          <ref role="37wK5l" to="qhup:~MutableInt.increment()" resolve="increment" />
+                          <ref role="37wK5l" to="cfsy:~MutableInt.increment()" resolve="increment" />
                         </node>
                       </node>
                     </node>
@@ -470,7 +470,7 @@
                   <node concept="37vLTG" id="9jWrhFl79Q" role="1bW2Oz">
                     <property role="TrG5h" value="m" />
                     <node concept="3uibUv" id="9jWrhFl7A$" role="1tU5fm">
-                      <ref role="3uigEE" to="qhup:~MutableInt" resolve="MutableInt" />
+                      <ref role="3uigEE" to="cfsy:~MutableInt" resolve="MutableInt" />
                     </node>
                   </node>
                   <node concept="3clFbS" id="9jWrhFl73g" role="1bW5cS">
@@ -523,7 +523,7 @@
                             <ref role="3cqZAo" node="9jWrhFl79Q" resolve="m" />
                           </node>
                           <node concept="liA8E" id="9jWrhFl9tj" role="2OqNvi">
-                            <ref role="37wK5l" to="qhup:~MutableInt.getValue()" resolve="getValue" />
+                            <ref role="37wK5l" to="cfsy:~MutableInt.getValue()" resolve="getValue" />
                           </node>
                         </node>
                       </node>
@@ -617,7 +617,7 @@
                   <ref role="3cqZAo" node="9jWrhFl41r" resolve="expensiveCount" />
                 </node>
                 <node concept="liA8E" id="9jWrhFl42k" role="2OqNvi">
-                  <ref role="37wK5l" to="qhup:~MutableInt.getValue()" resolve="getValue" />
+                  <ref role="37wK5l" to="cfsy:~MutableInt.getValue()" resolve="getValue" />
                 </node>
               </node>
             </node>
@@ -709,7 +709,7 @@
                   <ref role="3cqZAo" node="9jWrhFl41r" resolve="expensiveCount" />
                 </node>
                 <node concept="liA8E" id="9jWrhFl42Q" role="2OqNvi">
-                  <ref role="37wK5l" to="qhup:~MutableInt.getValue()" resolve="getValue" />
+                  <ref role="37wK5l" to="cfsy:~MutableInt.getValue()" resolve="getValue" />
                 </node>
               </node>
             </node>
@@ -773,7 +773,7 @@
                 <ref role="3cqZAo" node="9jWrhFl5iH" resolve="m" />
               </node>
               <node concept="liA8E" id="9jWrhFlbnC" role="2OqNvi">
-                <ref role="37wK5l" to="qhup:~MutableInt.increment()" resolve="increment" />
+                <ref role="37wK5l" to="cfsy:~MutableInt.increment()" resolve="increment" />
               </node>
             </node>
           </node>
@@ -811,7 +811,7 @@
                   <ref role="3cqZAo" node="9jWrhFl41r" resolve="expensiveCount" />
                 </node>
                 <node concept="liA8E" id="9jWrhFlbJY" role="2OqNvi">
-                  <ref role="37wK5l" to="qhup:~MutableInt.getValue()" resolve="getValue" />
+                  <ref role="37wK5l" to="cfsy:~MutableInt.getValue()" resolve="getValue" />
                 </node>
               </node>
             </node>
@@ -894,7 +894,7 @@
                   <ref role="3cqZAo" node="9jWrhFl41r" resolve="expensiveCount" />
                 </node>
                 <node concept="liA8E" id="9jWrhFldb9" role="2OqNvi">
-                  <ref role="37wK5l" to="qhup:~MutableInt.getValue()" resolve="getValue" />
+                  <ref role="37wK5l" to="cfsy:~MutableInt.getValue()" resolve="getValue" />
                 </node>
               </node>
             </node>

--- a/code/languages/com.mbeddr.mpsutil/tests/test.com.mbeddr.mpsutil.common/models/test.com.mbeddr.mpsutil.common.util@tests.mps
+++ b/code/languages/com.mbeddr.mpsutil/tests/test.com.mbeddr.mpsutil.common/models/test.com.mbeddr.mpsutil.common.util@tests.mps
@@ -552,7 +552,7 @@
                 <property role="3oM_SC" value="return" />
               </node>
               <node concept="3oM_SD" id="9jWrhFl41W" role="1PaTwD">
-                <property role="3oM_SC" value="777," />
+                <property role="3oM_SC" value="77," />
               </node>
               <node concept="3oM_SD" id="9jWrhFl41X" role="1PaTwD">
                 <property role="3oM_SC" value="and" />
@@ -650,7 +650,7 @@
                 <property role="3oM_SC" value="return" />
               </node>
               <node concept="3oM_SD" id="9jWrhFl42w" role="1PaTwD">
-                <property role="3oM_SC" value="777," />
+                <property role="3oM_SC" value="77," />
               </node>
               <node concept="3oM_SD" id="9jWrhFl42x" role="1PaTwD">
                 <property role="3oM_SC" value="but" />

--- a/code/languages/com.mbeddr.mpsutil/tests/test.com.mbeddr.mpsutil.common/test.com.mbeddr.mpsutil.common.msd
+++ b/code/languages/com.mbeddr.mpsutil/tests/test.com.mbeddr.mpsutil.common/test.com.mbeddr.mpsutil.common.msd
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<solution name="test.com.mbeddr.mpsutil.common" uuid="fceddec6-7184-49a0-9009-0da4dbdc8b95" moduleVersion="0" compileInMPS="true">
+  <models>
+    <modelRoot contentPath="${module}" type="default">
+      <sourceRoot location="models" />
+    </modelRoot>
+  </models>
+  <facets>
+    <facet type="java">
+      <classes generated="true" path="${module}/classes_gen" />
+    </facet>
+  </facets>
+  <sourcePath />
+  <dependencies>
+    <dependency reexport="false">c7a315e6-1d93-4186-85bc-2dfafd1ccc21(com.mbeddr.mpsutil.common)</dependency>
+    <dependency reexport="false">b0f8641f-bd77-4421-8425-30d9088a82f7(org.apache.commons)</dependency>
+    <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
+  </dependencies>
+  <languageVersions>
+    <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
+    <language slang="l:443f4c36-fcf5-4eb6-9500-8d06ed259e3e:jetbrains.mps.baseLanguage.classifiers" version="0" />
+    <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
+    <language slang="l:f61473f9-130f-42f6-b98d-6c438812c2f6:jetbrains.mps.baseLanguage.unitTest" version="1" />
+    <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
+    <language slang="l:8585453e-6bfb-4d80-98de-b16074f1d86c:jetbrains.mps.lang.test" version="6" />
+    <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
+  </languageVersions>
+  <dependencyVersions>
+    <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
+    <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
+    <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
+    <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
+    <module reference="c7a315e6-1d93-4186-85bc-2dfafd1ccc21(com.mbeddr.mpsutil.common)" version="0" />
+    <module reference="b0f8641f-bd77-4421-8425-30d9088a82f7(org.apache.commons)" version="0" />
+    <module reference="fceddec6-7184-49a0-9009-0da4dbdc8b95(test.com.mbeddr.mpsutil.common)" version="0" />
+  </dependencyVersions>
+</solution>
+

--- a/code/languages/com.mbeddr.mpsutil/tests/test.com.mbeddr.mpsutil.common/test.com.mbeddr.mpsutil.common.msd
+++ b/code/languages/com.mbeddr.mpsutil/tests/test.com.mbeddr.mpsutil.common/test.com.mbeddr.mpsutil.common.msd
@@ -13,8 +13,8 @@
   <sourcePath />
   <dependencies>
     <dependency reexport="false">c7a315e6-1d93-4186-85bc-2dfafd1ccc21(com.mbeddr.mpsutil.common)</dependency>
+    <dependency reexport="false">b0f8641f-bd77-4421-8425-30d9088a82f7(org.apache.commons)</dependency>
     <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
-    <dependency reexport="false">822a7acd-f487-45f5-bbb9-1ce595a1705f(com.mbeddr.mpsutil.ecore.stubs)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
@@ -31,7 +31,6 @@
     <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
     <module reference="c7a315e6-1d93-4186-85bc-2dfafd1ccc21(com.mbeddr.mpsutil.common)" version="0" />
-    <module reference="822a7acd-f487-45f5-bbb9-1ce595a1705f(com.mbeddr.mpsutil.ecore.stubs)" version="0" />
     <module reference="b0f8641f-bd77-4421-8425-30d9088a82f7(org.apache.commons)" version="0" />
     <module reference="fceddec6-7184-49a0-9009-0da4dbdc8b95(test.com.mbeddr.mpsutil.common)" version="0" />
   </dependencyVersions>

--- a/code/languages/com.mbeddr.mpsutil/tests/test.com.mbeddr.mpsutil.common/test.com.mbeddr.mpsutil.common.msd
+++ b/code/languages/com.mbeddr.mpsutil/tests/test.com.mbeddr.mpsutil.common/test.com.mbeddr.mpsutil.common.msd
@@ -13,8 +13,8 @@
   <sourcePath />
   <dependencies>
     <dependency reexport="false">c7a315e6-1d93-4186-85bc-2dfafd1ccc21(com.mbeddr.mpsutil.common)</dependency>
-    <dependency reexport="false">b0f8641f-bd77-4421-8425-30d9088a82f7(org.apache.commons)</dependency>
     <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
+    <dependency reexport="false">822a7acd-f487-45f5-bbb9-1ce595a1705f(com.mbeddr.mpsutil.ecore.stubs)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
@@ -31,6 +31,7 @@
     <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
     <module reference="c7a315e6-1d93-4186-85bc-2dfafd1ccc21(com.mbeddr.mpsutil.common)" version="0" />
+    <module reference="822a7acd-f487-45f5-bbb9-1ce595a1705f(com.mbeddr.mpsutil.ecore.stubs)" version="0" />
     <module reference="b0f8641f-bd77-4421-8425-30d9088a82f7(org.apache.commons)" version="0" />
     <module reference="fceddec6-7184-49a0-9009-0da4dbdc8b95(test.com.mbeddr.mpsutil.common)" version="0" />
   </dependencyVersions>


### PR DESCRIPTION
This PR provides two helper classes implementing the `Supplier<T>` interface. They can be used for lazy evaluation as well as lazy evaluation with an expensive and a cheap computation part. 

The PR also provides tests for these helper classes.

I also added existing tests for `c.m.mpsutil.compare` to the CI testing job, as I believe the tests are useful and should be executed on CI (boy scout's rule).

The change is not visible to users, so no CHANGELOG entry.

Solves #2424.

