### PR TITLE
mpsutil.comparator: small improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is _loosely_ based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). The project does _not_ follow
 Semantic Versioning and the changes are simply documented in reverse chronological order, grouped by calendar month.
 
+# July 2024
+
+## com.mbeddr.mpsutil.comparator
+
+### Added
+
+- In addition to some null checks, node annotations can now be compared and also children of references. The node difference descriptions were also improved.
+
 # June 2024
 
 ## com.mbeddr.mpsutil.conceptdiagram

--- a/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.comparator/comparator.msd
+++ b/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.comparator/comparator.msd
@@ -24,6 +24,7 @@
   </dependencies>
   <languageVersions>
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
+    <language slang="l:132aa4d8-a3f7-441c-a7eb-3fce23492c6a:jetbrains.mps.baseLanguage.builders" version="0" />
     <language slang="l:774bf8a0-62e5-41e1-af63-f4812e60e48b:jetbrains.mps.baseLanguage.checkedDots" version="0" />
     <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
     <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />

--- a/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.comparator/models/.model
+++ b/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.comparator/models/.model
@@ -12,6 +12,7 @@
     <use id="774bf8a0-62e5-41e1-af63-f4812e60e48b" name="jetbrains.mps.baseLanguage.checkedDots" version="0" />
     <use id="63650c59-16c8-498a-99c8-005c7ee9515d" name="jetbrains.mps.lang.access" version="0" />
     <use id="760a0a8c-eabb-4521-8bfd-65db761a9ba3" name="jetbrains.mps.baseLanguage.logging" version="0" />
+    <use id="132aa4d8-a3f7-441c-a7eb-3fce23492c6a" name="jetbrains.mps.baseLanguage.builders" version="0" />
   </languages>
   <imports>
     <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
@@ -32,6 +33,7 @@
     <import index="dxuu" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:javax.swing(JDK/)" />
     <import index="31cb" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.extapi.module(MPS.Core/)" />
     <import index="z1c4" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.project(MPS.Core/)" />
+    <import index="cttk" ref="r:5ff047e0-2953-4750-806a-bdc16824aa89(jetbrains.mps.smodel)" />
     <import index="qjvf" ref="r:82cadfba-0fcc-402e-8eaa-37395d383fb6(com.mbeddr.mpsutil.compare.behavior)" implicit="true" />
     <import index="guwi" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.io(JDK/)" implicit="true" />
   </imports>

--- a/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.comparator/models/AttributeDifference.mpsr
+++ b/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.comparator/models/AttributeDifference.mpsr
@@ -1,7 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <model ref="r:ec874b45-e888-42e6-995a-a298cefdff55(com.mbeddr.mpsutil.comparator.code)" content="root">
   <persistence version="9" />
-  <imports />
+  <imports>
+    <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
+    <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" implicit="true" />
+  </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
       <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
@@ -17,6 +20,9 @@
       <concept id="1197029447546" name="jetbrains.mps.baseLanguage.structure.FieldReferenceOperation" flags="nn" index="2OwXpG">
         <reference id="1197029500499" name="fieldDeclaration" index="2Oxat5" />
       </concept>
+      <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
+        <child id="1145553007750" name="creator" index="2ShVmc" />
+      </concept>
       <concept id="1070475354124" name="jetbrains.mps.baseLanguage.structure.ThisExpression" flags="nn" index="Xjq3P" />
       <concept id="1070475587102" name="jetbrains.mps.baseLanguage.structure.SuperConstructorInvocation" flags="nn" index="XkiVB" />
       <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
@@ -29,6 +35,12 @@
       <concept id="1068390468200" name="jetbrains.mps.baseLanguage.structure.FieldDeclaration" flags="ig" index="312cEg" />
       <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu">
         <child id="1165602531693" name="superclass" index="1zkMxy" />
+      </concept>
+      <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
+        <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ng" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
       </concept>
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
@@ -56,12 +68,19 @@
         <child id="1068581517665" name="statement" index="3cqZAp" />
       </concept>
       <concept id="1068580123140" name="jetbrains.mps.baseLanguage.structure.ConstructorDeclaration" flags="ig" index="3clFbW" />
-      <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
+      <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
+        <child id="1068581517676" name="expression" index="3cqZAk" />
+      </concept>
+      <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
+        <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
+      </concept>
+      <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
       <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
       <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
+      <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk" />
       <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
         <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
       </concept>
@@ -72,14 +91,9 @@
       <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
         <reference id="1107535924139" name="classifier" index="3uigEE" />
       </concept>
-      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
-        <child id="1081773367579" name="rightExpression" index="3uHU7w" />
-        <child id="1081773367580" name="leftExpression" index="3uHU7B" />
-      </concept>
       <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
       </concept>
-      <concept id="3066917033203108594" name="jetbrains.mps.baseLanguage.structure.LocalInstanceMethodCall" flags="nn" index="3P9mCS" />
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
       <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
       <concept id="1146644641414" name="jetbrains.mps.baseLanguage.structure.ProtectedVisibility" flags="nn" index="3Tmbuc" />
@@ -288,57 +302,132 @@
       <node concept="17QB3L" id="DYlgnA$j_J" role="3clF45" />
       <node concept="3Tmbuc" id="DYlgnA$j_K" role="1B3o_S" />
       <node concept="3clFbS" id="DYlgnA$j_L" role="3clF47">
-        <node concept="3clFbF" id="DYlgnA$j_M" role="3cqZAp">
-          <node concept="3cpWs3" id="DYlgnA$j_N" role="3clFbG">
-            <node concept="2YIFZM" id="DYlgnA$j_O" role="3uHU7w">
-              <ref role="1Pybhc" node="DYlgnAAVf1" resolve="StringUtils" />
-              <ref role="37wK5l" node="DYlgnAAVkz" resolve="indent" />
-              <node concept="2OqwBi" id="DYlgnA$j_P" role="37wK5m">
-                <node concept="37vLTw" id="DYlgnA$j_Q" role="2Oq$k0">
-                  <ref role="3cqZAo" node="DYlgnA$hRb" resolve="result" />
+        <node concept="3cpWs8" id="E9Bg7575ot" role="3cqZAp">
+          <node concept="3cpWsn" id="E9Bg7575ou" role="3cpWs9">
+            <property role="TrG5h" value="description" />
+            <node concept="3uibUv" id="E9Bg7575ov" role="1tU5fm">
+              <ref role="3uigEE" to="wyt6:~StringBuilder" resolve="StringBuilder" />
+            </node>
+            <node concept="2ShNRf" id="E9Bg7575SO" role="33vP2m">
+              <node concept="1pGfFk" id="E9Bg7576nx" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="wyt6:~StringBuilder.&lt;init&gt;()" resolve="StringBuilder" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="E9Bg7578gr" role="3cqZAp">
+          <node concept="2OqwBi" id="E9Bg7578VE" role="3clFbG">
+            <node concept="37vLTw" id="E9Bg7578gp" role="2Oq$k0">
+              <ref role="3cqZAo" node="E9Bg7575ou" resolve="description" />
+            </node>
+            <node concept="liA8E" id="E9Bg7579t7" role="2OqNvi">
+              <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String)" resolve="append" />
+              <node concept="37vLTw" id="E9Bg757a1h" role="37wK5m">
+                <ref role="3cqZAo" node="DYlgnA$hR5" resolve="attribute" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="E9Bg757blr" role="3cqZAp">
+          <node concept="2OqwBi" id="E9Bg757buO" role="3clFbG">
+            <node concept="37vLTw" id="E9Bg757blp" role="2Oq$k0">
+              <ref role="3cqZAo" node="E9Bg7575ou" resolve="description" />
+            </node>
+            <node concept="liA8E" id="E9Bg757bG1" role="2OqNvi">
+              <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String)" resolve="append" />
+              <node concept="Xl_RD" id="E9Bg757bUc" role="37wK5m">
+                <property role="Xl_RC" value=" (attribute of concept " />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="E9Bg757e16" role="3cqZAp">
+          <node concept="2OqwBi" id="E9Bg757eIZ" role="3clFbG">
+            <node concept="37vLTw" id="E9Bg757e14" role="2Oq$k0">
+              <ref role="3cqZAo" node="E9Bg7575ou" resolve="description" />
+            </node>
+            <node concept="liA8E" id="E9Bg757fjE" role="2OqNvi">
+              <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String)" resolve="append" />
+              <node concept="2OqwBi" id="E9Bg75a3q8" role="37wK5m">
+                <node concept="1rXfSq" id="E9Bg757fyL" role="2Oq$k0">
+                  <ref role="37wK5l" node="DYlgnA$vsL" resolve="getExpectedConcept" />
                 </node>
-                <node concept="liA8E" id="DYlgnA$j_R" role="2OqNvi">
-                  <ref role="37wK5l" node="DYlgnAAwiN" resolve="getDescription" />
+                <node concept="liA8E" id="E9Bg75a3LY" role="2OqNvi">
+                  <ref role="37wK5l" to="c17a:~SAbstractConcept.getName()" resolve="getName" />
                 </node>
               </node>
             </node>
-            <node concept="3cpWs3" id="DYlgnA$j_S" role="3uHU7B">
-              <node concept="3cpWs3" id="DYlgnA$j_T" role="3uHU7B">
-                <node concept="3cpWs3" id="DYlgnA$j_U" role="3uHU7B">
-                  <node concept="Xl_RD" id="DYlgnA$j_V" role="3uHU7w">
-                    <property role="Xl_RC" value=" index " />
+          </node>
+        </node>
+        <node concept="3clFbF" id="E9Bg757g$4" role="3cqZAp">
+          <node concept="2OqwBi" id="E9Bg757h1J" role="3clFbG">
+            <node concept="37vLTw" id="E9Bg757g$2" role="2Oq$k0">
+              <ref role="3cqZAo" node="E9Bg7575ou" resolve="description" />
+            </node>
+            <node concept="liA8E" id="E9Bg757hfY" role="2OqNvi">
+              <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String)" resolve="append" />
+              <node concept="Xl_RD" id="E9Bg757hwd" role="37wK5m">
+                <property role="Xl_RC" value=") in index " />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="E9Bg757iOF" role="3cqZAp">
+          <node concept="2OqwBi" id="E9Bg757j8c" role="3clFbG">
+            <node concept="37vLTw" id="E9Bg757iOD" role="2Oq$k0">
+              <ref role="3cqZAo" node="E9Bg7575ou" resolve="description" />
+            </node>
+            <node concept="liA8E" id="E9Bg757jnn" role="2OqNvi">
+              <ref role="37wK5l" to="wyt6:~StringBuilder.append(int)" resolve="append" />
+              <node concept="37vLTw" id="E9Bg757jO2" role="37wK5m">
+                <ref role="3cqZAo" node="DYlgnA$hR8" resolve="index" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="E9Bg757mlf" role="3cqZAp">
+          <node concept="2OqwBi" id="E9Bg757mE6" role="3clFbG">
+            <node concept="37vLTw" id="E9Bg757mld" role="2Oq$k0">
+              <ref role="3cqZAo" node="E9Bg7575ou" resolve="description" />
+            </node>
+            <node concept="liA8E" id="E9Bg757mUd" role="2OqNvi">
+              <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String)" resolve="append" />
+              <node concept="Xl_RD" id="E9Bg757nck" role="37wK5m">
+                <property role="Xl_RC" value=" doesn't match:\n\t" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="E9Bg757qCP" role="3cqZAp">
+          <node concept="2OqwBi" id="E9Bg757rqE" role="3clFbG">
+            <node concept="37vLTw" id="E9Bg757qCN" role="2Oq$k0">
+              <ref role="3cqZAo" node="E9Bg7575ou" resolve="description" />
+            </node>
+            <node concept="liA8E" id="E9Bg757s4r" role="2OqNvi">
+              <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String)" resolve="append" />
+              <node concept="2YIFZM" id="E9Bg757skA" role="37wK5m">
+                <ref role="1Pybhc" node="DYlgnAAVf1" resolve="StringUtils" />
+                <ref role="37wK5l" node="DYlgnAAVkz" resolve="indent" />
+                <node concept="2OqwBi" id="E9Bg757skB" role="37wK5m">
+                  <node concept="37vLTw" id="E9Bg757skC" role="2Oq$k0">
+                    <ref role="3cqZAo" node="DYlgnA$hRb" resolve="result" />
                   </node>
-                  <node concept="3cpWs3" id="DYlgnA$j_W" role="3uHU7B">
-                    <node concept="Xl_RD" id="DYlgnA$j_X" role="3uHU7w">
-                      <property role="Xl_RC" value=") " />
-                    </node>
-                    <node concept="3cpWs3" id="DYlgnA$j_Y" role="3uHU7B">
-                      <node concept="3cpWs3" id="DYlgnA$j_Z" role="3uHU7B">
-                        <node concept="3cpWs3" id="DYlgnA$jA0" role="3uHU7B">
-                          <node concept="Xl_RD" id="DYlgnA$jA1" role="3uHU7B">
-                            <property role="Xl_RC" value="Attribute of role " />
-                          </node>
-                          <node concept="37vLTw" id="DYlgnA$jA2" role="3uHU7w">
-                            <ref role="3cqZAo" node="DYlgnA$hR5" resolve="attribute" />
-                          </node>
-                        </node>
-                        <node concept="Xl_RD" id="DYlgnA$jA3" role="3uHU7w">
-                          <property role="Xl_RC" value=" (" />
-                        </node>
-                      </node>
-                      <node concept="3P9mCS" id="DYlgnA$jA4" role="3uHU7w">
-                        <ref role="37wK5l" node="DYlgnA$vt1" resolve="getExpectedConceptName" />
-                      </node>
-                    </node>
+                  <node concept="liA8E" id="E9Bg757skD" role="2OqNvi">
+                    <ref role="37wK5l" node="DYlgnAAwiN" resolve="getDescription" />
                   </node>
                 </node>
-                <node concept="37vLTw" id="DYlgnA$jA5" role="3uHU7w">
-                  <ref role="3cqZAo" node="DYlgnA$hR8" resolve="index" />
-                </node>
               </node>
-              <node concept="Xl_RD" id="DYlgnA$jA6" role="3uHU7w">
-                <property role="Xl_RC" value=" is different because:\n\t" />
-              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="E9Bg757txH" role="3cqZAp">
+          <node concept="2OqwBi" id="E9Bg757u5z" role="3cqZAk">
+            <node concept="37vLTw" id="E9Bg757tU3" role="2Oq$k0">
+              <ref role="3cqZAo" node="E9Bg7575ou" resolve="description" />
+            </node>
+            <node concept="liA8E" id="E9Bg757uog" role="2OqNvi">
+              <ref role="37wK5l" to="wyt6:~StringBuilder.toString()" resolve="toString" />
             </node>
           </node>
         </node>

--- a/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.comparator/models/ChildDifference.mpsr
+++ b/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.comparator/models/ChildDifference.mpsr
@@ -1,7 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <model ref="r:ec874b45-e888-42e6-995a-a298cefdff55(com.mbeddr.mpsutil.comparator.code)" content="root">
   <persistence version="9" />
-  <imports />
+  <imports>
+    <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
+    <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" implicit="true" />
+  </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
       <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
@@ -17,6 +20,9 @@
       <concept id="1197029447546" name="jetbrains.mps.baseLanguage.structure.FieldReferenceOperation" flags="nn" index="2OwXpG">
         <reference id="1197029500499" name="fieldDeclaration" index="2Oxat5" />
       </concept>
+      <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
+        <child id="1145553007750" name="creator" index="2ShVmc" />
+      </concept>
       <concept id="1070475354124" name="jetbrains.mps.baseLanguage.structure.ThisExpression" flags="nn" index="Xjq3P" />
       <concept id="1070475587102" name="jetbrains.mps.baseLanguage.structure.SuperConstructorInvocation" flags="nn" index="XkiVB" />
       <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
@@ -29,6 +35,12 @@
       <concept id="1068390468200" name="jetbrains.mps.baseLanguage.structure.FieldDeclaration" flags="ig" index="312cEg" />
       <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu">
         <child id="1165602531693" name="superclass" index="1zkMxy" />
+      </concept>
+      <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
+        <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ng" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
       </concept>
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
@@ -56,15 +68,19 @@
         <child id="1068581517665" name="statement" index="3cqZAp" />
       </concept>
       <concept id="1068580123140" name="jetbrains.mps.baseLanguage.structure.ConstructorDeclaration" flags="ig" index="3clFbW" />
-      <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
       <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
         <child id="1068581517676" name="expression" index="3cqZAk" />
       </concept>
+      <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
+        <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
+      </concept>
+      <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
       <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
       <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
+      <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk" />
       <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
         <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
       </concept>
@@ -75,14 +91,9 @@
       <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
         <reference id="1107535924139" name="classifier" index="3uigEE" />
       </concept>
-      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
-        <child id="1081773367579" name="rightExpression" index="3uHU7w" />
-        <child id="1081773367580" name="leftExpression" index="3uHU7B" />
-      </concept>
       <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
       </concept>
-      <concept id="3066917033203108594" name="jetbrains.mps.baseLanguage.structure.LocalInstanceMethodCall" flags="nn" index="3P9mCS" />
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
       <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
       <concept id="1146644641414" name="jetbrains.mps.baseLanguage.structure.ProtectedVisibility" flags="nn" index="3Tmbuc" />
@@ -292,57 +303,132 @@
       <node concept="17QB3L" id="DYlgnA$ERq" role="3clF45" />
       <node concept="3Tmbuc" id="DYlgnA$ERr" role="1B3o_S" />
       <node concept="3clFbS" id="DYlgnA$ERs" role="3clF47">
-        <node concept="3cpWs6" id="6fymoI4XsQN" role="3cqZAp">
-          <node concept="3cpWs3" id="6fymoI4XsQO" role="3cqZAk">
-            <node concept="2YIFZM" id="6fymoI4XsQP" role="3uHU7w">
-              <ref role="1Pybhc" node="DYlgnAAVf1" resolve="StringUtils" />
-              <ref role="37wK5l" node="DYlgnAAVkz" resolve="indent" />
-              <node concept="2OqwBi" id="6fymoI4XsQQ" role="37wK5m">
-                <node concept="37vLTw" id="6fymoI4XsQR" role="2Oq$k0">
-                  <ref role="3cqZAo" node="DYlgnA$D3g" resolve="result" />
+        <node concept="3cpWs8" id="E9Bg758VqY" role="3cqZAp">
+          <node concept="3cpWsn" id="E9Bg758VqZ" role="3cpWs9">
+            <property role="TrG5h" value="builder" />
+            <node concept="3uibUv" id="E9Bg758Vr0" role="1tU5fm">
+              <ref role="3uigEE" to="wyt6:~StringBuilder" resolve="StringBuilder" />
+            </node>
+            <node concept="2ShNRf" id="E9Bg758VLK" role="33vP2m">
+              <node concept="1pGfFk" id="E9Bg758WgD" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="wyt6:~StringBuilder.&lt;init&gt;()" resolve="StringBuilder" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="E9Bg758Yi1" role="3cqZAp">
+          <node concept="2OqwBi" id="E9Bg758YVR" role="3clFbG">
+            <node concept="37vLTw" id="E9Bg758YhZ" role="2Oq$k0">
+              <ref role="3cqZAo" node="E9Bg758VqZ" resolve="builder" />
+            </node>
+            <node concept="liA8E" id="E9Bg758ZuF" role="2OqNvi">
+              <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String)" resolve="append" />
+              <node concept="37vLTw" id="E9Bg758ZRK" role="37wK5m">
+                <ref role="3cqZAo" node="DYlgnA$D3a" resolve="link" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="E9Bg7591eB" role="3cqZAp">
+          <node concept="2OqwBi" id="E9Bg7591kN" role="3clFbG">
+            <node concept="37vLTw" id="E9Bg7591e_" role="2Oq$k0">
+              <ref role="3cqZAo" node="E9Bg758VqZ" resolve="builder" />
+            </node>
+            <node concept="liA8E" id="E9Bg7591z4" role="2OqNvi">
+              <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String)" resolve="append" />
+              <node concept="Xl_RD" id="E9Bg7591LE" role="37wK5m">
+                <property role="Xl_RC" value=" (child of concept " />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="E9Bg7594Dd" role="3cqZAp">
+          <node concept="2OqwBi" id="E9Bg7594JJ" role="3clFbG">
+            <node concept="37vLTw" id="E9Bg7594Db" role="2Oq$k0">
+              <ref role="3cqZAo" node="E9Bg758VqZ" resolve="builder" />
+            </node>
+            <node concept="liA8E" id="E9Bg7594Zv" role="2OqNvi">
+              <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String)" resolve="append" />
+              <node concept="2OqwBi" id="E9Bg75a69B" role="37wK5m">
+                <node concept="1rXfSq" id="E9Bg7595f1" role="2Oq$k0">
+                  <ref role="37wK5l" node="DYlgnA$vsL" resolve="getExpectedConcept" />
                 </node>
-                <node concept="liA8E" id="6fymoI4XsQS" role="2OqNvi">
-                  <ref role="37wK5l" node="DYlgnAAwiN" resolve="getDescription" />
+                <node concept="liA8E" id="E9Bg75a6uM" role="2OqNvi">
+                  <ref role="37wK5l" to="c17a:~SAbstractConcept.getName()" resolve="getName" />
                 </node>
               </node>
             </node>
-            <node concept="3cpWs3" id="6fymoI4XsQT" role="3uHU7B">
-              <node concept="3cpWs3" id="6fymoI4XsQU" role="3uHU7B">
-                <node concept="3cpWs3" id="6fymoI4XsQV" role="3uHU7B">
-                  <node concept="Xl_RD" id="6fymoI4XsQW" role="3uHU7w">
-                    <property role="Xl_RC" value=" index " />
+          </node>
+        </node>
+        <node concept="3clFbF" id="E9Bg7597g4" role="3cqZAp">
+          <node concept="2OqwBi" id="E9Bg7597Iy" role="3clFbG">
+            <node concept="37vLTw" id="E9Bg7597g2" role="2Oq$k0">
+              <ref role="3cqZAo" node="E9Bg758VqZ" resolve="builder" />
+            </node>
+            <node concept="liA8E" id="E9Bg7598mw" role="2OqNvi">
+              <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String)" resolve="append" />
+              <node concept="Xl_RD" id="E9Bg7598Ba" role="37wK5m">
+                <property role="Xl_RC" value=") at index " />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="E9Bg759ahT" role="3cqZAp">
+          <node concept="2OqwBi" id="E9Bg759apd" role="3clFbG">
+            <node concept="37vLTw" id="E9Bg759ahR" role="2Oq$k0">
+              <ref role="3cqZAo" node="E9Bg758VqZ" resolve="builder" />
+            </node>
+            <node concept="liA8E" id="E9Bg759aGn" role="2OqNvi">
+              <ref role="37wK5l" to="wyt6:~StringBuilder.append(int)" resolve="append" />
+              <node concept="37vLTw" id="E9Bg759bFm" role="37wK5m">
+                <ref role="3cqZAo" node="DYlgnA$D3d" resolve="index" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="E9Bg759dup" role="3cqZAp">
+          <node concept="2OqwBi" id="E9Bg759dA4" role="3clFbG">
+            <node concept="37vLTw" id="E9Bg759dun" role="2Oq$k0">
+              <ref role="3cqZAo" node="E9Bg758VqZ" resolve="builder" />
+            </node>
+            <node concept="liA8E" id="E9Bg759dUT" role="2OqNvi">
+              <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String)" resolve="append" />
+              <node concept="Xl_RD" id="E9Bg759edr" role="37wK5m">
+                <property role="Xl_RC" value=" doesn't match: \n\t" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="E9Bg759ghk" role="3cqZAp">
+          <node concept="2OqwBi" id="E9Bg759gpl" role="3clFbG">
+            <node concept="37vLTw" id="E9Bg759ghi" role="2Oq$k0">
+              <ref role="3cqZAo" node="E9Bg758VqZ" resolve="builder" />
+            </node>
+            <node concept="liA8E" id="E9Bg759gJD" role="2OqNvi">
+              <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String)" resolve="append" />
+              <node concept="2YIFZM" id="E9Bg759h0f" role="37wK5m">
+                <ref role="1Pybhc" node="DYlgnAAVf1" resolve="StringUtils" />
+                <ref role="37wK5l" node="DYlgnAAVkz" resolve="indent" />
+                <node concept="2OqwBi" id="E9Bg759h0g" role="37wK5m">
+                  <node concept="37vLTw" id="E9Bg759h0h" role="2Oq$k0">
+                    <ref role="3cqZAo" node="DYlgnA$D3g" resolve="result" />
                   </node>
-                  <node concept="3cpWs3" id="6fymoI4XsQX" role="3uHU7B">
-                    <node concept="Xl_RD" id="6fymoI4XsQY" role="3uHU7w">
-                      <property role="Xl_RC" value=") " />
-                    </node>
-                    <node concept="3cpWs3" id="6fymoI4XsQZ" role="3uHU7B">
-                      <node concept="3cpWs3" id="6fymoI4XsR0" role="3uHU7B">
-                        <node concept="3cpWs3" id="6fymoI4XsR1" role="3uHU7B">
-                          <node concept="Xl_RD" id="6fymoI4XsR2" role="3uHU7B">
-                            <property role="Xl_RC" value="Child of role " />
-                          </node>
-                          <node concept="37vLTw" id="6fymoI4XsR3" role="3uHU7w">
-                            <ref role="3cqZAo" node="DYlgnA$D3a" resolve="link" />
-                          </node>
-                        </node>
-                        <node concept="Xl_RD" id="6fymoI4XsR4" role="3uHU7w">
-                          <property role="Xl_RC" value=" (" />
-                        </node>
-                      </node>
-                      <node concept="3P9mCS" id="6fymoI4XsR5" role="3uHU7w">
-                        <ref role="37wK5l" node="DYlgnA$vt1" resolve="getExpectedConceptName" />
-                      </node>
-                    </node>
+                  <node concept="liA8E" id="E9Bg759h0i" role="2OqNvi">
+                    <ref role="37wK5l" node="DYlgnAAwiN" resolve="getDescription" />
                   </node>
                 </node>
-                <node concept="37vLTw" id="6fymoI4XsR6" role="3uHU7w">
-                  <ref role="3cqZAo" node="DYlgnA$D3d" resolve="index" />
-                </node>
               </node>
-              <node concept="Xl_RD" id="6fymoI4XsR7" role="3uHU7w">
-                <property role="Xl_RC" value=" is different because:\n\t" />
-              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="6fymoI4XsQN" role="3cqZAp">
+          <node concept="2OqwBi" id="E9Bg759i$J" role="3cqZAk">
+            <node concept="37vLTw" id="E9Bg759ir5" role="2Oq$k0">
+              <ref role="3cqZAo" node="E9Bg758VqZ" resolve="builder" />
+            </node>
+            <node concept="liA8E" id="E9Bg759jry" role="2OqNvi">
+              <ref role="37wK5l" to="wyt6:~StringBuilder.toString()" resolve="toString" />
             </node>
           </node>
         </node>

--- a/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.comparator/models/DiffView.mpsr
+++ b/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.comparator/models/DiffView.mpsr
@@ -11,7 +11,6 @@
     <import index="alof" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.ide.project(MPS.Platform/)" implicit="true" />
     <import index="jkm4" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.ui(MPS.IDEA/)" implicit="true" />
     <import index="qjvf" ref="r:82cadfba-0fcc-402e-8eaa-37395d383fb6(com.mbeddr.mpsutil.compare.behavior)" implicit="true" />
-    <import index="z1c3" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.project(MPS.Platform/)" implicit="true" />
     <import index="dxuu" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:javax.swing(JDK/)" implicit="true" />
     <import index="mhfm" ref="3f233e7f-b8a6-46d2-a57f-795d56775243/java:org.jetbrains.annotations(Annotations/)" implicit="true" />
     <import index="tp5g" ref="r:00000000-0000-4000-0000-011c89590388(jetbrains.mps.lang.test.structure)" implicit="true" />

--- a/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.comparator/models/DifferentConceptDifference.mpsr
+++ b/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.comparator/models/DifferentConceptDifference.mpsr
@@ -1,10 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <model ref="r:ec874b45-e888-42e6-995a-a298cefdff55(com.mbeddr.mpsutil.comparator.code)" content="root">
   <persistence version="9" />
-  <imports />
+  <imports>
+    <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
+  </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
       <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="nn" index="2tJIrI" />
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
       <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
         <child id="1145553007750" name="creator" index="2ShVmc" />
       </concept>
@@ -14,6 +21,12 @@
       </concept>
       <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu">
         <child id="1165602531693" name="superclass" index="1zkMxy" />
+      </concept>
+      <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
+        <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ng" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
       </concept>
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
@@ -40,15 +53,16 @@
         <child id="1068581517665" name="statement" index="3cqZAp" />
       </concept>
       <concept id="1068580123140" name="jetbrains.mps.baseLanguage.structure.ConstructorDeclaration" flags="ig" index="3clFbW" />
-      <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
-      <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
-        <child id="1068581517676" name="expression" index="3cqZAk" />
+      <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
+        <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
       </concept>
+      <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
       <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
       <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
+      <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk" />
       <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
         <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
       </concept>
@@ -58,10 +72,6 @@
       <concept id="7812454656619025412" name="jetbrains.mps.baseLanguage.structure.LocalMethodCall" flags="nn" index="1rXfSq" />
       <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
         <reference id="1107535924139" name="classifier" index="3uigEE" />
-      </concept>
-      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
-        <child id="1081773367579" name="rightExpression" index="3uHU7w" />
-        <child id="1081773367580" name="leftExpression" index="3uHU7B" />
       </concept>
       <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
@@ -163,43 +173,79 @@
       <node concept="17QB3L" id="DYlgnA$Lxx" role="3clF45" />
       <node concept="3Tmbuc" id="DYlgnA$Lxy" role="1B3o_S" />
       <node concept="3clFbS" id="DYlgnA$Lxz" role="3clF47">
-        <node concept="3cpWs6" id="6fymoI4Xswz" role="3cqZAp">
-          <node concept="3cpWs3" id="6fymoI4Xsw$" role="3cqZAk">
-            <node concept="1rXfSq" id="6fymoI4Xsw_" role="3uHU7w">
-              <ref role="37wK5l" node="DYlgnA$vtb" resolve="getActualConceptName" />
+        <node concept="3cpWs8" id="E9Bg74qn6r" role="3cqZAp">
+          <node concept="3cpWsn" id="E9Bg74qn6s" role="3cpWs9">
+            <property role="TrG5h" value="builder" />
+            <node concept="3uibUv" id="E9Bg74qn6t" role="1tU5fm">
+              <ref role="3uigEE" to="wyt6:~StringBuilder" resolve="StringBuilder" />
             </node>
-            <node concept="3cpWs3" id="6fymoI4XswA" role="3uHU7B">
-              <node concept="Xl_RD" id="6fymoI4XswB" role="3uHU7w">
-                <property role="Xl_RC" value="=" />
+            <node concept="2ShNRf" id="E9Bg74qnzP" role="33vP2m">
+              <node concept="1pGfFk" id="E9Bg74qoj2" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="wyt6:~StringBuilder.&lt;init&gt;()" resolve="StringBuilder" />
               </node>
-              <node concept="3cpWs3" id="6fymoI4XswC" role="3uHU7B">
-                <node concept="3cpWs3" id="6fymoI4XswD" role="3uHU7B">
-                  <node concept="3cpWs3" id="6fymoI4XswE" role="3uHU7B">
-                    <node concept="3cpWs3" id="6fymoI4XswF" role="3uHU7B">
-                      <node concept="Xl_RD" id="6fymoI4XswG" role="3uHU7w">
-                        <property role="Xl_RC" value="=" />
-                      </node>
-                      <node concept="3cpWs3" id="6fymoI4XswH" role="3uHU7B">
-                        <node concept="37vLTw" id="6fymoI4XswI" role="3uHU7w">
-                          <ref role="3cqZAo" node="DYlgnA$Lyc" resolve="expectedName" />
-                        </node>
-                        <node concept="Xl_RD" id="6fymoI4XswJ" role="3uHU7B">
-                          <property role="Xl_RC" value="the nodes have different concepts: " />
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="1rXfSq" id="6fymoI4XswK" role="3uHU7w">
-                      <ref role="37wK5l" node="DYlgnA$vt1" resolve="getExpectedConceptName" />
-                    </node>
-                  </node>
-                  <node concept="Xl_RD" id="6fymoI4XswL" role="3uHU7w">
-                    <property role="Xl_RC" value=", " />
-                  </node>
-                </node>
-                <node concept="37vLTw" id="6fymoI4XswM" role="3uHU7w">
-                  <ref role="3cqZAo" node="DYlgnA$Lye" resolve="actualName" />
-                </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="E9Bg74qoTc" role="3cqZAp">
+          <node concept="2OqwBi" id="E9Bg74qpsf" role="3clFbG">
+            <node concept="37vLTw" id="E9Bg74qoTa" role="2Oq$k0">
+              <ref role="3cqZAo" node="E9Bg74qn6s" resolve="builder" />
+            </node>
+            <node concept="liA8E" id="E9Bg74qpTS" role="2OqNvi">
+              <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String)" resolve="append" />
+              <node concept="Xl_RD" id="6fymoI4XswJ" role="37wK5m">
+                <property role="Xl_RC" value="Nodes have different concepts. Expected " />
               </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="E9Bg74qraO" role="3cqZAp">
+          <node concept="2OqwBi" id="E9Bg74qrgY" role="3clFbG">
+            <node concept="37vLTw" id="E9Bg74qraM" role="2Oq$k0">
+              <ref role="3cqZAo" node="E9Bg74qn6s" resolve="builder" />
+            </node>
+            <node concept="liA8E" id="E9Bg74qroT" role="2OqNvi">
+              <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.Object)" resolve="append" />
+              <node concept="1rXfSq" id="E9Bg74qryl" role="37wK5m">
+                <ref role="37wK5l" node="DYlgnA$vsL" resolve="getExpectedConcept" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="E9Bg74qsrz" role="3cqZAp">
+          <node concept="2OqwBi" id="E9Bg74qsye" role="3clFbG">
+            <node concept="37vLTw" id="E9Bg74qsrx" role="2Oq$k0">
+              <ref role="3cqZAo" node="E9Bg74qn6s" resolve="builder" />
+            </node>
+            <node concept="liA8E" id="E9Bg74qsFC" role="2OqNvi">
+              <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String)" resolve="append" />
+              <node concept="Xl_RD" id="E9Bg74qsQc" role="37wK5m">
+                <property role="Xl_RC" value=", got " />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="E9Bg74qtyS" role="3cqZAp">
+          <node concept="2OqwBi" id="E9Bg74qtyT" role="3clFbG">
+            <node concept="37vLTw" id="E9Bg74qtyU" role="2Oq$k0">
+              <ref role="3cqZAo" node="E9Bg74qn6s" resolve="builder" />
+            </node>
+            <node concept="liA8E" id="E9Bg74qtyV" role="2OqNvi">
+              <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.Object)" resolve="append" />
+              <node concept="1rXfSq" id="E9Bg74qu05" role="37wK5m">
+                <ref role="37wK5l" node="DYlgnA$vsT" resolve="getActualConcept" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="E9Bg74quUw" role="3cqZAp">
+          <node concept="2OqwBi" id="E9Bg74qv0B" role="3clFbG">
+            <node concept="37vLTw" id="E9Bg74quUu" role="2Oq$k0">
+              <ref role="3cqZAo" node="E9Bg74qn6s" resolve="builder" />
+            </node>
+            <node concept="liA8E" id="E9Bg74qvbW" role="2OqNvi">
+              <ref role="37wK5l" to="wyt6:~StringBuilder.toString()" resolve="toString" />
             </node>
           </node>
         </node>

--- a/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.comparator/models/DifferentNumberOfAttributesDifference.mpsr
+++ b/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.comparator/models/DifferentNumberOfAttributesDifference.mpsr
@@ -1,13 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <model ref="r:ec874b45-e888-42e6-995a-a298cefdff55(com.mbeddr.mpsutil.comparator.code)" content="root">
   <persistence version="9" />
-  <imports />
+  <imports>
+    <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
+  </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
       <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
         <child id="1068498886297" name="rValue" index="37vLTx" />
         <child id="1068498886295" name="lValue" index="37vLTJ" />
       </concept>
+      <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
       <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="nn" index="2tJIrI" />
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
         <child id="1197027771414" name="operand" index="2Oq$k0" />
@@ -28,6 +31,12 @@
       <concept id="1068390468200" name="jetbrains.mps.baseLanguage.structure.FieldDeclaration" flags="ig" index="312cEg" />
       <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu">
         <child id="1165602531693" name="superclass" index="1zkMxy" />
+      </concept>
+      <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
+        <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ng" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
       </concept>
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
@@ -55,15 +64,19 @@
         <child id="1068581517665" name="statement" index="3cqZAp" />
       </concept>
       <concept id="1068580123140" name="jetbrains.mps.baseLanguage.structure.ConstructorDeclaration" flags="ig" index="3clFbW" />
-      <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
       <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
         <child id="1068581517676" name="expression" index="3cqZAk" />
       </concept>
+      <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
+        <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
+      </concept>
+      <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
       <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
       <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
+      <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk" />
       <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
         <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
       </concept>
@@ -72,10 +85,6 @@
       </concept>
       <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
         <reference id="1107535924139" name="classifier" index="3uigEE" />
-      </concept>
-      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
-        <child id="1081773367579" name="rightExpression" index="3uHU7w" />
-        <child id="1081773367580" name="leftExpression" index="3uHU7B" />
       </concept>
       <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
@@ -258,53 +267,105 @@
       <node concept="17QB3L" id="DYlgnA$U7J" role="3clF45" />
       <node concept="3Tmbuc" id="DYlgnA$U7K" role="1B3o_S" />
       <node concept="3clFbS" id="DYlgnA$U7L" role="3clF47">
-        <node concept="3cpWs6" id="6fymoI4Xslx" role="3cqZAp">
-          <node concept="3cpWs3" id="6fymoI4Xsly" role="3cqZAk">
-            <node concept="37vLTw" id="6fymoI4Xslz" role="3uHU7w">
-              <ref role="3cqZAo" node="DYlgnA$S4l" resolve="actualCount" />
+        <node concept="3cpWs8" id="E9Bg7559ji" role="3cqZAp">
+          <node concept="3cpWsn" id="E9Bg7559jj" role="3cpWs9">
+            <property role="TrG5h" value="description" />
+            <node concept="3uibUv" id="E9Bg7559jk" role="1tU5fm">
+              <ref role="3uigEE" to="wyt6:~StringBuilder" resolve="StringBuilder" />
             </node>
-            <node concept="3cpWs3" id="6fymoI4Xsl$" role="3uHU7B">
-              <node concept="Xl_RD" id="6fymoI4Xsl_" role="3uHU7w">
-                <property role="Xl_RC" value=" has " />
+            <node concept="2ShNRf" id="E9Bg7559KJ" role="33vP2m">
+              <node concept="1pGfFk" id="E9Bg755aoR" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="wyt6:~StringBuilder.&lt;init&gt;()" resolve="StringBuilder" />
               </node>
-              <node concept="3cpWs3" id="6fymoI4XslA" role="3uHU7B">
-                <node concept="3cpWs3" id="6fymoI4XslB" role="3uHU7B">
-                  <node concept="3cpWs3" id="6fymoI4XslC" role="3uHU7B">
-                    <node concept="3cpWs3" id="6fymoI4XslD" role="3uHU7B">
-                      <node concept="Xl_RD" id="6fymoI4XslE" role="3uHU7w">
-                        <property role="Xl_RC" value=" has " />
-                      </node>
-                      <node concept="3cpWs3" id="6fymoI4XslF" role="3uHU7B">
-                        <node concept="37vLTw" id="6fymoI4XslG" role="3uHU7w">
-                          <ref role="3cqZAo" node="DYlgnA$U86" resolve="expectedName" />
-                        </node>
-                        <node concept="3cpWs3" id="6fymoI4XslH" role="3uHU7B">
-                          <node concept="3cpWs3" id="6fymoI4XslI" role="3uHU7B">
-                            <node concept="Xl_RD" id="6fymoI4XslJ" role="3uHU7B">
-                              <property role="Xl_RC" value="for role " />
-                            </node>
-                            <node concept="37vLTw" id="6fymoI4XslK" role="3uHU7w">
-                              <ref role="3cqZAo" node="DYlgnA$S4f" resolve="attribute" />
-                            </node>
-                          </node>
-                          <node concept="Xl_RD" id="6fymoI4XslL" role="3uHU7w">
-                            <property role="Xl_RC" value=" " />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="37vLTw" id="6fymoI4XslM" role="3uHU7w">
-                      <ref role="3cqZAo" node="DYlgnA$S4i" resolve="expectedCount" />
-                    </node>
-                  </node>
-                  <node concept="Xl_RD" id="6fymoI4XslN" role="3uHU7w">
-                    <property role="Xl_RC" value=" attributes, while " />
-                  </node>
-                </node>
-                <node concept="37vLTw" id="6fymoI4XslO" role="3uHU7w">
-                  <ref role="3cqZAo" node="DYlgnA$U88" resolve="actualName" />
-                </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="E9Bg755b8d" role="3cqZAp">
+          <node concept="2OqwBi" id="E9Bg755bEJ" role="3clFbG">
+            <node concept="37vLTw" id="E9Bg755b8b" role="2Oq$k0">
+              <ref role="3cqZAo" node="E9Bg7559jj" resolve="description" />
+            </node>
+            <node concept="liA8E" id="E9Bg755cmO" role="2OqNvi">
+              <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String)" resolve="append" />
+              <node concept="Xl_RD" id="E9Bg755cxJ" role="37wK5m">
+                <property role="Xl_RC" value="expected " />
               </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="E9Bg755iJg" role="3cqZAp">
+          <node concept="2OqwBi" id="E9Bg755jp4" role="3clFbG">
+            <node concept="37vLTw" id="E9Bg755iJe" role="2Oq$k0">
+              <ref role="3cqZAo" node="E9Bg7559jj" resolve="description" />
+            </node>
+            <node concept="liA8E" id="E9Bg755k4T" role="2OqNvi">
+              <ref role="37wK5l" to="wyt6:~StringBuilder.append(int)" resolve="append" />
+              <node concept="37vLTw" id="E9Bg755kgK" role="37wK5m">
+                <ref role="3cqZAo" node="DYlgnA$S4i" resolve="expectedCount" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="E9Bg755nPZ" role="3cqZAp">
+          <node concept="2OqwBi" id="E9Bg755orL" role="3clFbG">
+            <node concept="37vLTw" id="E9Bg755nPX" role="2Oq$k0">
+              <ref role="3cqZAo" node="E9Bg7559jj" resolve="description" />
+            </node>
+            <node concept="liA8E" id="E9Bg755oWC" role="2OqNvi">
+              <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String)" resolve="append" />
+              <node concept="Xl_RD" id="E9Bg755p9r" role="37wK5m">
+                <property role="Xl_RC" value=" for role " />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="E9Bg755rxx" role="3cqZAp">
+          <node concept="2OqwBi" id="E9Bg755s4L" role="3clFbG">
+            <node concept="37vLTw" id="E9Bg755rxv" role="2Oq$k0">
+              <ref role="3cqZAo" node="E9Bg7559jj" resolve="description" />
+            </node>
+            <node concept="liA8E" id="E9Bg755sNz" role="2OqNvi">
+              <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String)" resolve="append" />
+              <node concept="37vLTw" id="E9Bg755t1i" role="37wK5m">
+                <ref role="3cqZAo" node="DYlgnA$S4f" resolve="attribute" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="E9Bg755tOg" role="3cqZAp">
+          <node concept="2OqwBi" id="E9Bg755tXr" role="3clFbG">
+            <node concept="37vLTw" id="E9Bg755tOe" role="2Oq$k0">
+              <ref role="3cqZAo" node="E9Bg7559jj" resolve="description" />
+            </node>
+            <node concept="liA8E" id="E9Bg755ucu" role="2OqNvi">
+              <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String)" resolve="append" />
+              <node concept="Xl_RD" id="E9Bg755ure" role="37wK5m">
+                <property role="Xl_RC" value=", got " />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="E9Bg755vd0" role="3cqZAp">
+          <node concept="2OqwBi" id="E9Bg755vmA" role="3clFbG">
+            <node concept="37vLTw" id="E9Bg755vcY" role="2Oq$k0">
+              <ref role="3cqZAo" node="E9Bg7559jj" resolve="description" />
+            </node>
+            <node concept="liA8E" id="E9Bg755vB3" role="2OqNvi">
+              <ref role="37wK5l" to="wyt6:~StringBuilder.append(int)" resolve="append" />
+              <node concept="37vLTw" id="E9Bg755vQJ" role="37wK5m">
+                <ref role="3cqZAo" node="DYlgnA$S4l" resolve="actualCount" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="6fymoI4Xslx" role="3cqZAp">
+          <node concept="2OqwBi" id="E9Bg755xG8" role="3cqZAk">
+            <node concept="37vLTw" id="E9Bg755x$E" role="2Oq$k0">
+              <ref role="3cqZAo" node="E9Bg7559jj" resolve="description" />
+            </node>
+            <node concept="liA8E" id="E9Bg755xSQ" role="2OqNvi">
+              <ref role="37wK5l" to="wyt6:~StringBuilder.toString()" resolve="toString" />
             </node>
           </node>
         </node>

--- a/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.comparator/models/DifferentNumberOfChildrenDifference.mpsr
+++ b/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.comparator/models/DifferentNumberOfChildrenDifference.mpsr
@@ -2,8 +2,8 @@
 <model ref="r:ec874b45-e888-42e6-995a-a298cefdff55(com.mbeddr.mpsutil.comparator.code)" content="root">
   <persistence version="9" />
   <imports>
-    <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" implicit="true" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
+    <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" implicit="true" />
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
@@ -29,9 +29,16 @@
       <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
         <property id="1070475926801" name="value" index="Xl_RC" />
       </concept>
+      <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
       <concept id="1068390468200" name="jetbrains.mps.baseLanguage.structure.FieldDeclaration" flags="ig" index="312cEg" />
       <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu">
         <child id="1165602531693" name="superclass" index="1zkMxy" />
+      </concept>
+      <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
+        <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ng" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
       </concept>
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
@@ -52,6 +59,7 @@
       <concept id="1068580123165" name="jetbrains.mps.baseLanguage.structure.InstanceMethodDeclaration" flags="ig" index="3clFb_">
         <property id="1178608670077" name="isAbstract" index="1EzhhJ" />
       </concept>
+      <concept id="1068580123152" name="jetbrains.mps.baseLanguage.structure.EqualsExpression" flags="nn" index="3clFbC" />
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
@@ -59,15 +67,22 @@
         <child id="1068581517665" name="statement" index="3cqZAp" />
       </concept>
       <concept id="1068580123140" name="jetbrains.mps.baseLanguage.structure.ConstructorDeclaration" flags="ig" index="3clFbW" />
-      <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
+      <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
+        <property id="1068580320021" name="value" index="3cmrfH" />
+      </concept>
       <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
         <child id="1068581517676" name="expression" index="3cqZAk" />
       </concept>
+      <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
+        <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
+      </concept>
+      <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
       <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
       <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
+      <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk" />
       <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
         <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
       </concept>
@@ -84,6 +99,11 @@
       </concept>
       <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
+      </concept>
+      <concept id="1163668896201" name="jetbrains.mps.baseLanguage.structure.TernaryOperatorExpression" flags="nn" index="3K4zz7">
+        <child id="1163668914799" name="condition" index="3K4Cdx" />
+        <child id="1163668922816" name="ifTrue" index="3K4E3e" />
+        <child id="1163668934364" name="ifFalse" index="3K4GZi" />
       </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
       <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
@@ -236,131 +256,244 @@
       <node concept="17QB3L" id="DYlgnA_93q" role="3clF45" />
       <node concept="3Tmbuc" id="DYlgnA_93r" role="1B3o_S" />
       <node concept="3clFbS" id="DYlgnA_93s" role="3clF47">
-        <node concept="3cpWs6" id="6fymoI4XrZ2" role="3cqZAp">
-          <node concept="3cpWs3" id="6fymoI4XrZ3" role="3cqZAk">
-            <node concept="3cpWs3" id="6fymoI4XrZ4" role="3uHU7B">
-              <node concept="Xl_RD" id="6fymoI4XrZ5" role="3uHU7w">
-                <property role="Xl_RC" value=" has " />
+        <node concept="3cpWs8" id="E9Bg74Xh2L" role="3cqZAp">
+          <node concept="3cpWsn" id="E9Bg74Xh2M" role="3cpWs9">
+            <property role="TrG5h" value="description" />
+            <node concept="3uibUv" id="E9Bg74Xh2N" role="1tU5fm">
+              <ref role="3uigEE" to="wyt6:~StringBuilder" resolve="StringBuilder" />
+            </node>
+            <node concept="2ShNRf" id="E9Bg74Xi4b" role="33vP2m">
+              <node concept="1pGfFk" id="E9Bg74XiD0" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="wyt6:~StringBuilder.&lt;init&gt;()" resolve="StringBuilder" />
               </node>
-              <node concept="3cpWs3" id="6fymoI4XrZ6" role="3uHU7B">
-                <node concept="37vLTw" id="6fymoI4XrZ_" role="3uHU7w">
-                  <ref role="3cqZAo" node="DYlgnA_93V" resolve="actualName" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="E9Bg750OZ6" role="3cqZAp">
+          <node concept="3cpWsn" id="E9Bg750OZ7" role="3cpWs9">
+            <property role="TrG5h" value="expectedChildren" />
+            <node concept="10Oyi0" id="E9Bg750KYL" role="1tU5fm" />
+            <node concept="2OqwBi" id="E9Bg750OZ8" role="33vP2m">
+              <node concept="2OqwBi" id="E9Bg750OZ9" role="2Oq$k0">
+                <node concept="2OqwBi" id="E9Bg750OZa" role="2Oq$k0">
+                  <node concept="1rXfSq" id="E9Bg750OZb" role="2Oq$k0">
+                    <ref role="37wK5l" node="DYlgnA$vsF" resolve="getExpected" />
+                  </node>
+                  <node concept="32TBzR" id="E9Bg750OZc" role="2OqNvi" />
                 </node>
-                <node concept="3cpWs3" id="6fymoI4XrZ7" role="3uHU7B">
-                  <node concept="3cpWs3" id="6fymoI4XrZ8" role="3uHU7B">
-                    <node concept="3cpWs3" id="6fymoI4XrZ9" role="3uHU7B">
-                      <node concept="Xl_RD" id="6fymoI4XrZa" role="3uHU7w">
-                        <property role="Xl_RC" value=" has " />
-                      </node>
-                      <node concept="3cpWs3" id="6fymoI4XrZb" role="3uHU7B">
-                        <node concept="37vLTw" id="6fymoI4XrZc" role="3uHU7w">
-                          <ref role="3cqZAo" node="DYlgnA_93T" resolve="expectedName" />
-                        </node>
-                        <node concept="3cpWs3" id="6fymoI4XrZd" role="3uHU7B">
-                          <node concept="3cpWs3" id="6fymoI4XrZe" role="3uHU7B">
-                            <node concept="Xl_RD" id="6fymoI4XrZf" role="3uHU7B">
-                              <property role="Xl_RC" value="for role " />
+                <node concept="3zZkjj" id="E9Bg750OZd" role="2OqNvi">
+                  <node concept="1bVj0M" id="E9Bg750OZe" role="23t8la">
+                    <node concept="3clFbS" id="E9Bg750OZf" role="1bW5cS">
+                      <node concept="3clFbF" id="E9Bg750OZg" role="3cqZAp">
+                        <node concept="2OqwBi" id="E9Bg750OZh" role="3clFbG">
+                          <node concept="2EnYce" id="E9Bg750OZi" role="2Oq$k0">
+                            <node concept="2OqwBi" id="E9Bg750OZj" role="2Oq$k0">
+                              <node concept="37vLTw" id="E9Bg750OZk" role="2Oq$k0">
+                                <ref role="3cqZAo" node="E9Bg750OZp" resolve="it" />
+                              </node>
+                              <node concept="2NL2c5" id="E9Bg750OZl" role="2OqNvi" />
                             </node>
-                            <node concept="37vLTw" id="6fymoI4XrZg" role="3uHU7w">
+                            <node concept="liA8E" id="E9Bg750OZm" role="2OqNvi">
+                              <ref role="37wK5l" to="c17a:~SNamedElement.getName()" resolve="getName" />
+                            </node>
+                          </node>
+                          <node concept="liA8E" id="E9Bg750OZn" role="2OqNvi">
+                            <ref role="37wK5l" to="wyt6:~String.equals(java.lang.Object)" resolve="equals" />
+                            <node concept="37vLTw" id="E9Bg750OZo" role="37wK5m">
                               <ref role="3cqZAo" node="DYlgnA_739" resolve="link" />
                             </node>
                           </node>
-                          <node concept="Xl_RD" id="6fymoI4XrZh" role="3uHU7w">
-                            <property role="Xl_RC" value=" " />
-                          </node>
                         </node>
                       </node>
                     </node>
-                    <node concept="2OqwBi" id="6fymoI4XrZi" role="3uHU7w">
-                      <node concept="2OqwBi" id="6fymoI4XrZj" role="2Oq$k0">
-                        <node concept="2OqwBi" id="6fymoI4XrZk" role="2Oq$k0">
-                          <node concept="1rXfSq" id="6fymoI4XrZl" role="2Oq$k0">
-                            <ref role="37wK5l" node="DYlgnA$vsF" resolve="getExpected" />
-                          </node>
-                          <node concept="32TBzR" id="6fymoI4XrZm" role="2OqNvi" />
-                        </node>
-                        <node concept="3zZkjj" id="6fymoI4XrZn" role="2OqNvi">
-                          <node concept="1bVj0M" id="6fymoI4XrZo" role="23t8la">
-                            <node concept="3clFbS" id="6fymoI4XrZp" role="1bW5cS">
-                              <node concept="3clFbF" id="6fymoI4XrZq" role="3cqZAp">
-                                <node concept="2OqwBi" id="6fymoI4XrZr" role="3clFbG">
-                                  <node concept="2EnYce" id="6fymoI4XrZs" role="2Oq$k0">
-                                    <node concept="2OqwBi" id="5RIakkDJOSN" role="2Oq$k0">
-                                      <node concept="37vLTw" id="5RIakkDJOSO" role="2Oq$k0">
-                                        <ref role="3cqZAo" node="6fymoI4XrZx" resolve="it" />
-                                      </node>
-                                      <node concept="2NL2c5" id="5RIakkDJOSP" role="2OqNvi" />
-                                    </node>
-                                    <node concept="liA8E" id="5RIakkDJOSQ" role="2OqNvi">
-                                      <ref role="37wK5l" to="c17a:~SNamedElement.getName()" resolve="getName" />
-                                    </node>
-                                  </node>
-                                  <node concept="liA8E" id="6fymoI4XrZv" role="2OqNvi">
-                                    <ref role="37wK5l" to="wyt6:~String.equals(java.lang.Object)" resolve="equals" />
-                                    <node concept="37vLTw" id="6fymoI4XrZw" role="37wK5m">
-                                      <ref role="3cqZAo" node="DYlgnA_739" resolve="link" />
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                            <node concept="Rh6nW" id="6fymoI4XrZx" role="1bW2Oz">
-                              <property role="TrG5h" value="it" />
-                              <node concept="2jxLKc" id="6fymoI4XrZy" role="1tU5fm" />
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="34oBXx" id="6fymoI4XrZz" role="2OqNvi" />
+                    <node concept="Rh6nW" id="E9Bg750OZp" role="1bW2Oz">
+                      <property role="TrG5h" value="it" />
+                      <node concept="2jxLKc" id="E9Bg750OZq" role="1tU5fm" />
                     </node>
                   </node>
-                  <node concept="Xl_RD" id="6fymoI4XrZ$" role="3uHU7w">
-                    <property role="Xl_RC" value=" children, while " />
+                </node>
+              </node>
+              <node concept="34oBXx" id="E9Bg750OZr" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="E9Bg74XnrB" role="3cqZAp">
+          <node concept="2OqwBi" id="E9Bg74XnPV" role="3clFbG">
+            <node concept="37vLTw" id="E9Bg74Xnr_" role="2Oq$k0">
+              <ref role="3cqZAo" node="E9Bg74Xh2M" resolve="description" />
+            </node>
+            <node concept="liA8E" id="E9Bg74Xo89" role="2OqNvi">
+              <ref role="37wK5l" to="wyt6:~StringBuilder.append(int)" resolve="append" />
+              <node concept="37vLTw" id="E9Bg750OZs" role="37wK5m">
+                <ref role="3cqZAo" node="E9Bg750OZ7" resolve="i" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="E9Bg751LMr" role="3cqZAp">
+          <node concept="2OqwBi" id="E9Bg751Mvy" role="3clFbG">
+            <node concept="37vLTw" id="E9Bg751LMp" role="2Oq$k0">
+              <ref role="3cqZAo" node="E9Bg74Xh2M" resolve="description" />
+            </node>
+            <node concept="liA8E" id="E9Bg751Ntg" role="2OqNvi">
+              <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String)" resolve="append" />
+              <node concept="Xl_RD" id="E9Bg751NYy" role="37wK5m">
+                <property role="Xl_RC" value=" " />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="E9Bg750RJT" role="3cqZAp">
+          <node concept="2OqwBi" id="E9Bg750SRi" role="3clFbG">
+            <node concept="37vLTw" id="E9Bg750RJR" role="2Oq$k0">
+              <ref role="3cqZAo" node="E9Bg74Xh2M" resolve="description" />
+            </node>
+            <node concept="liA8E" id="E9Bg750TCc" role="2OqNvi">
+              <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String)" resolve="append" />
+              <node concept="3K4zz7" id="E9Bg75107P" role="37wK5m">
+                <node concept="Xl_RD" id="E9Bg7510AI" role="3K4E3e">
+                  <property role="Xl_RC" value="child" />
+                </node>
+                <node concept="Xl_RD" id="E9Bg7511LH" role="3K4GZi">
+                  <property role="Xl_RC" value="children" />
+                </node>
+                <node concept="3clFbC" id="E9Bg750YO3" role="3K4Cdx">
+                  <node concept="3cmrfG" id="E9Bg750YR2" role="3uHU7w">
+                    <property role="3cmrfH" value="1" />
+                  </node>
+                  <node concept="37vLTw" id="E9Bg750U1$" role="3uHU7B">
+                    <ref role="3cqZAo" node="E9Bg750OZ7" resolve="expectedChildren" />
                   </node>
                 </node>
               </node>
             </node>
-            <node concept="2OqwBi" id="6fymoI4XrZA" role="3uHU7w">
-              <node concept="2OqwBi" id="6fymoI4XrZB" role="2Oq$k0">
-                <node concept="2OqwBi" id="6fymoI4XrZC" role="2Oq$k0">
-                  <node concept="1rXfSq" id="6fymoI4XrZD" role="2Oq$k0">
-                    <ref role="37wK5l" node="DYlgnA$vtl" resolve="getActual" />
+          </node>
+        </node>
+        <node concept="3clFbF" id="E9Bg74Xv_N" role="3cqZAp">
+          <node concept="2OqwBi" id="E9Bg74Xx7L" role="3clFbG">
+            <node concept="37vLTw" id="E9Bg74Xv_L" role="2Oq$k0">
+              <ref role="3cqZAo" node="E9Bg74Xh2M" resolve="description" />
+            </node>
+            <node concept="liA8E" id="E9Bg74XxRS" role="2OqNvi">
+              <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String)" resolve="append" />
+              <node concept="Xl_RD" id="E9Bg74XyjG" role="37wK5m">
+                <property role="Xl_RC" value=" expected for role " />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="E9Bg74XzYa" role="3cqZAp">
+          <node concept="2OqwBi" id="E9Bg74X$kb" role="3clFbG">
+            <node concept="37vLTw" id="E9Bg74XzY8" role="2Oq$k0">
+              <ref role="3cqZAo" node="E9Bg74Xh2M" resolve="description" />
+            </node>
+            <node concept="liA8E" id="E9Bg74X$Rn" role="2OqNvi">
+              <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String)" resolve="append" />
+              <node concept="37vLTw" id="E9Bg74XAuw" role="37wK5m">
+                <ref role="3cqZAo" node="DYlgnA_93T" resolve="expectedName" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="E9Bg74YFAB" role="3cqZAp">
+          <node concept="2OqwBi" id="E9Bg74YGpf" role="3clFbG">
+            <node concept="37vLTw" id="E9Bg74YFA_" role="2Oq$k0">
+              <ref role="3cqZAo" node="E9Bg74Xh2M" resolve="description" />
+            </node>
+            <node concept="liA8E" id="E9Bg74YH9Y" role="2OqNvi">
+              <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String)" resolve="append" />
+              <node concept="Xl_RD" id="E9Bg74YHzb" role="37wK5m">
+                <property role="Xl_RC" value=", got " />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="E9Bg74XHq6" role="3cqZAp">
+          <node concept="2OqwBi" id="E9Bg74XIfE" role="3clFbG">
+            <node concept="37vLTw" id="E9Bg74XHq4" role="2Oq$k0">
+              <ref role="3cqZAo" node="E9Bg74Xh2M" resolve="description" />
+            </node>
+            <node concept="liA8E" id="E9Bg74XJiJ" role="2OqNvi">
+              <ref role="37wK5l" to="wyt6:~StringBuilder.append(int)" resolve="append" />
+              <node concept="2OqwBi" id="E9Bg74YDfG" role="37wK5m">
+                <node concept="2OqwBi" id="E9Bg74XJGA" role="2Oq$k0">
+                  <node concept="2OqwBi" id="E9Bg74XJGB" role="2Oq$k0">
+                    <node concept="1rXfSq" id="E9Bg74XJGC" role="2Oq$k0">
+                      <ref role="37wK5l" node="DYlgnA$vtl" resolve="getActual" />
+                    </node>
+                    <node concept="32TBzR" id="E9Bg74XJGD" role="2OqNvi" />
                   </node>
-                  <node concept="32TBzR" id="6fymoI4XrZE" role="2OqNvi" />
-                </node>
-                <node concept="3zZkjj" id="6fymoI4XrZF" role="2OqNvi">
-                  <node concept="1bVj0M" id="6fymoI4XrZG" role="23t8la">
-                    <node concept="3clFbS" id="6fymoI4XrZH" role="1bW5cS">
-                      <node concept="3clFbF" id="6fymoI4XrZI" role="3cqZAp">
-                        <node concept="2OqwBi" id="6fymoI4XrZJ" role="3clFbG">
-                          <node concept="2EnYce" id="6fymoI4XrZK" role="2Oq$k0">
-                            <node concept="2OqwBi" id="5RIakkDJOT2" role="2Oq$k0">
-                              <node concept="37vLTw" id="5RIakkDJOT3" role="2Oq$k0">
-                                <ref role="3cqZAo" node="6fymoI4XrZP" resolve="it" />
+                  <node concept="3zZkjj" id="E9Bg74XJGE" role="2OqNvi">
+                    <node concept="1bVj0M" id="E9Bg74XJGF" role="23t8la">
+                      <node concept="3clFbS" id="E9Bg74XJGG" role="1bW5cS">
+                        <node concept="3clFbF" id="E9Bg74XJGH" role="3cqZAp">
+                          <node concept="2OqwBi" id="E9Bg74XJGI" role="3clFbG">
+                            <node concept="2EnYce" id="E9Bg74XJGJ" role="2Oq$k0">
+                              <node concept="2OqwBi" id="E9Bg74XJGK" role="2Oq$k0">
+                                <node concept="37vLTw" id="E9Bg74XJGL" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="E9Bg74XJGQ" resolve="it" />
+                                </node>
+                                <node concept="2NL2c5" id="E9Bg74XJGM" role="2OqNvi" />
                               </node>
-                              <node concept="2NL2c5" id="5RIakkDJOT4" role="2OqNvi" />
+                              <node concept="liA8E" id="E9Bg74XJGN" role="2OqNvi">
+                                <ref role="37wK5l" to="c17a:~SNamedElement.getName()" resolve="getName" />
+                              </node>
                             </node>
-                            <node concept="liA8E" id="5RIakkDJOT5" role="2OqNvi">
-                              <ref role="37wK5l" to="c17a:~SNamedElement.getName()" resolve="getName" />
-                            </node>
-                          </node>
-                          <node concept="liA8E" id="6fymoI4XrZN" role="2OqNvi">
-                            <ref role="37wK5l" to="wyt6:~String.equals(java.lang.Object)" resolve="equals" />
-                            <node concept="37vLTw" id="6fymoI4XrZO" role="37wK5m">
-                              <ref role="3cqZAo" node="DYlgnA_739" resolve="link" />
+                            <node concept="liA8E" id="E9Bg74XJGO" role="2OqNvi">
+                              <ref role="37wK5l" to="wyt6:~String.equals(java.lang.Object)" resolve="equals" />
+                              <node concept="37vLTw" id="E9Bg74XJGP" role="37wK5m">
+                                <ref role="3cqZAo" node="DYlgnA_739" resolve="link" />
+                              </node>
                             </node>
                           </node>
                         </node>
                       </node>
-                    </node>
-                    <node concept="Rh6nW" id="6fymoI4XrZP" role="1bW2Oz">
-                      <property role="TrG5h" value="it" />
-                      <node concept="2jxLKc" id="6fymoI4XrZQ" role="1tU5fm" />
+                      <node concept="Rh6nW" id="E9Bg74XJGQ" role="1bW2Oz">
+                        <property role="TrG5h" value="it" />
+                        <node concept="2jxLKc" id="E9Bg74XJGR" role="1tU5fm" />
+                      </node>
                     </node>
                   </node>
                 </node>
+                <node concept="34oBXx" id="E9Bg74YDRq" role="2OqNvi" />
               </node>
-              <node concept="34oBXx" id="6fymoI4XrZR" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="E9Bg74XL$P" role="3cqZAp">
+          <node concept="2OqwBi" id="E9Bg74XMqJ" role="3clFbG">
+            <node concept="37vLTw" id="E9Bg74XL$N" role="2Oq$k0">
+              <ref role="3cqZAo" node="E9Bg74Xh2M" resolve="description" />
+            </node>
+            <node concept="liA8E" id="E9Bg74XMXg" role="2OqNvi">
+              <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String)" resolve="append" />
+              <node concept="Xl_RD" id="E9Bg74XNwD" role="37wK5m">
+                <property role="Xl_RC" value=" in role " />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="E9Bg74XPPw" role="3cqZAp">
+          <node concept="2OqwBi" id="E9Bg74XRcS" role="3clFbG">
+            <node concept="37vLTw" id="E9Bg74XPPu" role="2Oq$k0">
+              <ref role="3cqZAo" node="E9Bg74Xh2M" resolve="description" />
+            </node>
+            <node concept="liA8E" id="E9Bg74XS5w" role="2OqNvi">
+              <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String)" resolve="append" />
+              <node concept="37vLTw" id="E9Bg74XSDP" role="37wK5m">
+                <ref role="3cqZAo" node="DYlgnA_93V" resolve="actualName" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="E9Bg74XV7v" role="3cqZAp">
+          <node concept="2OqwBi" id="E9Bg74XVDj" role="3clFbG">
+            <node concept="37vLTw" id="E9Bg74XV7t" role="2Oq$k0">
+              <ref role="3cqZAo" node="E9Bg74Xh2M" resolve="description" />
+            </node>
+            <node concept="liA8E" id="E9Bg74XW28" role="2OqNvi">
+              <ref role="37wK5l" to="wyt6:~StringBuilder.toString()" resolve="toString" />
             </node>
           </node>
         </node>

--- a/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.comparator/models/IgnoredProperty.mpsr
+++ b/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.comparator/models/IgnoredProperty.mpsr
@@ -1,13 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <model ref="r:ec874b45-e888-42e6-995a-a298cefdff55(com.mbeddr.mpsutil.comparator.code)" content="root">
   <persistence version="9" />
-  <imports />
+  <imports>
+    <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" implicit="true" />
+  </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
       <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
         <child id="1068498886297" name="rValue" index="37vLTx" />
         <child id="1068498886295" name="lValue" index="37vLTJ" />
       </concept>
+      <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
       <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="nn" index="2tJIrI" />
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
         <child id="1197027771414" name="operand" index="2Oq$k0" />
@@ -49,8 +52,15 @@
       </concept>
       <concept id="1068580123140" name="jetbrains.mps.baseLanguage.structure.ConstructorDeclaration" flags="ig" index="3clFbW" />
       <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
+      </concept>
       <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
         <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
+      </concept>
+      <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
+        <reference id="1107535924139" name="classifier" index="3uigEE" />
       </concept>
       <concept id="1202065242027" name="jetbrains.mps.baseLanguage.structure.DefaultGetAccessor" flags="ng" index="3wEZqW" />
       <concept id="1202077725299" name="jetbrains.mps.baseLanguage.structure.DefaultSetAccessor" flags="ng" index="3xqBd$">
@@ -61,6 +71,7 @@
       </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
       <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
+      <concept id="1178893518978" name="jetbrains.mps.baseLanguage.structure.ThisConstructorInvocation" flags="nn" index="1VxSAg" />
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
       <concept id="6677504323281689838" name="jetbrains.mps.lang.smodel.structure.SConceptType" flags="in" index="3bZ5Sz" />
@@ -96,6 +107,37 @@
       <node concept="17QB3L" id="DYlgnBsv__" role="2RkE6I" />
     </node>
     <node concept="2tJIrI" id="DYlgnBsvA$" role="jymVt" />
+    <node concept="3clFbW" id="E9Bg756o2F" role="jymVt">
+      <node concept="3cqZAl" id="E9Bg756o2G" role="3clF45" />
+      <node concept="3clFbS" id="E9Bg756o2I" role="3clF47">
+        <node concept="1VxSAg" id="E9Bg756oc8" role="3cqZAp">
+          <ref role="37wK5l" node="DYlgnBsvDk" resolve="IgnoredProperty" />
+          <node concept="37vLTw" id="E9Bg756o_q" role="37wK5m">
+            <ref role="3cqZAo" node="E9Bg756o6b" resolve="concept" />
+          </node>
+          <node concept="2OqwBi" id="E9Bg756oRZ" role="37wK5m">
+            <node concept="37vLTw" id="E9Bg756oEl" role="2Oq$k0">
+              <ref role="3cqZAo" node="E9Bg756o6f" resolve="property" />
+            </node>
+            <node concept="liA8E" id="E9Bg756p6A" role="2OqNvi">
+              <ref role="37wK5l" to="c17a:~SProperty.getName()" resolve="getName" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="E9Bg756nY5" role="1B3o_S" />
+      <node concept="37vLTG" id="E9Bg756o6b" role="3clF46">
+        <property role="TrG5h" value="concept" />
+        <node concept="3bZ5Sz" id="E9Bg756o6a" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="E9Bg756o6f" role="3clF46">
+        <property role="TrG5h" value="property" />
+        <node concept="3uibUv" id="E9Bg756o8o" role="1tU5fm">
+          <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="E9Bg756nOy" role="jymVt" />
     <node concept="3clFbW" id="DYlgnBsvDk" role="jymVt">
       <node concept="37vLTG" id="DYlgnBsvEn" role="3clF46">
         <property role="TrG5h" value="concept" />

--- a/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.comparator/models/IgnoredReference.mpsr
+++ b/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.comparator/models/IgnoredReference.mpsr
@@ -1,13 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <model ref="r:ec874b45-e888-42e6-995a-a298cefdff55(com.mbeddr.mpsutil.comparator.code)" content="root">
   <persistence version="9" />
-  <imports />
+  <imports>
+    <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" implicit="true" />
+  </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
       <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
         <child id="1068498886297" name="rValue" index="37vLTx" />
         <child id="1068498886295" name="lValue" index="37vLTJ" />
       </concept>
+      <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
       <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="nn" index="2tJIrI" />
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
         <child id="1197027771414" name="operand" index="2Oq$k0" />
@@ -49,6 +52,10 @@
       </concept>
       <concept id="1068580123140" name="jetbrains.mps.baseLanguage.structure.ConstructorDeclaration" flags="ig" index="3clFbW" />
       <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
+      </concept>
       <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
         <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
       </concept>
@@ -61,8 +68,14 @@
       </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
       <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
+      <concept id="1178893518978" name="jetbrains.mps.baseLanguage.structure.ThisConstructorInvocation" flags="nn" index="1VxSAg" />
+    </language>
+    <language id="774bf8a0-62e5-41e1-af63-f4812e60e48b" name="jetbrains.mps.baseLanguage.checkedDots">
+      <concept id="4079382982702596667" name="jetbrains.mps.baseLanguage.checkedDots.structure.CheckedDotExpression" flags="nn" index="2EnYce" />
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="8758390115029295477" name="jetbrains.mps.lang.smodel.structure.SReferenceType" flags="in" index="2z4iKi" />
+      <concept id="2926695023085807517" name="jetbrains.mps.lang.smodel.structure.Reference_ContainingLinkOperation" flags="nn" index="CsP83" />
       <concept id="6677504323281689838" name="jetbrains.mps.lang.smodel.structure.SConceptType" flags="in" index="3bZ5Sz" />
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
@@ -96,6 +109,38 @@
       <node concept="17QB3L" id="3qPjHtYqUfu" role="2RkE6I" />
     </node>
     <node concept="2tJIrI" id="3qPjHtYqUfv" role="jymVt" />
+    <node concept="3clFbW" id="E9Bg74THqR" role="jymVt">
+      <node concept="37vLTG" id="E9Bg74THqS" role="3clF46">
+        <property role="TrG5h" value="concept" />
+        <node concept="3bZ5Sz" id="E9Bg74THqT" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="E9Bg74THqU" role="3clF46">
+        <property role="TrG5h" value="reference" />
+        <node concept="2z4iKi" id="E9Bg74THAf" role="1tU5fm" />
+      </node>
+      <node concept="3cqZAl" id="E9Bg74THqW" role="3clF45" />
+      <node concept="3clFbS" id="E9Bg74THqX" role="3clF47">
+        <node concept="1VxSAg" id="E9Bg74THGD" role="3cqZAp">
+          <ref role="37wK5l" node="3qPjHtYqUfw" resolve="IgnoredReference" />
+          <node concept="37vLTw" id="E9Bg74TI5I" role="37wK5m">
+            <ref role="3cqZAo" node="E9Bg74THqS" resolve="concept" />
+          </node>
+          <node concept="2EnYce" id="E9Bg74TJ9I" role="37wK5m">
+            <node concept="2OqwBi" id="E9Bg74TIm1" role="2Oq$k0">
+              <node concept="37vLTw" id="E9Bg74TIaJ" role="2Oq$k0">
+                <ref role="3cqZAo" node="E9Bg74THqU" resolve="reference" />
+              </node>
+              <node concept="CsP83" id="E9Bg74TIsg" role="2OqNvi" />
+            </node>
+            <node concept="liA8E" id="E9Bg74TJrc" role="2OqNvi">
+              <ref role="37wK5l" to="c17a:~SNamedElement.getName()" resolve="getName" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="E9Bg74THra" role="1B3o_S" />
+    </node>
+    <node concept="2tJIrI" id="E9Bg74THa6" role="jymVt" />
     <node concept="3clFbW" id="3qPjHtYqUfw" role="jymVt">
       <node concept="37vLTG" id="3qPjHtYqUfx" role="3clF46">
         <property role="TrG5h" value="concept" />

--- a/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.comparator/models/MPSComparatorOptions.mpsr
+++ b/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.comparator/models/MPSComparatorOptions.mpsr
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:ec874b45-e888-42e6-995a-a298cefdff55(com.mbeddr.mpsutil.comparator.code)" content="root">
+  <persistence version="9" />
+  <imports />
+  <registry>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
+      <concept id="1068390468200" name="jetbrains.mps.baseLanguage.structure.FieldDeclaration" flags="ig" index="312cEg" />
+      <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu" />
+      <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
+        <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
+        <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
+      <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT" />
+      <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
+        <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
+      </concept>
+      <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
+        <reference id="1107535924139" name="classifier" index="3uigEE" />
+      </concept>
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
+        <child id="1178549979242" name="visibility" index="1B3o_S" />
+      </concept>
+      <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+    <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
+      <concept id="1151688443754" name="jetbrains.mps.baseLanguage.collections.structure.ListType" flags="in" index="_YKpA">
+        <child id="1151688676805" name="elementType" index="_ZDj9" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="312cEu" id="E9Bg74y9pX">
+    <property role="TrG5h" value="MPSComparatorOptions" />
+    <node concept="312cEg" id="E9Bg74H7ua" role="jymVt">
+      <property role="TrG5h" value="ignoredProperties" />
+      <node concept="_YKpA" id="E9Bg74H7ry" role="1tU5fm">
+        <node concept="3uibUv" id="E9Bg74H7u7" role="_ZDj9">
+          <ref role="3uigEE" node="DYlgnBstFb" resolve="IgnoredProperty" />
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="E9Bg74WAJb" role="1B3o_S" />
+    </node>
+    <node concept="312cEg" id="E9Bg74H7$G" role="jymVt">
+      <property role="TrG5h" value="ignoredReferences" />
+      <node concept="_YKpA" id="E9Bg74H7y1" role="1tU5fm">
+        <node concept="3uibUv" id="E9Bg74H7$D" role="_ZDj9">
+          <ref role="3uigEE" node="2mzdNw3ouFX" resolve="IgnoredReference" />
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="E9Bg74WAJr" role="1B3o_S" />
+    </node>
+    <node concept="312cEg" id="E9Bg74yDJd" role="jymVt">
+      <property role="TrG5h" value="compareChildren" />
+      <node concept="10P_77" id="E9Bg74yDIS" role="1tU5fm" />
+      <node concept="3Tm1VV" id="E9Bg74WAJF" role="1B3o_S" />
+      <node concept="3clFbT" id="E9Bg752Lxz" role="33vP2m" />
+    </node>
+    <node concept="312cEg" id="E9Bg74yDTc" role="jymVt">
+      <property role="TrG5h" value="compareChildrenOfReferences" />
+      <node concept="10P_77" id="E9Bg74yDSP" role="1tU5fm" />
+      <node concept="3Tm1VV" id="E9Bg74WAJS" role="1B3o_S" />
+    </node>
+    <node concept="312cEg" id="E9Bg752xHS" role="jymVt">
+      <property role="TrG5h" value="compareAnnotations" />
+      <node concept="3Tm1VV" id="E9Bg752x$l" role="1B3o_S" />
+      <node concept="10P_77" id="E9Bg752xHG" role="1tU5fm" />
+    </node>
+    <node concept="312cEg" id="E9Bg74yE37" role="jymVt">
+      <property role="TrG5h" value="verbose" />
+      <node concept="10P_77" id="E9Bg74yE2I" role="1tU5fm" />
+      <node concept="3Tm1VV" id="E9Bg74WAK5" role="1B3o_S" />
+    </node>
+    <node concept="3Tm1VV" id="E9Bg74y9pY" role="1B3o_S" />
+  </node>
+</model>
+

--- a/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.comparator/models/MPSNodeComparator.mpsr
+++ b/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.comparator/models/MPSNodeComparator.mpsr
@@ -39,6 +39,9 @@
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
       </concept>
+      <concept id="1197029447546" name="jetbrains.mps.baseLanguage.structure.FieldReferenceOperation" flags="nn" index="2OwXpG">
+        <reference id="1197029500499" name="fieldDeclaration" index="2Oxat5" />
+      </concept>
       <concept id="1201385106094" name="jetbrains.mps.baseLanguage.structure.PropertyReference" flags="nn" index="2S8uIT">
         <reference id="1201385237847" name="property" index="2S8YL0" />
       </concept>
@@ -72,12 +75,16 @@
         <property id="1176718929932" name="isFinal" index="3TUv4t" />
         <child id="1068431790190" name="initializer" index="33vP2m" />
       </concept>
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ng" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
+      </concept>
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
       <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
       <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
       <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
+      <concept id="1225271221393" name="jetbrains.mps.baseLanguage.structure.NPENotEqualsExpression" flags="nn" index="17QLQc" />
       <concept id="1225271283259" name="jetbrains.mps.baseLanguage.structure.NPEEqualsExpression" flags="nn" index="17R0WA" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
@@ -181,6 +188,21 @@
         <child id="1199569916463" name="body" index="1bW5cS" />
       </concept>
     </language>
+    <language id="132aa4d8-a3f7-441c-a7eb-3fce23492c6a" name="jetbrains.mps.baseLanguage.builders">
+      <concept id="7057666463730155278" name="jetbrains.mps.baseLanguage.builders.structure.BuilderCreator" flags="nn" index="g8Q5f" />
+      <concept id="7057666463730155299" name="jetbrains.mps.baseLanguage.builders.structure.BuilderStatement" flags="nn" index="g8Q5y" />
+      <concept id="5389689214217404511" name="jetbrains.mps.baseLanguage.builders.structure.SimpleBuilderPropertyBuilder" flags="ng" index="2tSGmn">
+        <reference id="5389689214217404513" name="declaration" index="2tSGmD" />
+        <child id="5389689214217404512" name="value" index="2tSGmC" />
+      </concept>
+      <concept id="7288041816793071802" name="jetbrains.mps.baseLanguage.builders.structure.SimpleBuilder" flags="ng" index="1b09fh">
+        <reference id="7288041816793071803" name="declaration" index="1b09fg" />
+      </concept>
+      <concept id="7802271442981792228" name="jetbrains.mps.baseLanguage.builders.structure.BuilderContainer" flags="ng" index="1$nplI">
+        <child id="4797501453849924252" name="body" index="GGjiV" />
+        <child id="4797501453850567416" name="builder" index="GIGjv" />
+      </concept>
+    </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
       <concept id="4705942098322609812" name="jetbrains.mps.lang.smodel.structure.EnumMember_IsOperation" flags="ng" index="21noJN">
         <child id="4705942098322609813" name="member" index="21noJM" />
@@ -235,18 +257,8 @@
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
-      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
-        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
-      </concept>
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
-      </concept>
-      <concept id="709746936026466394" name="jetbrains.mps.lang.core.structure.ChildAttribute" flags="ng" index="3VBwX9">
-        <property id="709746936026609031" name="linkId" index="3V$3ak" />
-        <property id="709746936026609029" name="role_DebugInfo" index="3V$3am" />
-      </concept>
-      <concept id="4452961908202556907" name="jetbrains.mps.lang.core.structure.BaseCommentAttribute" flags="ng" index="1X3_iC">
-        <child id="3078666699043039389" name="commentedNode" index="8Wnug" />
       </concept>
     </language>
     <language id="c7fb639f-be78-4307-89b0-b5959c3fa8c8" name="jetbrains.mps.lang.text">
@@ -503,14 +515,139 @@
       <property role="DiZV1" value="false" />
       <property role="2aFKle" value="false" />
       <node concept="3clFbS" id="6fymoI4RKZL" role="3clF47">
+        <node concept="3cpWs8" id="E9Bg74DX3v" role="3cqZAp">
+          <node concept="3cpWsn" id="E9Bg74DX3w" role="3cpWs9">
+            <property role="TrG5h" value="options" />
+            <node concept="3uibUv" id="E9Bg74DHeB" role="1tU5fm">
+              <ref role="3uigEE" node="E9Bg74y9pX" resolve="MPSComparatorOptions" />
+            </node>
+            <node concept="2ShNRf" id="E9Bg74DX3x" role="33vP2m">
+              <node concept="g8Q5f" id="E9Bg74DX3y" role="2ShVmc">
+                <node concept="3clFbS" id="E9Bg74DX3z" role="GGjiV">
+                  <node concept="g8Q5y" id="E9Bg74DX3$" role="3cqZAp">
+                    <node concept="3clFbS" id="E9Bg74DX3_" role="GGjiV" />
+                    <node concept="2tSGmn" id="E9Bg74DX3A" role="GIGjv">
+                      <ref role="2tSGmD" node="E9Bg74yEix" resolve="compareChildren" />
+                      <node concept="37vLTw" id="E9Bg74DX3B" role="2tSGmC">
+                        <ref role="3cqZAo" node="6fymoI4TziN" resolve="compareChildren" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="g8Q5y" id="E9Bg74DX3C" role="3cqZAp">
+                    <node concept="3clFbS" id="E9Bg74DX3D" role="GGjiV" />
+                    <node concept="2tSGmn" id="E9Bg74DX3E" role="GIGjv">
+                      <ref role="2tSGmD" node="E9Bg74yF1r" resolve="verbose" />
+                      <node concept="37vLTw" id="E9Bg74DX3F" role="2tSGmC">
+                        <ref role="3cqZAo" node="6fymoI4RPkl" resolve="verbose" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="1b09fh" id="E9Bg74DX3G" role="GIGjv">
+                  <ref role="1b09fg" node="E9Bg74y6p_" resolve="options" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="E9Bg74Ed5a" role="3cqZAp">
+          <node concept="2OqwBi" id="E9Bg74FuxR" role="3clFbG">
+            <node concept="2OqwBi" id="E9Bg74EfJ_" role="2Oq$k0">
+              <node concept="37vLTw" id="E9Bg74Ed58" role="2Oq$k0">
+                <ref role="3cqZAo" node="E9Bg74DX3w" resolve="options" />
+              </node>
+              <node concept="2OwXpG" id="E9Bg74HicX" role="2OqNvi">
+                <ref role="2Oxat5" node="E9Bg74H7ua" resolve="ignoredProperties" />
+              </node>
+            </node>
+            <node concept="X8dFx" id="E9Bg74FIYq" role="2OqNvi">
+              <node concept="37vLTw" id="E9Bg74FPHw" role="25WWJ7">
+                <ref role="3cqZAo" node="6fymoI4RPkF" resolve="ignoredProperties" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="E9Bg74G4fB" role="3cqZAp">
+          <node concept="2OqwBi" id="E9Bg74Gfkd" role="3clFbG">
+            <node concept="2OqwBi" id="E9Bg74G6iT" role="2Oq$k0">
+              <node concept="37vLTw" id="E9Bg74G4f_" role="2Oq$k0">
+                <ref role="3cqZAo" node="E9Bg74DX3w" resolve="options" />
+              </node>
+              <node concept="2OwXpG" id="E9Bg74HoT1" role="2OqNvi">
+                <ref role="2Oxat5" node="E9Bg74H7$G" resolve="ignoredReferences" />
+              </node>
+            </node>
+            <node concept="X8dFx" id="E9Bg74Gm$p" role="2OqNvi">
+              <node concept="37vLTw" id="E9Bg74Gtrr" role="25WWJ7">
+                <ref role="3cqZAo" node="3qPjHtYsu0a" resolve="ignoredReferences" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="E9Bg74AnU6" role="3cqZAp">
+          <node concept="1rXfSq" id="E9Bg74A$Px" role="3cqZAk">
+            <ref role="37wK5l" node="E9Bg74z9w7" resolve="compare" />
+            <node concept="37vLTw" id="E9Bg74AGEH" role="37wK5m">
+              <ref role="3cqZAo" node="6fymoI4RKZO" resolve="expected" />
+            </node>
+            <node concept="37vLTw" id="E9Bg74AP$b" role="37wK5m">
+              <ref role="3cqZAo" node="6fymoI4RKZQ" resolve="actual" />
+            </node>
+            <node concept="37vLTw" id="E9Bg74DX3H" role="37wK5m">
+              <ref role="3cqZAo" node="E9Bg74DX3w" resolve="options" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="6fymoI4RKZM" role="1B3o_S" />
+      <node concept="3uibUv" id="6fymoI4RKZN" role="3clF45">
+        <ref role="3uigEE" node="494SuRWLRaN" resolve="MPSNodeComparisonResult" />
+      </node>
+      <node concept="37vLTG" id="6fymoI4RKZO" role="3clF46">
+        <property role="TrG5h" value="expected" />
+        <node concept="3Tqbb2" id="6fymoI4RKZP" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="6fymoI4RKZQ" role="3clF46">
+        <property role="TrG5h" value="actual" />
+        <node concept="3Tqbb2" id="6fymoI4RKZR" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="6fymoI4RPkF" role="3clF46">
+        <property role="TrG5h" value="ignoredProperties" />
+        <node concept="_YKpA" id="6fymoI4RPkG" role="1tU5fm">
+          <node concept="3uibUv" id="6fymoI4RPkH" role="_ZDj9">
+            <ref role="3uigEE" node="DYlgnBstFb" resolve="IgnoredProperty" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="3qPjHtYsu0a" role="3clF46">
+        <property role="TrG5h" value="ignoredReferences" />
+        <node concept="_YKpA" id="3qPjHtYsu0b" role="1tU5fm">
+          <node concept="3uibUv" id="2mzdNw3oDkJ" role="_ZDj9">
+            <ref role="3uigEE" node="2mzdNw3ouFX" resolve="IgnoredReference" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="6fymoI4TziN" role="3clF46">
+        <property role="TrG5h" value="compareChildren" />
+        <node concept="10P_77" id="6fymoI4Tzwz" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="6fymoI4RPkl" role="3clF46">
+        <property role="TrG5h" value="verbose" />
+        <node concept="10P_77" id="6fymoI4RPm2" role="1tU5fm" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="E9Bg74yF71" role="jymVt" />
+    <node concept="2YIFZL" id="E9Bg74z9w7" role="jymVt">
+      <property role="TrG5h" value="compare" />
+      <node concept="3clFbS" id="E9Bg74z9wa" role="3clF47">
         <node concept="3clFbF" id="7ESlTHsb7Pc" role="3cqZAp">
           <node concept="1rXfSq" id="7ESlTHsb7Pa" role="3clFbG">
             <ref role="37wK5l" node="7ESlTHsaRAN" resolve="updateExpectedActual" />
             <node concept="37vLTw" id="7ESlTHsba2A" role="37wK5m">
-              <ref role="3cqZAo" node="6fymoI4RKZO" resolve="expected" />
+              <ref role="3cqZAo" node="E9Bg74ztp3" resolve="expected" />
             </node>
             <node concept="37vLTw" id="7ESlTHsbajW" role="37wK5m">
-              <ref role="3cqZAo" node="6fymoI4RKZQ" resolve="actual" />
+              <ref role="3cqZAo" node="E9Bg74zxp9" resolve="actual" />
             </node>
           </node>
         </node>
@@ -523,10 +660,10 @@
             <node concept="2ShNRf" id="7UDYbVGNc4d" role="33vP2m">
               <node concept="1pGfFk" id="7UDYbVGNc4e" role="2ShVmc">
                 <ref role="37wK5l" node="DYlgnAAtW3" resolve="MPSNodeComparisonResult" />
-                <node concept="37vLTw" id="6fymoI4Uj9r" role="37wK5m">
+                <node concept="37vLTw" id="E9Bg74zNhJ" role="37wK5m">
                   <ref role="3cqZAo" node="6fymoI4U8cX" resolve="EXPECTED" />
                 </node>
-                <node concept="37vLTw" id="6fymoI4Ujkf" role="37wK5m">
+                <node concept="37vLTw" id="E9Bg74zNk9" role="37wK5m">
                   <ref role="3cqZAo" node="6fymoI4Uf5W" resolve="ACTUAL" />
                 </node>
               </node>
@@ -538,12 +675,12 @@
             <node concept="3clFbC" id="1iOzU6lb$yu" role="3uHU7w">
               <node concept="10Nm6u" id="1iOzU6lb$$S" role="3uHU7w" />
               <node concept="37vLTw" id="1iOzU6lb$vx" role="3uHU7B">
-                <ref role="3cqZAo" node="6fymoI4RKZO" resolve="expected" />
+                <ref role="3cqZAo" node="E9Bg74ztp3" resolve="expected" />
               </node>
             </node>
             <node concept="3clFbC" id="7UDYbVGNc40" role="3uHU7B">
               <node concept="37vLTw" id="7UDYbVGNc42" role="3uHU7B">
-                <ref role="3cqZAo" node="6fymoI4RKZQ" resolve="actual" />
+                <ref role="3cqZAo" node="E9Bg74zxp9" resolve="actual" />
               </node>
               <node concept="10Nm6u" id="7UDYbVGNc41" role="3uHU7w" />
             </node>
@@ -560,15 +697,15 @@
                     <node concept="1pGfFk" id="1iOzU6lbsuD" role="2ShVmc">
                       <ref role="37wK5l" node="DYlgnA$L0T" resolve="DifferentConceptDifference" />
                       <node concept="37vLTw" id="1iOzU6lbsuE" role="37wK5m">
-                        <ref role="3cqZAo" node="6fymoI4RKZO" resolve="expected" />
+                        <ref role="3cqZAo" node="E9Bg74ztp3" resolve="expected" />
                       </node>
                       <node concept="37vLTw" id="1iOzU6lbsuF" role="37wK5m">
-                        <ref role="3cqZAo" node="6fymoI4RKZQ" resolve="actual" />
+                        <ref role="3cqZAo" node="E9Bg74zxp9" resolve="actual" />
                       </node>
-                      <node concept="37vLTw" id="6fymoI4Ujvc" role="37wK5m">
+                      <node concept="37vLTw" id="E9Bg74zNmz" role="37wK5m">
                         <ref role="3cqZAo" node="6fymoI4U8cX" resolve="EXPECTED" />
                       </node>
-                      <node concept="37vLTw" id="6fymoI4Ujzg" role="37wK5m">
+                      <node concept="37vLTw" id="E9Bg74zNoX" role="37wK5m">
                         <ref role="3cqZAo" node="6fymoI4Uf5W" resolve="ACTUAL" />
                       </node>
                     </node>
@@ -618,10 +755,10 @@
           </node>
           <node concept="17R0WA" id="7tPee3dgXvb" role="3clFbw">
             <node concept="37vLTw" id="7tPee3dh0Je" role="3uHU7w">
-              <ref role="3cqZAo" node="6fymoI4RKZQ" resolve="actual" />
+              <ref role="3cqZAo" node="E9Bg74zxp9" resolve="actual" />
             </node>
             <node concept="37vLTw" id="7tPee3dgU9T" role="3uHU7B">
-              <ref role="3cqZAo" node="6fymoI4RKZO" resolve="expected" />
+              <ref role="3cqZAo" node="E9Bg74ztp3" resolve="expected" />
             </node>
           </node>
         </node>
@@ -633,7 +770,7 @@
                 <node concept="3cpWs3" id="7UDYbVGNc4l" role="37wK5m">
                   <node concept="2OqwBi" id="7UDYbVGNc4m" role="3uHU7w">
                     <node concept="37vLTw" id="7UDYbVGNc4n" role="2Oq$k0">
-                      <ref role="3cqZAo" node="6fymoI4RKZQ" resolve="actual" />
+                      <ref role="3cqZAo" node="E9Bg74zxp9" resolve="actual" />
                     </node>
                     <node concept="2yIwOk" id="7UDYbVGNc4o" role="2OqNvi" />
                   </node>
@@ -642,7 +779,7 @@
                       <property role="Xl_RC" value=" = " />
                     </node>
                     <node concept="3cpWs3" id="7UDYbVGNc4r" role="3uHU7B">
-                      <node concept="37vLTw" id="6fymoI4UjIF" role="3uHU7w">
+                      <node concept="37vLTw" id="E9Bg74zNrn" role="3uHU7w">
                         <ref role="3cqZAo" node="6fymoI4Uf5W" resolve="ACTUAL" />
                       </node>
                       <node concept="3cpWs3" id="7UDYbVGNc4t" role="3uHU7B">
@@ -655,14 +792,14 @@
                               <node concept="Xl_RD" id="7UDYbVGNc4y" role="3uHU7B">
                                 <property role="Xl_RC" value="different concepts " />
                               </node>
-                              <node concept="37vLTw" id="6fymoI4UjBm" role="3uHU7w">
+                              <node concept="37vLTw" id="E9Bg74zNtL" role="3uHU7w">
                                 <ref role="3cqZAo" node="6fymoI4U8cX" resolve="EXPECTED" />
                               </node>
                             </node>
                           </node>
                           <node concept="2OqwBi" id="7UDYbVGNc4$" role="3uHU7w">
                             <node concept="37vLTw" id="7UDYbVGNc4_" role="2Oq$k0">
-                              <ref role="3cqZAo" node="6fymoI4RKZO" resolve="expected" />
+                              <ref role="3cqZAo" node="E9Bg74ztp3" resolve="expected" />
                             </node>
                             <node concept="2yIwOk" id="7UDYbVGNc4A" role="2OqNvi" />
                           </node>
@@ -675,13 +812,18 @@
                   </node>
                 </node>
                 <node concept="37vLTw" id="7UDYbVGNc4C" role="37wK5m">
-                  <ref role="3cqZAo" node="6fymoI4RKZO" resolve="expected" />
+                  <ref role="3cqZAo" node="E9Bg74ztp3" resolve="expected" />
                 </node>
                 <node concept="37vLTw" id="7UDYbVGNc4D" role="37wK5m">
-                  <ref role="3cqZAo" node="6fymoI4RKZQ" resolve="actual" />
+                  <ref role="3cqZAo" node="E9Bg74zxp9" resolve="actual" />
                 </node>
-                <node concept="37vLTw" id="6fymoI4UqSi" role="37wK5m">
-                  <ref role="3cqZAo" node="6fymoI4RPkl" resolve="verbose" />
+                <node concept="2OqwBi" id="E9Bg74zWSI" role="37wK5m">
+                  <node concept="37vLTw" id="6fymoI4UqSi" role="2Oq$k0">
+                    <ref role="3cqZAo" node="E9Bg74zlwI" resolve="options" />
+                  </node>
+                  <node concept="2OwXpG" id="E9Bg74$1eJ" role="2OqNvi">
+                    <ref role="2Oxat5" node="E9Bg74yE37" resolve="verbose" />
+                  </node>
                 </node>
               </node>
             </node>
@@ -696,15 +838,15 @@
                     <node concept="1pGfFk" id="7UDYbVGNc4J" role="2ShVmc">
                       <ref role="37wK5l" node="DYlgnA$L0T" resolve="DifferentConceptDifference" />
                       <node concept="37vLTw" id="7UDYbVGNc4K" role="37wK5m">
-                        <ref role="3cqZAo" node="6fymoI4RKZO" resolve="expected" />
+                        <ref role="3cqZAo" node="E9Bg74ztp3" resolve="expected" />
                       </node>
                       <node concept="37vLTw" id="7UDYbVGNc4L" role="37wK5m">
-                        <ref role="3cqZAo" node="6fymoI4RKZQ" resolve="actual" />
+                        <ref role="3cqZAo" node="E9Bg74zxp9" resolve="actual" />
                       </node>
-                      <node concept="37vLTw" id="6fymoI4UrzK" role="37wK5m">
+                      <node concept="37vLTw" id="E9Bg74zNwb" role="37wK5m">
                         <ref role="3cqZAo" node="6fymoI4U8cX" resolve="EXPECTED" />
                       </node>
-                      <node concept="37vLTw" id="6fymoI4Us8p" role="37wK5m">
+                      <node concept="37vLTw" id="E9Bg74zNy_" role="37wK5m">
                         <ref role="3cqZAo" node="6fymoI4Uf5W" resolve="ACTUAL" />
                       </node>
                     </node>
@@ -713,23 +855,18 @@
               </node>
             </node>
           </node>
-          <node concept="3fqX7Q" id="26TZFrzEB5T" role="3clFbw">
-            <node concept="2OqwBi" id="26TZFrzEB5V" role="3fr31v">
-              <node concept="2OqwBi" id="26TZFrzEB5W" role="2Oq$k0">
-                <node concept="37vLTw" id="26TZFrzEB5X" role="2Oq$k0">
-                  <ref role="3cqZAo" node="6fymoI4RKZO" resolve="expected" />
-                </node>
-                <node concept="2yIwOk" id="26TZFrzEB5Y" role="2OqNvi" />
+          <node concept="17QLQc" id="E9Bg75hYMf" role="3clFbw">
+            <node concept="2OqwBi" id="26TZFrzEB5W" role="3uHU7B">
+              <node concept="37vLTw" id="26TZFrzEB5X" role="2Oq$k0">
+                <ref role="3cqZAo" node="E9Bg74ztp3" resolve="expected" />
               </node>
-              <node concept="liA8E" id="26TZFrzEB5Z" role="2OqNvi">
-                <ref role="37wK5l" to="wyt6:~Object.equals(java.lang.Object)" resolve="equals" />
-                <node concept="2OqwBi" id="26TZFrzEB60" role="37wK5m">
-                  <node concept="37vLTw" id="26TZFrzEB61" role="2Oq$k0">
-                    <ref role="3cqZAo" node="6fymoI4RKZQ" resolve="actual" />
-                  </node>
-                  <node concept="2yIwOk" id="26TZFrzEB62" role="2OqNvi" />
-                </node>
+              <node concept="2yIwOk" id="26TZFrzEB5Y" role="2OqNvi" />
+            </node>
+            <node concept="2OqwBi" id="26TZFrzEB60" role="3uHU7w">
+              <node concept="37vLTw" id="26TZFrzEB61" role="2Oq$k0">
+                <ref role="3cqZAo" node="E9Bg74zxp9" resolve="actual" />
               </node>
+              <node concept="2yIwOk" id="26TZFrzEB62" role="2OqNvi" />
             </node>
           </node>
           <node concept="9aQIb" id="7UDYbVGNc4V" role="9aQIa">
@@ -740,8 +877,13 @@
                   <node concept="Xl_RD" id="7UDYbVGNc4Z" role="37wK5m">
                     <property role="Xl_RC" value="same concept" />
                   </node>
-                  <node concept="37vLTw" id="6fymoI4U_Gk" role="37wK5m">
-                    <ref role="3cqZAo" node="6fymoI4RPkl" resolve="verbose" />
+                  <node concept="2OqwBi" id="E9Bg74$6VG" role="37wK5m">
+                    <node concept="37vLTw" id="6fymoI4U_Gk" role="2Oq$k0">
+                      <ref role="3cqZAo" node="E9Bg74zlwI" resolve="options" />
+                    </node>
+                    <node concept="2OwXpG" id="E9Bg74$bn5" role="2OqNvi">
+                      <ref role="2Oxat5" node="E9Bg74yE37" resolve="verbose" />
+                    </node>
                   </node>
                 </node>
               </node>
@@ -749,19 +891,16 @@
                 <node concept="1rXfSq" id="6fymoI4VO_i" role="3clFbG">
                   <ref role="37wK5l" node="6fymoI4UAep" resolve="fillDifferencesOnProperties" />
                   <node concept="37vLTw" id="6fymoI4VOIQ" role="37wK5m">
-                    <ref role="3cqZAo" node="6fymoI4RKZO" resolve="expected" />
+                    <ref role="3cqZAo" node="E9Bg74ztp3" resolve="expected" />
                   </node>
                   <node concept="37vLTw" id="6fymoI4VOIR" role="37wK5m">
-                    <ref role="3cqZAo" node="6fymoI4RKZQ" resolve="actual" />
+                    <ref role="3cqZAo" node="E9Bg74zxp9" resolve="actual" />
                   </node>
                   <node concept="37vLTw" id="6fymoI4VOIS" role="37wK5m">
                     <ref role="3cqZAo" node="7UDYbVGNc4b" resolve="result" />
                   </node>
-                  <node concept="37vLTw" id="6fymoI4VVjf" role="37wK5m">
-                    <ref role="3cqZAo" node="6fymoI4RPkF" resolve="ignoredProperties" />
-                  </node>
-                  <node concept="37vLTw" id="6fymoI4VVTQ" role="37wK5m">
-                    <ref role="3cqZAo" node="6fymoI4RPkl" resolve="verbose" />
+                  <node concept="37vLTw" id="E9Bg74$Coa" role="37wK5m">
+                    <ref role="3cqZAo" node="E9Bg74zlwI" resolve="options" />
                   </node>
                 </node>
               </node>
@@ -769,49 +908,45 @@
                 <node concept="1rXfSq" id="6fymoI4W$$7" role="3clFbG">
                   <ref role="37wK5l" node="6fymoI4W4Lw" resolve="fillDifferencesOnReferences" />
                   <node concept="37vLTw" id="6fymoI4W$I9" role="37wK5m">
-                    <ref role="3cqZAo" node="6fymoI4RKZO" resolve="expected" />
+                    <ref role="3cqZAo" node="E9Bg74ztp3" resolve="expected" />
                   </node>
                   <node concept="37vLTw" id="6fymoI4W$SA" role="37wK5m">
-                    <ref role="3cqZAo" node="6fymoI4RKZQ" resolve="actual" />
+                    <ref role="3cqZAo" node="E9Bg74zxp9" resolve="actual" />
                   </node>
                   <node concept="37vLTw" id="6fymoI4W_3q" role="37wK5m">
                     <ref role="3cqZAo" node="7UDYbVGNc4b" resolve="result" />
                   </node>
-                  <node concept="37vLTw" id="6fymoI4W_n5" role="37wK5m">
-                    <ref role="3cqZAo" node="6fymoI4RPkF" resolve="ignoredProperties" />
-                  </node>
-                  <node concept="37vLTw" id="3qPjHtYsPiY" role="37wK5m">
-                    <ref role="3cqZAo" node="3qPjHtYsu0a" resolve="ignoredReferences" />
-                  </node>
-                  <node concept="37vLTw" id="6fymoI4W_ai" role="37wK5m">
-                    <ref role="3cqZAo" node="6fymoI4RPkl" resolve="verbose" />
+                  <node concept="37vLTw" id="E9Bg74$TJb" role="37wK5m">
+                    <ref role="3cqZAo" node="E9Bg74zlwI" resolve="options" />
                   </node>
                 </node>
               </node>
-              <node concept="1X3_iC" id="6fymoI4WQeO" role="lGtFl">
-                <property role="3V$3am" value="statement" />
-                <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-                <node concept="3clFbF" id="6fymoI4WPiJ" role="8Wnug">
-                  <node concept="1rXfSq" id="6fymoI4WPiH" role="3clFbG">
-                    <ref role="37wK5l" node="6fymoI4W7$J" resolve="fillDifferencesOnAnnotations" />
-                    <node concept="37vLTw" id="6fymoI4WPr2" role="37wK5m">
-                      <ref role="3cqZAo" node="6fymoI4RKZO" resolve="expected" />
+              <node concept="3clFbJ" id="E9Bg752XEj" role="3cqZAp">
+                <node concept="3clFbS" id="E9Bg752XEl" role="3clFbx">
+                  <node concept="3clFbF" id="E9Bg753kwc" role="3cqZAp">
+                    <node concept="1rXfSq" id="6fymoI4WPiH" role="3clFbG">
+                      <ref role="37wK5l" node="6fymoI4W7$J" resolve="fillDifferencesOnAnnotations" />
+                      <node concept="37vLTw" id="6fymoI4WPr2" role="37wK5m">
+                        <ref role="3cqZAo" node="E9Bg74ztp3" resolve="expected" />
+                      </node>
+                      <node concept="37vLTw" id="6fymoI4WPwx" role="37wK5m">
+                        <ref role="3cqZAo" node="E9Bg74zxp9" resolve="actual" />
+                      </node>
+                      <node concept="37vLTw" id="6fymoI4WPAc" role="37wK5m">
+                        <ref role="3cqZAo" node="7UDYbVGNc4b" resolve="result" />
+                      </node>
+                      <node concept="37vLTw" id="E9Bg753MBx" role="37wK5m">
+                        <ref role="3cqZAo" node="E9Bg74zlwI" resolve="options" />
+                      </node>
                     </node>
-                    <node concept="37vLTw" id="6fymoI4WPwx" role="37wK5m">
-                      <ref role="3cqZAo" node="6fymoI4RKZQ" resolve="actual" />
-                    </node>
-                    <node concept="37vLTw" id="6fymoI4WPAc" role="37wK5m">
-                      <ref role="3cqZAo" node="7UDYbVGNc4b" resolve="result" />
-                    </node>
-                    <node concept="37vLTw" id="6fymoI4WPLm" role="37wK5m">
-                      <ref role="3cqZAo" node="6fymoI4RPkF" resolve="ignoredProperties" />
-                    </node>
-                    <node concept="37vLTw" id="6fymoI4WPXq" role="37wK5m">
-                      <ref role="3cqZAo" node="6fymoI4TziN" resolve="compareChildren" />
-                    </node>
-                    <node concept="37vLTw" id="6fymoI4WQ5X" role="37wK5m">
-                      <ref role="3cqZAo" node="6fymoI4RPkl" resolve="verbose" />
-                    </node>
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="E9Bg7535Ii" role="3clFbw">
+                  <node concept="37vLTw" id="E9Bg7532VW" role="2Oq$k0">
+                    <ref role="3cqZAo" node="E9Bg74zlwI" resolve="options" />
+                  </node>
+                  <node concept="2OwXpG" id="E9Bg753aWD" role="2OqNvi">
+                    <ref role="2Oxat5" node="E9Bg752xHS" resolve="compareAnnotations" />
                   </node>
                 </node>
               </node>
@@ -822,31 +957,27 @@
                     <node concept="1rXfSq" id="6fymoI4Xfs7" role="3clFbG">
                       <ref role="37wK5l" node="6fymoI4WamM" resolve="fillDifferencesOnChildren" />
                       <node concept="37vLTw" id="6fymoI4XfAL" role="37wK5m">
-                        <ref role="3cqZAo" node="6fymoI4RKZO" resolve="expected" />
+                        <ref role="3cqZAo" node="E9Bg74ztp3" resolve="expected" />
                       </node>
                       <node concept="37vLTw" id="6fymoI4XfOk" role="37wK5m">
-                        <ref role="3cqZAo" node="6fymoI4RKZQ" resolve="actual" />
+                        <ref role="3cqZAo" node="E9Bg74zxp9" resolve="actual" />
                       </node>
                       <node concept="37vLTw" id="6fymoI4Xg0Q" role="37wK5m">
                         <ref role="3cqZAo" node="7UDYbVGNc4b" resolve="result" />
                       </node>
-                      <node concept="37vLTw" id="6fymoI4Xgf9" role="37wK5m">
-                        <ref role="3cqZAo" node="6fymoI4RPkF" resolve="ignoredProperties" />
-                      </node>
-                      <node concept="37vLTw" id="3qPjHtYsQZu" role="37wK5m">
-                        <ref role="3cqZAo" node="3qPjHtYsu0a" resolve="ignoredReferences" />
-                      </node>
-                      <node concept="37vLTw" id="6fymoI4Xgs_" role="37wK5m">
-                        <ref role="3cqZAo" node="6fymoI4TziN" resolve="compareChildren" />
-                      </node>
-                      <node concept="37vLTw" id="6fymoI4XgE1" role="37wK5m">
-                        <ref role="3cqZAo" node="6fymoI4RPkl" resolve="verbose" />
+                      <node concept="37vLTw" id="E9Bg74_6KK" role="37wK5m">
+                        <ref role="3cqZAo" node="E9Bg74zlwI" resolve="options" />
                       </node>
                     </node>
                   </node>
                 </node>
-                <node concept="37vLTw" id="7UDYbVGNfvx" role="3clFbw">
-                  <ref role="3cqZAo" node="6fymoI4TziN" resolve="compareChildren" />
+                <node concept="2OqwBi" id="E9Bg74_gVM" role="3clFbw">
+                  <node concept="37vLTw" id="7UDYbVGNfvx" role="2Oq$k0">
+                    <ref role="3cqZAo" node="E9Bg74zlwI" resolve="options" />
+                  </node>
+                  <node concept="2OwXpG" id="E9Bg74_lcY" role="2OqNvi">
+                    <ref role="2Oxat5" node="E9Bg74yDJd" resolve="compareChildren" />
+                  </node>
                 </node>
               </node>
             </node>
@@ -858,41 +989,23 @@
           </node>
         </node>
       </node>
-      <node concept="3Tm1VV" id="6fymoI4RKZM" role="1B3o_S" />
-      <node concept="3uibUv" id="6fymoI4RKZN" role="3clF45">
+      <node concept="3Tm1VV" id="E9Bg74Vp1o" role="1B3o_S" />
+      <node concept="3uibUv" id="E9Bg74z5yh" role="3clF45">
         <ref role="3uigEE" node="494SuRWLRaN" resolve="MPSNodeComparisonResult" />
       </node>
-      <node concept="37vLTG" id="6fymoI4RKZO" role="3clF46">
+      <node concept="37vLTG" id="E9Bg74ztp3" role="3clF46">
         <property role="TrG5h" value="expected" />
-        <node concept="3Tqbb2" id="6fymoI4RKZP" role="1tU5fm" />
+        <node concept="3Tqbb2" id="E9Bg74ztp4" role="1tU5fm" />
       </node>
-      <node concept="37vLTG" id="6fymoI4RKZQ" role="3clF46">
+      <node concept="37vLTG" id="E9Bg74zxp9" role="3clF46">
         <property role="TrG5h" value="actual" />
-        <node concept="3Tqbb2" id="6fymoI4RKZR" role="1tU5fm" />
+        <node concept="3Tqbb2" id="E9Bg74zxpa" role="1tU5fm" />
       </node>
-      <node concept="37vLTG" id="6fymoI4RPkF" role="3clF46">
-        <property role="TrG5h" value="ignoredProperties" />
-        <node concept="_YKpA" id="6fymoI4RPkG" role="1tU5fm">
-          <node concept="3uibUv" id="6fymoI4RPkH" role="_ZDj9">
-            <ref role="3uigEE" node="DYlgnBstFb" resolve="IgnoredProperty" />
-          </node>
+      <node concept="37vLTG" id="E9Bg74zlwI" role="3clF46">
+        <property role="TrG5h" value="options" />
+        <node concept="3uibUv" id="E9Bg74zlwH" role="1tU5fm">
+          <ref role="3uigEE" node="E9Bg74y9pX" resolve="MPSComparatorOptions" />
         </node>
-      </node>
-      <node concept="37vLTG" id="3qPjHtYsu0a" role="3clF46">
-        <property role="TrG5h" value="ignoredReferences" />
-        <node concept="_YKpA" id="3qPjHtYsu0b" role="1tU5fm">
-          <node concept="3uibUv" id="2mzdNw3oDkJ" role="_ZDj9">
-            <ref role="3uigEE" node="2mzdNw3ouFX" resolve="IgnoredReference" />
-          </node>
-        </node>
-      </node>
-      <node concept="37vLTG" id="6fymoI4TziN" role="3clF46">
-        <property role="TrG5h" value="compareChildren" />
-        <node concept="10P_77" id="6fymoI4Tzwz" role="1tU5fm" />
-      </node>
-      <node concept="37vLTG" id="6fymoI4RPkl" role="3clF46">
-        <property role="TrG5h" value="verbose" />
-        <node concept="10P_77" id="6fymoI4RPm2" role="1tU5fm" />
       </node>
     </node>
     <node concept="2tJIrI" id="6fymoI4RpiD" role="jymVt" />
@@ -1216,8 +1329,13 @@
                             <ref role="2Gs0qQ" node="DYlgnAA7xB" resolve="p" />
                           </node>
                         </node>
-                        <node concept="37vLTw" id="6fymoI4Vior" role="37wK5m">
-                          <ref role="3cqZAo" node="6fymoI4UGH8" resolve="verbose" />
+                        <node concept="2OqwBi" id="E9Bg74JesG" role="37wK5m">
+                          <node concept="37vLTw" id="E9Bg74JesH" role="2Oq$k0">
+                            <ref role="3cqZAo" node="E9Bg74I4Wp" resolve="options" />
+                          </node>
+                          <node concept="2OwXpG" id="E9Bg74JesI" role="2OqNvi">
+                            <ref role="2Oxat5" node="E9Bg74yE37" resolve="verbose" />
+                          </node>
                         </node>
                       </node>
                     </node>
@@ -1389,8 +1507,13 @@
                             <node concept="37vLTw" id="QGTX7emcoB" role="37wK5m">
                               <ref role="3cqZAo" node="DYlgnAA7yf" resolve="actual" />
                             </node>
-                            <node concept="37vLTw" id="6fymoI4V56G" role="37wK5m">
-                              <ref role="3cqZAo" node="6fymoI4UGH8" resolve="verbose" />
+                            <node concept="2OqwBi" id="E9Bg74JuSm" role="37wK5m">
+                              <node concept="37vLTw" id="E9Bg74JuSn" role="2Oq$k0">
+                                <ref role="3cqZAo" node="E9Bg74I4Wp" resolve="options" />
+                              </node>
+                              <node concept="2OwXpG" id="E9Bg74JuSo" role="2OqNvi">
+                                <ref role="2Oxat5" node="E9Bg74yE37" resolve="verbose" />
+                              </node>
                             </node>
                           </node>
                         </node>
@@ -1416,13 +1539,8 @@
                                   <node concept="37vLTw" id="6fymoI4UZZi" role="37wK5m">
                                     <ref role="3cqZAo" node="6fymoI4Uf5W" resolve="ACTUAL" />
                                   </node>
-                                  <node concept="2OqwBi" id="4_9e_ML91wE" role="37wK5m">
-                                    <node concept="2GrUjf" id="DYlgnAT_us" role="2Oq$k0">
-                                      <ref role="2Gs0qQ" node="DYlgnAA7xB" resolve="p" />
-                                    </node>
-                                    <node concept="liA8E" id="4_9e_ML967F" role="2OqNvi">
-                                      <ref role="37wK5l" to="c17a:~SProperty.getName()" resolve="getName" />
-                                    </node>
+                                  <node concept="2GrUjf" id="DYlgnAT_us" role="37wK5m">
+                                    <ref role="2Gs0qQ" node="DYlgnAA7xB" resolve="p" />
                                   </node>
                                 </node>
                               </node>
@@ -1446,15 +1564,12 @@
                   </node>
                   <node concept="2OqwBi" id="2lpUxXMW2VL" role="3clFbw">
                     <node concept="2OqwBi" id="2lpUxXMVqe3" role="2Oq$k0">
-                      <node concept="37vLTw" id="2lpUxXMVp0q" role="2Oq$k0">
-                        <ref role="3cqZAo" node="6fymoI4UGH3" resolve="ignoredProperties" />
-                      </node>
                       <node concept="3zZkjj" id="2lpUxXMVVbe" role="2OqNvi">
                         <node concept="1bVj0M" id="2lpUxXMVVbg" role="23t8la">
                           <node concept="3clFbS" id="2lpUxXMVVbh" role="1bW5cS">
                             <node concept="3clFbF" id="2lpUxXMVVbi" role="3cqZAp">
-                              <node concept="2OqwBi" id="2lpUxXMVVbj" role="3clFbG">
-                                <node concept="2OqwBi" id="2lpUxXMVVbk" role="2Oq$k0">
+                              <node concept="17R0WA" id="E9Bg75ilbD" role="3clFbG">
+                                <node concept="2OqwBi" id="2lpUxXMVVbk" role="3uHU7B">
                                   <node concept="37vLTw" id="2lpUxXMVVbl" role="2Oq$k0">
                                     <ref role="3cqZAo" node="2lpUxXMVVbp" resolve="it" />
                                   </node>
@@ -1462,15 +1577,12 @@
                                     <ref role="2S8YL0" node="DYlgnBsvwB" resolve="property" />
                                   </node>
                                 </node>
-                                <node concept="liA8E" id="2lpUxXMVVbn" role="2OqNvi">
-                                  <ref role="37wK5l" to="wyt6:~String.equals(java.lang.Object)" resolve="equals" />
-                                  <node concept="2OqwBi" id="4_9e_ML9shG" role="37wK5m">
-                                    <node concept="2GrUjf" id="2lpUxXMVVbo" role="2Oq$k0">
-                                      <ref role="2Gs0qQ" node="DYlgnAA7xB" resolve="p" />
-                                    </node>
-                                    <node concept="liA8E" id="4_9e_ML9xdr" role="2OqNvi">
-                                      <ref role="37wK5l" to="c17a:~SProperty.getName()" resolve="getName" />
-                                    </node>
+                                <node concept="2OqwBi" id="4_9e_ML9shG" role="3uHU7w">
+                                  <node concept="2GrUjf" id="2lpUxXMVVbo" role="2Oq$k0">
+                                    <ref role="2Gs0qQ" node="DYlgnAA7xB" resolve="p" />
+                                  </node>
+                                  <node concept="liA8E" id="4_9e_ML9xdr" role="2OqNvi">
+                                    <ref role="37wK5l" to="c17a:~SProperty.getName()" resolve="getName" />
                                   </node>
                                 </node>
                               </node>
@@ -1480,6 +1592,14 @@
                             <property role="TrG5h" value="it" />
                             <node concept="2jxLKc" id="2lpUxXMVVbq" role="1tU5fm" />
                           </node>
+                        </node>
+                      </node>
+                      <node concept="2OqwBi" id="E9Bg74J7nR" role="2Oq$k0">
+                        <node concept="37vLTw" id="E9Bg74J7nS" role="2Oq$k0">
+                          <ref role="3cqZAo" node="E9Bg74I4Wp" resolve="options" />
+                        </node>
+                        <node concept="2OwXpG" id="E9Bg74J7nT" role="2OqNvi">
+                          <ref role="2Oxat5" node="E9Bg74H7ua" resolve="ignoredProperties" />
                         </node>
                       </node>
                     </node>
@@ -1496,8 +1616,13 @@
                   <node concept="37vLTw" id="780iRhLEhep" role="37wK5m">
                     <ref role="3cqZAo" node="DYlgnAA7yf" resolve="actual" />
                   </node>
-                  <node concept="37vLTw" id="780iRhLEhiW" role="37wK5m">
-                    <ref role="3cqZAo" node="6fymoI4UGH3" resolve="ignoredProperties" />
+                  <node concept="2OqwBi" id="E9Bg74IJDV" role="37wK5m">
+                    <node concept="37vLTw" id="780iRhLEhiW" role="2Oq$k0">
+                      <ref role="3cqZAo" node="E9Bg74I4Wp" resolve="options" />
+                    </node>
+                    <node concept="2OwXpG" id="E9Bg74IZ3X" role="2OqNvi">
+                      <ref role="2Oxat5" node="E9Bg74H7ua" resolve="ignoredProperties" />
+                    </node>
                   </node>
                   <node concept="2OqwBi" id="4_9e_ML8I6m" role="37wK5m">
                     <node concept="2GrUjf" id="780iRhLEiGK" role="2Oq$k0">
@@ -1527,17 +1652,11 @@
           <ref role="3uigEE" node="494SuRWLRaN" resolve="MPSNodeComparisonResult" />
         </node>
       </node>
-      <node concept="37vLTG" id="6fymoI4UGH3" role="3clF46">
-        <property role="TrG5h" value="ignoredProperties" />
-        <node concept="_YKpA" id="6fymoI4UGH4" role="1tU5fm">
-          <node concept="3uibUv" id="6fymoI4UGH5" role="_ZDj9">
-            <ref role="3uigEE" node="DYlgnBstFb" resolve="IgnoredProperty" />
-          </node>
+      <node concept="37vLTG" id="E9Bg74I4Wp" role="3clF46">
+        <property role="TrG5h" value="options" />
+        <node concept="3uibUv" id="E9Bg74Ieo8" role="1tU5fm">
+          <ref role="3uigEE" node="E9Bg74y9pX" resolve="MPSComparatorOptions" />
         </node>
-      </node>
-      <node concept="37vLTG" id="6fymoI4UGH8" role="3clF46">
-        <property role="TrG5h" value="verbose" />
-        <node concept="10P_77" id="6fymoI4UGH9" role="1tU5fm" />
       </node>
       <node concept="3cqZAl" id="DYlgnAA7x9" role="3clF45" />
       <node concept="3Tm6S6" id="DYlgnAA7xa" role="1B3o_S" />
@@ -1561,19 +1680,16 @@
                   <node concept="3clFbS" id="780iRhLF7qG" role="1bW5cS">
                     <node concept="3clFbF" id="780iRhLF7Hc" role="3cqZAp">
                       <node concept="1Wc70l" id="780iRhLF7He" role="3clFbG">
-                        <node concept="2OqwBi" id="780iRhLF7Hf" role="3uHU7w">
-                          <node concept="37vLTw" id="780iRhLF7Hg" role="2Oq$k0">
+                        <node concept="17R0WA" id="E9Bg75jzVO" role="3uHU7w">
+                          <node concept="37vLTw" id="780iRhLF7Hg" role="3uHU7B">
                             <ref role="3cqZAo" node="780iRhLDEbC" resolve="property" />
                           </node>
-                          <node concept="liA8E" id="780iRhLF7Hh" role="2OqNvi">
-                            <ref role="37wK5l" to="wyt6:~String.equals(java.lang.Object)" resolve="equals" />
-                            <node concept="2OqwBi" id="780iRhLF7Hi" role="37wK5m">
-                              <node concept="37vLTw" id="780iRhLFcBl" role="2Oq$k0">
-                                <ref role="3cqZAo" node="780iRhLF7qH" resolve="it" />
-                              </node>
-                              <node concept="2S8uIT" id="780iRhLF7Hk" role="2OqNvi">
-                                <ref role="2S8YL0" node="DYlgnBsvwB" resolve="property" />
-                              </node>
+                          <node concept="2OqwBi" id="780iRhLF7Hi" role="3uHU7w">
+                            <node concept="37vLTw" id="780iRhLFcBl" role="2Oq$k0">
+                              <ref role="3cqZAo" node="780iRhLF7qH" resolve="it" />
+                            </node>
+                            <node concept="2S8uIT" id="780iRhLF7Hk" role="2OqNvi">
+                              <ref role="2S8YL0" node="DYlgnBsvwB" resolve="property" />
                             </node>
                           </node>
                         </node>
@@ -1696,8 +1812,11 @@
                     <node concept="1bVj0M" id="5uUCR4LO8LM" role="23t8la">
                       <node concept="3clFbS" id="5uUCR4LO8LN" role="1bW5cS">
                         <node concept="3clFbF" id="5uUCR4LPnrA" role="3cqZAp">
-                          <node concept="2OqwBi" id="5uUCR4LPx_v" role="3clFbG">
-                            <node concept="2OqwBi" id="5uUCR4LPoy5" role="2Oq$k0">
+                          <node concept="17R0WA" id="E9Bg75iKUn" role="3clFbG">
+                            <node concept="37vLTw" id="E9Bg75iR2G" role="3uHU7w">
+                              <ref role="3cqZAo" node="780iRhLDEbC" resolve="property" />
+                            </node>
+                            <node concept="2OqwBi" id="5uUCR4LPoy5" role="3uHU7B">
                               <node concept="1PxgMI" id="4YRIhSKFHXL" role="2Oq$k0">
                                 <node concept="2OqwBi" id="4YRIhSKFs20" role="1m5AlR">
                                   <node concept="37vLTw" id="5uUCR4LPnr_" role="2Oq$k0">
@@ -1713,12 +1832,6 @@
                               </node>
                               <node concept="3TrcHB" id="4YRIhSKG1si" role="2OqNvi">
                                 <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
-                              </node>
-                            </node>
-                            <node concept="liA8E" id="5uUCR4LPAw3" role="2OqNvi">
-                              <ref role="37wK5l" to="wyt6:~String.equals(java.lang.Object)" resolve="equals" />
-                              <node concept="37vLTw" id="5uUCR4LPCMJ" role="37wK5m">
-                                <ref role="3cqZAo" node="780iRhLDEbC" resolve="property" />
                               </node>
                             </node>
                           </node>
@@ -1842,8 +1955,11 @@
                       <node concept="1bVj0M" id="5uUCR4LOtTj" role="23t8la">
                         <node concept="3clFbS" id="5uUCR4LOtTk" role="1bW5cS">
                           <node concept="3clFbF" id="5uUCR4LORNf" role="3cqZAp">
-                            <node concept="2OqwBi" id="5uUCR4LP0vi" role="3clFbG">
-                              <node concept="2OqwBi" id="5uUCR4LOTa_" role="2Oq$k0">
+                            <node concept="17R0WA" id="E9Bg75j7gC" role="3clFbG">
+                              <node concept="37vLTw" id="E9Bg75jexi" role="3uHU7w">
+                                <ref role="3cqZAo" node="780iRhLDEbC" resolve="property" />
+                              </node>
+                              <node concept="2OqwBi" id="5uUCR4LOTa_" role="3uHU7B">
                                 <node concept="1PxgMI" id="4YRIhSKGL0b" role="2Oq$k0">
                                   <node concept="2OqwBi" id="4YRIhSKGsgq" role="1m5AlR">
                                     <node concept="37vLTw" id="5uUCR4LORNe" role="2Oq$k0">
@@ -1859,12 +1975,6 @@
                                 </node>
                                 <node concept="3TrcHB" id="4YRIhSKH3$A" role="2OqNvi">
                                   <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
-                                </node>
-                              </node>
-                              <node concept="liA8E" id="5uUCR4LP4X0" role="2OqNvi">
-                                <ref role="37wK5l" to="wyt6:~String.equals(java.lang.Object)" resolve="equals" />
-                                <node concept="37vLTw" id="5uUCR4LP7zB" role="37wK5m">
-                                  <ref role="3cqZAo" node="780iRhLDEbC" resolve="property" />
                                 </node>
                               </node>
                             </node>
@@ -2047,19 +2157,16 @@
                   <node concept="3clFbS" id="3qPjHtYt08O" role="1bW5cS">
                     <node concept="3clFbF" id="3qPjHtYt08P" role="3cqZAp">
                       <node concept="1Wc70l" id="3qPjHtYt08Q" role="3clFbG">
-                        <node concept="2OqwBi" id="3qPjHtYt08R" role="3uHU7w">
-                          <node concept="37vLTw" id="3qPjHtYt08S" role="2Oq$k0">
+                        <node concept="17R0WA" id="E9Bg75jXhY" role="3uHU7w">
+                          <node concept="37vLTw" id="3qPjHtYt08S" role="3uHU7B">
                             <ref role="3cqZAo" node="3qPjHtYt0bV" resolve="role" />
                           </node>
-                          <node concept="liA8E" id="3qPjHtYt08T" role="2OqNvi">
-                            <ref role="37wK5l" to="wyt6:~String.equals(java.lang.Object)" resolve="equals" />
-                            <node concept="2OqwBi" id="3qPjHtYt08U" role="37wK5m">
-                              <node concept="37vLTw" id="3qPjHtYtzrm" role="2Oq$k0">
-                                <ref role="3cqZAo" node="3qPjHtYt09d" resolve="it" />
-                              </node>
-                              <node concept="2S8uIT" id="3qPjHtYt_uw" role="2OqNvi">
-                                <ref role="2S8YL0" node="3qPjHtYqUfo" resolve="reference" />
-                              </node>
+                          <node concept="2OqwBi" id="3qPjHtYt08U" role="3uHU7w">
+                            <node concept="37vLTw" id="3qPjHtYtzrm" role="2Oq$k0">
+                              <ref role="3cqZAo" node="3qPjHtYt09d" resolve="it" />
+                            </node>
+                            <node concept="2S8uIT" id="3qPjHtYt_uw" role="2OqNvi">
+                              <ref role="2S8YL0" node="3qPjHtYqUfo" resolve="reference" />
                             </node>
                           </node>
                         </node>
@@ -2311,8 +2418,13 @@
                 <node concept="37vLTw" id="3qPjHtYtN7h" role="37wK5m">
                   <ref role="3cqZAo" node="DYlgnAA7ym" resolve="actual" />
                 </node>
-                <node concept="37vLTw" id="3qPjHtYtNvB" role="37wK5m">
-                  <ref role="3cqZAo" node="3qPjHtYsMPq" resolve="ignoredReferences" />
+                <node concept="2OqwBi" id="E9Bg74KfFj" role="37wK5m">
+                  <node concept="37vLTw" id="3qPjHtYtNvB" role="2Oq$k0">
+                    <ref role="3cqZAo" node="E9Bg74JS8A" resolve="options" />
+                  </node>
+                  <node concept="2OwXpG" id="E9Bg74Kl_y" role="2OqNvi">
+                    <ref role="2Oxat5" node="E9Bg74H7$G" resolve="ignoredReferences" />
+                  </node>
                 </node>
                 <node concept="2GrUjf" id="3qPjHtYtNNE" role="37wK5m">
                   <ref role="2Gs0qQ" node="DYlgnAA7zl" resolve="role" />
@@ -2379,8 +2491,11 @@
                         <node concept="3clFbS" id="5uUCR4LTuCC" role="1bW5cS">
                           <node concept="3clFbF" id="5uUCR4LTuCD" role="3cqZAp">
                             <node concept="1Wc70l" id="5uUCR4LTuCE" role="3clFbG">
-                              <node concept="2OqwBi" id="5uUCR4LTuCF" role="3uHU7B">
-                                <node concept="2OqwBi" id="5uUCR4LTuCG" role="2Oq$k0">
+                              <node concept="17R0WA" id="E9Bg75f$QB" role="3uHU7B">
+                                <node concept="2GrUjf" id="E9Bg75fDPb" role="3uHU7w">
+                                  <ref role="2Gs0qQ" node="DYlgnAA7zl" resolve="role" />
+                                </node>
+                                <node concept="2OqwBi" id="5uUCR4LTuCG" role="3uHU7B">
                                   <node concept="1PxgMI" id="4YRIhSKLSRf" role="2Oq$k0">
                                     <node concept="2OqwBi" id="4YRIhSKLQ8O" role="1m5AlR">
                                       <node concept="37vLTw" id="5uUCR4LTuCH" role="2Oq$k0">
@@ -2396,12 +2511,6 @@
                                   </node>
                                   <node concept="3TrcHB" id="4YRIhSKLVTr" role="2OqNvi">
                                     <ref role="3TsBF5" to="tpce:fA0kJcN" resolve="role" />
-                                  </node>
-                                </node>
-                                <node concept="liA8E" id="5uUCR4LTuCJ" role="2OqNvi">
-                                  <ref role="37wK5l" to="wyt6:~String.equals(java.lang.Object)" resolve="equals" />
-                                  <node concept="2GrUjf" id="5uUCR4LTuCK" role="37wK5m">
-                                    <ref role="2Gs0qQ" node="DYlgnAA7zl" resolve="role" />
                                   </node>
                                 </node>
                               </node>
@@ -2549,8 +2658,11 @@
                                     </node>
                                   </node>
                                 </node>
-                                <node concept="2OqwBi" id="5uUCR4LTuDv" role="3uHU7B">
-                                  <node concept="2OqwBi" id="5uUCR4LTuDw" role="2Oq$k0">
+                                <node concept="17R0WA" id="E9Bg75fN$M" role="3uHU7B">
+                                  <node concept="2GrUjf" id="E9Bg75fSLT" role="3uHU7w">
+                                    <ref role="2Gs0qQ" node="DYlgnAA7zl" resolve="role" />
+                                  </node>
+                                  <node concept="2OqwBi" id="5uUCR4LTuDw" role="3uHU7B">
                                     <node concept="1PxgMI" id="4YRIhSKLsIF" role="2Oq$k0">
                                       <node concept="2OqwBi" id="4YRIhSKLoEK" role="1m5AlR">
                                         <node concept="37vLTw" id="5uUCR4LTuDx" role="2Oq$k0">
@@ -2566,12 +2678,6 @@
                                     </node>
                                     <node concept="3TrcHB" id="4YRIhSKLvBR" role="2OqNvi">
                                       <ref role="3TsBF5" to="tpce:fA0kJcN" resolve="role" />
-                                    </node>
-                                  </node>
-                                  <node concept="liA8E" id="5uUCR4LTuDz" role="2OqNvi">
-                                    <ref role="37wK5l" to="wyt6:~String.equals(java.lang.Object)" resolve="equals" />
-                                    <node concept="2GrUjf" id="5uUCR4LTuD$" role="37wK5m">
-                                      <ref role="2Gs0qQ" node="DYlgnAA7zl" resolve="role" />
                                     </node>
                                   </node>
                                 </node>
@@ -2708,8 +2814,13 @@
                     <ref role="2Gs0qQ" node="DYlgnAA7zl" resolve="role" />
                   </node>
                 </node>
-                <node concept="37vLTw" id="6fymoI4WmaK" role="37wK5m">
-                  <ref role="3cqZAo" node="6fymoI4WjfU" resolve="verbose" />
+                <node concept="2OqwBi" id="E9Bg74KuiT" role="37wK5m">
+                  <node concept="37vLTw" id="6fymoI4WmaK" role="2Oq$k0">
+                    <ref role="3cqZAo" node="E9Bg74JS8A" resolve="options" />
+                  </node>
+                  <node concept="2OwXpG" id="E9Bg74K$8X" role="2OqNvi">
+                    <ref role="2Oxat5" node="E9Bg74yE37" resolve="verbose" />
+                  </node>
                 </node>
               </node>
             </node>
@@ -2728,8 +2839,11 @@
                     <node concept="1bVj0M" id="DYlgnAHaKd" role="23t8la">
                       <node concept="3clFbS" id="DYlgnAHaKe" role="1bW5cS">
                         <node concept="3clFbF" id="DYlgnAHaKf" role="3cqZAp">
-                          <node concept="2OqwBi" id="DYlgnAHaKg" role="3clFbG">
-                            <node concept="2EnYce" id="DYlgnAHaKh" role="2Oq$k0">
+                          <node concept="17R0WA" id="E9Bg75f7yz" role="3clFbG">
+                            <node concept="2GrUjf" id="E9Bg75fctC" role="3uHU7w">
+                              <ref role="2Gs0qQ" node="DYlgnAA7zl" resolve="role" />
+                            </node>
+                            <node concept="2EnYce" id="DYlgnAHaKh" role="3uHU7B">
                               <node concept="2OqwBi" id="5RIakkDJOTk" role="2Oq$k0">
                                 <node concept="CsP83" id="5RIakkDJOTl" role="2OqNvi" />
                                 <node concept="37vLTw" id="5RIakkDJOTm" role="2Oq$k0">
@@ -2738,12 +2852,6 @@
                               </node>
                               <node concept="liA8E" id="5RIakkDJOTn" role="2OqNvi">
                                 <ref role="37wK5l" to="c17a:~SNamedElement.getName()" resolve="getName" />
-                              </node>
-                            </node>
-                            <node concept="liA8E" id="DYlgnAHaKk" role="2OqNvi">
-                              <ref role="37wK5l" to="wyt6:~String.equals(java.lang.Object)" resolve="equals" />
-                              <node concept="2GrUjf" id="DYlgnAHaKl" role="37wK5m">
-                                <ref role="2Gs0qQ" node="DYlgnAA7zl" resolve="role" />
                               </node>
                             </node>
                           </node>
@@ -2773,8 +2881,11 @@
                     <node concept="1bVj0M" id="DYlgnAH9Sc" role="23t8la">
                       <node concept="3clFbS" id="DYlgnAH9Sd" role="1bW5cS">
                         <node concept="3clFbF" id="DYlgnAH9Se" role="3cqZAp">
-                          <node concept="2OqwBi" id="DYlgnAH9Sf" role="3clFbG">
-                            <node concept="2EnYce" id="DYlgnAH9Sg" role="2Oq$k0">
+                          <node concept="17R0WA" id="E9Bg75flHO" role="3clFbG">
+                            <node concept="2GrUjf" id="E9Bg75fqCG" role="3uHU7w">
+                              <ref role="2Gs0qQ" node="DYlgnAA7zl" resolve="role" />
+                            </node>
+                            <node concept="2EnYce" id="DYlgnAH9Sg" role="3uHU7B">
                               <node concept="2OqwBi" id="5RIakkDJOTp" role="2Oq$k0">
                                 <node concept="CsP83" id="5RIakkDJOTq" role="2OqNvi" />
                                 <node concept="37vLTw" id="5RIakkDJOTr" role="2Oq$k0">
@@ -2783,12 +2894,6 @@
                               </node>
                               <node concept="liA8E" id="5RIakkDJOTs" role="2OqNvi">
                                 <ref role="37wK5l" to="c17a:~SNamedElement.getName()" resolve="getName" />
-                              </node>
-                            </node>
-                            <node concept="liA8E" id="DYlgnAH9Sj" role="2OqNvi">
-                              <ref role="37wK5l" to="wyt6:~String.equals(java.lang.Object)" resolve="equals" />
-                              <node concept="2GrUjf" id="DYlgnAH9Sk" role="37wK5m">
-                                <ref role="2Gs0qQ" node="DYlgnAA7zl" resolve="role" />
                               </node>
                             </node>
                           </node>
@@ -2806,6 +2911,124 @@
             <node concept="3clFbH" id="Pu8Vy2ceWw" role="3cqZAp" />
             <node concept="3clFbJ" id="Pu8Vy2cfH5" role="3cqZAp">
               <node concept="3clFbS" id="Pu8Vy2cfH7" role="3clFbx">
+                <node concept="3cpWs8" id="E9Bg74Q0kV" role="3cqZAp">
+                  <node concept="3cpWsn" id="E9Bg74Q0kW" role="3cpWs9">
+                    <property role="TrG5h" value="newOptions" />
+                    <node concept="3uibUv" id="E9Bg74OYLT" role="1tU5fm">
+                      <ref role="3uigEE" node="E9Bg74y9pX" resolve="MPSComparatorOptions" />
+                    </node>
+                    <node concept="2ShNRf" id="E9Bg74QkZM" role="33vP2m">
+                      <node concept="HV5vD" id="E9Bg74Q$Sl" role="2ShVmc">
+                        <property role="373rjd" value="true" />
+                        <ref role="HV5vE" node="E9Bg74y9pX" resolve="MPSComparatorOptions" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbF" id="E9Bg74QHK5" role="3cqZAp">
+                  <node concept="37vLTI" id="E9Bg74R4IT" role="3clFbG">
+                    <node concept="2OqwBi" id="E9Bg74QKzb" role="37vLTJ">
+                      <node concept="37vLTw" id="E9Bg74QHK3" role="2Oq$k0">
+                        <ref role="3cqZAo" node="E9Bg74Q0kW" resolve="newOptions" />
+                      </node>
+                      <node concept="2OwXpG" id="E9Bg74QP_3" role="2OqNvi">
+                        <ref role="2Oxat5" node="E9Bg74yDJd" resolve="compareChildren" />
+                      </node>
+                    </node>
+                    <node concept="2OqwBi" id="E9Bg74Sff4" role="37vLTx">
+                      <node concept="37vLTw" id="E9Bg74Sff5" role="2Oq$k0">
+                        <ref role="3cqZAo" node="E9Bg74JS8A" resolve="options" />
+                      </node>
+                      <node concept="2OwXpG" id="E9Bg74Sff6" role="2OqNvi">
+                        <ref role="2Oxat5" node="E9Bg74yDTc" resolve="compareChildrenOfReferences" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbF" id="E9Bg74RpAu" role="3cqZAp">
+                  <node concept="37vLTI" id="E9Bg74R_sG" role="3clFbG">
+                    <node concept="2OqwBi" id="E9Bg74RGHQ" role="37vLTx">
+                      <node concept="37vLTw" id="E9Bg74REND" role="2Oq$k0">
+                        <ref role="3cqZAo" node="E9Bg74JS8A" resolve="options" />
+                      </node>
+                      <node concept="2OwXpG" id="E9Bg74RL_s" role="2OqNvi">
+                        <ref role="2Oxat5" node="E9Bg74yDTc" resolve="compareChildrenOfReferences" />
+                      </node>
+                    </node>
+                    <node concept="2OqwBi" id="E9Bg74Rrxc" role="37vLTJ">
+                      <node concept="37vLTw" id="E9Bg74RpAs" role="2Oq$k0">
+                        <ref role="3cqZAo" node="E9Bg74Q0kW" resolve="newOptions" />
+                      </node>
+                      <node concept="2OwXpG" id="E9Bg74Rw_1" role="2OqNvi">
+                        <ref role="2Oxat5" node="E9Bg74yDTc" resolve="compareChildrenOfReferences" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbF" id="E9Bg74S0Gv" role="3cqZAp">
+                  <node concept="2OqwBi" id="E9Bg74Sufw" role="3clFbG">
+                    <node concept="2OqwBi" id="E9Bg74S3vE" role="2Oq$k0">
+                      <node concept="37vLTw" id="E9Bg74S0Gt" role="2Oq$k0">
+                        <ref role="3cqZAo" node="E9Bg74Q0kW" resolve="newOptions" />
+                      </node>
+                      <node concept="2OwXpG" id="E9Bg74Sp86" role="2OqNvi">
+                        <ref role="2Oxat5" node="E9Bg74H7ua" resolve="ignoredProperties" />
+                      </node>
+                    </node>
+                    <node concept="X8dFx" id="E9Bg74Syvi" role="2OqNvi">
+                      <node concept="2OqwBi" id="E9Bg74SDBu" role="25WWJ7">
+                        <node concept="37vLTw" id="E9Bg74SBx4" role="2Oq$k0">
+                          <ref role="3cqZAo" node="E9Bg74JS8A" resolve="options" />
+                        </node>
+                        <node concept="2OwXpG" id="E9Bg74SJ2t" role="2OqNvi">
+                          <ref role="2Oxat5" node="E9Bg74H7ua" resolve="ignoredProperties" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbF" id="E9Bg74SNWI" role="3cqZAp">
+                  <node concept="2OqwBi" id="E9Bg74SNWJ" role="3clFbG">
+                    <node concept="2OqwBi" id="E9Bg74SNWK" role="2Oq$k0">
+                      <node concept="37vLTw" id="E9Bg74SNWL" role="2Oq$k0">
+                        <ref role="3cqZAo" node="E9Bg74Q0kW" resolve="newOptions" />
+                      </node>
+                      <node concept="2OwXpG" id="E9Bg74SNWM" role="2OqNvi">
+                        <ref role="2Oxat5" node="E9Bg74H7$G" resolve="ignoredReferences" />
+                      </node>
+                    </node>
+                    <node concept="X8dFx" id="E9Bg74SNWN" role="2OqNvi">
+                      <node concept="2OqwBi" id="E9Bg74SNWO" role="25WWJ7">
+                        <node concept="37vLTw" id="E9Bg74SNWP" role="2Oq$k0">
+                          <ref role="3cqZAo" node="E9Bg74JS8A" resolve="options" />
+                        </node>
+                        <node concept="2OwXpG" id="E9Bg74SNWQ" role="2OqNvi">
+                          <ref role="2Oxat5" node="E9Bg74H7$G" resolve="ignoredReferences" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbF" id="E9Bg74T9a$" role="3cqZAp">
+                  <node concept="37vLTI" id="E9Bg74TltV" role="3clFbG">
+                    <node concept="2OqwBi" id="E9Bg74TsXy" role="37vLTx">
+                      <node concept="37vLTw" id="E9Bg74Tr1Z" role="2Oq$k0">
+                        <ref role="3cqZAo" node="E9Bg74JS8A" resolve="options" />
+                      </node>
+                      <node concept="2OwXpG" id="E9Bg74TxP4" role="2OqNvi">
+                        <ref role="2Oxat5" node="E9Bg74yE37" resolve="verbose" />
+                      </node>
+                    </node>
+                    <node concept="2OqwBi" id="E9Bg74Tbao" role="37vLTJ">
+                      <node concept="37vLTw" id="E9Bg74T9ay" role="2Oq$k0">
+                        <ref role="3cqZAo" node="E9Bg74Q0kW" resolve="newOptions" />
+                      </node>
+                      <node concept="2OwXpG" id="E9Bg74Tgg6" role="2OqNvi">
+                        <ref role="2Oxat5" node="E9Bg74yE37" resolve="verbose" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
                 <node concept="3cpWs8" id="DYlgnAA7$2" role="3cqZAp">
                   <node concept="3cpWsn" id="DYlgnAA7$3" role="3cpWs9">
                     <property role="TrG5h" value="comparison" />
@@ -2813,7 +3036,7 @@
                       <ref role="3uigEE" node="494SuRWLRaN" resolve="MPSNodeComparisonResult" />
                     </node>
                     <node concept="1rXfSq" id="6fymoI4Woiy" role="33vP2m">
-                      <ref role="37wK5l" node="6fymoI4RKZK" resolve="compare" />
+                      <ref role="37wK5l" node="E9Bg74z9w7" resolve="compare" />
                       <node concept="2OqwBi" id="DYlgnAA7$6" role="37wK5m">
                         <node concept="37vLTw" id="DYlgnAA7$7" role="2Oq$k0">
                           <ref role="3cqZAo" node="DYlgnAA7zA" resolve="aRef" />
@@ -2826,17 +3049,8 @@
                         </node>
                         <node concept="2ZHEkA" id="DYlgnAHgPX" role="2OqNvi" />
                       </node>
-                      <node concept="37vLTw" id="6fymoI4Wqbh" role="37wK5m">
-                        <ref role="3cqZAo" node="6fymoI4WjfR" resolve="ignoredProperties" />
-                      </node>
-                      <node concept="37vLTw" id="3qPjHtYsTb6" role="37wK5m">
-                        <ref role="3cqZAo" node="3qPjHtYsMPq" resolve="ignoredReferences" />
-                      </node>
-                      <node concept="3clFbT" id="3n2rqT9V7TZ" role="37wK5m">
-                        <property role="3clFbU" value="false" />
-                      </node>
-                      <node concept="37vLTw" id="6fymoI4Wrtc" role="37wK5m">
-                        <ref role="3cqZAo" node="6fymoI4WjfU" resolve="verbose" />
+                      <node concept="37vLTw" id="E9Bg74Q0kY" role="37wK5m">
+                        <ref role="3cqZAo" node="E9Bg74Q0kW" resolve="options" />
                       </node>
                     </node>
                   </node>
@@ -2860,8 +3074,13 @@
                         <node concept="37vLTw" id="Pu8Vy2cmgT" role="37wK5m">
                           <ref role="3cqZAo" node="DYlgnAA7ym" resolve="actual" />
                         </node>
-                        <node concept="37vLTw" id="Pu8Vy2cmgU" role="37wK5m">
-                          <ref role="3cqZAo" node="6fymoI4WjfU" resolve="verbose" />
+                        <node concept="2OqwBi" id="E9Bg74LmmT" role="37wK5m">
+                          <node concept="37vLTw" id="E9Bg74LmmU" role="2Oq$k0">
+                            <ref role="3cqZAo" node="E9Bg74JS8A" resolve="options" />
+                          </node>
+                          <node concept="2OwXpG" id="E9Bg74LmmV" role="2OqNvi">
+                            <ref role="2Oxat5" node="E9Bg74yE37" resolve="verbose" />
+                          </node>
                         </node>
                       </node>
                     </node>
@@ -2944,8 +3163,13 @@
                       <node concept="37vLTw" id="Pu8Vy2cAsz" role="37wK5m">
                         <ref role="3cqZAo" node="DYlgnAA7ym" resolve="actual" />
                       </node>
-                      <node concept="37vLTw" id="Pu8Vy2cAs$" role="37wK5m">
-                        <ref role="3cqZAo" node="6fymoI4WjfU" resolve="verbose" />
+                      <node concept="2OqwBi" id="E9Bg74Lsew" role="37wK5m">
+                        <node concept="37vLTw" id="E9Bg74Lsex" role="2Oq$k0">
+                          <ref role="3cqZAo" node="E9Bg74JS8A" resolve="options" />
+                        </node>
+                        <node concept="2OwXpG" id="E9Bg74Lsey" role="2OqNvi">
+                          <ref role="2Oxat5" node="E9Bg74yE37" resolve="verbose" />
+                        </node>
                       </node>
                     </node>
                   </node>
@@ -3083,25 +3307,11 @@
           <ref role="3uigEE" node="494SuRWLRaN" resolve="MPSNodeComparisonResult" />
         </node>
       </node>
-      <node concept="37vLTG" id="6fymoI4WjfR" role="3clF46">
-        <property role="TrG5h" value="ignoredProperties" />
-        <node concept="_YKpA" id="6fymoI4WjfS" role="1tU5fm">
-          <node concept="3uibUv" id="6fymoI4WjfT" role="_ZDj9">
-            <ref role="3uigEE" node="DYlgnBstFb" resolve="IgnoredProperty" />
-          </node>
+      <node concept="37vLTG" id="E9Bg74JS8A" role="3clF46">
+        <property role="TrG5h" value="options" />
+        <node concept="3uibUv" id="E9Bg74JS8B" role="1tU5fm">
+          <ref role="3uigEE" node="E9Bg74y9pX" resolve="MPSComparatorOptions" />
         </node>
-      </node>
-      <node concept="37vLTG" id="3qPjHtYsMPq" role="3clF46">
-        <property role="TrG5h" value="ignoredReferences" />
-        <node concept="_YKpA" id="3qPjHtYsMPr" role="1tU5fm">
-          <node concept="3uibUv" id="2mzdNw3oDkD" role="_ZDj9">
-            <ref role="3uigEE" node="2mzdNw3ouFX" resolve="IgnoredReference" />
-          </node>
-        </node>
-      </node>
-      <node concept="37vLTG" id="6fymoI4WjfU" role="3clF46">
-        <property role="TrG5h" value="verbose" />
-        <node concept="10P_77" id="6fymoI4WjfV" role="1tU5fm" />
       </node>
       <node concept="3cqZAl" id="DYlgnAA7yq" role="3clF45" />
       <node concept="3Tm6S6" id="DYlgnAA7yr" role="1B3o_S" />
@@ -3310,8 +3520,13 @@
                     <node concept="37vLTw" id="6fymoI4WA9T" role="37wK5m">
                       <ref role="3cqZAo" node="DYlgnAA7Bd" resolve="actual" />
                     </node>
-                    <node concept="37vLTw" id="6fymoI4WCNN" role="37wK5m">
-                      <ref role="3cqZAo" node="6fymoI4WBMF" resolve="verbose" />
+                    <node concept="2OqwBi" id="E9Bg74PqTT" role="37wK5m">
+                      <node concept="37vLTw" id="6fymoI4WCNN" role="2Oq$k0">
+                        <ref role="3cqZAo" node="E9Bg74P3Ha" resolve="options" />
+                      </node>
+                      <node concept="2OwXpG" id="E9Bg74PtP5" role="2OqNvi">
+                        <ref role="2Oxat5" node="E9Bg74yE37" resolve="verbose" />
+                      </node>
                     </node>
                   </node>
                 </node>
@@ -3381,8 +3596,13 @@
                       <node concept="Xl_RD" id="6fymoI4WFcr" role="37wK5m">
                         <property role="Xl_RC" value="same number of attributes" />
                       </node>
-                      <node concept="37vLTw" id="6fymoI4WFn3" role="37wK5m">
-                        <ref role="3cqZAo" node="6fymoI4WBMF" resolve="verbose" />
+                      <node concept="2OqwBi" id="E9Bg74PwCv" role="37wK5m">
+                        <node concept="37vLTw" id="E9Bg74PwCw" role="2Oq$k0">
+                          <ref role="3cqZAo" node="E9Bg74P3Ha" resolve="options" />
+                        </node>
+                        <node concept="2OwXpG" id="E9Bg74PwCx" role="2OqNvi">
+                          <ref role="2Oxat5" node="E9Bg74yE37" resolve="verbose" />
+                        </node>
                       </node>
                     </node>
                   </node>
@@ -3396,7 +3616,7 @@
                             <ref role="3uigEE" node="494SuRWLRaN" resolve="MPSNodeComparisonResult" />
                           </node>
                           <node concept="1rXfSq" id="6fymoI4WHlY" role="33vP2m">
-                            <ref role="37wK5l" node="6fymoI4RKZK" resolve="compare" />
+                            <ref role="37wK5l" node="E9Bg74z9w7" resolve="compare" />
                             <node concept="2OqwBi" id="6fymoI4WHp$" role="37wK5m">
                               <node concept="liA8E" id="6fymoI4WHp_" role="2OqNvi">
                                 <ref role="37wK5l" to="33ny:~List.get(int)" resolve="get" />
@@ -3420,16 +3640,7 @@
                               </node>
                             </node>
                             <node concept="37vLTw" id="6fymoI4WI2T" role="37wK5m">
-                              <ref role="3cqZAo" node="6fymoI4WBMC" resolve="ignoredProperties" />
-                            </node>
-                            <node concept="37vLTw" id="3qPjHtYsWV8" role="37wK5m">
-                              <ref role="3cqZAo" node="3qPjHtYsWaR" resolve="ignoredReferences" />
-                            </node>
-                            <node concept="37vLTw" id="6fymoI4WIwA" role="37wK5m">
-                              <ref role="3cqZAo" node="6fymoI4WCfm" resolve="compareChildren" />
-                            </node>
-                            <node concept="37vLTw" id="6fymoI4WJ2G" role="37wK5m">
-                              <ref role="3cqZAo" node="6fymoI4WBMF" resolve="verbose" />
+                              <ref role="3cqZAo" node="E9Bg74P3Ha" resolve="options" />
                             </node>
                           </node>
                         </node>
@@ -3474,8 +3685,13 @@
                                   <ref role="3cqZAo" node="DYlgnAA7_H" resolve="attrsOfBWithGivenRole" />
                                 </node>
                               </node>
-                              <node concept="37vLTw" id="6fymoI4WMjN" role="37wK5m">
-                                <ref role="3cqZAo" node="6fymoI4WBMF" resolve="verbose" />
+                              <node concept="2OqwBi" id="E9Bg74PS7V" role="37wK5m">
+                                <node concept="37vLTw" id="6fymoI4WMjN" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="E9Bg74P3Ha" resolve="options" />
+                                </node>
+                                <node concept="2OwXpG" id="E9Bg74PVdP" role="2OqNvi">
+                                  <ref role="2Oxat5" node="E9Bg74yE37" resolve="verbose" />
+                                </node>
                               </node>
                             </node>
                           </node>
@@ -3595,29 +3811,11 @@
           <ref role="3uigEE" node="494SuRWLRaN" resolve="MPSNodeComparisonResult" />
         </node>
       </node>
-      <node concept="37vLTG" id="6fymoI4WBMC" role="3clF46">
-        <property role="TrG5h" value="ignoredProperties" />
-        <node concept="_YKpA" id="6fymoI4WBMD" role="1tU5fm">
-          <node concept="3uibUv" id="6fymoI4WBME" role="_ZDj9">
-            <ref role="3uigEE" node="DYlgnBstFb" resolve="IgnoredProperty" />
-          </node>
+      <node concept="37vLTG" id="E9Bg74P3Ha" role="3clF46">
+        <property role="TrG5h" value="options" />
+        <node concept="3uibUv" id="E9Bg74P7nj" role="1tU5fm">
+          <ref role="3uigEE" node="E9Bg74y9pX" resolve="MPSComparatorOptions" />
         </node>
-      </node>
-      <node concept="37vLTG" id="3qPjHtYsWaR" role="3clF46">
-        <property role="TrG5h" value="ignoredReferences" />
-        <node concept="_YKpA" id="3qPjHtYsWaS" role="1tU5fm">
-          <node concept="3uibUv" id="2mzdNw3oDkF" role="_ZDj9">
-            <ref role="3uigEE" node="2mzdNw3ouFX" resolve="IgnoredReference" />
-          </node>
-        </node>
-      </node>
-      <node concept="37vLTG" id="6fymoI4WCfm" role="3clF46">
-        <property role="TrG5h" value="compareChildren" />
-        <node concept="10P_77" id="6fymoI4WCFS" role="1tU5fm" />
-      </node>
-      <node concept="37vLTG" id="6fymoI4WBMF" role="3clF46">
-        <property role="TrG5h" value="verbose" />
-        <node concept="10P_77" id="6fymoI4WBMG" role="1tU5fm" />
       </node>
       <node concept="3cqZAl" id="DYlgnAA7$z" role="3clF45" />
       <node concept="3Tm6S6" id="DYlgnAA7$$" role="1B3o_S" />
@@ -3754,15 +3952,12 @@
               <node concept="3clFbS" id="4YRIhSKQoYL" role="3clFbx">
                 <node concept="3N13vt" id="4YRIhSKQoYM" role="3cqZAp" />
               </node>
-              <node concept="2OqwBi" id="4YRIhSKQoYN" role="3clFbw">
-                <node concept="Xl_RD" id="4YRIhSKQoYO" role="2Oq$k0">
-                  <property role="Xl_RC" value="smodelAttribute" />
+              <node concept="17R0WA" id="E9Bg75g4bw" role="3clFbw">
+                <node concept="2GrUjf" id="E9Bg75g9bf" role="3uHU7w">
+                  <ref role="2Gs0qQ" node="DYlgnAA7BI" resolve="role" />
                 </node>
-                <node concept="liA8E" id="4YRIhSKQoYP" role="2OqNvi">
-                  <ref role="37wK5l" to="wyt6:~String.equals(java.lang.Object)" resolve="equals" />
-                  <node concept="2GrUjf" id="4YRIhSKQoYQ" role="37wK5m">
-                    <ref role="2Gs0qQ" node="DYlgnAA7BI" resolve="role" />
-                  </node>
+                <node concept="Xl_RD" id="4YRIhSKQoYO" role="3uHU7B">
+                  <property role="Xl_RC" value="smodelAttribute" />
                 </node>
               </node>
             </node>
@@ -3822,8 +4017,11 @@
                         <node concept="3clFbS" id="5uUCR4LQ7L8" role="1bW5cS">
                           <node concept="3clFbF" id="5uUCR4LQ7Po" role="3cqZAp">
                             <node concept="1Wc70l" id="5uUCR4LQh7i" role="3clFbG">
-                              <node concept="2OqwBi" id="5uUCR4LQaOo" role="3uHU7B">
-                                <node concept="2OqwBi" id="5uUCR4LQ7YG" role="2Oq$k0">
+                              <node concept="17R0WA" id="E9Bg75gkdy" role="3uHU7B">
+                                <node concept="2GrUjf" id="E9Bg75gp6G" role="3uHU7w">
+                                  <ref role="2Gs0qQ" node="DYlgnAA7BI" resolve="role" />
+                                </node>
+                                <node concept="2OqwBi" id="5uUCR4LQ7YG" role="3uHU7B">
                                   <node concept="1PxgMI" id="4YRIhSKN4vv" role="2Oq$k0">
                                     <node concept="2OqwBi" id="4YRIhSKMZV3" role="1m5AlR">
                                       <node concept="37vLTw" id="5uUCR4LQ7Pn" role="2Oq$k0">
@@ -3839,12 +4037,6 @@
                                   </node>
                                   <node concept="3TrcHB" id="4YRIhSKN9A3" role="2OqNvi">
                                     <ref role="3TsBF5" to="tpce:fA0kJcN" resolve="role" />
-                                  </node>
-                                </node>
-                                <node concept="liA8E" id="5uUCR4LQdww" role="2OqNvi">
-                                  <ref role="37wK5l" to="wyt6:~String.equals(java.lang.Object)" resolve="equals" />
-                                  <node concept="2GrUjf" id="5uUCR4LQdJ9" role="37wK5m">
-                                    <ref role="2Gs0qQ" node="DYlgnAA7BI" resolve="role" />
                                   </node>
                                 </node>
                               </node>
@@ -3992,8 +4184,11 @@
                                     </node>
                                   </node>
                                 </node>
-                                <node concept="2OqwBi" id="5uUCR4LQguZ" role="3uHU7B">
-                                  <node concept="2OqwBi" id="5uUCR4LQgv0" role="2Oq$k0">
+                                <node concept="17R0WA" id="E9Bg75gyJU" role="3uHU7B">
+                                  <node concept="2GrUjf" id="E9Bg75gBCI" role="3uHU7w">
+                                    <ref role="2Gs0qQ" node="DYlgnAA7BI" resolve="role" />
+                                  </node>
+                                  <node concept="2OqwBi" id="5uUCR4LQgv0" role="3uHU7B">
                                     <node concept="1PxgMI" id="4YRIhSKMr10" role="2Oq$k0">
                                       <node concept="2OqwBi" id="4YRIhSKMmmO" role="1m5AlR">
                                         <node concept="37vLTw" id="5uUCR4LQgv1" role="2Oq$k0">
@@ -4009,12 +4204,6 @@
                                     </node>
                                     <node concept="3TrcHB" id="4YRIhSKMvY8" role="2OqNvi">
                                       <ref role="3TsBF5" to="tpce:fA0kJcN" resolve="role" />
-                                    </node>
-                                  </node>
-                                  <node concept="liA8E" id="5uUCR4LQgv3" role="2OqNvi">
-                                    <ref role="37wK5l" to="wyt6:~String.equals(java.lang.Object)" resolve="equals" />
-                                    <node concept="2GrUjf" id="5uUCR4LQgv4" role="37wK5m">
-                                      <ref role="2Gs0qQ" node="DYlgnAA7BI" resolve="role" />
                                     </node>
                                   </node>
                                 </node>
@@ -4151,8 +4340,13 @@
                     <ref role="2Gs0qQ" node="DYlgnAA7BI" resolve="role" />
                   </node>
                 </node>
-                <node concept="37vLTw" id="6fymoI4WW0G" role="37wK5m">
-                  <ref role="3cqZAo" node="6fymoI4WQot" resolve="verbose" />
+                <node concept="2OqwBi" id="E9Bg74MKoX" role="37wK5m">
+                  <node concept="37vLTw" id="6fymoI4WW0G" role="2Oq$k0">
+                    <ref role="3cqZAo" node="E9Bg74M7jI" resolve="options" />
+                  </node>
+                  <node concept="2OwXpG" id="E9Bg74MPKd" role="2OqNvi">
+                    <ref role="2Oxat5" node="E9Bg74yE37" resolve="verbose" />
+                  </node>
                 </node>
               </node>
             </node>
@@ -4172,8 +4366,11 @@
                       <node concept="1bVj0M" id="DYlgnADtbs" role="23t8la">
                         <node concept="3clFbS" id="DYlgnADtbt" role="1bW5cS">
                           <node concept="3clFbF" id="DYlgnADtbu" role="3cqZAp">
-                            <node concept="2OqwBi" id="DYlgnADtbv" role="3clFbG">
-                              <node concept="2EnYce" id="DYlgnADtbw" role="2Oq$k0">
+                            <node concept="17R0WA" id="E9Bg75gJFH" role="3clFbG">
+                              <node concept="2GrUjf" id="E9Bg75gPZJ" role="3uHU7w">
+                                <ref role="2Gs0qQ" node="DYlgnAA7BI" resolve="role" />
+                              </node>
+                              <node concept="2EnYce" id="DYlgnADtbw" role="3uHU7B">
                                 <node concept="2OqwBi" id="5RIakkDJOSS" role="2Oq$k0">
                                   <node concept="37vLTw" id="5RIakkDJOST" role="2Oq$k0">
                                     <ref role="3cqZAo" node="DYlgnADtb_" resolve="it" />
@@ -4182,12 +4379,6 @@
                                 </node>
                                 <node concept="liA8E" id="5RIakkDJOSV" role="2OqNvi">
                                   <ref role="37wK5l" to="c17a:~SNamedElement.getName()" resolve="getName" />
-                                </node>
-                              </node>
-                              <node concept="liA8E" id="DYlgnADtbz" role="2OqNvi">
-                                <ref role="37wK5l" to="wyt6:~String.equals(java.lang.Object)" resolve="equals" />
-                                <node concept="2GrUjf" id="DYlgnADtb$" role="37wK5m">
-                                  <ref role="2Gs0qQ" node="DYlgnAA7BI" resolve="role" />
                                 </node>
                               </node>
                             </node>
@@ -4220,8 +4411,11 @@
                       <node concept="1bVj0M" id="DYlgnADxRp" role="23t8la">
                         <node concept="3clFbS" id="DYlgnADxRq" role="1bW5cS">
                           <node concept="3clFbF" id="DYlgnADxRr" role="3cqZAp">
-                            <node concept="2OqwBi" id="DYlgnADxRs" role="3clFbG">
-                              <node concept="2EnYce" id="DYlgnADxRt" role="2Oq$k0">
+                            <node concept="17R0WA" id="E9Bg75gYVm" role="3clFbG">
+                              <node concept="2GrUjf" id="E9Bg75h3Or" role="3uHU7w">
+                                <ref role="2Gs0qQ" node="DYlgnAA7BI" resolve="role" />
+                              </node>
+                              <node concept="2EnYce" id="DYlgnADxRt" role="3uHU7B">
                                 <node concept="2OqwBi" id="5RIakkDJOSX" role="2Oq$k0">
                                   <node concept="37vLTw" id="5RIakkDJOSY" role="2Oq$k0">
                                     <ref role="3cqZAo" node="DYlgnADxRy" resolve="it" />
@@ -4230,12 +4424,6 @@
                                 </node>
                                 <node concept="liA8E" id="5RIakkDJOT0" role="2OqNvi">
                                   <ref role="37wK5l" to="c17a:~SNamedElement.getName()" resolve="getName" />
-                                </node>
-                              </node>
-                              <node concept="liA8E" id="DYlgnADxRw" role="2OqNvi">
-                                <ref role="37wK5l" to="wyt6:~String.equals(java.lang.Object)" resolve="equals" />
-                                <node concept="2GrUjf" id="DYlgnADxRx" role="37wK5m">
-                                  <ref role="2Gs0qQ" node="DYlgnAA7BI" resolve="role" />
                                 </node>
                               </node>
                             </node>
@@ -4266,8 +4454,13 @@
                     <node concept="37vLTw" id="6fymoI4X5Je" role="37wK5m">
                       <ref role="3cqZAo" node="DYlgnAA7Dt" resolve="actual" />
                     </node>
-                    <node concept="37vLTw" id="6fymoI4X5XE" role="37wK5m">
-                      <ref role="3cqZAo" node="6fymoI4WQot" resolve="verbose" />
+                    <node concept="2OqwBi" id="E9Bg74MV0v" role="37wK5m">
+                      <node concept="37vLTw" id="E9Bg74MV0w" role="2Oq$k0">
+                        <ref role="3cqZAo" node="E9Bg74M7jI" resolve="options" />
+                      </node>
+                      <node concept="2OwXpG" id="E9Bg74MV0x" role="2OqNvi">
+                        <ref role="2Oxat5" node="E9Bg74yE37" resolve="verbose" />
+                      </node>
                     </node>
                   </node>
                 </node>
@@ -4328,8 +4521,13 @@
                       <node concept="Xl_RD" id="6fymoI4X9B4" role="37wK5m">
                         <property role="Xl_RC" value="same number of children" />
                       </node>
-                      <node concept="37vLTw" id="6fymoI4X9N4" role="37wK5m">
-                        <ref role="3cqZAo" node="6fymoI4WQot" resolve="verbose" />
+                      <node concept="2OqwBi" id="E9Bg74N0iN" role="37wK5m">
+                        <node concept="37vLTw" id="E9Bg74N0iO" role="2Oq$k0">
+                          <ref role="3cqZAo" node="E9Bg74M7jI" resolve="options" />
+                        </node>
+                        <node concept="2OwXpG" id="E9Bg74N0iP" role="2OqNvi">
+                          <ref role="2Oxat5" node="E9Bg74yE37" resolve="verbose" />
+                        </node>
                       </node>
                     </node>
                   </node>
@@ -4365,17 +4563,37 @@
                                 </node>
                               </node>
                             </node>
-                            <node concept="37vLTw" id="6fymoI4X1Nk" role="37wK5m">
-                              <ref role="3cqZAo" node="6fymoI4WQoo" resolve="ignoredProperties" />
+                            <node concept="2OqwBi" id="E9Bg74Ngfj" role="37wK5m">
+                              <node concept="37vLTw" id="E9Bg74Ngfk" role="2Oq$k0">
+                                <ref role="3cqZAo" node="E9Bg74M7jI" resolve="options" />
+                              </node>
+                              <node concept="2OwXpG" id="E9Bg74NAhC" role="2OqNvi">
+                                <ref role="2Oxat5" node="E9Bg74H7ua" resolve="ignoredProperties" />
+                              </node>
                             </node>
-                            <node concept="37vLTw" id="3qPjHtYsYTM" role="37wK5m">
-                              <ref role="3cqZAo" node="3qPjHtYsPoe" resolve="ignoredReferences" />
+                            <node concept="2OqwBi" id="E9Bg74NFzc" role="37wK5m">
+                              <node concept="37vLTw" id="E9Bg74NFzd" role="2Oq$k0">
+                                <ref role="3cqZAo" node="E9Bg74M7jI" resolve="options" />
+                              </node>
+                              <node concept="2OwXpG" id="E9Bg74NFze" role="2OqNvi">
+                                <ref role="2Oxat5" node="E9Bg74H7$G" resolve="ignoredReferences" />
+                              </node>
                             </node>
-                            <node concept="37vLTw" id="6fymoI4X2j5" role="37wK5m">
-                              <ref role="3cqZAo" node="6fymoI4WQor" resolve="compareChildren" />
+                            <node concept="2OqwBi" id="E9Bg74NQva" role="37wK5m">
+                              <node concept="37vLTw" id="E9Bg74NQvb" role="2Oq$k0">
+                                <ref role="3cqZAo" node="E9Bg74M7jI" resolve="options" />
+                              </node>
+                              <node concept="2OwXpG" id="E9Bg74NQvc" role="2OqNvi">
+                                <ref role="2Oxat5" node="E9Bg74yDJd" resolve="compareChildren" />
+                              </node>
                             </node>
-                            <node concept="37vLTw" id="6fymoI4X2Mf" role="37wK5m">
-                              <ref role="3cqZAo" node="6fymoI4WQot" resolve="verbose" />
+                            <node concept="2OqwBi" id="E9Bg74NaS8" role="37wK5m">
+                              <node concept="37vLTw" id="E9Bg74NaS9" role="2Oq$k0">
+                                <ref role="3cqZAo" node="E9Bg74M7jI" resolve="options" />
+                              </node>
+                              <node concept="2OwXpG" id="E9Bg74NaSa" role="2OqNvi">
+                                <ref role="2Oxat5" node="E9Bg74yE37" resolve="verbose" />
+                              </node>
                             </node>
                           </node>
                         </node>
@@ -4418,8 +4636,13 @@
                                   </node>
                                 </node>
                               </node>
-                              <node concept="37vLTw" id="6fymoI4XdPj" role="37wK5m">
-                                <ref role="3cqZAo" node="6fymoI4WQot" resolve="verbose" />
+                              <node concept="2OqwBi" id="E9Bg74N5_g" role="37wK5m">
+                                <node concept="37vLTw" id="E9Bg74N5_h" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="E9Bg74M7jI" resolve="options" />
+                                </node>
+                                <node concept="2OwXpG" id="E9Bg74N5_i" role="2OqNvi">
+                                  <ref role="2Oxat5" node="E9Bg74yE37" resolve="verbose" />
+                                </node>
                               </node>
                             </node>
                           </node>
@@ -4518,29 +4741,11 @@
           <ref role="3uigEE" node="494SuRWLRaN" resolve="MPSNodeComparisonResult" />
         </node>
       </node>
-      <node concept="37vLTG" id="6fymoI4WQoo" role="3clF46">
-        <property role="TrG5h" value="ignoredProperties" />
-        <node concept="_YKpA" id="6fymoI4WQop" role="1tU5fm">
-          <node concept="3uibUv" id="6fymoI4WQoq" role="_ZDj9">
-            <ref role="3uigEE" node="DYlgnBstFb" resolve="IgnoredProperty" />
-          </node>
+      <node concept="37vLTG" id="E9Bg74M7jI" role="3clF46">
+        <property role="TrG5h" value="options" />
+        <node concept="3uibUv" id="E9Bg74MdKx" role="1tU5fm">
+          <ref role="3uigEE" node="E9Bg74y9pX" resolve="MPSComparatorOptions" />
         </node>
-      </node>
-      <node concept="37vLTG" id="3qPjHtYsPoe" role="3clF46">
-        <property role="TrG5h" value="ignoredReferences" />
-        <node concept="_YKpA" id="3qPjHtYsPof" role="1tU5fm">
-          <node concept="3uibUv" id="2mzdNw3oDkH" role="_ZDj9">
-            <ref role="3uigEE" node="2mzdNw3ouFX" resolve="IgnoredReference" />
-          </node>
-        </node>
-      </node>
-      <node concept="37vLTG" id="6fymoI4WQor" role="3clF46">
-        <property role="TrG5h" value="compareChildren" />
-        <node concept="10P_77" id="6fymoI4WQos" role="1tU5fm" />
-      </node>
-      <node concept="37vLTG" id="6fymoI4WQot" role="3clF46">
-        <property role="TrG5h" value="verbose" />
-        <node concept="10P_77" id="6fymoI4WQou" role="1tU5fm" />
       </node>
       <node concept="3cqZAl" id="DYlgnAA7Bi" role="3clF45" />
       <node concept="3Tm6S6" id="DYlgnAA7Bj" role="1B3o_S" />

--- a/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.comparator/models/MissingReferenceDifference.mpsr
+++ b/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.comparator/models/MissingReferenceDifference.mpsr
@@ -433,7 +433,7 @@
         <node concept="3clFbF" id="Pu8Vy2crRx" role="3cqZAp">
           <node concept="3cpWs3" id="Pu8Vy2dL6_" role="3clFbG">
             <node concept="Xl_RD" id="Pu8Vy2dL71" role="3uHU7w">
-              <property role="Xl_RC" value="]" />
+              <property role="Xl_RC" value=")" />
             </node>
             <node concept="3cpWs3" id="Pu8Vy2dKO7" role="3uHU7B">
               <node concept="3cpWs3" id="Pu8Vy2dKET" role="3uHU7B">
@@ -466,7 +466,7 @@
                   </node>
                 </node>
                 <node concept="Xl_RD" id="Pu8Vy2dKIt" role="3uHU7w">
-                  <property role="Xl_RC" value="[" />
+                  <property role="Xl_RC" value="(" />
                 </node>
               </node>
               <node concept="2OqwBi" id="Pu8Vy2dKZE" role="3uHU7w">

--- a/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.comparator/models/MpsNodeComparatorOptionsBuilder.mpsr
+++ b/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.comparator/models/MpsNodeComparatorOptionsBuilder.mpsr
@@ -1,0 +1,257 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:ec874b45-e888-42e6-995a-a298cefdff55(com.mbeddr.mpsutil.comparator.code)" content="root">
+  <persistence version="9" />
+  <imports>
+    <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
+        <child id="1068498886297" name="rValue" index="37vLTx" />
+        <child id="1068498886295" name="lValue" index="37vLTJ" />
+      </concept>
+      <concept id="2820489544401957797" name="jetbrains.mps.baseLanguage.structure.DefaultClassCreator" flags="nn" index="HV5vD">
+        <reference id="2820489544401957798" name="classifier" index="HV5vE" />
+      </concept>
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1197029447546" name="jetbrains.mps.baseLanguage.structure.FieldReferenceOperation" flags="nn" index="2OwXpG">
+        <reference id="1197029500499" name="fieldDeclaration" index="2Oxat5" />
+      </concept>
+      <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
+        <child id="1145553007750" name="creator" index="2ShVmc" />
+      </concept>
+      <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ng" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
+      </concept>
+      <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
+      </concept>
+      <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk" />
+      <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
+        <reference id="1107535924139" name="classifier" index="3uigEE" />
+      </concept>
+    </language>
+    <language id="132aa4d8-a3f7-441c-a7eb-3fce23492c6a" name="jetbrains.mps.baseLanguage.builders">
+      <concept id="5425713840853682520" name="jetbrains.mps.baseLanguage.builders.structure.SimpleBuilderParameter" flags="ng" index="2ijgy_">
+        <child id="5425713840853682521" name="type" index="2ijgy$" />
+      </concept>
+      <concept id="5425713840853785828" name="jetbrains.mps.baseLanguage.builders.structure.SimpleBuilderParameterReference" flags="nn" index="2ijDOp">
+        <reference id="5425713840853785829" name="parameter" index="2ijDOo" />
+      </concept>
+      <concept id="5389689214217248394" name="jetbrains.mps.baseLanguage.builders.structure.SimpleBuilderPropertyValue" flags="nn" index="2tS5H2" />
+      <concept id="5389689214217248368" name="jetbrains.mps.baseLanguage.builders.structure.SimpleBuilderPropertyParent" flags="nn" index="2tS5IS" />
+      <concept id="5389689214216990954" name="jetbrains.mps.baseLanguage.builders.structure.SimpleBuilderProperty" flags="ng" index="2tT7ky">
+        <child id="5389689214216997399" name="type" index="2tT8Zv" />
+        <child id="5389689214217175694" name="set" index="2tTOt6" />
+      </concept>
+      <concept id="7288041816792577338" name="jetbrains.mps.baseLanguage.builders.structure.SimpleBuilderChild" flags="ng" index="1bemph">
+        <reference id="7288041816792577339" name="child" index="1bempg" />
+        <child id="7288041816792607835" name="attachStatement" index="1bevWK" />
+      </concept>
+      <concept id="7288041816792577342" name="jetbrains.mps.baseLanguage.builders.structure.SimpleBuilderChildExpression" flags="nn" index="1bempl" />
+      <concept id="7288041816792577340" name="jetbrains.mps.baseLanguage.builders.structure.SimpleBuilderParentExpression" flags="nn" index="1bempn" />
+      <concept id="7288041816792374843" name="jetbrains.mps.baseLanguage.builders.structure.SimpleBuilders" flags="ng" index="1bf$Pg">
+        <child id="7288041816792374845" name="builder" index="1bf$Pm" />
+      </concept>
+      <concept id="7288041816792374840" name="jetbrains.mps.baseLanguage.builders.structure.SimpleBuilderDeclaration" flags="ng" index="1bf$Pj">
+        <property id="7288041816792489431" name="root" index="1bfSUW" />
+        <child id="5425713840853683089" name="parameter" index="2ijgDG" />
+        <child id="5389689214217081351" name="property" index="2tTtvf" />
+        <child id="7288041816793525038" name="creator" index="1b3Zx5" />
+        <child id="7288041816792733124" name="child" index="1beWqJ" />
+        <child id="3816167865390455307" name="type" index="1nbxDZ" />
+      </concept>
+    </language>
+    <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="8758390115029295477" name="jetbrains.mps.lang.smodel.structure.SReferenceType" flags="in" index="2z4iKi" />
+      <concept id="6677504323281689838" name="jetbrains.mps.lang.smodel.structure.SConceptType" flags="in" index="3bZ5Sz" />
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+    <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
+      <concept id="540871147943773365" name="jetbrains.mps.baseLanguage.collections.structure.SingleArgumentSequenceOperation" flags="nn" index="25WWJ4">
+        <child id="540871147943773366" name="argument" index="25WWJ7" />
+      </concept>
+      <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="nn" index="TSZUe" />
+    </language>
+  </registry>
+  <node concept="1bf$Pg" id="E9Bg74y3p1">
+    <property role="TrG5h" value="MpsNodeComparatorOptionsBuilder" />
+    <property role="3GE5qa" value="" />
+    <node concept="1bf$Pj" id="E9Bg74y6p_" role="1bf$Pm">
+      <property role="1bfSUW" value="true" />
+      <property role="TrG5h" value="options" />
+      <node concept="2tT7ky" id="E9Bg74yEix" role="2tTtvf">
+        <property role="TrG5h" value="compareChildren" />
+        <node concept="10P_77" id="E9Bg74yEj4" role="2tT8Zv" />
+        <node concept="3clFbF" id="E9Bg74yEj9" role="2tTOt6">
+          <node concept="37vLTI" id="E9Bg74yERb" role="3clFbG">
+            <node concept="2tS5H2" id="E9Bg74yEWh" role="37vLTx" />
+            <node concept="2OqwBi" id="E9Bg74yEoW" role="37vLTJ">
+              <node concept="2tS5IS" id="E9Bg74yEj7" role="2Oq$k0" />
+              <node concept="2OwXpG" id="E9Bg74yEuM" role="2OqNvi">
+                <ref role="2Oxat5" node="E9Bg74yDJd" resolve="compareChildren" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2tT7ky" id="E9Bg74yEWT" role="2tTtvf">
+        <property role="TrG5h" value="compareChildrenOfReferences" />
+        <node concept="10P_77" id="E9Bg74yEWU" role="2tT8Zv" />
+        <node concept="3clFbF" id="E9Bg74yEWV" role="2tTOt6">
+          <node concept="37vLTI" id="E9Bg74yEWW" role="3clFbG">
+            <node concept="2tS5H2" id="E9Bg74yEWX" role="37vLTx" />
+            <node concept="2OqwBi" id="E9Bg74yEWY" role="37vLTJ">
+              <node concept="2tS5IS" id="E9Bg74yEWZ" role="2Oq$k0" />
+              <node concept="2OwXpG" id="E9Bg74yEX0" role="2OqNvi">
+                <ref role="2Oxat5" node="E9Bg74yDTc" resolve="compareChildrenOfReferences" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2tT7ky" id="E9Bg752xOA" role="2tTtvf">
+        <property role="TrG5h" value="compareAnnotations" />
+        <node concept="10P_77" id="E9Bg752xOB" role="2tT8Zv" />
+        <node concept="3clFbF" id="E9Bg752xOC" role="2tTOt6">
+          <node concept="37vLTI" id="E9Bg752xOD" role="3clFbG">
+            <node concept="2tS5H2" id="E9Bg752xOE" role="37vLTx" />
+            <node concept="2OqwBi" id="E9Bg752xOF" role="37vLTJ">
+              <node concept="2tS5IS" id="E9Bg752xOG" role="2Oq$k0" />
+              <node concept="2OwXpG" id="E9Bg752xOH" role="2OqNvi">
+                <ref role="2Oxat5" node="E9Bg752xHS" resolve="compareAttributes" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2tT7ky" id="E9Bg74yF1r" role="2tTtvf">
+        <property role="TrG5h" value="verbose" />
+        <node concept="10P_77" id="E9Bg74yF1s" role="2tT8Zv" />
+        <node concept="3clFbF" id="E9Bg74yF1t" role="2tTOt6">
+          <node concept="37vLTI" id="E9Bg74yF1u" role="3clFbG">
+            <node concept="2tS5H2" id="E9Bg74yF1v" role="37vLTx" />
+            <node concept="2OqwBi" id="E9Bg74yF1w" role="37vLTJ">
+              <node concept="2tS5IS" id="E9Bg74yF1x" role="2Oq$k0" />
+              <node concept="2OwXpG" id="E9Bg74yF5s" role="2OqNvi">
+                <ref role="2Oxat5" node="E9Bg74yE37" resolve="verbose" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3uibUv" id="E9Bg74yE3G" role="1nbxDZ">
+        <ref role="3uigEE" node="E9Bg74y9pX" resolve="MPSComparatorOptions" />
+      </node>
+      <node concept="2ShNRf" id="E9Bg74yE3K" role="1b3Zx5">
+        <node concept="HV5vD" id="E9Bg74yEij" role="2ShVmc">
+          <property role="373rjd" value="true" />
+          <ref role="HV5vE" node="E9Bg74y9pX" resolve="MPSComparatorOptions" />
+        </node>
+      </node>
+      <node concept="1bemph" id="E9Bg74CVsR" role="1beWqJ">
+        <ref role="1bempg" node="E9Bg74CCnu" resolve="ignoredProperty" />
+        <node concept="3clFbF" id="E9Bg74CVvj" role="1bevWK">
+          <node concept="2OqwBi" id="E9Bg74CVNx" role="3clFbG">
+            <node concept="2OqwBi" id="E9Bg74CV_g" role="2Oq$k0">
+              <node concept="1bempn" id="E9Bg74CVvu" role="2Oq$k0" />
+              <node concept="2OwXpG" id="E9Bg74TAWX" role="2OqNvi">
+                <ref role="2Oxat5" node="E9Bg74H7ua" resolve="ignoredProperties" />
+              </node>
+            </node>
+            <node concept="TSZUe" id="E9Bg74CVUE" role="2OqNvi">
+              <node concept="1bempl" id="E9Bg74CVYq" role="25WWJ7" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1bemph" id="E9Bg74CVZO" role="1beWqJ">
+        <ref role="1bempg" node="E9Bg74CDhI" resolve="ignoredReference" />
+        <node concept="3clFbF" id="E9Bg74CVZP" role="1bevWK">
+          <node concept="2OqwBi" id="E9Bg74CVZQ" role="3clFbG">
+            <node concept="2OqwBi" id="E9Bg74CVZR" role="2Oq$k0">
+              <node concept="1bempn" id="E9Bg74CVZS" role="2Oq$k0" />
+              <node concept="2OwXpG" id="E9Bg74TB4S" role="2OqNvi">
+                <ref role="2Oxat5" node="E9Bg74H7$G" resolve="ignoredReferences" />
+              </node>
+            </node>
+            <node concept="TSZUe" id="E9Bg74CVZU" role="2OqNvi">
+              <node concept="1bempl" id="E9Bg74CVZV" role="25WWJ7" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1bf$Pj" id="E9Bg74CCnu" role="1bf$Pm">
+      <property role="TrG5h" value="ignoredProperty" />
+      <node concept="3uibUv" id="E9Bg74CCom" role="1nbxDZ">
+        <ref role="3uigEE" node="DYlgnBstFb" resolve="IgnoredProperty" />
+      </node>
+      <node concept="2ShNRf" id="E9Bg74CCop" role="1b3Zx5">
+        <node concept="1pGfFk" id="E9Bg74CCAW" role="2ShVmc">
+          <property role="373rjd" value="true" />
+          <ref role="37wK5l" node="E9Bg756o2F" resolve="IgnoredProperty" />
+          <node concept="2ijDOp" id="E9Bg74CCEp" role="37wK5m">
+            <ref role="2ijDOo" node="E9Bg74CCDH" resolve="concept" />
+          </node>
+          <node concept="2ijDOp" id="E9Bg74CCQP" role="37wK5m">
+            <ref role="2ijDOo" node="E9Bg74CCE0" resolve="property" />
+          </node>
+        </node>
+      </node>
+      <node concept="2ijgy_" id="E9Bg74CCDH" role="2ijgDG">
+        <property role="TrG5h" value="concept" />
+        <node concept="3bZ5Sz" id="E9Bg74CCDV" role="2ijgy$" />
+      </node>
+      <node concept="2ijgy_" id="E9Bg74CCE0" role="2ijgDG">
+        <property role="TrG5h" value="property" />
+        <node concept="3uibUv" id="E9Bg74CCEi" role="2ijgy$">
+          <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
+        </node>
+      </node>
+    </node>
+    <node concept="1bf$Pj" id="E9Bg74CDhI" role="1bf$Pm">
+      <property role="TrG5h" value="ignoredReference" />
+      <node concept="2ijgy_" id="E9Bg74CDzP" role="2ijgDG">
+        <property role="TrG5h" value="concept" />
+        <node concept="3bZ5Sz" id="E9Bg74CD$3" role="2ijgy$" />
+      </node>
+      <node concept="2ijgy_" id="E9Bg74CD$8" role="2ijgDG">
+        <property role="TrG5h" value="reference" />
+        <node concept="2z4iKi" id="E9Bg74TGfv" role="2ijgy$" />
+      </node>
+      <node concept="3uibUv" id="E9Bg74CDjv" role="1nbxDZ">
+        <ref role="3uigEE" node="2mzdNw3ouFX" resolve="IgnoredReference" />
+      </node>
+      <node concept="2ShNRf" id="E9Bg74CDjD" role="1b3Zx5">
+        <node concept="1pGfFk" id="E9Bg74CDye" role="2ShVmc">
+          <property role="373rjd" value="true" />
+          <ref role="37wK5l" node="E9Bg74THqR" resolve="IgnoredReference" />
+          <node concept="2ijDOp" id="E9Bg74CD$x" role="37wK5m">
+            <ref role="2ijDOo" node="E9Bg74CDzP" resolve="concept" />
+          </node>
+          <node concept="2ijDOp" id="E9Bg74CD_6" role="37wK5m">
+            <ref role="2ijDOo" node="E9Bg74CD$8" resolve="reference" />
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.comparator/models/NodeDifference.mpsr
+++ b/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.comparator/models/NodeDifference.mpsr
@@ -112,6 +112,9 @@
         <reference id="1116615189566" name="classifier" index="3VsUkX" />
       </concept>
     </language>
+    <language id="774bf8a0-62e5-41e1-af63-f4812e60e48b" name="jetbrains.mps.baseLanguage.checkedDots">
+      <concept id="4079382982702596667" name="jetbrains.mps.baseLanguage.checkedDots.structure.CheckedDotExpression" flags="nn" index="2EnYce" />
+    </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
       <concept id="7453996997717780434" name="jetbrains.mps.lang.smodel.structure.Node_GetSConceptOperation" flags="nn" index="2yIwOk" />
       <concept id="6677504323281689838" name="jetbrains.mps.lang.smodel.structure.SConceptType" flags="in" index="3bZ5Sz" />
@@ -319,7 +322,7 @@
       <node concept="3Tmbuc" id="DYlgnA$vt3" role="1B3o_S" />
       <node concept="3clFbS" id="DYlgnA$vt4" role="3clF47">
         <node concept="3cpWs6" id="6fymoI4XrqQ" role="3cqZAp">
-          <node concept="2OqwBi" id="6fymoI4XrqR" role="3cqZAk">
+          <node concept="2EnYce" id="E9Bg75kjNT" role="3cqZAk">
             <node concept="2OqwBi" id="6fymoI4XrqS" role="2Oq$k0">
               <node concept="37vLTw" id="6fymoI4XrqT" role="2Oq$k0">
                 <ref role="3cqZAo" node="DYlgnA$stH" resolve="expected" />
@@ -369,7 +372,7 @@
       <node concept="3Tmbuc" id="DYlgnA$vtd" role="1B3o_S" />
       <node concept="3clFbS" id="DYlgnA$vte" role="3clF47">
         <node concept="3cpWs6" id="6fymoI4Xrlm" role="3cqZAp">
-          <node concept="2OqwBi" id="6fymoI4Xrln" role="3cqZAk">
+          <node concept="2EnYce" id="E9Bg75kkBA" role="3cqZAk">
             <node concept="2OqwBi" id="6fymoI4Xrlo" role="2Oq$k0">
               <node concept="37vLTw" id="6fymoI4Xrlp" role="2Oq$k0">
                 <ref role="3cqZAo" node="DYlgnA$stK" resolve="actual" />

--- a/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.comparator/models/PropertyDifference.mpsr
+++ b/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.comparator/models/PropertyDifference.mpsr
@@ -2,10 +2,16 @@
 <model ref="r:ec874b45-e888-42e6-995a-a298cefdff55(com.mbeddr.mpsutil.comparator.code)" content="root">
   <persistence version="9" />
   <imports>
+    <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" implicit="true" />
+    <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
+    <import index="cttk" ref="r:5ff047e0-2953-4750-806a-bdc16824aa89(jetbrains.mps.smodel)" implicit="true" />
     <import index="mhbf" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.model(MPS.OpenAPI/)" implicit="true" />
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1082485599095" name="jetbrains.mps.baseLanguage.structure.BlockStatement" flags="nn" index="9aQIb">
+        <child id="1082485599096" name="statements" index="9aQI4" />
+      </concept>
       <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
         <child id="1068498886297" name="rValue" index="37vLTx" />
         <child id="1068498886295" name="lValue" index="37vLTJ" />
@@ -27,9 +33,19 @@
       <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
         <property id="1070475926801" name="value" index="Xl_RC" />
       </concept>
+      <concept id="1070533707846" name="jetbrains.mps.baseLanguage.structure.StaticFieldReference" flags="nn" index="10M0yZ">
+        <reference id="1144433057691" name="classifier" index="1PxDUh" />
+      </concept>
+      <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
       <concept id="1068390468200" name="jetbrains.mps.baseLanguage.structure.FieldDeclaration" flags="ig" index="312cEg" />
       <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu">
         <child id="1165602531693" name="superclass" index="1zkMxy" />
+      </concept>
+      <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
+        <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ng" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
       </concept>
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
@@ -37,6 +53,7 @@
       <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
       <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
       <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
+      <concept id="1225271283259" name="jetbrains.mps.baseLanguage.structure.NPEEqualsExpression" flags="nn" index="17R0WA" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
       </concept>
@@ -53,25 +70,35 @@
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
+      <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
+        <child id="1082485599094" name="ifFalseStatement" index="9aQIa" />
+        <child id="1068580123160" name="condition" index="3clFbw" />
+        <child id="1068580123161" name="ifTrue" index="3clFbx" />
+      </concept>
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
       </concept>
       <concept id="1068580123140" name="jetbrains.mps.baseLanguage.structure.ConstructorDeclaration" flags="ig" index="3clFbW" />
-      <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
       <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
         <child id="1068581517676" name="expression" index="3cqZAk" />
       </concept>
+      <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
+        <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
+      </concept>
+      <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
       <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
       <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
+      <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk" />
       <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
         <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
       </concept>
       <concept id="7812454656619025416" name="jetbrains.mps.baseLanguage.structure.MethodDeclaration" flags="ng" index="1rXfSm">
         <property id="8355037393041754995" name="isNative" index="2aFKle" />
       </concept>
+      <concept id="7812454656619025412" name="jetbrains.mps.baseLanguage.structure.LocalMethodCall" flags="nn" index="1rXfSq" />
       <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
         <reference id="1107535924139" name="classifier" index="3uigEE" />
       </concept>
@@ -79,6 +106,7 @@
         <child id="1081773367579" name="rightExpression" index="3uHU7w" />
         <child id="1081773367580" name="leftExpression" index="3uHU7B" />
       </concept>
+      <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
       <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
       </concept>
@@ -118,7 +146,9 @@
     <node concept="312cEg" id="DYlgnAAI3f" role="jymVt">
       <property role="TrG5h" value="property" />
       <node concept="3Tm6S6" id="DYlgnAAI3g" role="1B3o_S" />
-      <node concept="17QB3L" id="1rBPbD3KLxJ" role="1tU5fm" />
+      <node concept="3uibUv" id="E9Bg74gELs" role="1tU5fm">
+        <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
+      </node>
     </node>
     <node concept="2tJIrI" id="DYlgnAAI2T" role="jymVt" />
     <node concept="3clFbW" id="DYlgnAAIIk" role="jymVt">
@@ -140,7 +170,9 @@
       </node>
       <node concept="37vLTG" id="DYlgnAAIIt" role="3clF46">
         <property role="TrG5h" value="property" />
-        <node concept="17QB3L" id="1rBPbD3KLIz" role="1tU5fm" />
+        <node concept="3uibUv" id="E9Bg74gFqO" role="1tU5fm">
+          <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
+        </node>
       </node>
       <node concept="3cqZAl" id="DYlgnAAIIv" role="3clF45" />
       <node concept="3clFbS" id="DYlgnAAIIw" role="3clF47">
@@ -186,7 +218,9 @@
           </node>
         </node>
       </node>
-      <node concept="17QB3L" id="1rBPbD3KLJm" role="3clF45" />
+      <node concept="3uibUv" id="E9Bg74h6tg" role="3clF45">
+        <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
+      </node>
     </node>
     <node concept="2tJIrI" id="1rBPbD3Jj$1" role="jymVt" />
     <node concept="3clFb_" id="Pu8Vy2dm20" role="jymVt">
@@ -220,73 +254,361 @@
       <node concept="17QB3L" id="DYlgnAAJ$l" role="3clF45" />
       <node concept="3Tmbuc" id="DYlgnAAJ$m" role="1B3o_S" />
       <node concept="3clFbS" id="DYlgnAAJ$n" role="3clF47">
-        <node concept="3cpWs6" id="6fymoI4X$p7" role="3cqZAp">
-          <node concept="3cpWs3" id="6fymoI4X$p8" role="3cqZAk">
-            <node concept="2OqwBi" id="6fymoI4X$p9" role="3uHU7w">
-              <node concept="2JrnkZ" id="6fymoI4X$pa" role="2Oq$k0">
-                <node concept="3P9mCS" id="6fymoI4X$pb" role="2JrQYb">
-                  <ref role="37wK5l" node="DYlgnA$vtl" resolve="getActual" />
-                </node>
+        <node concept="3cpWs8" id="E9Bg74h7IW" role="3cqZAp">
+          <node concept="3cpWsn" id="E9Bg74h7IX" role="3cpWs9">
+            <property role="TrG5h" value="description" />
+            <node concept="3uibUv" id="E9Bg74h7IY" role="1tU5fm">
+              <ref role="3uigEE" to="wyt6:~StringBuilder" resolve="StringBuilder" />
+            </node>
+            <node concept="2ShNRf" id="E9Bg74h8D5" role="33vP2m">
+              <node concept="1pGfFk" id="E9Bg74hdso" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="wyt6:~StringBuilder.&lt;init&gt;()" resolve="StringBuilder" />
               </node>
-              <node concept="liA8E" id="6fymoI4X$pc" role="2OqNvi">
-                <ref role="37wK5l" to="mhbf:~SNode.getProperty(java.lang.String)" resolve="getProperty" />
-                <node concept="37vLTw" id="6fymoI4X$pd" role="37wK5m">
-                  <ref role="3cqZAo" node="DYlgnAAI3f" resolve="property" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="E9Bg74hnSQ" role="3cqZAp">
+          <node concept="3clFbS" id="E9Bg74hnSS" role="3clFbx">
+            <node concept="3clFbF" id="E9Bg74h_OB" role="3cqZAp">
+              <node concept="2OqwBi" id="E9Bg74hB4X" role="3clFbG">
+                <node concept="37vLTw" id="E9Bg74h_O_" role="2Oq$k0">
+                  <ref role="3cqZAo" node="E9Bg74h7IX" resolve="description" />
+                </node>
+                <node concept="liA8E" id="E9Bg74hBFS" role="2OqNvi">
+                  <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String)" resolve="append" />
+                  <node concept="Xl_RD" id="E9Bg74hBYw" role="37wK5m">
+                    <property role="Xl_RC" value="name (property) is different: expected '" />
+                  </node>
                 </node>
               </node>
             </node>
-            <node concept="3cpWs3" id="6fymoI4X$pe" role="3uHU7B">
-              <node concept="Xl_RD" id="6fymoI4X$pf" role="3uHU7w">
-                <property role="Xl_RC" value=" it is " />
+            <node concept="3clFbF" id="E9Bg74k33a" role="3cqZAp">
+              <node concept="2OqwBi" id="E9Bg74k3WX" role="3clFbG">
+                <node concept="37vLTw" id="E9Bg74k338" role="2Oq$k0">
+                  <ref role="3cqZAo" node="E9Bg74h7IX" resolve="description" />
+                </node>
+                <node concept="liA8E" id="E9Bg74k4WF" role="2OqNvi">
+                  <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String)" resolve="append" />
+                  <node concept="37vLTw" id="E9Bg74k5v2" role="37wK5m">
+                    <ref role="3cqZAo" node="DYlgnAAJ$O" resolve="nameForA" />
+                  </node>
+                </node>
               </node>
-              <node concept="3cpWs3" id="6fymoI4X$pg" role="3uHU7B">
-                <node concept="3cpWs3" id="6fymoI4X$ph" role="3uHU7B">
-                  <node concept="3cpWs3" id="6fymoI4X$pi" role="3uHU7B">
-                    <node concept="3cpWs3" id="6fymoI4X$pj" role="3uHU7B">
-                      <node concept="Xl_RD" id="6fymoI4X$pk" role="3uHU7w">
-                        <property role="Xl_RC" value=" it is " />
+            </node>
+            <node concept="3clFbF" id="E9Bg74k6In" role="3cqZAp">
+              <node concept="2OqwBi" id="E9Bg74k7bj" role="3clFbG">
+                <node concept="37vLTw" id="E9Bg74k6Il" role="2Oq$k0">
+                  <ref role="3cqZAo" node="E9Bg74h7IX" resolve="description" />
+                </node>
+                <node concept="liA8E" id="E9Bg74k7GO" role="2OqNvi">
+                  <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String)" resolve="append" />
+                  <node concept="Xl_RD" id="E9Bg74hEWD" role="37wK5m">
+                    <property role="Xl_RC" value="' got '" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="E9Bg74ka1f" role="3cqZAp">
+              <node concept="2OqwBi" id="E9Bg74kafI" role="3clFbG">
+                <node concept="37vLTw" id="E9Bg74ka1d" role="2Oq$k0">
+                  <ref role="3cqZAo" node="E9Bg74h7IX" resolve="description" />
+                </node>
+                <node concept="liA8E" id="E9Bg74kaML" role="2OqNvi">
+                  <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String)" resolve="append" />
+                  <node concept="37vLTw" id="E9Bg74kbmU" role="37wK5m">
+                    <ref role="3cqZAo" node="DYlgnAAJ$Q" resolve="nameForB" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="E9Bg74kdfy" role="3cqZAp">
+              <node concept="2OqwBi" id="E9Bg74kdxb" role="3clFbG">
+                <node concept="37vLTw" id="E9Bg74kdfw" role="2Oq$k0">
+                  <ref role="3cqZAo" node="E9Bg74h7IX" resolve="description" />
+                </node>
+                <node concept="liA8E" id="E9Bg74ke4W" role="2OqNvi">
+                  <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String)" resolve="append" />
+                  <node concept="Xl_RD" id="E9Bg74jUZJ" role="37wK5m">
+                    <property role="Xl_RC" value="'" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="17R0WA" id="E9Bg74h_ii" role="3clFbw">
+            <node concept="37vLTw" id="E9Bg74ho$v" role="3uHU7B">
+              <ref role="3cqZAo" node="DYlgnAAI3f" resolve="property" />
+            </node>
+            <node concept="10M0yZ" id="E9Bg74hznt" role="3uHU7w">
+              <ref role="3cqZAo" to="cttk:2iMJRNxJZUI" resolve="property_INamedConcept_name" />
+              <ref role="1PxDUh" to="cttk:1YioXbrr5pb" resolve="SNodeUtil" />
+            </node>
+          </node>
+          <node concept="9aQIb" id="E9Bg74hGsf" role="9aQIa">
+            <node concept="3clFbS" id="E9Bg74hGsg" role="9aQI4">
+              <node concept="3clFbF" id="E9Bg74hhil" role="3cqZAp">
+                <node concept="2OqwBi" id="E9Bg74hhzE" role="3clFbG">
+                  <node concept="37vLTw" id="E9Bg74hhij" role="2Oq$k0">
+                    <ref role="3cqZAo" node="E9Bg74h7IX" resolve="description" />
+                  </node>
+                  <node concept="liA8E" id="E9Bg74hhLd" role="2OqNvi">
+                    <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String)" resolve="append" />
+                    <node concept="2OqwBi" id="E9Bg74hk35" role="37wK5m">
+                      <node concept="37vLTw" id="E9Bg74hi$D" role="2Oq$k0">
+                        <ref role="3cqZAo" node="DYlgnAAI3f" resolve="property" />
                       </node>
-                      <node concept="3cpWs3" id="6fymoI4X$pl" role="3uHU7B">
-                        <node concept="3cpWs3" id="6fymoI4X$pm" role="3uHU7B">
-                          <node concept="3cpWs3" id="6fymoI4X$pn" role="3uHU7B">
-                            <node concept="Xl_RD" id="6fymoI4X$po" role="3uHU7B">
-                              <property role="Xl_RC" value="property " />
-                            </node>
-                            <node concept="37vLTw" id="6fymoI4X$pp" role="3uHU7w">
-                              <ref role="3cqZAo" node="DYlgnAAI3f" resolve="property" />
-                            </node>
-                          </node>
-                          <node concept="Xl_RD" id="6fymoI4X$pq" role="3uHU7w">
-                            <property role="Xl_RC" value=" is different. For " />
-                          </node>
-                        </node>
-                        <node concept="37vLTw" id="6fymoI4X$pr" role="3uHU7w">
-                          <ref role="3cqZAo" node="DYlgnAAJ$O" resolve="nameForA" />
-                        </node>
+                      <node concept="liA8E" id="E9Bg74hkuF" role="2OqNvi">
+                        <ref role="37wK5l" to="c17a:~SProperty.getName()" resolve="getName" />
                       </node>
                     </node>
-                    <node concept="2OqwBi" id="6fymoI4X$ps" role="3uHU7w">
-                      <node concept="2JrnkZ" id="6fymoI4X$pt" role="2Oq$k0">
-                        <node concept="3P9mCS" id="6fymoI4X$pu" role="2JrQYb">
-                          <ref role="37wK5l" node="DYlgnA$vsF" resolve="getExpected" />
-                        </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbF" id="E9Bg74hjll" role="3cqZAp">
+                <node concept="2OqwBi" id="E9Bg74hjC0" role="3clFbG">
+                  <node concept="37vLTw" id="E9Bg74hjlj" role="2Oq$k0">
+                    <ref role="3cqZAo" node="E9Bg74h7IX" resolve="description" />
+                  </node>
+                  <node concept="liA8E" id="E9Bg74hl2W" role="2OqNvi">
+                    <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String)" resolve="append" />
+                    <node concept="Xl_RD" id="E9Bg74hlxK" role="37wK5m">
+                      <property role="Xl_RC" value=" (property) is different: expected " />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbF" id="E9Bg74iOkd" role="3cqZAp">
+                <node concept="2OqwBi" id="E9Bg74iP15" role="3clFbG">
+                  <node concept="37vLTw" id="E9Bg74iOkb" role="2Oq$k0">
+                    <ref role="3cqZAo" node="E9Bg74h7IX" resolve="description" />
+                  </node>
+                  <node concept="liA8E" id="E9Bg74iQgE" role="2OqNvi">
+                    <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String)" resolve="append" />
+                    <node concept="37vLTw" id="E9Bg74iRJS" role="37wK5m">
+                      <ref role="3cqZAo" node="DYlgnAAJ$O" resolve="nameForA" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbF" id="E9Bg74iSDx" role="3cqZAp">
+                <node concept="2OqwBi" id="E9Bg74iSDy" role="3clFbG">
+                  <node concept="37vLTw" id="E9Bg74iSDz" role="2Oq$k0">
+                    <ref role="3cqZAo" node="E9Bg74h7IX" resolve="description" />
+                  </node>
+                  <node concept="liA8E" id="E9Bg74iSD$" role="2OqNvi">
+                    <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String)" resolve="append" />
+                    <node concept="Xl_RD" id="E9Bg74iTKJ" role="37wK5m">
+                      <property role="Xl_RC" value=" = " />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3cpWs8" id="E9Bg74mZLz" role="3cqZAp">
+                <node concept="3cpWsn" id="E9Bg74mZL$" role="3cpWs9">
+                  <property role="TrG5h" value="expected" />
+                  <node concept="17QB3L" id="E9Bg74naHU" role="1tU5fm" />
+                  <node concept="2OqwBi" id="E9Bg74mZL_" role="33vP2m">
+                    <node concept="2JrnkZ" id="E9Bg74mZLA" role="2Oq$k0">
+                      <node concept="3P9mCS" id="E9Bg74mZLB" role="2JrQYb">
+                        <ref role="37wK5l" node="DYlgnA$vsF" resolve="getExpected" />
                       </node>
-                      <node concept="liA8E" id="6fymoI4X$pv" role="2OqNvi">
-                        <ref role="37wK5l" to="mhbf:~SNode.getProperty(java.lang.String)" resolve="getProperty" />
-                        <node concept="37vLTw" id="6fymoI4X$pw" role="37wK5m">
-                          <ref role="3cqZAo" node="DYlgnAAI3f" resolve="property" />
+                    </node>
+                    <node concept="liA8E" id="E9Bg74mZLC" role="2OqNvi">
+                      <ref role="37wK5l" to="mhbf:~SNode.getProperty(org.jetbrains.mps.openapi.language.SProperty)" resolve="getProperty" />
+                      <node concept="37vLTw" id="E9Bg74mZLD" role="37wK5m">
+                        <ref role="3cqZAo" node="DYlgnAAI3f" resolve="property" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbJ" id="E9Bg74n1Np" role="3cqZAp">
+                <node concept="3clFbS" id="E9Bg74n1Nr" role="3clFbx">
+                  <node concept="3clFbF" id="E9Bg74n55x" role="3cqZAp">
+                    <node concept="2OqwBi" id="E9Bg74n5UU" role="3clFbG">
+                      <node concept="37vLTw" id="E9Bg74n55v" role="2Oq$k0">
+                        <ref role="3cqZAo" node="E9Bg74h7IX" resolve="description" />
+                      </node>
+                      <node concept="liA8E" id="E9Bg74n6K5" role="2OqNvi">
+                        <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String)" resolve="append" />
+                        <node concept="Xl_RD" id="E9Bg74n7ef" role="37wK5m">
+                          <property role="Xl_RC" value="'" />
                         </node>
                       </node>
                     </node>
                   </node>
-                  <node concept="Xl_RD" id="6fymoI4X$px" role="3uHU7w">
-                    <property role="Xl_RC" value=", for " />
+                </node>
+                <node concept="3y3z36" id="E9Bg74n3qz" role="3clFbw">
+                  <node concept="10Nm6u" id="E9Bg74n4cv" role="3uHU7w" />
+                  <node concept="37vLTw" id="E9Bg74n2DS" role="3uHU7B">
+                    <ref role="3cqZAo" node="E9Bg74mZL$" resolve="expected" />
                   </node>
                 </node>
-                <node concept="37vLTw" id="6fymoI4X$py" role="3uHU7w">
-                  <ref role="3cqZAo" node="DYlgnAAJ$Q" resolve="nameForB" />
+              </node>
+              <node concept="3clFbF" id="E9Bg74iVU0" role="3cqZAp">
+                <node concept="2OqwBi" id="E9Bg74iWwP" role="3clFbG">
+                  <node concept="37vLTw" id="E9Bg74iVTY" role="2Oq$k0">
+                    <ref role="3cqZAo" node="E9Bg74h7IX" resolve="description" />
+                  </node>
+                  <node concept="liA8E" id="E9Bg74iX2$" role="2OqNvi">
+                    <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String)" resolve="append" />
+                    <node concept="37vLTw" id="E9Bg74mZLE" role="37wK5m">
+                      <ref role="3cqZAo" node="E9Bg74mZL$" resolve="property" />
+                    </node>
+                  </node>
                 </node>
               </node>
+              <node concept="3clFbJ" id="E9Bg74n93F" role="3cqZAp">
+                <node concept="3clFbS" id="E9Bg74n93G" role="3clFbx">
+                  <node concept="3clFbF" id="E9Bg74n93H" role="3cqZAp">
+                    <node concept="2OqwBi" id="E9Bg74n93I" role="3clFbG">
+                      <node concept="37vLTw" id="E9Bg74n93J" role="2Oq$k0">
+                        <ref role="3cqZAo" node="E9Bg74h7IX" resolve="description" />
+                      </node>
+                      <node concept="liA8E" id="E9Bg74n93K" role="2OqNvi">
+                        <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String)" resolve="append" />
+                        <node concept="Xl_RD" id="E9Bg74n93L" role="37wK5m">
+                          <property role="Xl_RC" value="'" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3y3z36" id="E9Bg74n93M" role="3clFbw">
+                  <node concept="10Nm6u" id="E9Bg74n93N" role="3uHU7w" />
+                  <node concept="37vLTw" id="E9Bg74n93O" role="3uHU7B">
+                    <ref role="3cqZAo" node="E9Bg74mZL$" resolve="expected" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbF" id="E9Bg74j9OM" role="3cqZAp">
+                <node concept="2OqwBi" id="E9Bg74jaSX" role="3clFbG">
+                  <node concept="37vLTw" id="E9Bg74j9OK" role="2Oq$k0">
+                    <ref role="3cqZAo" node="E9Bg74h7IX" resolve="description" />
+                  </node>
+                  <node concept="liA8E" id="E9Bg74jbH8" role="2OqNvi">
+                    <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String)" resolve="append" />
+                    <node concept="Xl_RD" id="E9Bg74jcd2" role="37wK5m">
+                      <property role="Xl_RC" value=", got " />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbF" id="E9Bg74iZ4M" role="3cqZAp">
+                <node concept="2OqwBi" id="E9Bg74iZ4N" role="3clFbG">
+                  <node concept="37vLTw" id="E9Bg74iZ4O" role="2Oq$k0">
+                    <ref role="3cqZAo" node="E9Bg74h7IX" resolve="description" />
+                  </node>
+                  <node concept="liA8E" id="E9Bg74iZ4P" role="2OqNvi">
+                    <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String)" resolve="append" />
+                    <node concept="37vLTw" id="E9Bg74iZ4Q" role="37wK5m">
+                      <ref role="3cqZAo" node="DYlgnAAJ$Q" resolve="nameForB" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3cpWs8" id="E9Bg74nbcG" role="3cqZAp">
+                <node concept="3cpWsn" id="E9Bg74nbcH" role="3cpWs9">
+                  <property role="TrG5h" value="actual" />
+                  <node concept="17QB3L" id="E9Bg74nbcI" role="1tU5fm" />
+                  <node concept="2OqwBi" id="E9Bg74nbcJ" role="33vP2m">
+                    <node concept="2JrnkZ" id="E9Bg74nbcK" role="2Oq$k0">
+                      <node concept="1rXfSq" id="E9Bg74ncIc" role="2JrQYb">
+                        <ref role="37wK5l" node="DYlgnA$vtl" resolve="getActual" />
+                      </node>
+                    </node>
+                    <node concept="liA8E" id="E9Bg74nbcM" role="2OqNvi">
+                      <ref role="37wK5l" to="mhbf:~SNode.getProperty(org.jetbrains.mps.openapi.language.SProperty)" resolve="getProperty" />
+                      <node concept="37vLTw" id="E9Bg74nbcN" role="37wK5m">
+                        <ref role="3cqZAo" node="DYlgnAAI3f" resolve="property" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbF" id="E9Bg74iZ4R" role="3cqZAp">
+                <node concept="2OqwBi" id="E9Bg74iZ4S" role="3clFbG">
+                  <node concept="37vLTw" id="E9Bg74iZ4T" role="2Oq$k0">
+                    <ref role="3cqZAo" node="E9Bg74h7IX" resolve="description" />
+                  </node>
+                  <node concept="liA8E" id="E9Bg74iZ4U" role="2OqNvi">
+                    <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String)" resolve="append" />
+                    <node concept="Xl_RD" id="E9Bg74iZ4V" role="37wK5m">
+                      <property role="Xl_RC" value=" = " />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbJ" id="E9Bg74nfxW" role="3cqZAp">
+                <node concept="3clFbS" id="E9Bg74nfxX" role="3clFbx">
+                  <node concept="3clFbF" id="E9Bg74nfxY" role="3cqZAp">
+                    <node concept="2OqwBi" id="E9Bg74nfxZ" role="3clFbG">
+                      <node concept="37vLTw" id="E9Bg74nfy0" role="2Oq$k0">
+                        <ref role="3cqZAo" node="E9Bg74h7IX" resolve="description" />
+                      </node>
+                      <node concept="liA8E" id="E9Bg74nfy1" role="2OqNvi">
+                        <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String)" resolve="append" />
+                        <node concept="Xl_RD" id="E9Bg74nfy2" role="37wK5m">
+                          <property role="Xl_RC" value="'" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3y3z36" id="E9Bg74nfy3" role="3clFbw">
+                  <node concept="10Nm6u" id="E9Bg74nfy4" role="3uHU7w" />
+                  <node concept="37vLTw" id="E9Bg74nfy5" role="3uHU7B">
+                    <ref role="3cqZAo" node="E9Bg74nbcH" resolve="actual" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbF" id="E9Bg74iZ4W" role="3cqZAp">
+                <node concept="2OqwBi" id="E9Bg74iZ4X" role="3clFbG">
+                  <node concept="37vLTw" id="E9Bg74iZ4Y" role="2Oq$k0">
+                    <ref role="3cqZAo" node="E9Bg74h7IX" resolve="description" />
+                  </node>
+                  <node concept="liA8E" id="E9Bg74iZ4Z" role="2OqNvi">
+                    <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String)" resolve="append" />
+                    <node concept="37vLTw" id="E9Bg74ndJ4" role="37wK5m">
+                      <ref role="3cqZAo" node="E9Bg74nbcH" resolve="actual" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbJ" id="E9Bg74nhDF" role="3cqZAp">
+                <node concept="3clFbS" id="E9Bg74nhDG" role="3clFbx">
+                  <node concept="3clFbF" id="E9Bg74nhDH" role="3cqZAp">
+                    <node concept="2OqwBi" id="E9Bg74nhDI" role="3clFbG">
+                      <node concept="37vLTw" id="E9Bg74nhDJ" role="2Oq$k0">
+                        <ref role="3cqZAo" node="E9Bg74h7IX" resolve="description" />
+                      </node>
+                      <node concept="liA8E" id="E9Bg74nhDK" role="2OqNvi">
+                        <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String)" resolve="append" />
+                        <node concept="Xl_RD" id="E9Bg74nhDL" role="37wK5m">
+                          <property role="Xl_RC" value="'" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3y3z36" id="E9Bg74nhDM" role="3clFbw">
+                  <node concept="10Nm6u" id="E9Bg74nhDN" role="3uHU7w" />
+                  <node concept="37vLTw" id="E9Bg74nhDO" role="3uHU7B">
+                    <ref role="3cqZAo" node="E9Bg74nbcH" resolve="actual" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="6fymoI4X$p7" role="3cqZAp">
+          <node concept="2OqwBi" id="E9Bg74hYdD" role="3cqZAk">
+            <node concept="37vLTw" id="E9Bg74hXlg" role="2Oq$k0">
+              <ref role="3cqZAo" node="E9Bg74h7IX" resolve="description" />
+            </node>
+            <node concept="liA8E" id="E9Bg74hZ36" role="2OqNvi">
+              <ref role="37wK5l" to="wyt6:~StringBuilder.toString()" resolve="toString" />
             </node>
           </node>
         </node>
@@ -314,7 +636,7 @@
               </node>
             </node>
             <node concept="liA8E" id="6fymoI4X$$a" role="2OqNvi">
-              <ref role="37wK5l" to="mhbf:~SNode.getProperty(java.lang.String)" resolve="getProperty" />
+              <ref role="37wK5l" to="mhbf:~SNode.getProperty(org.jetbrains.mps.openapi.language.SProperty)" resolve="getProperty" />
               <node concept="37vLTw" id="6fymoI4X$$b" role="37wK5m">
                 <ref role="3cqZAo" node="DYlgnAAI3f" resolve="property" />
               </node>
@@ -337,7 +659,7 @@
               </node>
             </node>
             <node concept="liA8E" id="6fymoI4X$D3" role="2OqNvi">
-              <ref role="37wK5l" to="mhbf:~SNode.getProperty(java.lang.String)" resolve="getProperty" />
+              <ref role="37wK5l" to="mhbf:~SNode.getProperty(org.jetbrains.mps.openapi.language.SProperty)" resolve="getProperty" />
               <node concept="37vLTw" id="6fymoI4X$D4" role="37wK5m">
                 <ref role="3cqZAo" node="DYlgnAAI3f" resolve="property" />
               </node>

--- a/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.comparator/models/ReferenceDifference.mpsr
+++ b/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.comparator/models/ReferenceDifference.mpsr
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <model ref="r:ec874b45-e888-42e6-995a-a298cefdff55(com.mbeddr.mpsutil.comparator.code)" content="root">
   <persistence version="9" />
-  <imports />
+  <imports>
+    <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
+  </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
       <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
@@ -17,6 +19,9 @@
       <concept id="1197029447546" name="jetbrains.mps.baseLanguage.structure.FieldReferenceOperation" flags="nn" index="2OwXpG">
         <reference id="1197029500499" name="fieldDeclaration" index="2Oxat5" />
       </concept>
+      <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
+        <child id="1145553007750" name="creator" index="2ShVmc" />
+      </concept>
       <concept id="1070475354124" name="jetbrains.mps.baseLanguage.structure.ThisExpression" flags="nn" index="Xjq3P" />
       <concept id="1070475587102" name="jetbrains.mps.baseLanguage.structure.SuperConstructorInvocation" flags="nn" index="XkiVB" />
       <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
@@ -28,6 +33,12 @@
       <concept id="1068390468200" name="jetbrains.mps.baseLanguage.structure.FieldDeclaration" flags="ig" index="312cEg" />
       <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu">
         <child id="1165602531693" name="superclass" index="1zkMxy" />
+      </concept>
+      <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
+        <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ng" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
       </concept>
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
@@ -55,15 +66,19 @@
         <child id="1068581517665" name="statement" index="3cqZAp" />
       </concept>
       <concept id="1068580123140" name="jetbrains.mps.baseLanguage.structure.ConstructorDeclaration" flags="ig" index="3clFbW" />
-      <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
       <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
         <child id="1068581517676" name="expression" index="3cqZAk" />
       </concept>
+      <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
+        <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
+      </concept>
+      <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
       <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
       <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
+      <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk" />
       <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
         <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
       </concept>
@@ -73,10 +88,6 @@
       <concept id="7812454656619025412" name="jetbrains.mps.baseLanguage.structure.LocalMethodCall" flags="nn" index="1rXfSq" />
       <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
         <reference id="1107535924139" name="classifier" index="3uigEE" />
-      </concept>
-      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
-        <child id="1081773367579" name="rightExpression" index="3uHU7w" />
-        <child id="1081773367580" name="leftExpression" index="3uHU7B" />
       </concept>
       <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
@@ -255,32 +266,75 @@
       <node concept="17QB3L" id="DYlgnAAR3D" role="3clF45" />
       <node concept="3Tmbuc" id="DYlgnAAR3E" role="1B3o_S" />
       <node concept="3clFbS" id="DYlgnAAR3F" role="3clF47">
-        <node concept="3cpWs6" id="6fymoI4X_0I" role="3cqZAp">
-          <node concept="3cpWs3" id="6fymoI4X_0J" role="3cqZAk">
-            <node concept="2YIFZM" id="6fymoI4X_0K" role="3uHU7w">
-              <ref role="1Pybhc" node="DYlgnAAVf1" resolve="StringUtils" />
-              <ref role="37wK5l" node="DYlgnAAVkz" resolve="indent" />
-              <node concept="2OqwBi" id="6fymoI4X_0L" role="37wK5m">
-                <node concept="37vLTw" id="6fymoI4X_0M" role="2Oq$k0">
-                  <ref role="3cqZAo" node="DYlgnAAQeQ" resolve="result" />
-                </node>
-                <node concept="liA8E" id="6fymoI4X_0N" role="2OqNvi">
-                  <ref role="37wK5l" node="DYlgnAAwiN" resolve="getDescription" />
+        <node concept="3cpWs8" id="E9Bg74u1vn" role="3cqZAp">
+          <node concept="3cpWsn" id="E9Bg74u1vo" role="3cpWs9">
+            <property role="TrG5h" value="description" />
+            <node concept="3uibUv" id="E9Bg74u1vp" role="1tU5fm">
+              <ref role="3uigEE" to="wyt6:~StringBuilder" resolve="StringBuilder" />
+            </node>
+            <node concept="2ShNRf" id="E9Bg74u1VS" role="33vP2m">
+              <node concept="1pGfFk" id="E9Bg74u2oO" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="wyt6:~StringBuilder.&lt;init&gt;()" resolve="StringBuilder" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="E9Bg74u39y" role="3cqZAp">
+          <node concept="2OqwBi" id="E9Bg74u4Sj" role="3clFbG">
+            <node concept="37vLTw" id="E9Bg74u39w" role="2Oq$k0">
+              <ref role="3cqZAo" node="E9Bg74u1vo" resolve="description" />
+            </node>
+            <node concept="liA8E" id="E9Bg74u51L" role="2OqNvi">
+              <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String)" resolve="append" />
+              <node concept="37vLTw" id="E9Bg74u5oH" role="37wK5m">
+                <ref role="3cqZAo" node="DYlgnAAQeN" resolve="link" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="E9Bg74u6s$" role="3cqZAp">
+          <node concept="2OqwBi" id="E9Bg74u6DV" role="3clFbG">
+            <node concept="37vLTw" id="E9Bg74u6sy" role="2Oq$k0">
+              <ref role="3cqZAo" node="E9Bg74u1vo" resolve="description" />
+            </node>
+            <node concept="liA8E" id="E9Bg74u6Oo" role="2OqNvi">
+              <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String)" resolve="append" />
+              <node concept="Xl_RD" id="E9Bg74u7oX" role="37wK5m">
+                <property role="Xl_RC" value=" (reference) is different:\n\t" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="E9Bg74u9Mf" role="3cqZAp">
+          <node concept="2OqwBi" id="E9Bg74uaom" role="3clFbG">
+            <node concept="37vLTw" id="E9Bg74u9Md" role="2Oq$k0">
+              <ref role="3cqZAo" node="E9Bg74u1vo" resolve="description" />
+            </node>
+            <node concept="liA8E" id="E9Bg74uaU2" role="2OqNvi">
+              <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String)" resolve="append" />
+              <node concept="2YIFZM" id="E9Bg74ub4z" role="37wK5m">
+                <ref role="1Pybhc" node="DYlgnAAVf1" resolve="StringUtils" />
+                <ref role="37wK5l" node="DYlgnAAVkz" resolve="indent" />
+                <node concept="2OqwBi" id="E9Bg74ub4$" role="37wK5m">
+                  <node concept="37vLTw" id="E9Bg74ub4_" role="2Oq$k0">
+                    <ref role="3cqZAo" node="DYlgnAAQeQ" resolve="result" />
+                  </node>
+                  <node concept="liA8E" id="E9Bg74ub4A" role="2OqNvi">
+                    <ref role="37wK5l" node="DYlgnAAwiN" resolve="getDescription" />
+                  </node>
                 </node>
               </node>
             </node>
-            <node concept="3cpWs3" id="6fymoI4X_0O" role="3uHU7B">
-              <node concept="3cpWs3" id="6fymoI4X_0P" role="3uHU7B">
-                <node concept="Xl_RD" id="6fymoI4X_0Q" role="3uHU7B">
-                  <property role="Xl_RC" value="Reference of role " />
-                </node>
-                <node concept="37vLTw" id="6fymoI4X_0R" role="3uHU7w">
-                  <ref role="3cqZAo" node="DYlgnAAQeN" resolve="link" />
-                </node>
-              </node>
-              <node concept="Xl_RD" id="6fymoI4X_0S" role="3uHU7w">
-                <property role="Xl_RC" value=" is different because:\n\t" />
-              </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="6fymoI4X_0I" role="3cqZAp">
+          <node concept="2OqwBi" id="E9Bg74ubZ9" role="3cqZAk">
+            <node concept="37vLTw" id="E9Bg74ubRz" role="2Oq$k0">
+              <ref role="3cqZAo" node="E9Bg74u1vo" resolve="description" />
+            </node>
+            <node concept="liA8E" id="E9Bg74ucaY" role="2OqNvi">
+              <ref role="37wK5l" to="wyt6:~StringBuilder.toString()" resolve="toString" />
             </node>
           </node>
         </node>


### PR DESCRIPTION
 In addition to some null checks, node annotations and children of references can now be compared. The node difference descriptions were also improved. Also fixes #2308 but there is no separate error message because I couldn't reproduce the issue that I reported myself.