### PR TITLE
mpsutils: create a new language for check-in handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Semantic Versioning and the changes are simply documented in reverse chronologic
 
 ## com.mbeddr.platform
 
+### Added
+
+- A new language `com.mbeddr.mpsutil.checkinHandler` was added that can be used to execute pre-commit handlers which can approve or reject commits or execute arbitrary code before the checkin happens.
+
 ### Removed
 
 - The tests build script (`com.mbeddr.platform.tests.ts.build`) is no longer part of the `com.mbeddr.platform` build

--- a/code/languages/com.mbeddr.build/solutions/com.mbeddr.platform/models/com/mbeddr/platform/build.mps
+++ b/code/languages/com.mbeddr.build/solutions/com.mbeddr.platform/models/com/mbeddr/platform/build.mps
@@ -20901,6 +20901,10 @@
         <ref role="m_rDy" node="3lcj7hzsuXf" resolve="com.mbeddr.mpsutil.logicalChild" />
         <node concept="pUk6x" id="3lcj7hzsE8a" role="pUk7w" />
       </node>
+      <node concept="m$_wl" id="SUkpD3RkHU" role="39821P">
+        <ref role="m_rDy" node="2hNr1jFzOYG" resolve="com.mbeddr.mpsutil.checkinHandler" />
+        <node concept="pUk6x" id="SUkpD3Rllc" role="pUk7w" />
+      </node>
     </node>
     <node concept="m$_wf" id="64SK4bcO2rO" role="3989C9">
       <property role="m$_wk" value="com.mbeddr.mpsutil.projectview.favourites" />
@@ -21207,6 +21211,112 @@
       </node>
       <node concept="m$f5U" id="3lcj7hzs_XZ" role="m$_yh">
         <ref role="m$f5T" node="3lcj7hzsgVW" resolve="com.mbeddr.mpsutil.logicalChild" />
+      </node>
+    </node>
+    <node concept="2G$12M" id="2hNr1jFzOYr" role="3989C9">
+      <property role="TrG5h" value="com.mbeddr.mpsutil.checkinHandler" />
+      <node concept="1E1JtA" id="2hNr1jFzSEf" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="com.mbeddr.mpsutil.checkinHandler" />
+        <property role="3LESm3" value="5e43bd52-71f1-484a-90fa-e1e624f7e44b" />
+        <node concept="398BVA" id="2hNr1jFzSXU" role="3LF7KH">
+          <ref role="398BVh" node="7uZw0yZ2_Lj" resolve="mpsutil" />
+          <node concept="2Ry0Ak" id="2hNr1jFzSXV" role="iGT6I">
+            <property role="2Ry0Am" value="solutions" />
+            <node concept="2Ry0Ak" id="2hNr1jFzSXW" role="2Ry0An">
+              <property role="2Ry0Am" value="com.mbeddr.mpsutil.checkinHandler" />
+              <node concept="2Ry0Ak" id="5mHD6CprAVT" role="2Ry0An">
+                <property role="2Ry0Am" value="com.mbeddr.mpsutil.checkinHandler.msd" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2hNr1jFzUtA" role="3bR37C">
+          <node concept="3bR9La" id="2hNr1jFzUtB" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:1H905DlDUSw" resolve="MPS.OpenAPI" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2hNr1jFzUtC" role="3bR37C">
+          <node concept="3bR9La" id="2hNr1jFzUtD" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2hNr1jFzUtE" role="3bR37C">
+          <node concept="3bR9La" id="2hNr1jFzUtF" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:44LXwdzyvTi" resolve="Annotations" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2hNr1jFzUtG" role="3bR37C">
+          <node concept="3bR9La" id="2hNr1jFzUtH" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:1TaHNgiIbJb" resolve="MPS.Platform" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2hNr1jFzUtI" role="3bR37C">
+          <node concept="3bR9La" id="2hNr1jFzUtJ" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:1TaHNgiIbIQ" resolve="MPS.Core" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2hNr1jFzUtK" role="3bR37C">
+          <node concept="3bR9La" id="2hNr1jFzUtL" role="1SiIV1">
+            <property role="3bR36h" value="true" />
+            <ref role="3bR37D" to="ffeo:1ia2VB5guYy" resolve="MPS.IDEA" />
+          </node>
+        </node>
+        <node concept="1BupzO" id="2hNr1jFzUtX" role="3bR31x">
+          <property role="3ZfqAx" value="models" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="2hNr1jFzUtY" role="1HemKq">
+            <node concept="398BVA" id="2hNr1jFzUtM" role="3LXTmr">
+              <ref role="398BVh" node="7uZw0yZ2_Lj" resolve="mpsutil" />
+              <node concept="2Ry0Ak" id="2hNr1jFzUtN" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="2hNr1jFzUtO" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mbeddr.mpsutil.checkinHandler" />
+                  <node concept="2Ry0Ak" id="2hNr1jFzUtP" role="2Ry0An">
+                    <property role="2Ry0Am" value="models" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="2hNr1jFzUtZ" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="m$_wf" id="2hNr1jFzOYG" role="3989C9">
+      <property role="m$_wk" value="com.mbeddr.mpsutil.checkinHandler" />
+      <node concept="m$_yC" id="2hNr1jFzOYH" role="m$_yJ">
+        <ref role="m$_y1" to="ffeo:4k71ibbKLe8" resolve="jetbrains.mps.core" />
+      </node>
+      <node concept="3_J27D" id="2hNr1jFzOYI" role="m$_yQ">
+        <node concept="3Mxwew" id="2hNr1jFzOYJ" role="3MwsjC">
+          <property role="3MwjfP" value="com.mbeddr.mpsutil.checkinHandler" />
+        </node>
+      </node>
+      <node concept="3_J27D" id="2hNr1jFzOYK" role="m_cZH">
+        <node concept="3Mxwew" id="2hNr1jFzOYL" role="3MwsjC">
+          <property role="3MwjfP" value="com.mbeddr.mpsutil.checkinHandler" />
+        </node>
+      </node>
+      <node concept="3_J27D" id="2hNr1jFzOYM" role="m$_w8">
+        <node concept="3Mxwew" id="2hNr1jFzOYN" role="3MwsjC">
+          <property role="3MwjfP" value="mbeddr" />
+        </node>
+      </node>
+      <node concept="2iUeEo" id="2hNr1jFzOYO" role="2iVFfd">
+        <property role="2iUeEt" value="mbeddr" />
+        <property role="2iUeEu" value="http://mbeddr.com" />
+      </node>
+      <node concept="m$f5U" id="2hNr1jFzOYP" role="m$_yh">
+        <ref role="m$f5T" node="2hNr1jFzOYr" resolve="com.mbeddr.mpsutil.checkinHandler" />
+      </node>
+      <node concept="3_J27D" id="2hNr1jFzWjE" role="3s6cr7">
+        <node concept="3Mxwew" id="2hNr1jFzWjF" role="3MwsjC">
+          <property role="3MwjfP" value="helper plugin to create version control pre-commit handlers" />
+        </node>
       </node>
     </node>
   </node>

--- a/code/languages/com.mbeddr.mpsutil/.mps/modules.xml
+++ b/code/languages/com.mbeddr.mpsutil/.mps/modules.xml
@@ -2,7 +2,6 @@
 <project version="4">
   <component name="MPSProject">
     <projectModules>
-      <modulePath path="$PROJECT_DIR$/2023-12-07T13:42:50.640931Z/2023-12-07T13:42:50.640931Z.msd" folder="" />
       <modulePath path="$PROJECT_DIR$/devkits/com.mbeddr.commenting.devkit" folder="staging.margincell_review" />
       <modulePath path="$PROJECT_DIR$/devkits/com.mbeddr.mpsutil.guides/com.mbeddr.mpsutil.guides.devkit" folder="staging.editingGuide" />
       <modulePath path="$PROJECT_DIR$/languages/EcoreImporter_TestLanguage1/EcoreImporter_TestLanguage1.mpl" folder="testlanguages" />
@@ -14,6 +13,8 @@
       <modulePath path="$PROJECT_DIR$/languages/com.mbeddr.mpsutil.ccmenu.reftarget/com.mbeddr.mpsutil.ccmenu.reftarget.mpl" folder="rest.ccmenu" />
       <modulePath path="$PROJECT_DIR$/languages/com.mbeddr.mpsutil.ccmenu.sandboxlang/com.mbeddr.mpsutil.ccmenu.sandboxlang.mpl" folder="rest.ccmenu" />
       <modulePath path="$PROJECT_DIR$/languages/com.mbeddr.mpsutil.ccmenu/com.mbeddr.mpsutil.ccmenu.mpl" folder="rest.ccmenu" />
+      <modulePath path="$PROJECT_DIR$/languages/com.mbeddr.mpsutil.checkinHandler.demo/com.mbeddr.mpsutil.checkinHandler.demo.mpl" folder="" />
+      <modulePath path="$PROJECT_DIR$/languages/com.mbeddr.mpsutil.checkinHandler/com.mbeddr.mpsutil.checkinHandler.mpl" folder="" />
       <modulePath path="$PROJECT_DIR$/languages/com.mbeddr.mpsutil.compare.pattern.baselang/com.mbeddr.mpsutil.compare.pattern.baselang.mpl" folder="staging.comparator" />
       <modulePath path="$PROJECT_DIR$/languages/com.mbeddr.mpsutil.compare.pattern.generator/com.mbeddr.mpsutil.compare.pattern.generator.mpl" folder="staging.comparator" />
       <modulePath path="$PROJECT_DIR$/languages/com.mbeddr.mpsutil.compare.pattern/com.mbeddr.mpsutil.compare.pattern.mpl" folder="staging.comparator" />
@@ -108,6 +109,8 @@
       <modulePath path="$PROJECT_DIR$/solutions/com.mbeddr.mpsutil.ccmenu.reftarget.runtime/com.mbeddr.mpsutil.ccmenu.reftarget.runtime.msd" folder="rest.ccmenu" />
       <modulePath path="$PROJECT_DIR$/solutions/com.mbeddr.mpsutil.ccmenu.runtime/com.mbeddr.mpsutil.ccmenu.runtime.msd" folder="rest.ccmenu" />
       <modulePath path="$PROJECT_DIR$/solutions/com.mbeddr.mpsutil.ccmenu.sandbox/com.mbeddr.mpsutil.ccmenu.sandbox.msd" folder="rest.ccmenu" />
+      <modulePath path="$PROJECT_DIR$/solutions/com.mbeddr.mpsutil.checkinHandler.demo.plugin/com.mbeddr.mpsutil.checkinHandler.demo.plugin.msd" folder="checkinHandler" />
+      <modulePath path="$PROJECT_DIR$/solutions/com.mbeddr.mpsutil.checkinHandler/com.mbeddr.mpsutil.checkinHandler.msd" folder="checkinHandler" />
       <modulePath path="$PROJECT_DIR$/solutions/com.mbeddr.mpsutil.common/com.mbeddr.mpsutil.common.msd" folder="staging.common" />
       <modulePath path="$PROJECT_DIR$/solutions/com.mbeddr.mpsutil.comparator.diff.demo.genplan/com.mbeddr.mpsutil.comparator.diff.demo.genplan.msd" folder="staging.comparator.demo" />
       <modulePath path="$PROJECT_DIR$/solutions/com.mbeddr.mpsutil.comparator.diff.demo.tests/com.mbeddr.mpsutil.comparator.diff.demo.tests.msd" folder="staging.comparator.demo" />

--- a/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.checkinHandler.demo.plugin/com.mbeddr.mpsutil.checkinHandler.demo.plugin.msd
+++ b/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.checkinHandler.demo.plugin/com.mbeddr.mpsutil.checkinHandler.demo.plugin.msd
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<solution name="com.mbeddr.mpsutil.checkinHandler.demo.plugin" uuid="d6e92aa0-3505-4109-85fa-4d99aa283ca4" moduleVersion="0" compileInMPS="true">
+  <models>
+    <modelRoot type="default" contentPath="${module}">
+      <sourceRoot location="models" />
+    </modelRoot>
+  </models>
+  <facets>
+    <facet compile="mps" classes="mps" ext="yes" type="java">
+      <classes generated="true" path="${module}/classes_gen" />
+    </facet>
+  </facets>
+  <sourcePath />
+  <dependencies>
+    <dependency reexport="false">5e43bd52-71f1-484a-90fa-e1e624f7e44b(com.mbeddr.mpsutil.checkinHandler)</dependency>
+    <dependency reexport="false">f57286e3-4e19-4d8d-8045-3900761f6530(jetbrains.mps.git4idea.stubs)</dependency>
+    <dependency reexport="false">498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)</dependency>
+    <dependency reexport="false">6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)</dependency>
+    <dependency reexport="false">ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)</dependency>
+    <dependency reexport="false">f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)</dependency>
+  </dependencies>
+  <languageVersions>
+    <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
+    <language slang="l:443f4c36-fcf5-4eb6-9500-8d06ed259e3e:jetbrains.mps.baseLanguage.classifiers" version="0" />
+    <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
+    <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
+    <language slang="l:c7d5b9dd-a05f-4be2-bc73-f2e16994cc67:jetbrains.mps.baseLanguage.lightweightdsl" version="1" />
+    <language slang="l:63650c59-16c8-498a-99c8-005c7ee9515d:jetbrains.mps.lang.access" version="0" />
+    <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
+    <language slang="l:c0080a47-7e37-4558-bee9-9ae18e690549:jetbrains.mps.lang.extension" version="2" />
+    <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
+    <language slang="l:28f9e497-3b42-4291-aeba-0a1039153ab1:jetbrains.mps.lang.plugin" version="5" />
+    <language slang="l:ef7bf5ac-d06c-4342-b11d-e42104eb9343:jetbrains.mps.lang.plugin.standalone" version="0" />
+    <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="19" />
+    <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
+  </languageVersions>
+  <dependencyVersions>
+    <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
+    <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
+    <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
+    <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
+    <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
+    <module reference="5e43bd52-71f1-484a-90fa-e1e624f7e44b(com.mbeddr.mpsutil.checkinHandler)" version="0" />
+    <module reference="d6e92aa0-3505-4109-85fa-4d99aa283ca4(com.mbeddr.mpsutil.checkinHandler.demo.plugin)" version="0" />
+    <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
+    <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
+    <module reference="f57286e3-4e19-4d8d-8045-3900761f6530(jetbrains.mps.git4idea.stubs)" version="0" />
+    <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
+    <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
+    <module reference="9ded098b-ad6a-4657-bfd9-48636cfe8bc3(jetbrains.mps.lang.traceable)" version="0" />
+  </dependencyVersions>
+</solution>

--- a/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.checkinHandler.demo.plugin/com.mbeddr.mpsutil.checkinHandler.demo.plugin.msd
+++ b/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.checkinHandler.demo.plugin/com.mbeddr.mpsutil.checkinHandler.demo.plugin.msd
@@ -18,6 +18,8 @@
     <dependency reexport="false">6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)</dependency>
     <dependency reexport="false">ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)</dependency>
     <dependency reexport="false">f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)</dependency>
+    <dependency reexport="false">742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)</dependency>
+    <dependency reexport="false">019b622b-0aef-4dd3-86d0-4eef01f3f6bb(jetbrains.mps.ide)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
@@ -38,15 +40,21 @@
     <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
     <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
     <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
+    <module reference="1ed103c3-3aa6-49b7-9c21-6765ee11f224(MPS.Editor)" version="0" />
     <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
+    <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
     <module reference="5e43bd52-71f1-484a-90fa-e1e624f7e44b(com.mbeddr.mpsutil.checkinHandler)" version="0" />
     <module reference="d6e92aa0-3505-4109-85fa-4d99aa283ca4(com.mbeddr.mpsutil.checkinHandler.demo.plugin)" version="0" />
     <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
     <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
+    <module reference="bfbdd672-7ff5-403f-af4f-16da5226f34c(jetbrains.mps.findUsages.runtime)" version="0" />
     <module reference="f57286e3-4e19-4d8d-8045-3900761f6530(jetbrains.mps.git4idea.stubs)" version="0" />
+    <module reference="019b622b-0aef-4dd3-86d0-4eef01f3f6bb(jetbrains.mps.ide)" version="0" />
+    <module reference="25092e07-e655-497c-92fb-558a8e3080ed(jetbrains.mps.ide.ui)" version="0" />
     <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
     <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
     <module reference="9ded098b-ad6a-4657-bfd9-48636cfe8bc3(jetbrains.mps.lang.traceable)" version="0" />
   </dependencyVersions>
 </solution>
+

--- a/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.checkinHandler.demo.plugin/models/com.mbeddr.mpsutil.checkinHandler.demo.plugin.plugin.mps
+++ b/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.checkinHandler.demo.plugin/models/com.mbeddr.mpsutil.checkinHandler.demo.plugin.plugin.mps
@@ -1,0 +1,1159 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:c5016297-53b3-439f-9cac-841277dda14f(com.mbeddr.mpsutil.checkinHandler.demo.plugin.plugin)">
+  <persistence version="9" />
+  <languages>
+    <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="12" />
+    <use id="c0080a47-7e37-4558-bee9-9ae18e690549" name="jetbrains.mps.lang.extension" version="2" />
+    <use id="c7d5b9dd-a05f-4be2-bc73-f2e16994cc67" name="jetbrains.mps.baseLanguage.lightweightdsl" version="1" />
+    <use id="ef7bf5ac-d06c-4342-b11d-e42104eb9343" name="jetbrains.mps.lang.plugin.standalone" version="0" />
+    <use id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections" version="1" />
+    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
+    <use id="63650c59-16c8-498a-99c8-005c7ee9515d" name="jetbrains.mps.lang.access" version="0" />
+  </languages>
+  <imports>
+    <import index="90d" ref="r:421d64ed-8024-497f-aeab-8bddeb389dd2(jetbrains.mps.lang.extension.methods)" />
+    <import index="aqel" ref="r:ecd3c807-fa84-48be-b99b-f9c5f7f6cc51(com.mbeddr.mpsutil.checkinHandler.plugin)" />
+    <import index="hr4p" ref="f57286e3-4e19-4d8d-8045-3900761f6530/java:git4idea(jetbrains.mps.git4idea.stubs/)" />
+    <import index="c0fd" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.vcs.commit(MPS.IDEA/)" />
+    <import index="fnpx" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.notification(MPS.IDEA/)" />
+    <import index="jlcu" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.vcs(MPS.IDEA/)" />
+    <import index="5mlj" ref="f57286e3-4e19-4d8d-8045-3900761f6530/java:git4idea.repo(jetbrains.mps.git4idea.stubs/)" />
+    <import index="18nx" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.vcs.checkin(MPS.IDEA/)" />
+    <import index="18ew" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.util(MPS.Core/)" />
+    <import index="z1c3" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.project(MPS.Core/)" />
+    <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" />
+    <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" />
+    <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="ef7bf5ac-d06c-4342-b11d-e42104eb9343" name="jetbrains.mps.lang.plugin.standalone">
+      <concept id="7520713872864775836" name="jetbrains.mps.lang.plugin.standalone.structure.StandalonePluginDescriptor" flags="ng" index="2DaZZR" />
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1082485599095" name="jetbrains.mps.baseLanguage.structure.BlockStatement" flags="nn" index="9aQIb">
+        <child id="1082485599096" name="statements" index="9aQI4" />
+      </concept>
+      <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
+        <child id="1068498886297" name="rValue" index="37vLTx" />
+        <child id="1068498886295" name="lValue" index="37vLTJ" />
+      </concept>
+      <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
+      <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="8118189177080264853" name="jetbrains.mps.baseLanguage.structure.AlternativeType" flags="ig" index="nSUau">
+        <child id="8118189177080264854" name="alternative" index="nSUat" />
+      </concept>
+      <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="nn" index="2tJIrI" />
+      <concept id="1188207840427" name="jetbrains.mps.baseLanguage.structure.AnnotationInstance" flags="nn" index="2AHcQZ">
+        <reference id="1188208074048" name="annotation" index="2AI5Lk" />
+      </concept>
+      <concept id="1188208481402" name="jetbrains.mps.baseLanguage.structure.HasAnnotation" flags="ng" index="2AJDlI">
+        <child id="1188208488637" name="annotation" index="2AJF6D" />
+      </concept>
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1197029447546" name="jetbrains.mps.baseLanguage.structure.FieldReferenceOperation" flags="nn" index="2OwXpG">
+        <reference id="1197029500499" name="fieldDeclaration" index="2Oxat5" />
+      </concept>
+      <concept id="1083260308424" name="jetbrains.mps.baseLanguage.structure.EnumConstantReference" flags="nn" index="Rm8GO">
+        <reference id="1083260308426" name="enumConstantDeclaration" index="Rm8GQ" />
+        <reference id="1144432896254" name="enumClass" index="1Px2BO" />
+      </concept>
+      <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
+        <child id="1145553007750" name="creator" index="2ShVmc" />
+      </concept>
+      <concept id="1070462154015" name="jetbrains.mps.baseLanguage.structure.StaticFieldDeclaration" flags="ig" index="Wx3nA" />
+      <concept id="1070475354124" name="jetbrains.mps.baseLanguage.structure.ThisExpression" flags="nn" index="Xjq3P" />
+      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
+        <property id="1070475926801" name="value" index="Xl_RC" />
+      </concept>
+      <concept id="4952749571008284462" name="jetbrains.mps.baseLanguage.structure.CatchVariable" flags="ng" index="XOnhg" />
+      <concept id="1182160077978" name="jetbrains.mps.baseLanguage.structure.AnonymousClassCreator" flags="nn" index="YeOm9">
+        <child id="1182160096073" name="cls" index="YeSDq" />
+      </concept>
+      <concept id="1081236700938" name="jetbrains.mps.baseLanguage.structure.StaticMethodDeclaration" flags="ig" index="2YIFZL" />
+      <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
+        <reference id="1144433194310" name="classConcept" index="1Pybhc" />
+      </concept>
+      <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
+      <concept id="1070534934090" name="jetbrains.mps.baseLanguage.structure.CastExpression" flags="nn" index="10QFUN">
+        <child id="1070534934091" name="type" index="10QFUM" />
+        <child id="1070534934092" name="expression" index="10QFUP" />
+      </concept>
+      <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu" />
+      <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
+        <property id="1176718929932" name="isFinal" index="3TUv4t" />
+        <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
+        <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
+      </concept>
+      <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
+      <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
+      <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
+      <concept id="1225271221393" name="jetbrains.mps.baseLanguage.structure.NPENotEqualsExpression" flags="nn" index="17QLQc" />
+      <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
+        <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
+      <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
+        <child id="1068580123133" name="returnType" index="3clF45" />
+        <child id="1068580123134" name="parameter" index="3clF46" />
+        <child id="1068580123135" name="body" index="3clF47" />
+      </concept>
+      <concept id="1068580123165" name="jetbrains.mps.baseLanguage.structure.InstanceMethodDeclaration" flags="ig" index="3clFb_" />
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
+      <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
+        <child id="1082485599094" name="ifFalseStatement" index="9aQIa" />
+        <child id="1068580123160" name="condition" index="3clFbw" />
+        <child id="1068580123161" name="ifTrue" index="3clFbx" />
+      </concept>
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT">
+        <property id="1068580123138" name="value" index="3clFbU" />
+      </concept>
+      <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
+        <property id="1068580320021" name="value" index="3cmrfH" />
+      </concept>
+      <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
+      <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
+        <child id="1068581517676" name="expression" index="3cqZAk" />
+      </concept>
+      <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
+        <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
+      </concept>
+      <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
+      <concept id="1079359253375" name="jetbrains.mps.baseLanguage.structure.ParenthesizedExpression" flags="nn" index="1eOMI4">
+        <child id="1079359253376" name="expression" index="1eOMHV" />
+      </concept>
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
+      </concept>
+      <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk" />
+      <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
+        <property id="521412098689998745" name="nonStatic" index="2bfB8j" />
+        <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
+      </concept>
+      <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
+        <reference id="1107535924139" name="classifier" index="3uigEE" />
+      </concept>
+      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
+        <child id="1081773367579" name="rightExpression" index="3uHU7w" />
+        <child id="1081773367580" name="leftExpression" index="3uHU7B" />
+      </concept>
+      <concept id="3093926081414150598" name="jetbrains.mps.baseLanguage.structure.MultipleCatchClause" flags="ng" index="3uVAMA">
+        <child id="8276990574895933173" name="catchBody" index="1zc67A" />
+        <child id="8276990574895933172" name="throwable" index="1zc67B" />
+      </concept>
+      <concept id="8276990574909231788" name="jetbrains.mps.baseLanguage.structure.FinallyClause" flags="ng" index="1wplmZ">
+        <child id="8276990574909234106" name="finallyBody" index="1wplMD" />
+      </concept>
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
+        <child id="1178549979242" name="visibility" index="1B3o_S" />
+      </concept>
+      <concept id="5351203823916750322" name="jetbrains.mps.baseLanguage.structure.TryUniversalStatement" flags="nn" index="3J1_TO">
+        <child id="8276990574886367510" name="catchClause" index="1zxBo5" />
+        <child id="8276990574886367509" name="finallyClause" index="1zxBo6" />
+        <child id="8276990574886367508" name="body" index="1zxBo7" />
+      </concept>
+      <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
+      <concept id="1146644641414" name="jetbrains.mps.baseLanguage.structure.ProtectedVisibility" flags="nn" index="3Tmbuc" />
+      <concept id="1170345865475" name="jetbrains.mps.baseLanguage.structure.AnonymousClass" flags="ig" index="1Y3b0j">
+        <reference id="1170346070688" name="classifier" index="1Y3XeK" />
+      </concept>
+    </language>
+    <language id="c0080a47-7e37-4558-bee9-9ae18e690549" name="jetbrains.mps.lang.extension">
+      <concept id="126958800891274162" name="jetbrains.mps.lang.extension.structure.Extension" flags="ig" index="1lYeZD">
+        <reference id="126958800891274597" name="extensionPoint" index="1lYe$Y" />
+      </concept>
+    </language>
+    <language id="63650c59-16c8-498a-99c8-005c7ee9515d" name="jetbrains.mps.lang.access">
+      <concept id="8974276187400348173" name="jetbrains.mps.lang.access.structure.CommandClosureLiteral" flags="nn" index="1QHqEC" />
+      <concept id="8974276187400348170" name="jetbrains.mps.lang.access.structure.BaseExecuteCommandStatement" flags="nn" index="1QHqEJ">
+        <child id="1423104411234567454" name="repo" index="ukAjM" />
+        <child id="8974276187400348171" name="commandClosureLiteral" index="1QHqEI" />
+      </concept>
+      <concept id="8974276187400348177" name="jetbrains.mps.lang.access.structure.ExecuteCommandStatement" flags="nn" index="1QHqEO" />
+    </language>
+    <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
+      <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
+        <child id="1199569906740" name="parameter" index="1bW2Oz" />
+        <child id="1199569916463" name="body" index="1bW5cS" />
+      </concept>
+    </language>
+    <language id="c7d5b9dd-a05f-4be2-bc73-f2e16994cc67" name="jetbrains.mps.baseLanguage.lightweightdsl">
+      <concept id="3751132065236767083" name="jetbrains.mps.baseLanguage.lightweightdsl.structure.DependentTypeInstance" flags="ig" index="q3mfm">
+        <reference id="3751132065236767084" name="decl" index="q3mfh" />
+        <reference id="9097849371505568270" name="point" index="1QQUv3" />
+      </concept>
+      <concept id="3751132065236767060" name="jetbrains.mps.baseLanguage.lightweightdsl.structure.MethodInstance" flags="ig" index="q3mfD">
+        <reference id="19209059688387895" name="decl" index="2VtyIY" />
+      </concept>
+      <concept id="6478870542308703666" name="jetbrains.mps.baseLanguage.lightweightdsl.structure.MemberPlaceholder" flags="ng" index="3tTeZs">
+        <property id="6478870542308703667" name="caption" index="3tTeZt" />
+        <reference id="6478870542308703669" name="decl" index="3tTeZr" />
+      </concept>
+    </language>
+    <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
+        <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
+      </concept>
+      <concept id="1171315804604" name="jetbrains.mps.lang.smodel.structure.Model_RootsOperation" flags="nn" index="2RRcyG">
+        <child id="6750920497477046361" name="conceptArgument" index="3MHsoP" />
+      </concept>
+      <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
+        <reference id="1138405853777" name="concept" index="ehGHo" />
+      </concept>
+      <concept id="1138056022639" name="jetbrains.mps.lang.smodel.structure.SPropertyAccess" flags="nn" index="3TrcHB">
+        <reference id="1138056395725" name="property" index="3TsBF5" />
+      </concept>
+      <concept id="1228341669568" name="jetbrains.mps.lang.smodel.structure.Node_DetachOperation" flags="nn" index="3YRAZt" />
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+    <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
+      <concept id="1204796164442" name="jetbrains.mps.baseLanguage.collections.structure.InternalSequenceOperation" flags="nn" index="23sCx2">
+        <child id="1204796294226" name="closure" index="23t8la" />
+      </concept>
+      <concept id="1204980550705" name="jetbrains.mps.baseLanguage.collections.structure.VisitAllOperation" flags="nn" index="2es0OD" />
+      <concept id="1151689724996" name="jetbrains.mps.baseLanguage.collections.structure.SequenceType" flags="in" index="A3Dl8">
+        <child id="1151689745422" name="elementType" index="A3Ik2" />
+      </concept>
+      <concept id="1203518072036" name="jetbrains.mps.baseLanguage.collections.structure.SmartClosureParameterDeclaration" flags="ig" index="Rh6nW" />
+      <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="nn" index="34oBXx" />
+      <concept id="1240687580870" name="jetbrains.mps.baseLanguage.collections.structure.JoinOperation" flags="nn" index="3uJxvA">
+        <child id="1240687658305" name="delimiter" index="3uJOhx" />
+      </concept>
+      <concept id="7125221305512719026" name="jetbrains.mps.baseLanguage.collections.structure.CollectionType" flags="in" index="3vKaQO" />
+      <concept id="1202120902084" name="jetbrains.mps.baseLanguage.collections.structure.WhereOperation" flags="nn" index="3zZkjj" />
+      <concept id="1202128969694" name="jetbrains.mps.baseLanguage.collections.structure.SelectOperation" flags="nn" index="3$u5V9" />
+      <concept id="5686963296372573083" name="jetbrains.mps.baseLanguage.collections.structure.AbstractContainerType" flags="in" index="3O5elB">
+        <child id="5686963296372573084" name="elementType" index="3O5elw" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="312cEu" id="2hNr1jFDx56">
+    <property role="TrG5h" value="KeyProvider" />
+    <node concept="Wx3nA" id="2hNr1jFa2DC" role="jymVt">
+      <property role="TrG5h" value="PREFIX" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm1VV" id="2hNr1jFa1QS" role="1B3o_S" />
+      <node concept="17QB3L" id="2hNr1jFa2Dt" role="1tU5fm" />
+      <node concept="Xl_RD" id="2hNr1jFa3eg" role="33vP2m">
+        <property role="Xl_RC" value="com.mbeddr.mpsutil.checkinHandler.demo" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="2hNr1jFa1$Y" role="jymVt" />
+    <node concept="2YIFZL" id="2hNr1jFa1hM" role="jymVt">
+      <property role="TrG5h" value="getKey" />
+      <node concept="3clFbS" id="2hNr1jFa1hP" role="3clF47">
+        <node concept="3clFbF" id="2hNr1jFa3r_" role="3cqZAp">
+          <node concept="3cpWs3" id="2hNr1jFa3Wf" role="3clFbG">
+            <node concept="37vLTw" id="2hNr1jFa3Xw" role="3uHU7w">
+              <ref role="3cqZAo" node="2hNr1jFa1zZ" resolve="name" />
+            </node>
+            <node concept="3cpWs3" id="2hNr1jFa3OV" role="3uHU7B">
+              <node concept="37vLTw" id="2hNr1jFDx5Q" role="3uHU7B">
+                <ref role="3cqZAo" node="2hNr1jFa2DC" resolve="PREFIX" />
+              </node>
+              <node concept="Xl_RD" id="2hNr1jFa3Pp" role="3uHU7w">
+                <property role="Xl_RC" value="." />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="2hNr1jFa0HQ" role="1B3o_S" />
+      <node concept="17QB3L" id="2hNr1jFa1hC" role="3clF45" />
+      <node concept="37vLTG" id="2hNr1jFa1zZ" role="3clF46">
+        <property role="TrG5h" value="name" />
+        <node concept="17QB3L" id="2hNr1jFa1zY" role="1tU5fm" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="2hNr1jFoAly" role="jymVt" />
+    <node concept="2YIFZL" id="2hNr1jFoBi4" role="jymVt">
+      <property role="TrG5h" value="getNotificationKey" />
+      <node concept="3clFbS" id="2hNr1jFoBi7" role="3clF47">
+        <node concept="3clFbF" id="2hNr1jFoBmd" role="3cqZAp">
+          <node concept="3cpWs3" id="2hNr1jFoBJT" role="3clFbG">
+            <node concept="Xl_RD" id="2hNr1jFoBLj" role="3uHU7w">
+              <property role="Xl_RC" value=".notification" />
+            </node>
+            <node concept="37vLTw" id="2hNr1jFDx5V" role="3uHU7B">
+              <ref role="3cqZAo" node="2hNr1jFa2DC" resolve="PREFIX" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="2hNr1jFoAHK" role="1B3o_S" />
+      <node concept="17QB3L" id="2hNr1jFoBhN" role="3clF45" />
+    </node>
+    <node concept="3Tm1VV" id="2hNr1jFDx57" role="1B3o_S" />
+  </node>
+  <node concept="1lYeZD" id="2hNr1jFDxsE">
+    <property role="TrG5h" value="BugfixCommitMessageCheckin" />
+    <ref role="1lYe$Y" to="aqel:1yfWS2nNO6t" resolve="CheckinExtensionPoint" />
+    <node concept="3Tm1VV" id="2hNr1jFDxsF" role="1B3o_S" />
+    <node concept="2tJIrI" id="2hNr1jFDxsG" role="jymVt" />
+    <node concept="3tTeZs" id="2hNr1jFDxsH" role="jymVt">
+      <property role="3tTeZt" value="activate" />
+      <ref role="3tTeZr" to="90d:3zLwYDe0CPy" resolve="activate" />
+    </node>
+    <node concept="3tTeZs" id="2hNr1jFDxsI" role="jymVt">
+      <property role="3tTeZt" value="deactivate" />
+      <ref role="3tTeZr" to="90d:3zLwYDe0BDO" resolve="deactivate" />
+    </node>
+    <node concept="2tJIrI" id="2hNr1jFDxsJ" role="jymVt" />
+    <node concept="q3mfD" id="2hNr1jFDxsK" role="jymVt">
+      <property role="TrG5h" value="get" />
+      <ref role="2VtyIY" to="90d:3zLwYDe0svr" resolve="get" />
+      <node concept="3Tm1VV" id="2hNr1jFDxsM" role="1B3o_S" />
+      <node concept="3clFbS" id="2hNr1jFDxsO" role="3clF47">
+        <node concept="3clFbF" id="2hNr1jFDy3H" role="3cqZAp">
+          <node concept="2ShNRf" id="eZmA2p5tem" role="3clFbG">
+            <node concept="YeOm9" id="eZmA2p5ten" role="2ShVmc">
+              <node concept="1Y3b0j" id="eZmA2p5teo" role="YeSDq">
+                <property role="2bfB8j" value="true" />
+                <ref role="1Y3XeK" to="aqel:7uW9A9Lcnfm" resolve="BaseCheckinHandler" />
+                <ref role="37wK5l" to="aqel:1yfWS2nOYu5" resolve="BaseCheckinHandler" />
+                <node concept="3Tm1VV" id="eZmA2p5tep" role="1B3o_S" />
+                <node concept="3clFb_" id="eZmA2p5teq" role="jymVt">
+                  <property role="TrG5h" value="actionBeforeCommit" />
+                  <node concept="3Tmbuc" id="eZmA2p5ter" role="1B3o_S" />
+                  <node concept="3uibUv" id="eZmA2p5tes" role="3clF45">
+                    <ref role="3uigEE" to="18nx:~CheckinHandler$ReturnResult" resolve="ReturnResult" />
+                  </node>
+                  <node concept="3clFbS" id="eZmA2p5tet" role="3clF47">
+                    <node concept="3J1_TO" id="7SmYmUZGM0J" role="3cqZAp">
+                      <node concept="3uVAMA" id="7SmYmUZGM88" role="1zxBo5">
+                        <node concept="XOnhg" id="7SmYmUZGM89" role="1zc67B">
+                          <property role="TrG5h" value="e" />
+                          <node concept="nSUau" id="7SmYmUZGM8a" role="1tU5fm">
+                            <node concept="3uibUv" id="7SmYmUZGMpi" role="nSUat">
+                              <ref role="3uigEE" to="wyt6:~Exception" resolve="Exception" />
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3clFbS" id="7SmYmUZGM8b" role="1zc67A" />
+                      </node>
+                      <node concept="3clFbS" id="7SmYmUZGM0L" role="1zxBo7">
+                        <node concept="3cpWs8" id="2hNr1jFoekx" role="3cqZAp">
+                          <node concept="3cpWsn" id="2hNr1jFoek$" role="3cpWs9">
+                            <property role="TrG5h" value="message" />
+                            <node concept="17QB3L" id="2hNr1jFoekv" role="1tU5fm" />
+                            <node concept="2OqwBi" id="2G5dnSi7hDO" role="33vP2m">
+                              <node concept="2OqwBi" id="2G5dnSi7fFi" role="2Oq$k0">
+                                <node concept="2OqwBi" id="HyxJBtDUT$" role="2Oq$k0">
+                                  <node concept="1eOMI4" id="HyxJBtDQ__" role="2Oq$k0">
+                                    <node concept="10QFUN" id="HyxJBtDQ_y" role="1eOMHV">
+                                      <node concept="3uibUv" id="HyxJBtDQXF" role="10QFUM">
+                                        <ref role="3uigEE" to="c0fd:~ChangesViewCommitWorkflowHandler" resolve="ChangesViewCommitWorkflowHandler" />
+                                      </node>
+                                      <node concept="2OqwBi" id="HyxJBtDS7Z" role="10QFUP">
+                                        <node concept="2OqwBi" id="HyxJBtDRrU" role="2Oq$k0">
+                                          <node concept="Xjq3P" id="HyxJBtDlK9" role="2Oq$k0" />
+                                          <node concept="2OwXpG" id="HyxJBtDRTh" role="2OqNvi">
+                                            <ref role="2Oxat5" to="aqel:7uW9A9LcS0c" resolve="panel" />
+                                          </node>
+                                        </node>
+                                        <node concept="liA8E" id="HyxJBtDSrV" role="2OqNvi">
+                                          <ref role="37wK5l" to="jlcu:~CheckinProjectPanel.getCommitWorkflowHandler()" resolve="getCommitWorkflowHandler" />
+                                        </node>
+                                      </node>
+                                    </node>
+                                  </node>
+                                  <node concept="liA8E" id="HyxJBtDVLH" role="2OqNvi">
+                                    <ref role="37wK5l" to="c0fd:~ChangesViewCommitWorkflowHandler.getUi()" resolve="getUi" />
+                                  </node>
+                                </node>
+                                <node concept="liA8E" id="2G5dnSi7gaH" role="2OqNvi">
+                                  <ref role="37wK5l" to="c0fd:~CommitWorkflowUi.getCommitMessageUi()" resolve="getCommitMessageUi" />
+                                </node>
+                              </node>
+                              <node concept="liA8E" id="2G5dnSi7i9e" role="2OqNvi">
+                                <ref role="37wK5l" to="c0fd:~CommitMessageUi.getText()" resolve="getText" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3cpWs8" id="2hNr1jFogM_" role="3cqZAp">
+                          <node concept="3cpWsn" id="2hNr1jFogMC" role="3cpWs9">
+                            <property role="TrG5h" value="startsWithBugFixPrefix" />
+                            <node concept="10P_77" id="2hNr1jFogMz" role="1tU5fm" />
+                            <node concept="2OqwBi" id="2hNr1jFoiqs" role="33vP2m">
+                              <node concept="2OqwBi" id="2hNr1jFoiqt" role="2Oq$k0">
+                                <node concept="2OqwBi" id="2hNr1jFoiqu" role="2Oq$k0">
+                                  <node concept="Xjq3P" id="2hNr1jFoiqv" role="2Oq$k0" />
+                                  <node concept="2OwXpG" id="2hNr1jFoiqw" role="2OqNvi">
+                                    <ref role="2Oxat5" to="aqel:7uW9A9LcS0c" resolve="panel" />
+                                  </node>
+                                </node>
+                                <node concept="liA8E" id="2hNr1jFoiqx" role="2OqNvi">
+                                  <ref role="37wK5l" to="jlcu:~CheckinProjectPanel.getCommitMessage()" resolve="getCommitMessage" />
+                                </node>
+                              </node>
+                              <node concept="liA8E" id="2hNr1jFoiqy" role="2OqNvi">
+                                <ref role="37wK5l" to="wyt6:~String.startsWith(java.lang.String)" resolve="startsWith" />
+                                <node concept="Xl_RD" id="2hNr1jFoiqz" role="37wK5m">
+                                  <property role="Xl_RC" value="bugfix" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3cpWs8" id="2hNr1jFosU0" role="3cqZAp">
+                          <node concept="3cpWsn" id="2hNr1jFosU1" role="3cpWs9">
+                            <property role="TrG5h" value="repositories" />
+                            <node concept="2YIFZM" id="2hNr1jFosU2" role="33vP2m">
+                              <ref role="1Pybhc" to="hr4p:~GitUtil" resolve="GitUtil" />
+                              <ref role="37wK5l" to="hr4p:~GitUtil.getRepositories(com.intellij.openapi.project.Project)" resolve="getRepositories" />
+                              <node concept="2OqwBi" id="2hNr1jFosU3" role="37wK5m">
+                                <node concept="Xjq3P" id="2hNr1jFosU4" role="2Oq$k0" />
+                                <node concept="2OwXpG" id="2hNr1jFosU5" role="2OqNvi">
+                                  <ref role="2Oxat5" to="aqel:7uW9A9LcNXZ" resolve="ideaProject" />
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="3vKaQO" id="2hNr1jFotyi" role="1tU5fm">
+                              <node concept="3uibUv" id="2hNr1jFotTt" role="3O5elw">
+                                <ref role="3uigEE" to="5mlj:~GitRepository" resolve="GitRepository" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3cpWs8" id="eZmA2p5teu" role="3cqZAp">
+                          <node concept="3cpWsn" id="eZmA2p5tev" role="3cpWs9">
+                            <property role="TrG5h" value="notification" />
+                            <node concept="3uibUv" id="eZmA2p5tew" role="1tU5fm">
+                              <ref role="3uigEE" to="fnpx:~Notification" resolve="Notification" />
+                            </node>
+                            <node concept="2ShNRf" id="eZmA2p5tex" role="33vP2m">
+                              <node concept="1pGfFk" id="eZmA2p5tey" role="2ShVmc">
+                                <ref role="37wK5l" to="fnpx:~Notification.&lt;init&gt;(java.lang.String,java.lang.String,java.lang.String,com.intellij.notification.NotificationType)" resolve="Notification" />
+                                <node concept="2YIFZM" id="2hNr1jFoC7c" role="37wK5m">
+                                  <ref role="37wK5l" node="2hNr1jFoBi4" resolve="getNotificationKey" />
+                                  <ref role="1Pybhc" node="2hNr1jFDx56" resolve="KeyProvider" />
+                                </node>
+                                <node concept="Xl_RD" id="eZmA2p5te$" role="37wK5m">
+                                  <property role="Xl_RC" value="Hello from pre-commit" />
+                                </node>
+                                <node concept="3cpWs3" id="2hNr1jFormR" role="37wK5m">
+                                  <node concept="2OqwBi" id="2hNr1jFoxrN" role="3uHU7w">
+                                    <node concept="2OqwBi" id="2hNr1jFos98" role="2Oq$k0">
+                                      <node concept="37vLTw" id="2hNr1jFosU6" role="2Oq$k0">
+                                        <ref role="3cqZAo" node="2hNr1jFosU1" resolve="repositories" />
+                                      </node>
+                                      <node concept="3$u5V9" id="2hNr1jFouYK" role="2OqNvi">
+                                        <node concept="1bVj0M" id="2hNr1jFouYM" role="23t8la">
+                                          <node concept="3clFbS" id="2hNr1jFouYN" role="1bW5cS">
+                                            <node concept="3clFbF" id="2hNr1jFovwL" role="3cqZAp">
+                                              <node concept="2OqwBi" id="2hNr1jFovM8" role="3clFbG">
+                                                <node concept="37vLTw" id="2hNr1jFovwK" role="2Oq$k0">
+                                                  <ref role="3cqZAo" node="2hNr1jFouYO" resolve="it" />
+                                                </node>
+                                                <node concept="liA8E" id="2hNr1jFowZE" role="2OqNvi">
+                                                  <ref role="37wK5l" to="wyt6:~Object.toString()" resolve="toString" />
+                                                </node>
+                                              </node>
+                                            </node>
+                                          </node>
+                                          <node concept="Rh6nW" id="2hNr1jFouYO" role="1bW2Oz">
+                                            <property role="TrG5h" value="it" />
+                                            <node concept="2jxLKc" id="2hNr1jFouYP" role="1tU5fm" />
+                                          </node>
+                                        </node>
+                                      </node>
+                                    </node>
+                                    <node concept="3uJxvA" id="2hNr1jFoyeu" role="2OqNvi">
+                                      <node concept="Xl_RD" id="2hNr1jFozbm" role="3uJOhx">
+                                        <property role="Xl_RC" value="," />
+                                      </node>
+                                    </node>
+                                  </node>
+                                  <node concept="3cpWs3" id="2hNr1jFoo1C" role="3uHU7B">
+                                    <node concept="3cpWs3" id="2hNr1jFoqa7" role="3uHU7B">
+                                      <node concept="Xl_RD" id="2hNr1jFoqkX" role="3uHU7w">
+                                        <property role="Xl_RC" value="\n" />
+                                      </node>
+                                      <node concept="3cpWs3" id="2hNr1jFopfJ" role="3uHU7B">
+                                        <node concept="3cpWs3" id="2hNr1jFom$l" role="3uHU7B">
+                                          <node concept="3cpWs3" id="7Jaou$AUChu" role="3uHU7B">
+                                            <node concept="3cpWs3" id="HyxJBtDWBe" role="3uHU7B">
+                                              <node concept="Xl_RD" id="eZmA2p5yjX" role="3uHU7B">
+                                                <property role="Xl_RC" value="Commit message starts with 'bugfix':" />
+                                              </node>
+                                              <node concept="37vLTw" id="2hNr1jFojCa" role="3uHU7w">
+                                                <ref role="3cqZAo" node="2hNr1jFogMC" resolve="startsWithBugFixPrefix" />
+                                              </node>
+                                            </node>
+                                            <node concept="Xl_RD" id="2hNr1jFomIN" role="3uHU7w">
+                                              <property role="Xl_RC" value="\n" />
+                                            </node>
+                                          </node>
+                                          <node concept="Xl_RD" id="2hNr1jFoocF" role="3uHU7w">
+                                            <property role="Xl_RC" value=" Message:" />
+                                          </node>
+                                        </node>
+                                        <node concept="37vLTw" id="2hNr1jFopqC" role="3uHU7w">
+                                          <ref role="3cqZAo" node="2hNr1jFoek$" resolve="message" />
+                                        </node>
+                                      </node>
+                                    </node>
+                                    <node concept="Xl_RD" id="2hNr1jForyt" role="3uHU7w">
+                                      <property role="Xl_RC" value="Repositories: " />
+                                    </node>
+                                  </node>
+                                </node>
+                                <node concept="Rm8GO" id="eZmA2p5teI" role="37wK5m">
+                                  <ref role="Rm8GQ" to="fnpx:~NotificationType.INFORMATION" resolve="INFORMATION" />
+                                  <ref role="1Px2BO" to="fnpx:~NotificationType" resolve="NotificationType" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3clFbF" id="eZmA2p5teJ" role="3cqZAp">
+                          <node concept="2YIFZM" id="eZmA2p5teK" role="3clFbG">
+                            <ref role="37wK5l" to="fnpx:~Notifications$Bus.notify(com.intellij.notification.Notification)" resolve="notify" />
+                            <ref role="1Pybhc" to="fnpx:~Notifications$Bus" resolve="Bus" />
+                            <node concept="37vLTw" id="eZmA2p5teL" role="37wK5m">
+                              <ref role="3cqZAo" node="eZmA2p5tev" resolve="notification" />
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3clFbH" id="7SmYmUZGM0K" role="3cqZAp" />
+                      </node>
+                      <node concept="1wplmZ" id="7SmYmUZGP4Z" role="1zxBo6">
+                        <node concept="3clFbS" id="7SmYmUZGP50" role="1wplMD">
+                          <node concept="3cpWs6" id="7SmYmUZGPok" role="3cqZAp">
+                            <node concept="Rm8GO" id="eZmA2p5teN" role="3cqZAk">
+                              <ref role="1Px2BO" to="18nx:~CheckinHandler$ReturnResult" resolve="ReturnResult" />
+                              <ref role="Rm8GQ" to="18nx:~CheckinHandler$ReturnResult.CANCEL" resolve="CANCEL" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2AHcQZ" id="eZmA2p5teO" role="2AJF6D">
+                    <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                  </node>
+                </node>
+                <node concept="2YIFZM" id="2hNr1jFa4J0" role="37wK5m">
+                  <ref role="37wK5l" node="2hNr1jFa1hM" resolve="getKey" />
+                  <ref role="1Pybhc" node="2hNr1jFDx56" resolve="KeyProvider" />
+                  <node concept="Xl_RD" id="2hNr1jFa4Yd" role="37wK5m">
+                    <property role="Xl_RC" value="bugfix" />
+                  </node>
+                </node>
+                <node concept="3clFbT" id="eZmA2p5teQ" role="37wK5m">
+                  <property role="3clFbU" value="true" />
+                </node>
+                <node concept="Xl_RD" id="eZmA2p5teR" role="37wK5m">
+                  <property role="Xl_RC" value="Demo action: Bugfix" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="q3mfm" id="2hNr1jFDxsP" role="3clF45">
+        <ref role="q3mfh" to="90d:3zLwYDe0sv$" />
+        <ref role="1QQUv3" node="2hNr1jFDxsK" resolve="get" />
+      </node>
+    </node>
+  </node>
+  <node concept="2DaZZR" id="2hNr1jFDxQs" />
+  <node concept="1lYeZD" id="2hNr1jFD$Xi">
+    <property role="TrG5h" value="CapitalizedSubjectCheckin" />
+    <ref role="1lYe$Y" to="aqel:1yfWS2nNO6t" resolve="CheckinExtensionPoint" />
+    <node concept="3Tm1VV" id="2hNr1jFD$Xj" role="1B3o_S" />
+    <node concept="2tJIrI" id="2hNr1jFD$Xk" role="jymVt" />
+    <node concept="3tTeZs" id="2hNr1jFD$Xl" role="jymVt">
+      <property role="3tTeZt" value="activate" />
+      <ref role="3tTeZr" to="90d:3zLwYDe0CPy" resolve="activate" />
+    </node>
+    <node concept="3tTeZs" id="2hNr1jFD$Xm" role="jymVt">
+      <property role="3tTeZt" value="deactivate" />
+      <ref role="3tTeZr" to="90d:3zLwYDe0BDO" resolve="deactivate" />
+    </node>
+    <node concept="2tJIrI" id="2hNr1jFD$Xn" role="jymVt" />
+    <node concept="q3mfD" id="2hNr1jFD$Xo" role="jymVt">
+      <property role="TrG5h" value="get" />
+      <ref role="2VtyIY" to="90d:3zLwYDe0svr" resolve="get" />
+      <node concept="3Tm1VV" id="2hNr1jFD$Xq" role="1B3o_S" />
+      <node concept="3clFbS" id="2hNr1jFD$Xs" role="3clF47">
+        <node concept="3clFbF" id="2hNr1jFD$ZY" role="3cqZAp">
+          <node concept="2ShNRf" id="6uXv1_IYtIn" role="3clFbG">
+            <node concept="YeOm9" id="6uXv1_IYtIo" role="2ShVmc">
+              <node concept="1Y3b0j" id="6uXv1_IYtIp" role="YeSDq">
+                <property role="2bfB8j" value="true" />
+                <ref role="37wK5l" to="aqel:1yfWS2nOYu5" resolve="BaseCheckinHandler" />
+                <ref role="1Y3XeK" to="aqel:7uW9A9Lcnfm" resolve="BaseCheckinHandler" />
+                <node concept="3Tm1VV" id="6uXv1_IYtIq" role="1B3o_S" />
+                <node concept="3clFb_" id="6uXv1_IYtIr" role="jymVt">
+                  <property role="TrG5h" value="actionBeforeCommit" />
+                  <node concept="3Tmbuc" id="6uXv1_IYtIs" role="1B3o_S" />
+                  <node concept="3uibUv" id="6uXv1_IYtIt" role="3clF45">
+                    <ref role="3uigEE" to="18nx:~CheckinHandler$ReturnResult" resolve="ReturnResult" />
+                  </node>
+                  <node concept="3clFbS" id="6uXv1_IYtIu" role="3clF47">
+                    <node concept="3J1_TO" id="6uXv1_IYtIv" role="3cqZAp">
+                      <node concept="3uVAMA" id="6uXv1_IYtIw" role="1zxBo5">
+                        <node concept="XOnhg" id="6uXv1_IYtIx" role="1zc67B">
+                          <property role="TrG5h" value="e" />
+                          <node concept="nSUau" id="6uXv1_IYtIy" role="1tU5fm">
+                            <node concept="3uibUv" id="6uXv1_IYtIz" role="nSUat">
+                              <ref role="3uigEE" to="wyt6:~Exception" resolve="Exception" />
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3clFbS" id="6uXv1_IYtI$" role="1zc67A" />
+                      </node>
+                      <node concept="3clFbS" id="6uXv1_IYtI_" role="1zxBo7">
+                        <node concept="3cpWs8" id="6uXv1_IYCRD" role="3cqZAp">
+                          <node concept="3cpWsn" id="6uXv1_IYCRG" role="3cpWs9">
+                            <property role="TrG5h" value="message" />
+                            <node concept="17QB3L" id="6uXv1_IYCRB" role="1tU5fm" />
+                            <node concept="2OqwBi" id="6uXv1_IYtIL" role="33vP2m">
+                              <node concept="2OqwBi" id="6uXv1_IYtIM" role="2Oq$k0">
+                                <node concept="Xjq3P" id="6uXv1_IYtIN" role="2Oq$k0" />
+                                <node concept="2OwXpG" id="6uXv1_IYtIO" role="2OqNvi">
+                                  <ref role="2Oxat5" to="aqel:7uW9A9LcS0c" resolve="panel" />
+                                </node>
+                              </node>
+                              <node concept="liA8E" id="6uXv1_IYtIP" role="2OqNvi">
+                                <ref role="37wK5l" to="jlcu:~CheckinProjectPanel.getCommitMessage()" resolve="getCommitMessage" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3cpWs8" id="6uXv1_IYNbd" role="3cqZAp">
+                          <node concept="3cpWsn" id="6uXv1_IYNbe" role="3cpWs9">
+                            <property role="TrG5h" value="notification" />
+                            <node concept="3uibUv" id="6uXv1_IYNbf" role="1tU5fm">
+                              <ref role="3uigEE" to="fnpx:~Notification" resolve="Notification" />
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3cpWs8" id="6uXv1_IZ4I9" role="3cqZAp">
+                          <node concept="3cpWsn" id="6uXv1_IZ4Ia" role="3cpWs9">
+                            <property role="TrG5h" value="firstLetter" />
+                            <node concept="3uibUv" id="6uXv1_IZ4pk" role="1tU5fm">
+                              <ref role="3uigEE" to="wyt6:~String" resolve="String" />
+                            </node>
+                            <node concept="2OqwBi" id="6uXv1_IZ4Ib" role="33vP2m">
+                              <node concept="37vLTw" id="6uXv1_IZ4Ic" role="2Oq$k0">
+                                <ref role="3cqZAo" node="6uXv1_IYCRG" resolve="message" />
+                              </node>
+                              <node concept="liA8E" id="6uXv1_IZ4Id" role="2OqNvi">
+                                <ref role="37wK5l" to="wyt6:~String.substring(int,int)" resolve="substring" />
+                                <node concept="3cmrfG" id="6uXv1_IZ4Ie" role="37wK5m">
+                                  <property role="3cmrfH" value="0" />
+                                </node>
+                                <node concept="3cmrfG" id="6uXv1_IZ4If" role="37wK5m">
+                                  <property role="3cmrfH" value="1" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3clFbJ" id="6uXv1_IYD_m" role="3cqZAp">
+                          <node concept="3clFbS" id="6uXv1_IYD_o" role="3clFbx">
+                            <node concept="3clFbF" id="6uXv1_IYNJE" role="3cqZAp">
+                              <node concept="37vLTI" id="6uXv1_IYNWQ" role="3clFbG">
+                                <node concept="37vLTw" id="6uXv1_IYNJD" role="37vLTJ">
+                                  <ref role="3cqZAo" node="6uXv1_IYNbe" resolve="notification" />
+                                </node>
+                                <node concept="2ShNRf" id="6uXv1_IYKc0" role="37vLTx">
+                                  <node concept="1pGfFk" id="6uXv1_IYKEG" role="2ShVmc">
+                                    <ref role="37wK5l" to="fnpx:~Notification.&lt;init&gt;(java.lang.String,java.lang.String,java.lang.String,com.intellij.notification.NotificationType)" resolve="Notification" />
+                                    <node concept="2YIFZM" id="2hNr1jFoCUg" role="37wK5m">
+                                      <ref role="37wK5l" node="2hNr1jFoBi4" resolve="getNotificationKey" />
+                                      <ref role="1Pybhc" node="2hNr1jFDx56" resolve="KeyProvider" />
+                                    </node>
+                                    <node concept="3cpWs3" id="6uXv1_IZ1D3" role="37wK5m">
+                                      <node concept="37vLTw" id="6uXv1_IZ1OH" role="3uHU7w">
+                                        <ref role="3cqZAo" node="6uXv1_IYCRG" resolve="message" />
+                                      </node>
+                                      <node concept="Xl_RD" id="6uXv1_IYXIu" role="3uHU7B">
+                                        <property role="Xl_RC" value="Capitalize Checker for " />
+                                      </node>
+                                    </node>
+                                    <node concept="Xl_RD" id="6uXv1_IYKYr" role="37wK5m">
+                                      <property role="Xl_RC" value="Commit message is not capitalized" />
+                                    </node>
+                                    <node concept="Rm8GO" id="6uXv1_IYMx4" role="37wK5m">
+                                      <ref role="Rm8GQ" to="fnpx:~NotificationType.WARNING" resolve="WARNING" />
+                                      <ref role="1Px2BO" to="fnpx:~NotificationType" resolve="NotificationType" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="17QLQc" id="6uXv1_IYJOj" role="3clFbw">
+                            <node concept="37vLTw" id="6uXv1_IYJYL" role="3uHU7w">
+                              <ref role="3cqZAo" node="6uXv1_IZ4Ia" resolve="firstLetter" />
+                            </node>
+                            <node concept="2YIFZM" id="6uXv1_IYEqX" role="3uHU7B">
+                              <ref role="37wK5l" to="18ew:~NameUtil.capitalize(java.lang.String)" resolve="capitalize" />
+                              <ref role="1Pybhc" to="18ew:~NameUtil" resolve="NameUtil" />
+                              <node concept="37vLTw" id="6uXv1_IZ4Ig" role="37wK5m">
+                                <ref role="3cqZAo" node="6uXv1_IZ4Ia" resolve="firstLetter" />
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="9aQIb" id="6uXv1_IYOoP" role="9aQIa">
+                            <node concept="3clFbS" id="6uXv1_IYOoQ" role="9aQI4">
+                              <node concept="3clFbF" id="6uXv1_IYOH3" role="3cqZAp">
+                                <node concept="37vLTI" id="6uXv1_IYOH4" role="3clFbG">
+                                  <node concept="37vLTw" id="6uXv1_IYOH5" role="37vLTJ">
+                                    <ref role="3cqZAo" node="6uXv1_IYNbe" resolve="notification" />
+                                  </node>
+                                  <node concept="2ShNRf" id="6uXv1_IYOH6" role="37vLTx">
+                                    <node concept="1pGfFk" id="6uXv1_IYOH7" role="2ShVmc">
+                                      <ref role="37wK5l" to="fnpx:~Notification.&lt;init&gt;(java.lang.String,java.lang.String,java.lang.String,com.intellij.notification.NotificationType)" resolve="Notification" />
+                                      <node concept="2YIFZM" id="2hNr1jFoD5E" role="37wK5m">
+                                        <ref role="37wK5l" node="2hNr1jFoBi4" resolve="getNotificationKey" />
+                                        <ref role="1Pybhc" node="2hNr1jFDx56" resolve="KeyProvider" />
+                                      </node>
+                                      <node concept="3cpWs3" id="6uXv1_IZ1VU" role="37wK5m">
+                                        <node concept="37vLTw" id="6uXv1_IZ2b0" role="3uHU7w">
+                                          <ref role="3cqZAo" node="6uXv1_IYCRG" resolve="message" />
+                                        </node>
+                                        <node concept="Xl_RD" id="6uXv1_IYYAJ" role="3uHU7B">
+                                          <property role="Xl_RC" value="Capitalize Checker for" />
+                                        </node>
+                                      </node>
+                                      <node concept="Xl_RD" id="6uXv1_IYOH8" role="37wK5m">
+                                        <property role="Xl_RC" value="Commit message is capitalized" />
+                                      </node>
+                                      <node concept="Rm8GO" id="6uXv1_IYOTT" role="37wK5m">
+                                        <ref role="Rm8GQ" to="fnpx:~NotificationType.INFORMATION" resolve="INFORMATION" />
+                                        <ref role="1Px2BO" to="fnpx:~NotificationType" resolve="NotificationType" />
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3clFbF" id="6uXv1_IYtJg" role="3cqZAp">
+                          <node concept="2YIFZM" id="6uXv1_IYtJh" role="3clFbG">
+                            <ref role="37wK5l" to="fnpx:~Notifications$Bus.notify(com.intellij.notification.Notification)" resolve="notify" />
+                            <ref role="1Pybhc" to="fnpx:~Notifications$Bus" resolve="Bus" />
+                            <node concept="37vLTw" id="6uXv1_IYtJi" role="37wK5m">
+                              <ref role="3cqZAo" node="6uXv1_IYNbe" resolve="notification" />
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3clFbH" id="6uXv1_IYtJj" role="3cqZAp" />
+                      </node>
+                      <node concept="1wplmZ" id="6uXv1_IYtJk" role="1zxBo6">
+                        <node concept="3clFbS" id="6uXv1_IYtJl" role="1wplMD">
+                          <node concept="3cpWs6" id="6uXv1_IYtJm" role="3cqZAp">
+                            <node concept="Rm8GO" id="6uXv1_IYtJn" role="3cqZAk">
+                              <ref role="1Px2BO" to="18nx:~CheckinHandler$ReturnResult" resolve="ReturnResult" />
+                              <ref role="Rm8GQ" to="18nx:~CheckinHandler$ReturnResult.CANCEL" resolve="CANCEL" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2AHcQZ" id="6uXv1_IYtJo" role="2AJF6D">
+                    <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                  </node>
+                </node>
+                <node concept="2YIFZM" id="2hNr1jFa6E2" role="37wK5m">
+                  <ref role="37wK5l" node="2hNr1jFa1hM" resolve="getKey" />
+                  <ref role="1Pybhc" node="2hNr1jFDx56" resolve="KeyProvider" />
+                  <node concept="Xl_RD" id="2hNr1jFa6E3" role="37wK5m">
+                    <property role="Xl_RC" value="capitalized" />
+                  </node>
+                </node>
+                <node concept="3clFbT" id="6uXv1_IYtJq" role="37wK5m">
+                  <property role="3clFbU" value="true" />
+                </node>
+                <node concept="Xl_RD" id="6uXv1_IYtJr" role="37wK5m">
+                  <property role="Xl_RC" value="Demo action: Capitalized subject" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="q3mfm" id="2hNr1jFD$Xt" role="3clF45">
+        <ref role="q3mfh" to="90d:3zLwYDe0sv$" />
+        <ref role="1QQUv3" node="2hNr1jFD$Xo" resolve="get" />
+      </node>
+    </node>
+  </node>
+  <node concept="1lYeZD" id="2hNr1jFD$XS">
+    <property role="TrG5h" value="DeleteClassesCheckin" />
+    <ref role="1lYe$Y" to="aqel:1yfWS2nNO6t" resolve="CheckinExtensionPoint" />
+    <node concept="3Tm1VV" id="2hNr1jFD$XT" role="1B3o_S" />
+    <node concept="2tJIrI" id="2hNr1jFD$XU" role="jymVt" />
+    <node concept="3tTeZs" id="2hNr1jFD$XV" role="jymVt">
+      <property role="3tTeZt" value="activate" />
+      <ref role="3tTeZr" to="90d:3zLwYDe0CPy" resolve="activate" />
+    </node>
+    <node concept="3tTeZs" id="2hNr1jFD$XW" role="jymVt">
+      <property role="3tTeZt" value="deactivate" />
+      <ref role="3tTeZr" to="90d:3zLwYDe0BDO" resolve="deactivate" />
+    </node>
+    <node concept="2tJIrI" id="2hNr1jFD$XX" role="jymVt" />
+    <node concept="q3mfD" id="2hNr1jFD$XY" role="jymVt">
+      <property role="TrG5h" value="get" />
+      <ref role="2VtyIY" to="90d:3zLwYDe0svr" resolve="get" />
+      <node concept="3Tm1VV" id="2hNr1jFD$Y0" role="1B3o_S" />
+      <node concept="3clFbS" id="2hNr1jFD$Y2" role="3clF47">
+        <node concept="3clFbF" id="2hNr1jFDA5N" role="3cqZAp">
+          <node concept="2ShNRf" id="6uXv1_IZpvb" role="3clFbG">
+            <node concept="YeOm9" id="6uXv1_IZpvc" role="2ShVmc">
+              <node concept="1Y3b0j" id="6uXv1_IZpvd" role="YeSDq">
+                <property role="2bfB8j" value="true" />
+                <ref role="1Y3XeK" to="aqel:7uW9A9Lcnfm" resolve="BaseCheckinHandler" />
+                <ref role="37wK5l" to="aqel:1yfWS2nOYu5" resolve="BaseCheckinHandler" />
+                <node concept="3Tm1VV" id="6uXv1_IZpve" role="1B3o_S" />
+                <node concept="3clFb_" id="6uXv1_IZpvf" role="jymVt">
+                  <property role="TrG5h" value="actionBeforeCommit" />
+                  <node concept="3Tmbuc" id="6uXv1_IZpvg" role="1B3o_S" />
+                  <node concept="3uibUv" id="6uXv1_IZpvh" role="3clF45">
+                    <ref role="3uigEE" to="18nx:~CheckinHandler$ReturnResult" resolve="ReturnResult" />
+                  </node>
+                  <node concept="3clFbS" id="6uXv1_IZpvi" role="3clF47">
+                    <node concept="3clFbH" id="6uXv1_IZpvB" role="3cqZAp" />
+                    <node concept="1QHqEO" id="6uXv1_IZrQY" role="3cqZAp">
+                      <node concept="1QHqEC" id="6uXv1_IZrR0" role="1QHqEI">
+                        <node concept="3clFbS" id="6uXv1_IZrR2" role="1bW5cS">
+                          <node concept="3clFbF" id="6uXv1_IZvpw" role="3cqZAp">
+                            <node concept="2OqwBi" id="6uXv1_IZw57" role="3clFbG">
+                              <node concept="2OqwBi" id="6uXv1_IZvrW" role="2Oq$k0">
+                                <node concept="Xjq3P" id="6uXv1_IZvpv" role="2Oq$k0" />
+                                <node concept="liA8E" id="6uXv1_IZvws" role="2OqNvi">
+                                  <ref role="37wK5l" to="aqel:1yfWS2nPUdJ" resolve="getCommitedModels" />
+                                </node>
+                              </node>
+                              <node concept="2es0OD" id="6uXv1_IZwPy" role="2OqNvi">
+                                <node concept="1bVj0M" id="6uXv1_IZwP$" role="23t8la">
+                                  <node concept="3clFbS" id="6uXv1_IZwP_" role="1bW5cS">
+                                    <node concept="3cpWs8" id="2hNr1jFoDii" role="3cqZAp">
+                                      <node concept="3cpWsn" id="2hNr1jFoDij" role="3cpWs9">
+                                        <property role="TrG5h" value="affectedClasses" />
+                                        <node concept="A3Dl8" id="2hNr1jFo_$j" role="1tU5fm">
+                                          <node concept="3Tqbb2" id="2hNr1jFo_$m" role="A3Ik2">
+                                            <ref role="ehGHo" to="tpee:fz12cDA" resolve="ClassConcept" />
+                                          </node>
+                                        </node>
+                                        <node concept="2OqwBi" id="2hNr1jFoDik" role="33vP2m">
+                                          <node concept="2OqwBi" id="2hNr1jFoDil" role="2Oq$k0">
+                                            <node concept="37vLTw" id="2hNr1jFoDim" role="2Oq$k0">
+                                              <ref role="3cqZAo" node="6uXv1_IZwPA" resolve="it" />
+                                            </node>
+                                            <node concept="2RRcyG" id="2hNr1jFoDin" role="2OqNvi">
+                                              <node concept="chp4Y" id="2hNr1jFoDio" role="3MHsoP">
+                                                <ref role="cht4Q" to="tpee:fz12cDA" resolve="ClassConcept" />
+                                              </node>
+                                            </node>
+                                          </node>
+                                          <node concept="3zZkjj" id="2hNr1jFoDip" role="2OqNvi">
+                                            <node concept="1bVj0M" id="2hNr1jFoDiq" role="23t8la">
+                                              <node concept="3clFbS" id="2hNr1jFoDir" role="1bW5cS">
+                                                <node concept="3clFbF" id="2hNr1jFoDis" role="3cqZAp">
+                                                  <node concept="2OqwBi" id="2hNr1jFoDit" role="3clFbG">
+                                                    <node concept="2OqwBi" id="2hNr1jFoDiu" role="2Oq$k0">
+                                                      <node concept="37vLTw" id="2hNr1jFoDiv" role="2Oq$k0">
+                                                        <ref role="3cqZAo" node="2hNr1jFoDiz" resolve="it" />
+                                                      </node>
+                                                      <node concept="3TrcHB" id="2hNr1jFoDiw" role="2OqNvi">
+                                                        <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                                                      </node>
+                                                    </node>
+                                                    <node concept="liA8E" id="2hNr1jFoDix" role="2OqNvi">
+                                                      <ref role="37wK5l" to="wyt6:~String.startsWith(java.lang.String)" resolve="startsWith" />
+                                                      <node concept="Xl_RD" id="2hNr1jFoDiy" role="37wK5m">
+                                                        <property role="Xl_RC" value="MyClassToDelete" />
+                                                      </node>
+                                                    </node>
+                                                  </node>
+                                                </node>
+                                              </node>
+                                              <node concept="Rh6nW" id="2hNr1jFoDiz" role="1bW2Oz">
+                                                <property role="TrG5h" value="it" />
+                                                <node concept="2jxLKc" id="2hNr1jFoDi$" role="1tU5fm" />
+                                              </node>
+                                            </node>
+                                          </node>
+                                        </node>
+                                      </node>
+                                    </node>
+                                    <node concept="3clFbF" id="6uXv1_IZ$f0" role="3cqZAp">
+                                      <node concept="2OqwBi" id="6uXv1_IZEqi" role="3clFbG">
+                                        <node concept="37vLTw" id="2hNr1jFoDi_" role="2Oq$k0">
+                                          <ref role="3cqZAo" node="2hNr1jFoDij" resolve="affectedClasses" />
+                                        </node>
+                                        <node concept="2es0OD" id="6uXv1_IZQCY" role="2OqNvi">
+                                          <node concept="1bVj0M" id="6uXv1_IZQD0" role="23t8la">
+                                            <node concept="3clFbS" id="6uXv1_IZQD1" role="1bW5cS">
+                                              <node concept="3clFbF" id="6uXv1_IZQSl" role="3cqZAp">
+                                                <node concept="2OqwBi" id="6uXv1_IZRgn" role="3clFbG">
+                                                  <node concept="37vLTw" id="6uXv1_IZQSk" role="2Oq$k0">
+                                                    <ref role="3cqZAo" node="6uXv1_IZQD2" resolve="it" />
+                                                  </node>
+                                                  <node concept="3YRAZt" id="6uXv1_IZSaw" role="2OqNvi" />
+                                                </node>
+                                              </node>
+                                            </node>
+                                            <node concept="Rh6nW" id="6uXv1_IZQD2" role="1bW2Oz">
+                                              <property role="TrG5h" value="it" />
+                                              <node concept="2jxLKc" id="6uXv1_IZQD3" role="1tU5fm" />
+                                            </node>
+                                          </node>
+                                        </node>
+                                      </node>
+                                    </node>
+                                    <node concept="3cpWs8" id="2hNr1jFoE2E" role="3cqZAp">
+                                      <node concept="3cpWsn" id="2hNr1jFoE2F" role="3cpWs9">
+                                        <property role="TrG5h" value="notification" />
+                                        <node concept="3uibUv" id="2hNr1jFoE2G" role="1tU5fm">
+                                          <ref role="3uigEE" to="fnpx:~Notification" resolve="Notification" />
+                                        </node>
+                                        <node concept="2ShNRf" id="2hNr1jFoE2H" role="33vP2m">
+                                          <node concept="1pGfFk" id="2hNr1jFoE2I" role="2ShVmc">
+                                            <ref role="37wK5l" to="fnpx:~Notification.&lt;init&gt;(java.lang.String,java.lang.String,java.lang.String,com.intellij.notification.NotificationType)" resolve="Notification" />
+                                            <node concept="2YIFZM" id="2hNr1jFoE2J" role="37wK5m">
+                                              <ref role="37wK5l" node="2hNr1jFa1hM" resolve="getKey" />
+                                              <ref role="1Pybhc" node="2hNr1jFDx56" resolve="KeyProvider" />
+                                              <node concept="Xl_RD" id="2hNr1jFoE2K" role="37wK5m">
+                                                <property role="Xl_RC" value="notification" />
+                                              </node>
+                                            </node>
+                                            <node concept="Xl_RD" id="2hNr1jFoE2L" role="37wK5m">
+                                              <property role="Xl_RC" value="Hello from pre-commit from the local branch" />
+                                            </node>
+                                            <node concept="3cpWs3" id="2hNr1jFoE2N" role="37wK5m">
+                                              <node concept="Xl_RD" id="2hNr1jFoE2O" role="3uHU7B">
+                                                <property role="Xl_RC" value="Classes to delete:" />
+                                              </node>
+                                              <node concept="2OqwBi" id="2hNr1jFoE2P" role="3uHU7w">
+                                                <node concept="34oBXx" id="2hNr1jFoE2T" role="2OqNvi" />
+                                                <node concept="37vLTw" id="2hNr1jFoFIb" role="2Oq$k0">
+                                                  <ref role="3cqZAo" node="2hNr1jFoDij" resolve="affectedClasses" />
+                                                </node>
+                                              </node>
+                                            </node>
+                                            <node concept="Rm8GO" id="2hNr1jFoE2V" role="37wK5m">
+                                              <ref role="Rm8GQ" to="fnpx:~NotificationType.INFORMATION" resolve="INFORMATION" />
+                                              <ref role="1Px2BO" to="fnpx:~NotificationType" resolve="NotificationType" />
+                                            </node>
+                                          </node>
+                                        </node>
+                                      </node>
+                                    </node>
+                                    <node concept="3clFbF" id="2hNr1jFoEp2" role="3cqZAp">
+                                      <node concept="2YIFZM" id="2hNr1jFoEp3" role="3clFbG">
+                                        <ref role="37wK5l" to="fnpx:~Notifications$Bus.notify(com.intellij.notification.Notification)" resolve="notify" />
+                                        <ref role="1Pybhc" to="fnpx:~Notifications$Bus" resolve="Bus" />
+                                        <node concept="37vLTw" id="2hNr1jFoEp4" role="37wK5m">
+                                          <ref role="3cqZAo" node="2hNr1jFoE2F" resolve="notification" />
+                                        </node>
+                                      </node>
+                                    </node>
+                                    <node concept="3clFbH" id="2hNr1jFoDR_" role="3cqZAp" />
+                                  </node>
+                                  <node concept="Rh6nW" id="6uXv1_IZwPA" role="1bW2Oz">
+                                    <property role="TrG5h" value="it" />
+                                    <node concept="2jxLKc" id="6uXv1_IZwPB" role="1tU5fm" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="2OqwBi" id="6uXv1_IZuNR" role="ukAjM">
+                        <node concept="2OqwBi" id="6uXv1_IZujd" role="2Oq$k0">
+                          <node concept="Xjq3P" id="6uXv1_IZuaK" role="2Oq$k0" />
+                          <node concept="liA8E" id="6uXv1_IZuxa" role="2OqNvi">
+                            <ref role="37wK5l" to="aqel:1yfWS2nPWlQ" resolve="getMPSProject" />
+                          </node>
+                        </node>
+                        <node concept="liA8E" id="6uXv1_IZvi6" role="2OqNvi">
+                          <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbH" id="6uXv1_IZrsC" role="3cqZAp" />
+                    <node concept="3clFbF" id="6uXv1_IZpvC" role="3cqZAp">
+                      <node concept="Rm8GO" id="6uXv1_IZpvD" role="3clFbG">
+                        <ref role="1Px2BO" to="18nx:~CheckinHandler$ReturnResult" resolve="ReturnResult" />
+                        <ref role="Rm8GQ" to="18nx:~CheckinHandler$ReturnResult.CANCEL" resolve="CANCEL" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2AHcQZ" id="6uXv1_IZpvE" role="2AJF6D">
+                    <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                  </node>
+                </node>
+                <node concept="2YIFZM" id="2hNr1jFa8rR" role="37wK5m">
+                  <ref role="37wK5l" node="2hNr1jFa1hM" resolve="getKey" />
+                  <ref role="1Pybhc" node="2hNr1jFDx56" resolve="KeyProvider" />
+                  <node concept="Xl_RD" id="2hNr1jFa8rS" role="37wK5m">
+                    <property role="Xl_RC" value="deleteClasses" />
+                  </node>
+                </node>
+                <node concept="3clFbT" id="6uXv1_IZpvG" role="37wK5m">
+                  <property role="3clFbU" value="true" />
+                </node>
+                <node concept="Xl_RD" id="6uXv1_IZpvH" role="37wK5m">
+                  <property role="Xl_RC" value="Demo action: Delete classes" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="q3mfm" id="2hNr1jFD$Y3" role="3clF45">
+        <ref role="q3mfh" to="90d:3zLwYDe0sv$" />
+        <ref role="1QQUv3" node="2hNr1jFD$XY" resolve="get" />
+      </node>
+    </node>
+  </node>
+  <node concept="1lYeZD" id="2hNr1jFD$Yu">
+    <property role="TrG5h" value="HelloCheckin" />
+    <ref role="1lYe$Y" to="aqel:1yfWS2nNO6t" resolve="CheckinExtensionPoint" />
+    <node concept="3Tm1VV" id="2hNr1jFD$Yv" role="1B3o_S" />
+    <node concept="2tJIrI" id="2hNr1jFD$Yw" role="jymVt" />
+    <node concept="3tTeZs" id="2hNr1jFD$Yx" role="jymVt">
+      <property role="3tTeZt" value="activate" />
+      <ref role="3tTeZr" to="90d:3zLwYDe0CPy" resolve="activate" />
+    </node>
+    <node concept="3tTeZs" id="2hNr1jFD$Yy" role="jymVt">
+      <property role="3tTeZt" value="deactivate" />
+      <ref role="3tTeZr" to="90d:3zLwYDe0BDO" resolve="deactivate" />
+    </node>
+    <node concept="2tJIrI" id="2hNr1jFD$Yz" role="jymVt" />
+    <node concept="q3mfD" id="2hNr1jFD$Y$" role="jymVt">
+      <property role="TrG5h" value="get" />
+      <ref role="2VtyIY" to="90d:3zLwYDe0svr" resolve="get" />
+      <node concept="3Tm1VV" id="2hNr1jFD$YA" role="1B3o_S" />
+      <node concept="3clFbS" id="2hNr1jFD$YC" role="3clF47">
+        <node concept="3clFbF" id="2hNr1jFDBV8" role="3cqZAp">
+          <node concept="2ShNRf" id="1yfWS2nOWu7" role="3clFbG">
+            <node concept="YeOm9" id="1yfWS2nOWDy" role="2ShVmc">
+              <node concept="1Y3b0j" id="1yfWS2nOWD_" role="YeSDq">
+                <property role="2bfB8j" value="true" />
+                <ref role="1Y3XeK" to="aqel:7uW9A9Lcnfm" resolve="BaseCheckinHandler" />
+                <ref role="37wK5l" to="aqel:1yfWS2nOYu5" resolve="BaseCheckinHandler" />
+                <node concept="3Tm1VV" id="1yfWS2nOWDA" role="1B3o_S" />
+                <node concept="3clFb_" id="1yfWS2nQuNN" role="jymVt">
+                  <property role="TrG5h" value="actionBeforeCommit" />
+                  <node concept="3Tmbuc" id="1yfWS2nQuNP" role="1B3o_S" />
+                  <node concept="3uibUv" id="1yfWS2nQuNQ" role="3clF45">
+                    <ref role="3uigEE" to="18nx:~CheckinHandler$ReturnResult" resolve="ReturnResult" />
+                  </node>
+                  <node concept="3clFbS" id="1yfWS2nQuNS" role="3clF47">
+                    <node concept="3cpWs8" id="1yfWS2nQF2w" role="3cqZAp">
+                      <node concept="3cpWsn" id="1yfWS2nQF2x" role="3cpWs9">
+                        <property role="TrG5h" value="notification" />
+                        <node concept="3uibUv" id="1yfWS2nQEYz" role="1tU5fm">
+                          <ref role="3uigEE" to="fnpx:~Notification" resolve="Notification" />
+                        </node>
+                        <node concept="2ShNRf" id="1yfWS2nQF2y" role="33vP2m">
+                          <node concept="1pGfFk" id="1yfWS2nQF2z" role="2ShVmc">
+                            <ref role="37wK5l" to="fnpx:~Notification.&lt;init&gt;(java.lang.String,java.lang.String,java.lang.String,com.intellij.notification.NotificationType)" resolve="Notification" />
+                            <node concept="2YIFZM" id="2hNr1jFo$cJ" role="37wK5m">
+                              <ref role="37wK5l" node="2hNr1jFa1hM" resolve="getKey" />
+                              <ref role="1Pybhc" node="2hNr1jFDx56" resolve="KeyProvider" />
+                              <node concept="Xl_RD" id="2hNr1jFo$cK" role="37wK5m">
+                                <property role="Xl_RC" value="notification" />
+                              </node>
+                            </node>
+                            <node concept="Xl_RD" id="1yfWS2nQF2_" role="37wK5m">
+                              <property role="Xl_RC" value="Hello from pre-commit from the local branch " />
+                            </node>
+                            <node concept="3cpWs3" id="1yfWS2nQG04" role="37wK5m">
+                              <node concept="3cpWs3" id="1yfWS2nQF2A" role="3uHU7B">
+                                <node concept="Xl_RD" id="1yfWS2nQF2E" role="3uHU7B">
+                                  <property role="Xl_RC" value="Affected models in commit:" />
+                                </node>
+                                <node concept="2OqwBi" id="1yfWS2nR8hj" role="3uHU7w">
+                                  <node concept="2OqwBi" id="1yfWS2nQF2B" role="2Oq$k0">
+                                    <node concept="Xjq3P" id="1yfWS2nQF2C" role="2Oq$k0" />
+                                    <node concept="liA8E" id="1yfWS2nQF2D" role="2OqNvi">
+                                      <ref role="37wK5l" to="aqel:1yfWS2nPUdJ" resolve="getCommitedModels" />
+                                    </node>
+                                  </node>
+                                  <node concept="34oBXx" id="1yfWS2nR9ke" role="2OqNvi" />
+                                </node>
+                              </node>
+                              <node concept="Xl_RD" id="1yfWS2nQG4G" role="3uHU7w">
+                                <property role="Xl_RC" value=". Commit aborted" />
+                              </node>
+                            </node>
+                            <node concept="Rm8GO" id="1yfWS2nQFrz" role="37wK5m">
+                              <ref role="Rm8GQ" to="fnpx:~NotificationType.INFORMATION" resolve="INFORMATION" />
+                              <ref role="1Px2BO" to="fnpx:~NotificationType" resolve="NotificationType" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbF" id="1yfWS2nQyWh" role="3cqZAp">
+                      <node concept="2YIFZM" id="1yfWS2nQz$u" role="3clFbG">
+                        <ref role="37wK5l" to="fnpx:~Notifications$Bus.notify(com.intellij.notification.Notification)" resolve="notify" />
+                        <ref role="1Pybhc" to="fnpx:~Notifications$Bus" resolve="Bus" />
+                        <node concept="37vLTw" id="1yfWS2nQF2F" role="37wK5m">
+                          <ref role="3cqZAo" node="1yfWS2nQF2x" resolve="notification" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbH" id="P1Enn7$zFm" role="3cqZAp" />
+                    <node concept="3clFbF" id="1yfWS2nQEtL" role="3cqZAp">
+                      <node concept="Rm8GO" id="1yfWS2nQEx9" role="3clFbG">
+                        <ref role="Rm8GQ" to="18nx:~CheckinHandler$ReturnResult.CANCEL" resolve="CANCEL" />
+                        <ref role="1Px2BO" to="18nx:~CheckinHandler$ReturnResult" resolve="ReturnResult" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2AHcQZ" id="1yfWS2nQuNT" role="2AJF6D">
+                    <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                  </node>
+                </node>
+                <node concept="2YIFZM" id="2hNr1jFa9fw" role="37wK5m">
+                  <ref role="37wK5l" node="2hNr1jFa1hM" resolve="getKey" />
+                  <ref role="1Pybhc" node="2hNr1jFDx56" resolve="KeyProvider" />
+                  <node concept="Xl_RD" id="2hNr1jFa9fx" role="37wK5m">
+                    <property role="Xl_RC" value="hello" />
+                  </node>
+                </node>
+                <node concept="3clFbT" id="1yfWS2nQxzD" role="37wK5m">
+                  <property role="3clFbU" value="true" />
+                </node>
+                <node concept="Xl_RD" id="1yfWS2nQxNw" role="37wK5m">
+                  <property role="Xl_RC" value="Demo action: Affected models" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="q3mfm" id="2hNr1jFD$YD" role="3clF45">
+        <ref role="q3mfh" to="90d:3zLwYDe0sv$" />
+        <ref role="1QQUv3" node="2hNr1jFD$Y$" resolve="get" />
+      </node>
+    </node>
+  </node>
+</model>

--- a/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.checkinHandler.demo.plugin/models/com.mbeddr.mpsutil.checkinHandler.demo.plugin.plugin.mps
+++ b/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.checkinHandler.demo.plugin/models/com.mbeddr.mpsutil.checkinHandler.demo.plugin.plugin.mps
@@ -23,9 +23,21 @@
     <import index="z1c3" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.project(MPS.Core/)" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" />
     <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" />
+    <import index="qkt" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.actionSystem(MPS.IDEA/)" />
+    <import index="ddhc" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ide(MPS.IDEA/)" />
+    <import index="7bx7" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.workbench.action(MPS.Platform/)" />
+    <import index="l8al" ref="f57286e3-4e19-4d8d-8045-3900761f6530/java:git4idea.commands(jetbrains.mps.git4idea.stubs/)" />
+    <import index="xygl" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.progress(MPS.IDEA/)" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
+    <import index="tprs" ref="r:00000000-0000-4000-0000-011c895904a4(jetbrains.mps.ide.actions)" implicit="true" />
+    <import index="tkms" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.dvcs.repo(MPS.IDEA/)" implicit="true" />
   </imports>
   <registry>
+    <language id="28f9e497-3b42-4291-aeba-0a1039153ab1" name="jetbrains.mps.lang.plugin">
+      <concept id="3205675194086589964" name="jetbrains.mps.lang.plugin.structure.ActionAccessOperation" flags="nn" index="3$FdUm">
+        <reference id="3205675194086671728" name="action" index="3$FpRE" />
+      </concept>
+    </language>
     <language id="ef7bf5ac-d06c-4342-b11d-e42104eb9343" name="jetbrains.mps.lang.plugin.standalone">
       <concept id="7520713872864775836" name="jetbrains.mps.lang.plugin.standalone.structure.StandalonePluginDescriptor" flags="ng" index="2DaZZR" />
     </language>
@@ -76,6 +88,9 @@
       <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
         <reference id="1144433194310" name="classConcept" index="1Pybhc" />
       </concept>
+      <concept id="1070533707846" name="jetbrains.mps.baseLanguage.structure.StaticFieldReference" flags="nn" index="10M0yZ">
+        <reference id="1144433057691" name="classifier" index="1PxDUh" />
+      </concept>
       <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
       <concept id="1070534934090" name="jetbrains.mps.baseLanguage.structure.CastExpression" flags="nn" index="10QFUN">
         <child id="1070534934091" name="type" index="10QFUM" />
@@ -85,6 +100,9 @@
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <property id="1176718929932" name="isFinal" index="3TUv4t" />
         <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ng" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
       </concept>
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
@@ -224,15 +242,23 @@
       <concept id="1204796164442" name="jetbrains.mps.baseLanguage.collections.structure.InternalSequenceOperation" flags="nn" index="23sCx2">
         <child id="1204796294226" name="closure" index="23t8la" />
       </concept>
+      <concept id="540871147943773365" name="jetbrains.mps.baseLanguage.collections.structure.SingleArgumentSequenceOperation" flags="nn" index="25WWJ4">
+        <child id="540871147943773366" name="argument" index="25WWJ7" />
+      </concept>
       <concept id="1204980550705" name="jetbrains.mps.baseLanguage.collections.structure.VisitAllOperation" flags="nn" index="2es0OD" />
+      <concept id="1151688443754" name="jetbrains.mps.baseLanguage.collections.structure.ListType" flags="in" index="_YKpA">
+        <child id="1151688676805" name="elementType" index="_ZDj9" />
+      </concept>
       <concept id="1151689724996" name="jetbrains.mps.baseLanguage.collections.structure.SequenceType" flags="in" index="A3Dl8">
         <child id="1151689745422" name="elementType" index="A3Ik2" />
       </concept>
       <concept id="1203518072036" name="jetbrains.mps.baseLanguage.collections.structure.SmartClosureParameterDeclaration" flags="ig" index="Rh6nW" />
+      <concept id="1162934736510" name="jetbrains.mps.baseLanguage.collections.structure.GetElementOperation" flags="nn" index="34jXtK" />
       <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="nn" index="34oBXx" />
       <concept id="1240687580870" name="jetbrains.mps.baseLanguage.collections.structure.JoinOperation" flags="nn" index="3uJxvA">
         <child id="1240687658305" name="delimiter" index="3uJOhx" />
       </concept>
+      <concept id="1165530316231" name="jetbrains.mps.baseLanguage.collections.structure.IsEmptyOperation" flags="nn" index="1v1jN8" />
       <concept id="7125221305512719026" name="jetbrains.mps.baseLanguage.collections.structure.CollectionType" flags="in" index="3vKaQO" />
       <concept id="1202120902084" name="jetbrains.mps.baseLanguage.collections.structure.WhereOperation" flags="nn" index="3zZkjj" />
       <concept id="1202128969694" name="jetbrains.mps.baseLanguage.collections.structure.SelectOperation" flags="nn" index="3$u5V9" />
@@ -330,7 +356,7 @@
                   <property role="TrG5h" value="actionBeforeCommit" />
                   <node concept="3Tmbuc" id="eZmA2p5ter" role="1B3o_S" />
                   <node concept="3uibUv" id="eZmA2p5tes" role="3clF45">
-                    <ref role="3uigEE" to="18nx:~CheckinHandler$ReturnResult" resolve="ReturnResult" />
+                    <ref role="3uigEE" to="18nx:~CheckinHandler$ReturnResult" resolve="CheckinHandler.ReturnResult" />
                   </node>
                   <node concept="3clFbS" id="eZmA2p5tet" role="3clF47">
                     <node concept="3J1_TO" id="7SmYmUZGM0J" role="3cqZAp">
@@ -524,7 +550,7 @@
                         <node concept="3clFbF" id="eZmA2p5teJ" role="3cqZAp">
                           <node concept="2YIFZM" id="eZmA2p5teK" role="3clFbG">
                             <ref role="37wK5l" to="fnpx:~Notifications$Bus.notify(com.intellij.notification.Notification)" resolve="notify" />
-                            <ref role="1Pybhc" to="fnpx:~Notifications$Bus" resolve="Bus" />
+                            <ref role="1Pybhc" to="fnpx:~Notifications$Bus" resolve="Notifications.Bus" />
                             <node concept="37vLTw" id="eZmA2p5teL" role="37wK5m">
                               <ref role="3cqZAo" node="eZmA2p5tev" resolve="notification" />
                             </node>
@@ -536,7 +562,7 @@
                         <node concept="3clFbS" id="7SmYmUZGP50" role="1wplMD">
                           <node concept="3cpWs6" id="7SmYmUZGPok" role="3cqZAp">
                             <node concept="Rm8GO" id="eZmA2p5teN" role="3cqZAk">
-                              <ref role="1Px2BO" to="18nx:~CheckinHandler$ReturnResult" resolve="ReturnResult" />
+                              <ref role="1Px2BO" to="18nx:~CheckinHandler$ReturnResult" resolve="CheckinHandler.ReturnResult" />
                               <ref role="Rm8GQ" to="18nx:~CheckinHandler$ReturnResult.CANCEL" resolve="CANCEL" />
                             </node>
                           </node>
@@ -604,7 +630,7 @@
                   <property role="TrG5h" value="actionBeforeCommit" />
                   <node concept="3Tmbuc" id="6uXv1_IYtIs" role="1B3o_S" />
                   <node concept="3uibUv" id="6uXv1_IYtIt" role="3clF45">
-                    <ref role="3uigEE" to="18nx:~CheckinHandler$ReturnResult" resolve="ReturnResult" />
+                    <ref role="3uigEE" to="18nx:~CheckinHandler$ReturnResult" resolve="CheckinHandler.ReturnResult" />
                   </node>
                   <node concept="3clFbS" id="6uXv1_IYtIu" role="3clF47">
                     <node concept="3J1_TO" id="6uXv1_IYtIv" role="3cqZAp">
@@ -752,7 +778,7 @@
                         <node concept="3clFbF" id="6uXv1_IYtJg" role="3cqZAp">
                           <node concept="2YIFZM" id="6uXv1_IYtJh" role="3clFbG">
                             <ref role="37wK5l" to="fnpx:~Notifications$Bus.notify(com.intellij.notification.Notification)" resolve="notify" />
-                            <ref role="1Pybhc" to="fnpx:~Notifications$Bus" resolve="Bus" />
+                            <ref role="1Pybhc" to="fnpx:~Notifications$Bus" resolve="Notifications.Bus" />
                             <node concept="37vLTw" id="6uXv1_IYtJi" role="37wK5m">
                               <ref role="3cqZAo" node="6uXv1_IYNbe" resolve="notification" />
                             </node>
@@ -764,7 +790,7 @@
                         <node concept="3clFbS" id="6uXv1_IYtJl" role="1wplMD">
                           <node concept="3cpWs6" id="6uXv1_IYtJm" role="3cqZAp">
                             <node concept="Rm8GO" id="6uXv1_IYtJn" role="3cqZAk">
-                              <ref role="1Px2BO" to="18nx:~CheckinHandler$ReturnResult" resolve="ReturnResult" />
+                              <ref role="1Px2BO" to="18nx:~CheckinHandler$ReturnResult" resolve="CheckinHandler.ReturnResult" />
                               <ref role="Rm8GQ" to="18nx:~CheckinHandler$ReturnResult.CANCEL" resolve="CANCEL" />
                             </node>
                           </node>
@@ -831,7 +857,7 @@
                   <property role="TrG5h" value="actionBeforeCommit" />
                   <node concept="3Tmbuc" id="6uXv1_IZpvg" role="1B3o_S" />
                   <node concept="3uibUv" id="6uXv1_IZpvh" role="3clF45">
-                    <ref role="3uigEE" to="18nx:~CheckinHandler$ReturnResult" resolve="ReturnResult" />
+                    <ref role="3uigEE" to="18nx:~CheckinHandler$ReturnResult" resolve="CheckinHandler.ReturnResult" />
                   </node>
                   <node concept="3clFbS" id="6uXv1_IZpvi" role="3clF47">
                     <node concept="3clFbH" id="6uXv1_IZpvB" role="3cqZAp" />
@@ -965,7 +991,7 @@
                                     <node concept="3clFbF" id="2hNr1jFoEp2" role="3cqZAp">
                                       <node concept="2YIFZM" id="2hNr1jFoEp3" role="3clFbG">
                                         <ref role="37wK5l" to="fnpx:~Notifications$Bus.notify(com.intellij.notification.Notification)" resolve="notify" />
-                                        <ref role="1Pybhc" to="fnpx:~Notifications$Bus" resolve="Bus" />
+                                        <ref role="1Pybhc" to="fnpx:~Notifications$Bus" resolve="Notifications.Bus" />
                                         <node concept="37vLTw" id="2hNr1jFoEp4" role="37wK5m">
                                           <ref role="3cqZAo" node="2hNr1jFoE2F" resolve="notification" />
                                         </node>
@@ -998,7 +1024,7 @@
                     <node concept="3clFbH" id="6uXv1_IZrsC" role="3cqZAp" />
                     <node concept="3clFbF" id="6uXv1_IZpvC" role="3cqZAp">
                       <node concept="Rm8GO" id="6uXv1_IZpvD" role="3clFbG">
-                        <ref role="1Px2BO" to="18nx:~CheckinHandler$ReturnResult" resolve="ReturnResult" />
+                        <ref role="1Px2BO" to="18nx:~CheckinHandler$ReturnResult" resolve="CheckinHandler.ReturnResult" />
                         <ref role="Rm8GQ" to="18nx:~CheckinHandler$ReturnResult.CANCEL" resolve="CANCEL" />
                       </node>
                     </node>
@@ -1062,7 +1088,7 @@
                   <property role="TrG5h" value="actionBeforeCommit" />
                   <node concept="3Tmbuc" id="1yfWS2nQuNP" role="1B3o_S" />
                   <node concept="3uibUv" id="1yfWS2nQuNQ" role="3clF45">
-                    <ref role="3uigEE" to="18nx:~CheckinHandler$ReturnResult" resolve="ReturnResult" />
+                    <ref role="3uigEE" to="18nx:~CheckinHandler$ReturnResult" resolve="CheckinHandler.ReturnResult" />
                   </node>
                   <node concept="3clFbS" id="1yfWS2nQuNS" role="3clF47">
                     <node concept="3cpWs8" id="1yfWS2nQF2w" role="3cqZAp">
@@ -1114,7 +1140,7 @@
                     <node concept="3clFbF" id="1yfWS2nQyWh" role="3cqZAp">
                       <node concept="2YIFZM" id="1yfWS2nQz$u" role="3clFbG">
                         <ref role="37wK5l" to="fnpx:~Notifications$Bus.notify(com.intellij.notification.Notification)" resolve="notify" />
-                        <ref role="1Pybhc" to="fnpx:~Notifications$Bus" resolve="Bus" />
+                        <ref role="1Pybhc" to="fnpx:~Notifications$Bus" resolve="Notifications.Bus" />
                         <node concept="37vLTw" id="1yfWS2nQF2F" role="37wK5m">
                           <ref role="3cqZAo" node="1yfWS2nQF2x" resolve="notification" />
                         </node>
@@ -1124,7 +1150,7 @@
                     <node concept="3clFbF" id="1yfWS2nQEtL" role="3cqZAp">
                       <node concept="Rm8GO" id="1yfWS2nQEx9" role="3clFbG">
                         <ref role="Rm8GQ" to="18nx:~CheckinHandler$ReturnResult.CANCEL" resolve="CANCEL" />
-                        <ref role="1Px2BO" to="18nx:~CheckinHandler$ReturnResult" resolve="ReturnResult" />
+                        <ref role="1Px2BO" to="18nx:~CheckinHandler$ReturnResult" resolve="CheckinHandler.ReturnResult" />
                       </node>
                     </node>
                   </node>
@@ -1156,4 +1182,352 @@
       </node>
     </node>
   </node>
+  <node concept="1lYeZD" id="32CFzTqVtcV">
+    <property role="TrG5h" value="ForceSaveAllCheckin" />
+    <ref role="1lYe$Y" to="aqel:1yfWS2nNO6t" resolve="CheckinExtensionPoint" />
+    <node concept="3Tm1VV" id="32CFzTqVtcW" role="1B3o_S" />
+    <node concept="2tJIrI" id="32CFzTqVtcX" role="jymVt" />
+    <node concept="3tTeZs" id="32CFzTqVtcY" role="jymVt">
+      <property role="3tTeZt" value="activate" />
+      <ref role="3tTeZr" to="90d:3zLwYDe0CPy" resolve="activate" />
+    </node>
+    <node concept="3tTeZs" id="32CFzTqVtcZ" role="jymVt">
+      <property role="3tTeZt" value="deactivate" />
+      <ref role="3tTeZr" to="90d:3zLwYDe0BDO" resolve="deactivate" />
+    </node>
+    <node concept="2tJIrI" id="32CFzTqVtd0" role="jymVt" />
+    <node concept="q3mfD" id="32CFzTqVtd1" role="jymVt">
+      <property role="TrG5h" value="get" />
+      <ref role="2VtyIY" to="90d:3zLwYDe0svr" resolve="get" />
+      <node concept="3Tm1VV" id="32CFzTqVtd2" role="1B3o_S" />
+      <node concept="3clFbS" id="32CFzTqVtd3" role="3clF47">
+        <node concept="3clFbF" id="32CFzTqVtd4" role="3cqZAp">
+          <node concept="2ShNRf" id="32CFzTqVtd5" role="3clFbG">
+            <node concept="YeOm9" id="32CFzTqVtd6" role="2ShVmc">
+              <node concept="1Y3b0j" id="32CFzTqVtd7" role="YeSDq">
+                <property role="2bfB8j" value="true" />
+                <ref role="1Y3XeK" to="aqel:7uW9A9Lcnfm" resolve="BaseCheckinHandler" />
+                <ref role="37wK5l" to="aqel:1yfWS2nOYu5" resolve="BaseCheckinHandler" />
+                <node concept="3Tm1VV" id="32CFzTqVtd8" role="1B3o_S" />
+                <node concept="3clFb_" id="32CFzTqVtd9" role="jymVt">
+                  <property role="TrG5h" value="actionBeforeCommit" />
+                  <node concept="3Tmbuc" id="32CFzTqVtda" role="1B3o_S" />
+                  <node concept="3uibUv" id="32CFzTqVtdb" role="3clF45">
+                    <ref role="3uigEE" to="18nx:~CheckinHandler$ReturnResult" resolve="CheckinHandler.ReturnResult" />
+                  </node>
+                  <node concept="3clFbS" id="32CFzTqVtdc" role="3clF47">
+                    <node concept="3cpWs8" id="32CFzTqVNBA" role="3cqZAp">
+                      <node concept="3cpWsn" id="32CFzTqVNBB" role="3cpWs9">
+                        <property role="TrG5h" value="dataContext" />
+                        <node concept="3uibUv" id="32CFzTqVNBC" role="1tU5fm">
+                          <ref role="3uigEE" to="qkt:~DataContext" resolve="DataContext" />
+                        </node>
+                        <node concept="2OqwBi" id="32CFzTqVRjR" role="33vP2m">
+                          <node concept="2YIFZM" id="32CFzTqVRbG" role="2Oq$k0">
+                            <ref role="37wK5l" to="ddhc:~DataManager.getInstance()" resolve="getInstance" />
+                            <ref role="1Pybhc" to="ddhc:~DataManager" resolve="DataManager" />
+                          </node>
+                          <node concept="liA8E" id="32CFzTqVRva" role="2OqNvi">
+                            <ref role="37wK5l" to="ddhc:~DataManager.getDataContext(java.awt.Component)" resolve="getDataContext" />
+                            <node concept="2OqwBi" id="32CFzTqVTWN" role="37wK5m">
+                              <node concept="2OqwBi" id="32CFzTqVRPB" role="2Oq$k0">
+                                <node concept="Xjq3P" id="32CFzTqVRCl" role="2Oq$k0" />
+                                <node concept="2OwXpG" id="32CFzTqVS9V" role="2OqNvi">
+                                  <ref role="2Oxat5" to="aqel:7uW9A9LcS0c" resolve="panel" />
+                                </node>
+                              </node>
+                              <node concept="liA8E" id="32CFzTqVUhX" role="2OqNvi">
+                                <ref role="37wK5l" to="jlcu:~CheckinProjectPanel.getComponent()" resolve="getComponent" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3cpWs8" id="32CFzTqVULL" role="3cqZAp">
+                      <node concept="3cpWsn" id="32CFzTqVULM" role="3cpWs9">
+                        <property role="TrG5h" value="event" />
+                        <node concept="3uibUv" id="32CFzTqVULN" role="1tU5fm">
+                          <ref role="3uigEE" to="qkt:~AnActionEvent" resolve="AnActionEvent" />
+                        </node>
+                        <node concept="2YIFZM" id="32CFzTqVVwN" role="33vP2m">
+                          <ref role="37wK5l" to="7bx7:~ActionUtils.createEvent(java.lang.String,com.intellij.openapi.actionSystem.DataContext)" resolve="createEvent" />
+                          <ref role="1Pybhc" to="7bx7:~ActionUtils" resolve="ActionUtils" />
+                          <node concept="10M0yZ" id="32CFzTqVVDp" role="37wK5m">
+                            <ref role="3cqZAo" to="qkt:~ActionPlaces.UNKNOWN" resolve="UNKNOWN" />
+                            <ref role="1PxDUh" to="qkt:~ActionPlaces" resolve="ActionPlaces" />
+                          </node>
+                          <node concept="37vLTw" id="32CFzTqVVMo" role="37wK5m">
+                            <ref role="3cqZAo" node="32CFzTqVNBB" resolve="dataContext" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbF" id="32CFzTqVW8k" role="3cqZAp">
+                      <node concept="2YIFZM" id="32CFzTqVWdB" role="3clFbG">
+                        <ref role="37wK5l" to="7bx7:~ActionUtils.updateAndPerformAction(com.intellij.openapi.actionSystem.AnAction,com.intellij.openapi.actionSystem.AnActionEvent)" resolve="updateAndPerformAction" />
+                        <ref role="1Pybhc" to="7bx7:~ActionUtils" resolve="ActionUtils" />
+                        <node concept="3$FdUm" id="32CFzTqVWte" role="37wK5m">
+                          <ref role="3$FpRE" to="tprs:2cEqqWVQVCm" resolve="ForceSaveAll" />
+                        </node>
+                        <node concept="37vLTw" id="32CFzTqVWRI" role="37wK5m">
+                          <ref role="3cqZAo" node="32CFzTqVULM" resolve="event" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbH" id="2$lNLAkVcif" role="3cqZAp" />
+                    <node concept="3cpWs8" id="2$lNLAkVe4B" role="3cqZAp">
+                      <node concept="3cpWsn" id="2$lNLAkVe4C" role="3cpWs9">
+                        <property role="TrG5h" value="repositoryManager" />
+                        <node concept="3uibUv" id="2$lNLAkVe24" role="1tU5fm">
+                          <ref role="3uigEE" to="5mlj:~GitRepositoryManager" resolve="GitRepositoryManager" />
+                        </node>
+                        <node concept="2YIFZM" id="2$lNLAkVe4D" role="33vP2m">
+                          <ref role="37wK5l" to="hr4p:~GitUtil.getRepositoryManager(com.intellij.openapi.project.Project)" resolve="getRepositoryManager" />
+                          <ref role="1Pybhc" to="hr4p:~GitUtil" resolve="GitUtil" />
+                          <node concept="2OqwBi" id="2$lNLAkVe4E" role="37wK5m">
+                            <node concept="Xjq3P" id="2$lNLAkVe4F" role="2Oq$k0" />
+                            <node concept="2OwXpG" id="2$lNLAkVe4G" role="2OqNvi">
+                              <ref role="2Oxat5" to="aqel:7uW9A9LcNXZ" resolve="ideaProject" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3cpWs8" id="2$lNLAkVfIm" role="3cqZAp">
+                      <node concept="3cpWsn" id="2$lNLAkVfIn" role="3cpWs9">
+                        <property role="TrG5h" value="repositories" />
+                        <node concept="2OqwBi" id="2$lNLAkVfIo" role="33vP2m">
+                          <node concept="37vLTw" id="2$lNLAkVfIp" role="2Oq$k0">
+                            <ref role="3cqZAo" node="2$lNLAkVe4C" resolve="repositoryManager" />
+                          </node>
+                          <node concept="liA8E" id="2$lNLAkVfIq" role="2OqNvi">
+                            <ref role="37wK5l" to="5mlj:~GitRepositoryManager.getRepositories()" resolve="getRepositories" />
+                          </node>
+                        </node>
+                        <node concept="_YKpA" id="2$lNLAkVgI9" role="1tU5fm">
+                          <node concept="3uibUv" id="2$lNLAkVh3y" role="_ZDj9">
+                            <ref role="3uigEE" to="5mlj:~GitRepository" resolve="GitRepository" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbJ" id="2$lNLAkVgja" role="3cqZAp">
+                      <node concept="3clFbS" id="2$lNLAkVgjc" role="3clFbx">
+                        <node concept="3cpWs6" id="2$lNLAkVjRt" role="3cqZAp">
+                          <node concept="Rm8GO" id="2$lNLAkVl7G" role="3cqZAk">
+                            <ref role="Rm8GQ" to="18nx:~CheckinHandler$ReturnResult.CANCEL" resolve="CANCEL" />
+                            <ref role="1Px2BO" to="18nx:~CheckinHandler$ReturnResult" resolve="CheckinHandler.ReturnResult" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="2OqwBi" id="2$lNLAkVi1e" role="3clFbw">
+                        <node concept="37vLTw" id="2$lNLAkVhdH" role="2Oq$k0">
+                          <ref role="3cqZAo" node="2$lNLAkVfIn" resolve="repositories" />
+                        </node>
+                        <node concept="1v1jN8" id="2$lNLAkVjrp" role="2OqNvi" />
+                      </node>
+                    </node>
+                    <node concept="3clFbH" id="2$lNLAkVkGo" role="3cqZAp" />
+                    <node concept="3clFbF" id="4E9ClRMlW0" role="3cqZAp">
+                      <node concept="2OqwBi" id="4E9ClRMnKz" role="3clFbG">
+                        <node concept="2YIFZM" id="4E9ClRMnb_" role="2Oq$k0">
+                          <ref role="37wK5l" to="xygl:~ProgressManager.getInstance()" resolve="getInstance" />
+                          <ref role="1Pybhc" to="xygl:~ProgressManager" resolve="ProgressManager" />
+                        </node>
+                        <node concept="liA8E" id="4E9ClRMo$A" role="2OqNvi">
+                          <ref role="37wK5l" to="xygl:~ProgressManager.runProcessWithProgressSynchronously(java.lang.Runnable,java.lang.String,boolean,com.intellij.openapi.project.Project)" resolve="runProcessWithProgressSynchronously" />
+                          <node concept="1bVj0M" id="4E9ClRMq5r" role="37wK5m">
+                            <node concept="3clFbS" id="4E9ClRMq5s" role="1bW5cS">
+                              <node concept="3cpWs8" id="2$lNLAkVl$u" role="3cqZAp">
+                                <node concept="3cpWsn" id="2$lNLAkVl$v" role="3cpWs9">
+                                  <property role="TrG5h" value="repository" />
+                                  <node concept="3uibUv" id="2$lNLAkVl$w" role="1tU5fm">
+                                    <ref role="3uigEE" to="5mlj:~GitRepository" resolve="GitRepository" />
+                                  </node>
+                                  <node concept="2OqwBi" id="2$lNLAkVmOv" role="33vP2m">
+                                    <node concept="37vLTw" id="2$lNLAkVlPw" role="2Oq$k0">
+                                      <ref role="3cqZAo" node="2$lNLAkVfIn" resolve="repositories" />
+                                    </node>
+                                    <node concept="34jXtK" id="2$lNLAkVnNu" role="2OqNvi">
+                                      <node concept="3cmrfG" id="2$lNLAkVnXa" role="25WWJ7">
+                                        <property role="3cmrfH" value="0" />
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                              <node concept="3cpWs8" id="EINZMujMpp" role="3cqZAp">
+                                <node concept="3cpWsn" id="EINZMujMpq" role="3cpWs9">
+                                  <property role="TrG5h" value="addHandler" />
+                                  <node concept="3uibUv" id="EINZMujMpr" role="1tU5fm">
+                                    <ref role="3uigEE" to="l8al:~GitLineHandler" resolve="GitLineHandler" />
+                                  </node>
+                                  <node concept="2ShNRf" id="EINZMujMps" role="33vP2m">
+                                    <node concept="1pGfFk" id="EINZMujMpt" role="2ShVmc">
+                                      <property role="373rjd" value="true" />
+                                      <ref role="37wK5l" to="l8al:~GitLineHandler.&lt;init&gt;(com.intellij.openapi.project.Project,com.intellij.openapi.vfs.VirtualFile,git4idea.commands.GitCommand)" resolve="GitLineHandler" />
+                                      <node concept="2OqwBi" id="EINZMujMpu" role="37wK5m">
+                                        <node concept="Xjq3P" id="EINZMujMpv" role="2Oq$k0" />
+                                        <node concept="2OwXpG" id="EINZMujMpw" role="2OqNvi">
+                                          <ref role="2Oxat5" to="aqel:7uW9A9LcNXZ" resolve="ideaProject" />
+                                        </node>
+                                      </node>
+                                      <node concept="2OqwBi" id="EINZMujMpx" role="37wK5m">
+                                        <node concept="37vLTw" id="EINZMujMpy" role="2Oq$k0">
+                                          <ref role="3cqZAo" node="2$lNLAkVl$v" resolve="repository" />
+                                        </node>
+                                        <node concept="liA8E" id="EINZMujMpz" role="2OqNvi">
+                                          <ref role="37wK5l" to="tkms:~Repository.getRoot()" resolve="getRoot" />
+                                        </node>
+                                      </node>
+                                      <node concept="10M0yZ" id="EINZMujOHv" role="37wK5m">
+                                        <ref role="3cqZAo" to="l8al:~GitCommand.ADD" resolve="ADD" />
+                                        <ref role="1PxDUh" to="l8al:~GitCommand" resolve="GitCommand" />
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                              <node concept="3clFbF" id="EINZMujQCb" role="3cqZAp">
+                                <node concept="2OqwBi" id="EINZMujRbL" role="3clFbG">
+                                  <node concept="37vLTw" id="EINZMujQC9" role="2Oq$k0">
+                                    <ref role="3cqZAo" node="EINZMujMpq" resolve="addHandler" />
+                                  </node>
+                                  <node concept="liA8E" id="EINZMujRHM" role="2OqNvi">
+                                    <ref role="37wK5l" to="l8al:~GitHandler.addParameters(java.lang.String...)" resolve="addParameters" />
+                                    <node concept="Xl_RD" id="EINZMujS28" role="37wK5m">
+                                      <property role="Xl_RC" value="-A" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                              <node concept="3clFbF" id="EINZMujTW6" role="3cqZAp">
+                                <node concept="2OqwBi" id="EINZMujMKE" role="3clFbG">
+                                  <node concept="2YIFZM" id="EINZMujMKF" role="2Oq$k0">
+                                    <ref role="37wK5l" to="l8al:~Git.getInstance()" resolve="getInstance" />
+                                    <ref role="1Pybhc" to="l8al:~Git" resolve="Git" />
+                                  </node>
+                                  <node concept="liA8E" id="EINZMujMKG" role="2OqNvi">
+                                    <ref role="37wK5l" to="l8al:~Git.runCommand(git4idea.commands.GitLineHandler)" resolve="runCommand" />
+                                    <node concept="37vLTw" id="EINZMujMKH" role="37wK5m">
+                                      <ref role="3cqZAo" node="EINZMujMpq" resolve="addHandler" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                              <node concept="3clFbH" id="EINZMujMgC" role="3cqZAp" />
+                              <node concept="3cpWs8" id="2$lNLAkVrWK" role="3cqZAp">
+                                <node concept="3cpWsn" id="2$lNLAkVrWL" role="3cpWs9">
+                                  <property role="TrG5h" value="commitHandler" />
+                                  <node concept="3uibUv" id="2$lNLAkVrWM" role="1tU5fm">
+                                    <ref role="3uigEE" to="l8al:~GitLineHandler" resolve="GitLineHandler" />
+                                  </node>
+                                  <node concept="2ShNRf" id="2$lNLAkVsaW" role="33vP2m">
+                                    <node concept="1pGfFk" id="2$lNLAkVwA5" role="2ShVmc">
+                                      <property role="373rjd" value="true" />
+                                      <ref role="37wK5l" to="l8al:~GitLineHandler.&lt;init&gt;(com.intellij.openapi.project.Project,com.intellij.openapi.vfs.VirtualFile,git4idea.commands.GitCommand)" resolve="GitLineHandler" />
+                                      <node concept="2OqwBi" id="2$lNLAkVx3Q" role="37wK5m">
+                                        <node concept="Xjq3P" id="2$lNLAkVwLR" role="2Oq$k0" />
+                                        <node concept="2OwXpG" id="2$lNLAkVxtB" role="2OqNvi">
+                                          <ref role="2Oxat5" to="aqel:7uW9A9LcNXZ" resolve="ideaProject" />
+                                        </node>
+                                      </node>
+                                      <node concept="2OqwBi" id="2$lNLAkVCVq" role="37wK5m">
+                                        <node concept="37vLTw" id="2$lNLAkVCC4" role="2Oq$k0">
+                                          <ref role="3cqZAo" node="2$lNLAkVl$v" resolve="repository" />
+                                        </node>
+                                        <node concept="liA8E" id="2$lNLAkVDmM" role="2OqNvi">
+                                          <ref role="37wK5l" to="tkms:~Repository.getRoot()" resolve="getRoot" />
+                                        </node>
+                                      </node>
+                                      <node concept="10M0yZ" id="2$lNLAkVDya" role="37wK5m">
+                                        <ref role="3cqZAo" to="l8al:~GitCommand.COMMIT" resolve="COMMIT" />
+                                        <ref role="1PxDUh" to="l8al:~GitCommand" resolve="GitCommand" />
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                              <node concept="3clFbF" id="2$lNLAkVJBD" role="3cqZAp">
+                                <node concept="2OqwBi" id="2$lNLAkVKb2" role="3clFbG">
+                                  <node concept="37vLTw" id="2$lNLAkVJBB" role="2Oq$k0">
+                                    <ref role="3cqZAo" node="2$lNLAkVrWL" resolve="commitHandler" />
+                                  </node>
+                                  <node concept="liA8E" id="2$lNLAkVKGw" role="2OqNvi">
+                                    <ref role="37wK5l" to="l8al:~GitHandler.addParameters(java.lang.String...)" resolve="addParameters" />
+                                    <node concept="Xl_RD" id="2$lNLAkVKUJ" role="37wK5m">
+                                      <property role="Xl_RC" value="-m" />
+                                    </node>
+                                    <node concept="Xl_RD" id="2$lNLAkVMqA" role="37wK5m">
+                                      <property role="Xl_RC" value="Force Save All" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                              <node concept="3clFbF" id="EINZMujVQ8" role="3cqZAp">
+                                <node concept="2OqwBi" id="3ccDGDuG02b" role="3clFbG">
+                                  <node concept="2YIFZM" id="3ccDGDuG02c" role="2Oq$k0">
+                                    <ref role="37wK5l" to="l8al:~Git.getInstance()" resolve="getInstance" />
+                                    <ref role="1Pybhc" to="l8al:~Git" resolve="Git" />
+                                  </node>
+                                  <node concept="liA8E" id="3ccDGDuG02d" role="2OqNvi">
+                                    <ref role="37wK5l" to="l8al:~Git.runCommand(git4idea.commands.GitLineHandler)" resolve="runCommand" />
+                                    <node concept="37vLTw" id="3ccDGDuG02e" role="37wK5m">
+                                      <ref role="3cqZAo" node="2$lNLAkVrWL" resolve="commitHandler" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="Xl_RD" id="4E9ClRMs$t" role="37wK5m">
+                            <property role="Xl_RC" value="Force Save All" />
+                          </node>
+                          <node concept="3clFbT" id="4E9ClRMtLm" role="37wK5m" />
+                          <node concept="2OqwBi" id="4E9ClRMuG6" role="37wK5m">
+                            <node concept="Xjq3P" id="4E9ClRMulU" role="2Oq$k0" />
+                            <node concept="2OwXpG" id="4E9ClRMvbI" role="2OqNvi">
+                              <ref role="2Oxat5" to="aqel:7uW9A9LcNXZ" resolve="ideaProject" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3cpWs6" id="2$lNLAkVkPb" role="3cqZAp">
+                      <node concept="Rm8GO" id="2$lNLAkVkPc" role="3cqZAk">
+                        <ref role="Rm8GQ" to="18nx:~CheckinHandler$ReturnResult.COMMIT" resolve="COMMIT" />
+                        <ref role="1Px2BO" to="18nx:~CheckinHandler$ReturnResult" resolve="CheckinHandler.ReturnResult" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2AHcQZ" id="32CFzTqVtd_" role="2AJF6D">
+                    <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                  </node>
+                </node>
+                <node concept="2YIFZM" id="32CFzTqVtdA" role="37wK5m">
+                  <ref role="37wK5l" node="2hNr1jFa1hM" resolve="getKey" />
+                  <ref role="1Pybhc" node="2hNr1jFDx56" resolve="KeyProvider" />
+                  <node concept="Xl_RD" id="32CFzTqVtdB" role="37wK5m">
+                    <property role="Xl_RC" value="forceSaveAll" />
+                  </node>
+                </node>
+                <node concept="3clFbT" id="32CFzTqVtdC" role="37wK5m">
+                  <property role="3clFbU" value="true" />
+                </node>
+                <node concept="Xl_RD" id="32CFzTqVtdD" role="37wK5m">
+                  <property role="Xl_RC" value="Demo action: Force Save All" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="q3mfm" id="32CFzTqVtdE" role="3clF45">
+        <ref role="q3mfh" to="90d:3zLwYDe0sv$" />
+        <ref role="1QQUv3" node="32CFzTqVtd1" resolve="get" />
+      </node>
+    </node>
+  </node>
 </model>
+

--- a/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.checkinHandler.demo/models/com.mbeddr.mpsutil.checkinHandler.demo.mps
+++ b/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.checkinHandler.demo/models/com.mbeddr.mpsutil.checkinHandler.demo.mps
@@ -1,0 +1,1160 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:5f2288fa-d3fa-4c36-9940-56d7725bea65(com.mbeddr.mpsutil.checkinHandler.demo)">
+  <persistence version="9" />
+  <languages>
+    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
+    <use id="c7d5b9dd-a05f-4be2-bc73-f2e16994cc67" name="jetbrains.mps.baseLanguage.lightweightdsl" version="1" />
+    <use id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections" version="1" />
+    <use id="c0080a47-7e37-4558-bee9-9ae18e690549" name="jetbrains.mps.lang.extension" version="2" />
+    <use id="ef7bf5ac-d06c-4342-b11d-e42104eb9343" name="jetbrains.mps.lang.plugin.standalone" version="0" />
+    <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="12" />
+    <use id="63650c59-16c8-498a-99c8-005c7ee9515d" name="jetbrains.mps.lang.access" version="0" />
+    <use id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures" version="0" />
+  </languages>
+  <imports>
+    <import index="z1c3" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.project(MPS.Core/)" />
+    <import index="hr4p" ref="f57286e3-4e19-4d8d-8045-3900761f6530/java:git4idea(jetbrains.mps.git4idea.stubs/)" />
+    <import index="c0fd" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.vcs.commit(MPS.IDEA/)" />
+    <import index="fnpx" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.notification(MPS.IDEA/)" />
+    <import index="90d" ref="r:421d64ed-8024-497f-aeab-8bddeb389dd2(jetbrains.mps.lang.extension.methods)" />
+    <import index="jlcu" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.vcs(MPS.IDEA/)" />
+    <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" />
+    <import index="18nx" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.vcs.checkin(MPS.IDEA/)" />
+    <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" />
+    <import index="18ew" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.util(MPS.Core/)" />
+    <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" />
+    <import index="aqel" ref="r:ecd3c807-fa84-48be-b99b-f9c5f7f6cc51(com.mbeddr.mpsutil.checkinHandler.plugin)" />
+    <import index="5mlj" ref="f57286e3-4e19-4d8d-8045-3900761f6530/java:git4idea.repo(jetbrains.mps.git4idea.stubs/)" />
+  </imports>
+  <registry>
+    <language id="ef7bf5ac-d06c-4342-b11d-e42104eb9343" name="jetbrains.mps.lang.plugin.standalone">
+      <concept id="7520713872864775836" name="jetbrains.mps.lang.plugin.standalone.structure.StandalonePluginDescriptor" flags="ng" index="2DaZZR" />
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1082485599095" name="jetbrains.mps.baseLanguage.structure.BlockStatement" flags="nn" index="9aQIb">
+        <child id="1082485599096" name="statements" index="9aQI4" />
+      </concept>
+      <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
+        <child id="1068498886297" name="rValue" index="37vLTx" />
+        <child id="1068498886295" name="lValue" index="37vLTJ" />
+      </concept>
+      <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
+      <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="8118189177080264853" name="jetbrains.mps.baseLanguage.structure.AlternativeType" flags="ig" index="nSUau">
+        <child id="8118189177080264854" name="alternative" index="nSUat" />
+      </concept>
+      <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="nn" index="2tJIrI" />
+      <concept id="1188207840427" name="jetbrains.mps.baseLanguage.structure.AnnotationInstance" flags="nn" index="2AHcQZ">
+        <reference id="1188208074048" name="annotation" index="2AI5Lk" />
+      </concept>
+      <concept id="1188208481402" name="jetbrains.mps.baseLanguage.structure.HasAnnotation" flags="ng" index="2AJDlI">
+        <child id="1188208488637" name="annotation" index="2AJF6D" />
+      </concept>
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1197029447546" name="jetbrains.mps.baseLanguage.structure.FieldReferenceOperation" flags="nn" index="2OwXpG">
+        <reference id="1197029500499" name="fieldDeclaration" index="2Oxat5" />
+      </concept>
+      <concept id="1083260308424" name="jetbrains.mps.baseLanguage.structure.EnumConstantReference" flags="nn" index="Rm8GO">
+        <reference id="1083260308426" name="enumConstantDeclaration" index="Rm8GQ" />
+        <reference id="1144432896254" name="enumClass" index="1Px2BO" />
+      </concept>
+      <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
+        <child id="1145553007750" name="creator" index="2ShVmc" />
+      </concept>
+      <concept id="1070462154015" name="jetbrains.mps.baseLanguage.structure.StaticFieldDeclaration" flags="ig" index="Wx3nA" />
+      <concept id="1070475354124" name="jetbrains.mps.baseLanguage.structure.ThisExpression" flags="nn" index="Xjq3P" />
+      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
+        <property id="1070475926801" name="value" index="Xl_RC" />
+      </concept>
+      <concept id="4952749571008284462" name="jetbrains.mps.baseLanguage.structure.CatchVariable" flags="ng" index="XOnhg" />
+      <concept id="1182160077978" name="jetbrains.mps.baseLanguage.structure.AnonymousClassCreator" flags="nn" index="YeOm9">
+        <child id="1182160096073" name="cls" index="YeSDq" />
+      </concept>
+      <concept id="1081236700938" name="jetbrains.mps.baseLanguage.structure.StaticMethodDeclaration" flags="ig" index="2YIFZL" />
+      <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
+        <reference id="1144433194310" name="classConcept" index="1Pybhc" />
+      </concept>
+      <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
+      <concept id="1070534934090" name="jetbrains.mps.baseLanguage.structure.CastExpression" flags="nn" index="10QFUN">
+        <child id="1070534934091" name="type" index="10QFUM" />
+        <child id="1070534934092" name="expression" index="10QFUP" />
+      </concept>
+      <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu" />
+      <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
+        <property id="1176718929932" name="isFinal" index="3TUv4t" />
+        <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
+        <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
+      </concept>
+      <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
+      <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
+      <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
+      <concept id="1225271221393" name="jetbrains.mps.baseLanguage.structure.NPENotEqualsExpression" flags="nn" index="17QLQc" />
+      <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
+        <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
+      <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
+        <child id="1068580123133" name="returnType" index="3clF45" />
+        <child id="1068580123134" name="parameter" index="3clF46" />
+        <child id="1068580123135" name="body" index="3clF47" />
+      </concept>
+      <concept id="1068580123165" name="jetbrains.mps.baseLanguage.structure.InstanceMethodDeclaration" flags="ig" index="3clFb_" />
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
+      <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
+        <child id="1082485599094" name="ifFalseStatement" index="9aQIa" />
+        <child id="1068580123160" name="condition" index="3clFbw" />
+        <child id="1068580123161" name="ifTrue" index="3clFbx" />
+      </concept>
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT">
+        <property id="1068580123138" name="value" index="3clFbU" />
+      </concept>
+      <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
+        <property id="1068580320021" name="value" index="3cmrfH" />
+      </concept>
+      <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
+      <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
+        <child id="1068581517676" name="expression" index="3cqZAk" />
+      </concept>
+      <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
+        <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
+      </concept>
+      <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
+      <concept id="1079359253375" name="jetbrains.mps.baseLanguage.structure.ParenthesizedExpression" flags="nn" index="1eOMI4">
+        <child id="1079359253376" name="expression" index="1eOMHV" />
+      </concept>
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
+      </concept>
+      <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk" />
+      <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
+        <property id="521412098689998745" name="nonStatic" index="2bfB8j" />
+        <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
+      </concept>
+      <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
+        <reference id="1107535924139" name="classifier" index="3uigEE" />
+      </concept>
+      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
+        <child id="1081773367579" name="rightExpression" index="3uHU7w" />
+        <child id="1081773367580" name="leftExpression" index="3uHU7B" />
+      </concept>
+      <concept id="3093926081414150598" name="jetbrains.mps.baseLanguage.structure.MultipleCatchClause" flags="ng" index="3uVAMA">
+        <child id="8276990574895933173" name="catchBody" index="1zc67A" />
+        <child id="8276990574895933172" name="throwable" index="1zc67B" />
+      </concept>
+      <concept id="8276990574909231788" name="jetbrains.mps.baseLanguage.structure.FinallyClause" flags="ng" index="1wplmZ">
+        <child id="8276990574909234106" name="finallyBody" index="1wplMD" />
+      </concept>
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
+        <child id="1178549979242" name="visibility" index="1B3o_S" />
+      </concept>
+      <concept id="5351203823916750322" name="jetbrains.mps.baseLanguage.structure.TryUniversalStatement" flags="nn" index="3J1_TO">
+        <child id="8276990574886367510" name="catchClause" index="1zxBo5" />
+        <child id="8276990574886367509" name="finallyClause" index="1zxBo6" />
+        <child id="8276990574886367508" name="body" index="1zxBo7" />
+      </concept>
+      <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
+      <concept id="1146644641414" name="jetbrains.mps.baseLanguage.structure.ProtectedVisibility" flags="nn" index="3Tmbuc" />
+      <concept id="1170345865475" name="jetbrains.mps.baseLanguage.structure.AnonymousClass" flags="ig" index="1Y3b0j">
+        <reference id="1170346070688" name="classifier" index="1Y3XeK" />
+      </concept>
+    </language>
+    <language id="c0080a47-7e37-4558-bee9-9ae18e690549" name="jetbrains.mps.lang.extension">
+      <concept id="126958800891274162" name="jetbrains.mps.lang.extension.structure.Extension" flags="ig" index="1lYeZD">
+        <reference id="126958800891274597" name="extensionPoint" index="1lYe$Y" />
+      </concept>
+    </language>
+    <language id="63650c59-16c8-498a-99c8-005c7ee9515d" name="jetbrains.mps.lang.access">
+      <concept id="8974276187400348173" name="jetbrains.mps.lang.access.structure.CommandClosureLiteral" flags="nn" index="1QHqEC" />
+      <concept id="8974276187400348170" name="jetbrains.mps.lang.access.structure.BaseExecuteCommandStatement" flags="nn" index="1QHqEJ">
+        <child id="1423104411234567454" name="repo" index="ukAjM" />
+        <child id="8974276187400348171" name="commandClosureLiteral" index="1QHqEI" />
+      </concept>
+      <concept id="8974276187400348177" name="jetbrains.mps.lang.access.structure.ExecuteCommandStatement" flags="nn" index="1QHqEO" />
+    </language>
+    <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
+      <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
+        <child id="1199569906740" name="parameter" index="1bW2Oz" />
+        <child id="1199569916463" name="body" index="1bW5cS" />
+      </concept>
+    </language>
+    <language id="c7d5b9dd-a05f-4be2-bc73-f2e16994cc67" name="jetbrains.mps.baseLanguage.lightweightdsl">
+      <concept id="3751132065236767083" name="jetbrains.mps.baseLanguage.lightweightdsl.structure.DependentTypeInstance" flags="ig" index="q3mfm">
+        <reference id="3751132065236767084" name="decl" index="q3mfh" />
+        <reference id="9097849371505568270" name="point" index="1QQUv3" />
+      </concept>
+      <concept id="3751132065236767060" name="jetbrains.mps.baseLanguage.lightweightdsl.structure.MethodInstance" flags="ig" index="q3mfD">
+        <reference id="19209059688387895" name="decl" index="2VtyIY" />
+      </concept>
+      <concept id="6478870542308703666" name="jetbrains.mps.baseLanguage.lightweightdsl.structure.MemberPlaceholder" flags="ng" index="3tTeZs">
+        <property id="6478870542308703667" name="caption" index="3tTeZt" />
+        <reference id="6478870542308703669" name="decl" index="3tTeZr" />
+      </concept>
+    </language>
+    <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
+        <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
+      </concept>
+      <concept id="1171315804604" name="jetbrains.mps.lang.smodel.structure.Model_RootsOperation" flags="nn" index="2RRcyG">
+        <child id="6750920497477046361" name="conceptArgument" index="3MHsoP" />
+      </concept>
+      <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
+        <reference id="1138405853777" name="concept" index="ehGHo" />
+      </concept>
+      <concept id="1138056022639" name="jetbrains.mps.lang.smodel.structure.SPropertyAccess" flags="nn" index="3TrcHB">
+        <reference id="1138056395725" name="property" index="3TsBF5" />
+      </concept>
+      <concept id="1228341669568" name="jetbrains.mps.lang.smodel.structure.Node_DetachOperation" flags="nn" index="3YRAZt" />
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+    <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
+      <concept id="1204796164442" name="jetbrains.mps.baseLanguage.collections.structure.InternalSequenceOperation" flags="nn" index="23sCx2">
+        <child id="1204796294226" name="closure" index="23t8la" />
+      </concept>
+      <concept id="1204980550705" name="jetbrains.mps.baseLanguage.collections.structure.VisitAllOperation" flags="nn" index="2es0OD" />
+      <concept id="1151689724996" name="jetbrains.mps.baseLanguage.collections.structure.SequenceType" flags="in" index="A3Dl8">
+        <child id="1151689745422" name="elementType" index="A3Ik2" />
+      </concept>
+      <concept id="1203518072036" name="jetbrains.mps.baseLanguage.collections.structure.SmartClosureParameterDeclaration" flags="ig" index="Rh6nW" />
+      <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="nn" index="34oBXx" />
+      <concept id="1240687580870" name="jetbrains.mps.baseLanguage.collections.structure.JoinOperation" flags="nn" index="3uJxvA">
+        <child id="1240687658305" name="delimiter" index="3uJOhx" />
+      </concept>
+      <concept id="7125221305512719026" name="jetbrains.mps.baseLanguage.collections.structure.CollectionType" flags="in" index="3vKaQO" />
+      <concept id="1202120902084" name="jetbrains.mps.baseLanguage.collections.structure.WhereOperation" flags="nn" index="3zZkjj" />
+      <concept id="1202128969694" name="jetbrains.mps.baseLanguage.collections.structure.SelectOperation" flags="nn" index="3$u5V9" />
+      <concept id="5686963296372573083" name="jetbrains.mps.baseLanguage.collections.structure.AbstractContainerType" flags="in" index="3O5elB">
+        <child id="5686963296372573084" name="elementType" index="3O5elw" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="1lYeZD" id="eZmA2p5tec">
+    <property role="TrG5h" value="BugfixCommitMessageCheckin" />
+    <ref role="1lYe$Y" to="aqel:1yfWS2nNO6t" resolve="CheckinExtensionPoint" />
+    <node concept="3Tm1VV" id="eZmA2p5ted" role="1B3o_S" />
+    <node concept="2tJIrI" id="eZmA2p5tee" role="jymVt" />
+    <node concept="3tTeZs" id="eZmA2p5tef" role="jymVt">
+      <property role="3tTeZt" value="activate" />
+      <ref role="3tTeZr" to="90d:3zLwYDe0CPy" resolve="activate" />
+    </node>
+    <node concept="3tTeZs" id="eZmA2p5teg" role="jymVt">
+      <property role="3tTeZt" value="deactivate" />
+      <ref role="3tTeZr" to="90d:3zLwYDe0BDO" resolve="deactivate" />
+    </node>
+    <node concept="2tJIrI" id="eZmA2p5teh" role="jymVt" />
+    <node concept="q3mfD" id="eZmA2p5tei" role="jymVt">
+      <property role="TrG5h" value="get" />
+      <ref role="2VtyIY" to="90d:3zLwYDe0svr" resolve="get" />
+      <node concept="3Tm1VV" id="eZmA2p5tej" role="1B3o_S" />
+      <node concept="3clFbS" id="eZmA2p5tek" role="3clF47">
+        <node concept="3clFbF" id="eZmA2p5tel" role="3cqZAp">
+          <node concept="2ShNRf" id="eZmA2p5tem" role="3clFbG">
+            <node concept="YeOm9" id="eZmA2p5ten" role="2ShVmc">
+              <node concept="1Y3b0j" id="eZmA2p5teo" role="YeSDq">
+                <property role="2bfB8j" value="true" />
+                <ref role="1Y3XeK" to="aqel:7uW9A9Lcnfm" resolve="BaseCheckinHandler" />
+                <ref role="37wK5l" to="aqel:1yfWS2nOYu5" resolve="BaseCheckinHandler" />
+                <node concept="3Tm1VV" id="eZmA2p5tep" role="1B3o_S" />
+                <node concept="3clFb_" id="eZmA2p5teq" role="jymVt">
+                  <property role="TrG5h" value="actionBeforeCommit" />
+                  <node concept="3Tmbuc" id="eZmA2p5ter" role="1B3o_S" />
+                  <node concept="3uibUv" id="eZmA2p5tes" role="3clF45">
+                    <ref role="3uigEE" to="18nx:~CheckinHandler$ReturnResult" resolve="ReturnResult" />
+                  </node>
+                  <node concept="3clFbS" id="eZmA2p5tet" role="3clF47">
+                    <node concept="3J1_TO" id="7SmYmUZGM0J" role="3cqZAp">
+                      <node concept="3uVAMA" id="7SmYmUZGM88" role="1zxBo5">
+                        <node concept="XOnhg" id="7SmYmUZGM89" role="1zc67B">
+                          <property role="TrG5h" value="e" />
+                          <node concept="nSUau" id="7SmYmUZGM8a" role="1tU5fm">
+                            <node concept="3uibUv" id="7SmYmUZGMpi" role="nSUat">
+                              <ref role="3uigEE" to="wyt6:~Exception" resolve="Exception" />
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3clFbS" id="7SmYmUZGM8b" role="1zc67A" />
+                      </node>
+                      <node concept="3clFbS" id="7SmYmUZGM0L" role="1zxBo7">
+                        <node concept="3cpWs8" id="2hNr1jFoekx" role="3cqZAp">
+                          <node concept="3cpWsn" id="2hNr1jFoek$" role="3cpWs9">
+                            <property role="TrG5h" value="message" />
+                            <node concept="17QB3L" id="2hNr1jFoekv" role="1tU5fm" />
+                            <node concept="2OqwBi" id="2G5dnSi7hDO" role="33vP2m">
+                              <node concept="2OqwBi" id="2G5dnSi7fFi" role="2Oq$k0">
+                                <node concept="2OqwBi" id="HyxJBtDUT$" role="2Oq$k0">
+                                  <node concept="1eOMI4" id="HyxJBtDQ__" role="2Oq$k0">
+                                    <node concept="10QFUN" id="HyxJBtDQ_y" role="1eOMHV">
+                                      <node concept="3uibUv" id="HyxJBtDQXF" role="10QFUM">
+                                        <ref role="3uigEE" to="c0fd:~ChangesViewCommitWorkflowHandler" resolve="ChangesViewCommitWorkflowHandler" />
+                                      </node>
+                                      <node concept="2OqwBi" id="HyxJBtDS7Z" role="10QFUP">
+                                        <node concept="2OqwBi" id="HyxJBtDRrU" role="2Oq$k0">
+                                          <node concept="Xjq3P" id="HyxJBtDlK9" role="2Oq$k0" />
+                                          <node concept="2OwXpG" id="HyxJBtDRTh" role="2OqNvi">
+                                            <ref role="2Oxat5" to="aqel:7uW9A9LcS0c" resolve="panel" />
+                                          </node>
+                                        </node>
+                                        <node concept="liA8E" id="HyxJBtDSrV" role="2OqNvi">
+                                          <ref role="37wK5l" to="jlcu:~CheckinProjectPanel.getCommitWorkflowHandler()" resolve="getCommitWorkflowHandler" />
+                                        </node>
+                                      </node>
+                                    </node>
+                                  </node>
+                                  <node concept="liA8E" id="HyxJBtDVLH" role="2OqNvi">
+                                    <ref role="37wK5l" to="c0fd:~ChangesViewCommitWorkflowHandler.getUi()" resolve="getUi" />
+                                  </node>
+                                </node>
+                                <node concept="liA8E" id="2G5dnSi7gaH" role="2OqNvi">
+                                  <ref role="37wK5l" to="c0fd:~CommitWorkflowUi.getCommitMessageUi()" resolve="getCommitMessageUi" />
+                                </node>
+                              </node>
+                              <node concept="liA8E" id="2G5dnSi7i9e" role="2OqNvi">
+                                <ref role="37wK5l" to="c0fd:~CommitMessageUi.getText()" resolve="getText" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3cpWs8" id="2hNr1jFogM_" role="3cqZAp">
+                          <node concept="3cpWsn" id="2hNr1jFogMC" role="3cpWs9">
+                            <property role="TrG5h" value="startsWithBugFixPrefix" />
+                            <node concept="10P_77" id="2hNr1jFogMz" role="1tU5fm" />
+                            <node concept="2OqwBi" id="2hNr1jFoiqs" role="33vP2m">
+                              <node concept="2OqwBi" id="2hNr1jFoiqt" role="2Oq$k0">
+                                <node concept="2OqwBi" id="2hNr1jFoiqu" role="2Oq$k0">
+                                  <node concept="Xjq3P" id="2hNr1jFoiqv" role="2Oq$k0" />
+                                  <node concept="2OwXpG" id="2hNr1jFoiqw" role="2OqNvi">
+                                    <ref role="2Oxat5" to="aqel:7uW9A9LcS0c" resolve="panel" />
+                                  </node>
+                                </node>
+                                <node concept="liA8E" id="2hNr1jFoiqx" role="2OqNvi">
+                                  <ref role="37wK5l" to="jlcu:~CheckinProjectPanel.getCommitMessage()" resolve="getCommitMessage" />
+                                </node>
+                              </node>
+                              <node concept="liA8E" id="2hNr1jFoiqy" role="2OqNvi">
+                                <ref role="37wK5l" to="wyt6:~String.startsWith(java.lang.String)" resolve="startsWith" />
+                                <node concept="Xl_RD" id="2hNr1jFoiqz" role="37wK5m">
+                                  <property role="Xl_RC" value="bugfix" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3cpWs8" id="2hNr1jFosU0" role="3cqZAp">
+                          <node concept="3cpWsn" id="2hNr1jFosU1" role="3cpWs9">
+                            <property role="TrG5h" value="repositories" />
+                            <node concept="2YIFZM" id="2hNr1jFosU2" role="33vP2m">
+                              <ref role="1Pybhc" to="hr4p:~GitUtil" resolve="GitUtil" />
+                              <ref role="37wK5l" to="hr4p:~GitUtil.getRepositories(com.intellij.openapi.project.Project)" resolve="getRepositories" />
+                              <node concept="2OqwBi" id="2hNr1jFosU3" role="37wK5m">
+                                <node concept="Xjq3P" id="2hNr1jFosU4" role="2Oq$k0" />
+                                <node concept="2OwXpG" id="2hNr1jFosU5" role="2OqNvi">
+                                  <ref role="2Oxat5" to="aqel:7uW9A9LcNXZ" resolve="ideaProject" />
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="3vKaQO" id="2hNr1jFotyi" role="1tU5fm">
+                              <node concept="3uibUv" id="2hNr1jFotTt" role="3O5elw">
+                                <ref role="3uigEE" to="5mlj:~GitRepository" resolve="GitRepository" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3cpWs8" id="eZmA2p5teu" role="3cqZAp">
+                          <node concept="3cpWsn" id="eZmA2p5tev" role="3cpWs9">
+                            <property role="TrG5h" value="notification" />
+                            <node concept="3uibUv" id="eZmA2p5tew" role="1tU5fm">
+                              <ref role="3uigEE" to="fnpx:~Notification" resolve="Notification" />
+                            </node>
+                            <node concept="2ShNRf" id="eZmA2p5tex" role="33vP2m">
+                              <node concept="1pGfFk" id="eZmA2p5tey" role="2ShVmc">
+                                <ref role="37wK5l" to="fnpx:~Notification.&lt;init&gt;(java.lang.String,java.lang.String,java.lang.String,com.intellij.notification.NotificationType)" resolve="Notification" />
+                                <node concept="2YIFZM" id="2hNr1jFoC7c" role="37wK5m">
+                                  <ref role="37wK5l" node="2hNr1jFoBi4" resolve="getNotificationKey" />
+                                  <ref role="1Pybhc" node="2hNr1jFa0rr" resolve="KeyProvider" />
+                                </node>
+                                <node concept="Xl_RD" id="eZmA2p5te$" role="37wK5m">
+                                  <property role="Xl_RC" value="Hello from pre-commit" />
+                                </node>
+                                <node concept="3cpWs3" id="2hNr1jFormR" role="37wK5m">
+                                  <node concept="2OqwBi" id="2hNr1jFoxrN" role="3uHU7w">
+                                    <node concept="2OqwBi" id="2hNr1jFos98" role="2Oq$k0">
+                                      <node concept="37vLTw" id="2hNr1jFosU6" role="2Oq$k0">
+                                        <ref role="3cqZAo" node="2hNr1jFosU1" resolve="repositories" />
+                                      </node>
+                                      <node concept="3$u5V9" id="2hNr1jFouYK" role="2OqNvi">
+                                        <node concept="1bVj0M" id="2hNr1jFouYM" role="23t8la">
+                                          <node concept="3clFbS" id="2hNr1jFouYN" role="1bW5cS">
+                                            <node concept="3clFbF" id="2hNr1jFovwL" role="3cqZAp">
+                                              <node concept="2OqwBi" id="2hNr1jFovM8" role="3clFbG">
+                                                <node concept="37vLTw" id="2hNr1jFovwK" role="2Oq$k0">
+                                                  <ref role="3cqZAo" node="2hNr1jFouYO" resolve="it" />
+                                                </node>
+                                                <node concept="liA8E" id="2hNr1jFowZE" role="2OqNvi">
+                                                  <ref role="37wK5l" to="wyt6:~Object.toString()" resolve="toString" />
+                                                </node>
+                                              </node>
+                                            </node>
+                                          </node>
+                                          <node concept="Rh6nW" id="2hNr1jFouYO" role="1bW2Oz">
+                                            <property role="TrG5h" value="it" />
+                                            <node concept="2jxLKc" id="2hNr1jFouYP" role="1tU5fm" />
+                                          </node>
+                                        </node>
+                                      </node>
+                                    </node>
+                                    <node concept="3uJxvA" id="2hNr1jFoyeu" role="2OqNvi">
+                                      <node concept="Xl_RD" id="2hNr1jFozbm" role="3uJOhx">
+                                        <property role="Xl_RC" value="," />
+                                      </node>
+                                    </node>
+                                  </node>
+                                  <node concept="3cpWs3" id="2hNr1jFoo1C" role="3uHU7B">
+                                    <node concept="3cpWs3" id="2hNr1jFoqa7" role="3uHU7B">
+                                      <node concept="Xl_RD" id="2hNr1jFoqkX" role="3uHU7w">
+                                        <property role="Xl_RC" value="\n" />
+                                      </node>
+                                      <node concept="3cpWs3" id="2hNr1jFopfJ" role="3uHU7B">
+                                        <node concept="3cpWs3" id="2hNr1jFom$l" role="3uHU7B">
+                                          <node concept="3cpWs3" id="7Jaou$AUChu" role="3uHU7B">
+                                            <node concept="3cpWs3" id="HyxJBtDWBe" role="3uHU7B">
+                                              <node concept="Xl_RD" id="eZmA2p5yjX" role="3uHU7B">
+                                                <property role="Xl_RC" value="Commit message starts with 'bugfix':" />
+                                              </node>
+                                              <node concept="37vLTw" id="2hNr1jFojCa" role="3uHU7w">
+                                                <ref role="3cqZAo" node="2hNr1jFogMC" resolve="startsWithBugFixPrefix" />
+                                              </node>
+                                            </node>
+                                            <node concept="Xl_RD" id="2hNr1jFomIN" role="3uHU7w">
+                                              <property role="Xl_RC" value="\n" />
+                                            </node>
+                                          </node>
+                                          <node concept="Xl_RD" id="2hNr1jFoocF" role="3uHU7w">
+                                            <property role="Xl_RC" value=" Message:" />
+                                          </node>
+                                        </node>
+                                        <node concept="37vLTw" id="2hNr1jFopqC" role="3uHU7w">
+                                          <ref role="3cqZAo" node="2hNr1jFoek$" resolve="message" />
+                                        </node>
+                                      </node>
+                                    </node>
+                                    <node concept="Xl_RD" id="2hNr1jForyt" role="3uHU7w">
+                                      <property role="Xl_RC" value="Repositories: " />
+                                    </node>
+                                  </node>
+                                </node>
+                                <node concept="Rm8GO" id="eZmA2p5teI" role="37wK5m">
+                                  <ref role="Rm8GQ" to="fnpx:~NotificationType.INFORMATION" resolve="INFORMATION" />
+                                  <ref role="1Px2BO" to="fnpx:~NotificationType" resolve="NotificationType" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3clFbF" id="eZmA2p5teJ" role="3cqZAp">
+                          <node concept="2YIFZM" id="eZmA2p5teK" role="3clFbG">
+                            <ref role="37wK5l" to="fnpx:~Notifications$Bus.notify(com.intellij.notification.Notification)" resolve="notify" />
+                            <ref role="1Pybhc" to="fnpx:~Notifications$Bus" resolve="Bus" />
+                            <node concept="37vLTw" id="eZmA2p5teL" role="37wK5m">
+                              <ref role="3cqZAo" node="eZmA2p5tev" resolve="notification" />
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3clFbH" id="7SmYmUZGM0K" role="3cqZAp" />
+                      </node>
+                      <node concept="1wplmZ" id="7SmYmUZGP4Z" role="1zxBo6">
+                        <node concept="3clFbS" id="7SmYmUZGP50" role="1wplMD">
+                          <node concept="3cpWs6" id="7SmYmUZGPok" role="3cqZAp">
+                            <node concept="Rm8GO" id="eZmA2p5teN" role="3cqZAk">
+                              <ref role="1Px2BO" to="18nx:~CheckinHandler$ReturnResult" resolve="ReturnResult" />
+                              <ref role="Rm8GQ" to="18nx:~CheckinHandler$ReturnResult.CANCEL" resolve="CANCEL" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2AHcQZ" id="eZmA2p5teO" role="2AJF6D">
+                    <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                  </node>
+                </node>
+                <node concept="2YIFZM" id="2hNr1jFa4J0" role="37wK5m">
+                  <ref role="37wK5l" node="2hNr1jFa1hM" resolve="getKey" />
+                  <ref role="1Pybhc" node="2hNr1jFa0rr" resolve="KeyProvider" />
+                  <node concept="Xl_RD" id="2hNr1jFa4Yd" role="37wK5m">
+                    <property role="Xl_RC" value="bugfix" />
+                  </node>
+                </node>
+                <node concept="3clFbT" id="eZmA2p5teQ" role="37wK5m">
+                  <property role="3clFbU" value="true" />
+                </node>
+                <node concept="Xl_RD" id="eZmA2p5teR" role="37wK5m">
+                  <property role="Xl_RC" value="Demo action: Bugfix" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="q3mfm" id="eZmA2p5teS" role="3clF45">
+        <ref role="q3mfh" to="90d:3zLwYDe0sv$" />
+        <ref role="1QQUv3" node="eZmA2p5tei" resolve="get" />
+      </node>
+    </node>
+  </node>
+  <node concept="1lYeZD" id="6uXv1_IYtId">
+    <property role="TrG5h" value="CapitalizedSubjectCheckin" />
+    <ref role="1lYe$Y" to="aqel:1yfWS2nNO6t" resolve="CheckinExtensionPoint" />
+    <node concept="3Tm1VV" id="6uXv1_IYtIe" role="1B3o_S" />
+    <node concept="2tJIrI" id="6uXv1_IYtIf" role="jymVt" />
+    <node concept="3tTeZs" id="6uXv1_IYtIg" role="jymVt">
+      <property role="3tTeZt" value="activate" />
+      <ref role="3tTeZr" to="90d:3zLwYDe0CPy" resolve="activate" />
+    </node>
+    <node concept="3tTeZs" id="6uXv1_IYtIh" role="jymVt">
+      <property role="3tTeZt" value="deactivate" />
+      <ref role="3tTeZr" to="90d:3zLwYDe0BDO" resolve="deactivate" />
+    </node>
+    <node concept="2tJIrI" id="6uXv1_IYtIi" role="jymVt" />
+    <node concept="q3mfD" id="6uXv1_IYtIj" role="jymVt">
+      <property role="TrG5h" value="get" />
+      <ref role="2VtyIY" to="90d:3zLwYDe0svr" resolve="get" />
+      <node concept="3Tm1VV" id="6uXv1_IYtIk" role="1B3o_S" />
+      <node concept="3clFbS" id="6uXv1_IYtIl" role="3clF47">
+        <node concept="3clFbF" id="6uXv1_IYtIm" role="3cqZAp">
+          <node concept="2ShNRf" id="6uXv1_IYtIn" role="3clFbG">
+            <node concept="YeOm9" id="6uXv1_IYtIo" role="2ShVmc">
+              <node concept="1Y3b0j" id="6uXv1_IYtIp" role="YeSDq">
+                <property role="2bfB8j" value="true" />
+                <ref role="37wK5l" to="aqel:1yfWS2nOYu5" resolve="BaseCheckinHandler" />
+                <ref role="1Y3XeK" to="aqel:7uW9A9Lcnfm" resolve="BaseCheckinHandler" />
+                <node concept="3Tm1VV" id="6uXv1_IYtIq" role="1B3o_S" />
+                <node concept="3clFb_" id="6uXv1_IYtIr" role="jymVt">
+                  <property role="TrG5h" value="actionBeforeCommit" />
+                  <node concept="3Tmbuc" id="6uXv1_IYtIs" role="1B3o_S" />
+                  <node concept="3uibUv" id="6uXv1_IYtIt" role="3clF45">
+                    <ref role="3uigEE" to="18nx:~CheckinHandler$ReturnResult" resolve="ReturnResult" />
+                  </node>
+                  <node concept="3clFbS" id="6uXv1_IYtIu" role="3clF47">
+                    <node concept="3J1_TO" id="6uXv1_IYtIv" role="3cqZAp">
+                      <node concept="3uVAMA" id="6uXv1_IYtIw" role="1zxBo5">
+                        <node concept="XOnhg" id="6uXv1_IYtIx" role="1zc67B">
+                          <property role="TrG5h" value="e" />
+                          <node concept="nSUau" id="6uXv1_IYtIy" role="1tU5fm">
+                            <node concept="3uibUv" id="6uXv1_IYtIz" role="nSUat">
+                              <ref role="3uigEE" to="wyt6:~Exception" resolve="Exception" />
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3clFbS" id="6uXv1_IYtI$" role="1zc67A" />
+                      </node>
+                      <node concept="3clFbS" id="6uXv1_IYtI_" role="1zxBo7">
+                        <node concept="3cpWs8" id="6uXv1_IYCRD" role="3cqZAp">
+                          <node concept="3cpWsn" id="6uXv1_IYCRG" role="3cpWs9">
+                            <property role="TrG5h" value="message" />
+                            <node concept="17QB3L" id="6uXv1_IYCRB" role="1tU5fm" />
+                            <node concept="2OqwBi" id="6uXv1_IYtIL" role="33vP2m">
+                              <node concept="2OqwBi" id="6uXv1_IYtIM" role="2Oq$k0">
+                                <node concept="Xjq3P" id="6uXv1_IYtIN" role="2Oq$k0" />
+                                <node concept="2OwXpG" id="6uXv1_IYtIO" role="2OqNvi">
+                                  <ref role="2Oxat5" to="aqel:7uW9A9LcS0c" resolve="panel" />
+                                </node>
+                              </node>
+                              <node concept="liA8E" id="6uXv1_IYtIP" role="2OqNvi">
+                                <ref role="37wK5l" to="jlcu:~CheckinProjectPanel.getCommitMessage()" resolve="getCommitMessage" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3cpWs8" id="6uXv1_IYNbd" role="3cqZAp">
+                          <node concept="3cpWsn" id="6uXv1_IYNbe" role="3cpWs9">
+                            <property role="TrG5h" value="notification" />
+                            <node concept="3uibUv" id="6uXv1_IYNbf" role="1tU5fm">
+                              <ref role="3uigEE" to="fnpx:~Notification" resolve="Notification" />
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3cpWs8" id="6uXv1_IZ4I9" role="3cqZAp">
+                          <node concept="3cpWsn" id="6uXv1_IZ4Ia" role="3cpWs9">
+                            <property role="TrG5h" value="firstLetter" />
+                            <node concept="3uibUv" id="6uXv1_IZ4pk" role="1tU5fm">
+                              <ref role="3uigEE" to="wyt6:~String" resolve="String" />
+                            </node>
+                            <node concept="2OqwBi" id="6uXv1_IZ4Ib" role="33vP2m">
+                              <node concept="37vLTw" id="6uXv1_IZ4Ic" role="2Oq$k0">
+                                <ref role="3cqZAo" node="6uXv1_IYCRG" resolve="message" />
+                              </node>
+                              <node concept="liA8E" id="6uXv1_IZ4Id" role="2OqNvi">
+                                <ref role="37wK5l" to="wyt6:~String.substring(int,int)" resolve="substring" />
+                                <node concept="3cmrfG" id="6uXv1_IZ4Ie" role="37wK5m">
+                                  <property role="3cmrfH" value="0" />
+                                </node>
+                                <node concept="3cmrfG" id="6uXv1_IZ4If" role="37wK5m">
+                                  <property role="3cmrfH" value="1" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3clFbJ" id="6uXv1_IYD_m" role="3cqZAp">
+                          <node concept="3clFbS" id="6uXv1_IYD_o" role="3clFbx">
+                            <node concept="3clFbF" id="6uXv1_IYNJE" role="3cqZAp">
+                              <node concept="37vLTI" id="6uXv1_IYNWQ" role="3clFbG">
+                                <node concept="37vLTw" id="6uXv1_IYNJD" role="37vLTJ">
+                                  <ref role="3cqZAo" node="6uXv1_IYNbe" resolve="notification" />
+                                </node>
+                                <node concept="2ShNRf" id="6uXv1_IYKc0" role="37vLTx">
+                                  <node concept="1pGfFk" id="6uXv1_IYKEG" role="2ShVmc">
+                                    <ref role="37wK5l" to="fnpx:~Notification.&lt;init&gt;(java.lang.String,java.lang.String,java.lang.String,com.intellij.notification.NotificationType)" resolve="Notification" />
+                                    <node concept="2YIFZM" id="2hNr1jFoCUg" role="37wK5m">
+                                      <ref role="37wK5l" node="2hNr1jFoBi4" resolve="getNotificationKey" />
+                                      <ref role="1Pybhc" node="2hNr1jFa0rr" resolve="KeyProvider" />
+                                    </node>
+                                    <node concept="3cpWs3" id="6uXv1_IZ1D3" role="37wK5m">
+                                      <node concept="37vLTw" id="6uXv1_IZ1OH" role="3uHU7w">
+                                        <ref role="3cqZAo" node="6uXv1_IYCRG" resolve="message" />
+                                      </node>
+                                      <node concept="Xl_RD" id="6uXv1_IYXIu" role="3uHU7B">
+                                        <property role="Xl_RC" value="Capitalize Checker for " />
+                                      </node>
+                                    </node>
+                                    <node concept="Xl_RD" id="6uXv1_IYKYr" role="37wK5m">
+                                      <property role="Xl_RC" value="Commit message is not capitalized" />
+                                    </node>
+                                    <node concept="Rm8GO" id="6uXv1_IYMx4" role="37wK5m">
+                                      <ref role="Rm8GQ" to="fnpx:~NotificationType.WARNING" resolve="WARNING" />
+                                      <ref role="1Px2BO" to="fnpx:~NotificationType" resolve="NotificationType" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="17QLQc" id="6uXv1_IYJOj" role="3clFbw">
+                            <node concept="37vLTw" id="6uXv1_IYJYL" role="3uHU7w">
+                              <ref role="3cqZAo" node="6uXv1_IZ4Ia" resolve="firstLetter" />
+                            </node>
+                            <node concept="2YIFZM" id="6uXv1_IYEqX" role="3uHU7B">
+                              <ref role="37wK5l" to="18ew:~NameUtil.capitalize(java.lang.String)" resolve="capitalize" />
+                              <ref role="1Pybhc" to="18ew:~NameUtil" resolve="NameUtil" />
+                              <node concept="37vLTw" id="6uXv1_IZ4Ig" role="37wK5m">
+                                <ref role="3cqZAo" node="6uXv1_IZ4Ia" resolve="firstLetter" />
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="9aQIb" id="6uXv1_IYOoP" role="9aQIa">
+                            <node concept="3clFbS" id="6uXv1_IYOoQ" role="9aQI4">
+                              <node concept="3clFbF" id="6uXv1_IYOH3" role="3cqZAp">
+                                <node concept="37vLTI" id="6uXv1_IYOH4" role="3clFbG">
+                                  <node concept="37vLTw" id="6uXv1_IYOH5" role="37vLTJ">
+                                    <ref role="3cqZAo" node="6uXv1_IYNbe" resolve="notification" />
+                                  </node>
+                                  <node concept="2ShNRf" id="6uXv1_IYOH6" role="37vLTx">
+                                    <node concept="1pGfFk" id="6uXv1_IYOH7" role="2ShVmc">
+                                      <ref role="37wK5l" to="fnpx:~Notification.&lt;init&gt;(java.lang.String,java.lang.String,java.lang.String,com.intellij.notification.NotificationType)" resolve="Notification" />
+                                      <node concept="2YIFZM" id="2hNr1jFoD5E" role="37wK5m">
+                                        <ref role="37wK5l" node="2hNr1jFoBi4" resolve="getNotificationKey" />
+                                        <ref role="1Pybhc" node="2hNr1jFa0rr" resolve="KeyProvider" />
+                                      </node>
+                                      <node concept="3cpWs3" id="6uXv1_IZ1VU" role="37wK5m">
+                                        <node concept="37vLTw" id="6uXv1_IZ2b0" role="3uHU7w">
+                                          <ref role="3cqZAo" node="6uXv1_IYCRG" resolve="message" />
+                                        </node>
+                                        <node concept="Xl_RD" id="6uXv1_IYYAJ" role="3uHU7B">
+                                          <property role="Xl_RC" value="Capitalize Checker for" />
+                                        </node>
+                                      </node>
+                                      <node concept="Xl_RD" id="6uXv1_IYOH8" role="37wK5m">
+                                        <property role="Xl_RC" value="Commit message is capitalized" />
+                                      </node>
+                                      <node concept="Rm8GO" id="6uXv1_IYOTT" role="37wK5m">
+                                        <ref role="Rm8GQ" to="fnpx:~NotificationType.INFORMATION" resolve="INFORMATION" />
+                                        <ref role="1Px2BO" to="fnpx:~NotificationType" resolve="NotificationType" />
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3clFbF" id="6uXv1_IYtJg" role="3cqZAp">
+                          <node concept="2YIFZM" id="6uXv1_IYtJh" role="3clFbG">
+                            <ref role="37wK5l" to="fnpx:~Notifications$Bus.notify(com.intellij.notification.Notification)" resolve="notify" />
+                            <ref role="1Pybhc" to="fnpx:~Notifications$Bus" resolve="Bus" />
+                            <node concept="37vLTw" id="6uXv1_IYtJi" role="37wK5m">
+                              <ref role="3cqZAo" node="6uXv1_IYNbe" resolve="notification" />
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3clFbH" id="6uXv1_IYtJj" role="3cqZAp" />
+                      </node>
+                      <node concept="1wplmZ" id="6uXv1_IYtJk" role="1zxBo6">
+                        <node concept="3clFbS" id="6uXv1_IYtJl" role="1wplMD">
+                          <node concept="3cpWs6" id="6uXv1_IYtJm" role="3cqZAp">
+                            <node concept="Rm8GO" id="6uXv1_IYtJn" role="3cqZAk">
+                              <ref role="1Px2BO" to="18nx:~CheckinHandler$ReturnResult" resolve="ReturnResult" />
+                              <ref role="Rm8GQ" to="18nx:~CheckinHandler$ReturnResult.CANCEL" resolve="CANCEL" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2AHcQZ" id="6uXv1_IYtJo" role="2AJF6D">
+                    <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                  </node>
+                </node>
+                <node concept="2YIFZM" id="2hNr1jFa6E2" role="37wK5m">
+                  <ref role="37wK5l" node="2hNr1jFa1hM" resolve="getKey" />
+                  <ref role="1Pybhc" node="2hNr1jFa0rr" resolve="KeyProvider" />
+                  <node concept="Xl_RD" id="2hNr1jFa6E3" role="37wK5m">
+                    <property role="Xl_RC" value="capitalized" />
+                  </node>
+                </node>
+                <node concept="3clFbT" id="6uXv1_IYtJq" role="37wK5m">
+                  <property role="3clFbU" value="true" />
+                </node>
+                <node concept="Xl_RD" id="6uXv1_IYtJr" role="37wK5m">
+                  <property role="Xl_RC" value="Demo action: Capitalized Subject" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="q3mfm" id="6uXv1_IYtJs" role="3clF45">
+        <ref role="q3mfh" to="90d:3zLwYDe0sv$" />
+        <ref role="1QQUv3" node="6uXv1_IYtIj" resolve="get" />
+      </node>
+    </node>
+  </node>
+  <node concept="1lYeZD" id="6uXv1_IZpv1">
+    <property role="TrG5h" value="DeleteClassesCheckin" />
+    <ref role="1lYe$Y" to="aqel:1yfWS2nNO6t" resolve="CheckinExtensionPoint" />
+    <node concept="3Tm1VV" id="6uXv1_IZpv2" role="1B3o_S" />
+    <node concept="2tJIrI" id="6uXv1_IZpv3" role="jymVt" />
+    <node concept="3tTeZs" id="6uXv1_IZpv4" role="jymVt">
+      <property role="3tTeZt" value="activate" />
+      <ref role="3tTeZr" to="90d:3zLwYDe0CPy" resolve="activate" />
+    </node>
+    <node concept="3tTeZs" id="6uXv1_IZpv5" role="jymVt">
+      <property role="3tTeZt" value="deactivate" />
+      <ref role="3tTeZr" to="90d:3zLwYDe0BDO" resolve="deactivate" />
+    </node>
+    <node concept="2tJIrI" id="6uXv1_IZpv6" role="jymVt" />
+    <node concept="q3mfD" id="6uXv1_IZpv7" role="jymVt">
+      <property role="TrG5h" value="get" />
+      <ref role="2VtyIY" to="90d:3zLwYDe0svr" resolve="get" />
+      <node concept="3Tm1VV" id="6uXv1_IZpv8" role="1B3o_S" />
+      <node concept="3clFbS" id="6uXv1_IZpv9" role="3clF47">
+        <node concept="3clFbF" id="6uXv1_IZpva" role="3cqZAp">
+          <node concept="2ShNRf" id="6uXv1_IZpvb" role="3clFbG">
+            <node concept="YeOm9" id="6uXv1_IZpvc" role="2ShVmc">
+              <node concept="1Y3b0j" id="6uXv1_IZpvd" role="YeSDq">
+                <property role="2bfB8j" value="true" />
+                <ref role="1Y3XeK" to="aqel:7uW9A9Lcnfm" resolve="BaseCheckinHandler" />
+                <ref role="37wK5l" to="aqel:1yfWS2nOYu5" resolve="BaseCheckinHandler" />
+                <node concept="3Tm1VV" id="6uXv1_IZpve" role="1B3o_S" />
+                <node concept="3clFb_" id="6uXv1_IZpvf" role="jymVt">
+                  <property role="TrG5h" value="actionBeforeCommit" />
+                  <node concept="3Tmbuc" id="6uXv1_IZpvg" role="1B3o_S" />
+                  <node concept="3uibUv" id="6uXv1_IZpvh" role="3clF45">
+                    <ref role="3uigEE" to="18nx:~CheckinHandler$ReturnResult" resolve="ReturnResult" />
+                  </node>
+                  <node concept="3clFbS" id="6uXv1_IZpvi" role="3clF47">
+                    <node concept="3clFbH" id="6uXv1_IZpvB" role="3cqZAp" />
+                    <node concept="1QHqEO" id="6uXv1_IZrQY" role="3cqZAp">
+                      <node concept="1QHqEC" id="6uXv1_IZrR0" role="1QHqEI">
+                        <node concept="3clFbS" id="6uXv1_IZrR2" role="1bW5cS">
+                          <node concept="3clFbF" id="6uXv1_IZvpw" role="3cqZAp">
+                            <node concept="2OqwBi" id="6uXv1_IZw57" role="3clFbG">
+                              <node concept="2OqwBi" id="6uXv1_IZvrW" role="2Oq$k0">
+                                <node concept="Xjq3P" id="6uXv1_IZvpv" role="2Oq$k0" />
+                                <node concept="liA8E" id="6uXv1_IZvws" role="2OqNvi">
+                                  <ref role="37wK5l" to="aqel:1yfWS2nPUdJ" resolve="getCommitedModels" />
+                                </node>
+                              </node>
+                              <node concept="2es0OD" id="6uXv1_IZwPy" role="2OqNvi">
+                                <node concept="1bVj0M" id="6uXv1_IZwP$" role="23t8la">
+                                  <node concept="3clFbS" id="6uXv1_IZwP_" role="1bW5cS">
+                                    <node concept="3cpWs8" id="2hNr1jFoDii" role="3cqZAp">
+                                      <node concept="3cpWsn" id="2hNr1jFoDij" role="3cpWs9">
+                                        <property role="TrG5h" value="affectedClasses" />
+                                        <node concept="A3Dl8" id="2hNr1jFo_$j" role="1tU5fm">
+                                          <node concept="3Tqbb2" id="2hNr1jFo_$m" role="A3Ik2">
+                                            <ref role="ehGHo" to="tpee:fz12cDA" resolve="ClassConcept" />
+                                          </node>
+                                        </node>
+                                        <node concept="2OqwBi" id="2hNr1jFoDik" role="33vP2m">
+                                          <node concept="2OqwBi" id="2hNr1jFoDil" role="2Oq$k0">
+                                            <node concept="37vLTw" id="2hNr1jFoDim" role="2Oq$k0">
+                                              <ref role="3cqZAo" node="6uXv1_IZwPA" resolve="it" />
+                                            </node>
+                                            <node concept="2RRcyG" id="2hNr1jFoDin" role="2OqNvi">
+                                              <node concept="chp4Y" id="2hNr1jFoDio" role="3MHsoP">
+                                                <ref role="cht4Q" to="tpee:fz12cDA" resolve="ClassConcept" />
+                                              </node>
+                                            </node>
+                                          </node>
+                                          <node concept="3zZkjj" id="2hNr1jFoDip" role="2OqNvi">
+                                            <node concept="1bVj0M" id="2hNr1jFoDiq" role="23t8la">
+                                              <node concept="3clFbS" id="2hNr1jFoDir" role="1bW5cS">
+                                                <node concept="3clFbF" id="2hNr1jFoDis" role="3cqZAp">
+                                                  <node concept="2OqwBi" id="2hNr1jFoDit" role="3clFbG">
+                                                    <node concept="2OqwBi" id="2hNr1jFoDiu" role="2Oq$k0">
+                                                      <node concept="37vLTw" id="2hNr1jFoDiv" role="2Oq$k0">
+                                                        <ref role="3cqZAo" node="2hNr1jFoDiz" resolve="it" />
+                                                      </node>
+                                                      <node concept="3TrcHB" id="2hNr1jFoDiw" role="2OqNvi">
+                                                        <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                                                      </node>
+                                                    </node>
+                                                    <node concept="liA8E" id="2hNr1jFoDix" role="2OqNvi">
+                                                      <ref role="37wK5l" to="wyt6:~String.startsWith(java.lang.String)" resolve="startsWith" />
+                                                      <node concept="Xl_RD" id="2hNr1jFoDiy" role="37wK5m">
+                                                        <property role="Xl_RC" value="myClassToDelete" />
+                                                      </node>
+                                                    </node>
+                                                  </node>
+                                                </node>
+                                              </node>
+                                              <node concept="Rh6nW" id="2hNr1jFoDiz" role="1bW2Oz">
+                                                <property role="TrG5h" value="it" />
+                                                <node concept="2jxLKc" id="2hNr1jFoDi$" role="1tU5fm" />
+                                              </node>
+                                            </node>
+                                          </node>
+                                        </node>
+                                      </node>
+                                    </node>
+                                    <node concept="3clFbF" id="6uXv1_IZ$f0" role="3cqZAp">
+                                      <node concept="2OqwBi" id="6uXv1_IZEqi" role="3clFbG">
+                                        <node concept="37vLTw" id="2hNr1jFoDi_" role="2Oq$k0">
+                                          <ref role="3cqZAo" node="2hNr1jFoDij" resolve="seq" />
+                                        </node>
+                                        <node concept="2es0OD" id="6uXv1_IZQCY" role="2OqNvi">
+                                          <node concept="1bVj0M" id="6uXv1_IZQD0" role="23t8la">
+                                            <node concept="3clFbS" id="6uXv1_IZQD1" role="1bW5cS">
+                                              <node concept="3clFbF" id="6uXv1_IZQSl" role="3cqZAp">
+                                                <node concept="2OqwBi" id="6uXv1_IZRgn" role="3clFbG">
+                                                  <node concept="37vLTw" id="6uXv1_IZQSk" role="2Oq$k0">
+                                                    <ref role="3cqZAo" node="6uXv1_IZQD2" resolve="it" />
+                                                  </node>
+                                                  <node concept="3YRAZt" id="6uXv1_IZSaw" role="2OqNvi" />
+                                                </node>
+                                              </node>
+                                            </node>
+                                            <node concept="Rh6nW" id="6uXv1_IZQD2" role="1bW2Oz">
+                                              <property role="TrG5h" value="it" />
+                                              <node concept="2jxLKc" id="6uXv1_IZQD3" role="1tU5fm" />
+                                            </node>
+                                          </node>
+                                        </node>
+                                      </node>
+                                    </node>
+                                    <node concept="3cpWs8" id="2hNr1jFoE2E" role="3cqZAp">
+                                      <node concept="3cpWsn" id="2hNr1jFoE2F" role="3cpWs9">
+                                        <property role="TrG5h" value="notification" />
+                                        <node concept="3uibUv" id="2hNr1jFoE2G" role="1tU5fm">
+                                          <ref role="3uigEE" to="fnpx:~Notification" resolve="Notification" />
+                                        </node>
+                                        <node concept="2ShNRf" id="2hNr1jFoE2H" role="33vP2m">
+                                          <node concept="1pGfFk" id="2hNr1jFoE2I" role="2ShVmc">
+                                            <ref role="37wK5l" to="fnpx:~Notification.&lt;init&gt;(java.lang.String,java.lang.String,java.lang.String,com.intellij.notification.NotificationType)" resolve="Notification" />
+                                            <node concept="2YIFZM" id="2hNr1jFoE2J" role="37wK5m">
+                                              <ref role="37wK5l" node="2hNr1jFa1hM" resolve="getKey" />
+                                              <ref role="1Pybhc" node="2hNr1jFa0rr" resolve="KeyProvider" />
+                                              <node concept="Xl_RD" id="2hNr1jFoE2K" role="37wK5m">
+                                                <property role="Xl_RC" value="notification" />
+                                              </node>
+                                            </node>
+                                            <node concept="Xl_RD" id="2hNr1jFoE2L" role="37wK5m">
+                                              <property role="Xl_RC" value="Hello from pre-commit from the local branch" />
+                                            </node>
+                                            <node concept="3cpWs3" id="2hNr1jFoE2N" role="37wK5m">
+                                              <node concept="Xl_RD" id="2hNr1jFoE2O" role="3uHU7B">
+                                                <property role="Xl_RC" value="Classes to delete:" />
+                                              </node>
+                                              <node concept="2OqwBi" id="2hNr1jFoE2P" role="3uHU7w">
+                                                <node concept="34oBXx" id="2hNr1jFoE2T" role="2OqNvi" />
+                                                <node concept="37vLTw" id="2hNr1jFoFIb" role="2Oq$k0">
+                                                  <ref role="3cqZAo" node="2hNr1jFoDij" resolve="affectedClasses" />
+                                                </node>
+                                              </node>
+                                            </node>
+                                            <node concept="Rm8GO" id="2hNr1jFoE2V" role="37wK5m">
+                                              <ref role="Rm8GQ" to="fnpx:~NotificationType.INFORMATION" resolve="INFORMATION" />
+                                              <ref role="1Px2BO" to="fnpx:~NotificationType" resolve="NotificationType" />
+                                            </node>
+                                          </node>
+                                        </node>
+                                      </node>
+                                    </node>
+                                    <node concept="3clFbF" id="2hNr1jFoEp2" role="3cqZAp">
+                                      <node concept="2YIFZM" id="2hNr1jFoEp3" role="3clFbG">
+                                        <ref role="37wK5l" to="fnpx:~Notifications$Bus.notify(com.intellij.notification.Notification)" resolve="notify" />
+                                        <ref role="1Pybhc" to="fnpx:~Notifications$Bus" resolve="Bus" />
+                                        <node concept="37vLTw" id="2hNr1jFoEp4" role="37wK5m">
+                                          <ref role="3cqZAo" node="2hNr1jFoE2F" resolve="notification" />
+                                        </node>
+                                      </node>
+                                    </node>
+                                    <node concept="3clFbH" id="2hNr1jFoDR_" role="3cqZAp" />
+                                  </node>
+                                  <node concept="Rh6nW" id="6uXv1_IZwPA" role="1bW2Oz">
+                                    <property role="TrG5h" value="it" />
+                                    <node concept="2jxLKc" id="6uXv1_IZwPB" role="1tU5fm" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="2OqwBi" id="6uXv1_IZuNR" role="ukAjM">
+                        <node concept="2OqwBi" id="6uXv1_IZujd" role="2Oq$k0">
+                          <node concept="Xjq3P" id="6uXv1_IZuaK" role="2Oq$k0" />
+                          <node concept="liA8E" id="6uXv1_IZuxa" role="2OqNvi">
+                            <ref role="37wK5l" to="aqel:1yfWS2nPWlQ" resolve="getMPSProject" />
+                          </node>
+                        </node>
+                        <node concept="liA8E" id="6uXv1_IZvi6" role="2OqNvi">
+                          <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbH" id="6uXv1_IZrsC" role="3cqZAp" />
+                    <node concept="3clFbF" id="6uXv1_IZpvC" role="3cqZAp">
+                      <node concept="Rm8GO" id="6uXv1_IZpvD" role="3clFbG">
+                        <ref role="1Px2BO" to="18nx:~CheckinHandler$ReturnResult" resolve="ReturnResult" />
+                        <ref role="Rm8GQ" to="18nx:~CheckinHandler$ReturnResult.CANCEL" resolve="CANCEL" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2AHcQZ" id="6uXv1_IZpvE" role="2AJF6D">
+                    <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                  </node>
+                </node>
+                <node concept="2YIFZM" id="2hNr1jFa8rR" role="37wK5m">
+                  <ref role="37wK5l" node="2hNr1jFa1hM" resolve="getKey" />
+                  <ref role="1Pybhc" node="2hNr1jFa0rr" resolve="KeyProvider" />
+                  <node concept="Xl_RD" id="2hNr1jFa8rS" role="37wK5m">
+                    <property role="Xl_RC" value="deleteClasses" />
+                  </node>
+                </node>
+                <node concept="3clFbT" id="6uXv1_IZpvG" role="37wK5m">
+                  <property role="3clFbU" value="true" />
+                </node>
+                <node concept="Xl_RD" id="6uXv1_IZpvH" role="37wK5m">
+                  <property role="Xl_RC" value="Demo action: Delete classes" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="q3mfm" id="6uXv1_IZpvI" role="3clF45">
+        <ref role="q3mfh" to="90d:3zLwYDe0sv$" />
+        <ref role="1QQUv3" node="6uXv1_IZpv7" resolve="get" />
+      </node>
+    </node>
+  </node>
+  <node concept="1lYeZD" id="1yfWS2nOW3B">
+    <property role="TrG5h" value="HelloCheckin" />
+    <ref role="1lYe$Y" to="aqel:1yfWS2nNO6t" resolve="CheckinExtensionPoint" />
+    <node concept="3Tm1VV" id="1yfWS2nOW3C" role="1B3o_S" />
+    <node concept="2tJIrI" id="1yfWS2nOW3D" role="jymVt" />
+    <node concept="3tTeZs" id="1yfWS2nOW3E" role="jymVt">
+      <property role="3tTeZt" value="activate" />
+      <ref role="3tTeZr" to="90d:3zLwYDe0CPy" resolve="activate" />
+    </node>
+    <node concept="3tTeZs" id="1yfWS2nOW3F" role="jymVt">
+      <property role="3tTeZt" value="deactivate" />
+      <ref role="3tTeZr" to="90d:3zLwYDe0BDO" resolve="deactivate" />
+    </node>
+    <node concept="2tJIrI" id="1yfWS2nOW3G" role="jymVt" />
+    <node concept="q3mfD" id="1yfWS2nOW3H" role="jymVt">
+      <property role="TrG5h" value="get" />
+      <ref role="2VtyIY" to="90d:3zLwYDe0svr" resolve="get" />
+      <node concept="3Tm1VV" id="1yfWS2nOW3J" role="1B3o_S" />
+      <node concept="3clFbS" id="1yfWS2nOW3L" role="3clF47">
+        <node concept="3clFbF" id="1yfWS2nOWu9" role="3cqZAp">
+          <node concept="2ShNRf" id="1yfWS2nOWu7" role="3clFbG">
+            <node concept="YeOm9" id="1yfWS2nOWDy" role="2ShVmc">
+              <node concept="1Y3b0j" id="1yfWS2nOWD_" role="YeSDq">
+                <property role="2bfB8j" value="true" />
+                <ref role="1Y3XeK" to="aqel:7uW9A9Lcnfm" resolve="BaseCheckinHandler" />
+                <ref role="37wK5l" to="aqel:1yfWS2nOYu5" resolve="BaseCheckinHandler" />
+                <node concept="3Tm1VV" id="1yfWS2nOWDA" role="1B3o_S" />
+                <node concept="3clFb_" id="1yfWS2nQuNN" role="jymVt">
+                  <property role="TrG5h" value="actionBeforeCommit" />
+                  <node concept="3Tmbuc" id="1yfWS2nQuNP" role="1B3o_S" />
+                  <node concept="3uibUv" id="1yfWS2nQuNQ" role="3clF45">
+                    <ref role="3uigEE" to="18nx:~CheckinHandler$ReturnResult" resolve="ReturnResult" />
+                  </node>
+                  <node concept="3clFbS" id="1yfWS2nQuNS" role="3clF47">
+                    <node concept="3cpWs8" id="1yfWS2nQF2w" role="3cqZAp">
+                      <node concept="3cpWsn" id="1yfWS2nQF2x" role="3cpWs9">
+                        <property role="TrG5h" value="notification" />
+                        <node concept="3uibUv" id="1yfWS2nQEYz" role="1tU5fm">
+                          <ref role="3uigEE" to="fnpx:~Notification" resolve="Notification" />
+                        </node>
+                        <node concept="2ShNRf" id="1yfWS2nQF2y" role="33vP2m">
+                          <node concept="1pGfFk" id="1yfWS2nQF2z" role="2ShVmc">
+                            <ref role="37wK5l" to="fnpx:~Notification.&lt;init&gt;(java.lang.String,java.lang.String,java.lang.String,com.intellij.notification.NotificationType)" resolve="Notification" />
+                            <node concept="2YIFZM" id="2hNr1jFo$cJ" role="37wK5m">
+                              <ref role="37wK5l" node="2hNr1jFa1hM" resolve="getKey" />
+                              <ref role="1Pybhc" node="2hNr1jFa0rr" resolve="KeyProvider" />
+                              <node concept="Xl_RD" id="2hNr1jFo$cK" role="37wK5m">
+                                <property role="Xl_RC" value="notification" />
+                              </node>
+                            </node>
+                            <node concept="Xl_RD" id="1yfWS2nQF2_" role="37wK5m">
+                              <property role="Xl_RC" value="Hello from pre-commit from the local branch " />
+                            </node>
+                            <node concept="3cpWs3" id="1yfWS2nQG04" role="37wK5m">
+                              <node concept="3cpWs3" id="1yfWS2nQF2A" role="3uHU7B">
+                                <node concept="Xl_RD" id="1yfWS2nQF2E" role="3uHU7B">
+                                  <property role="Xl_RC" value="Affected models in commit:" />
+                                </node>
+                                <node concept="2OqwBi" id="1yfWS2nR8hj" role="3uHU7w">
+                                  <node concept="2OqwBi" id="1yfWS2nQF2B" role="2Oq$k0">
+                                    <node concept="Xjq3P" id="1yfWS2nQF2C" role="2Oq$k0" />
+                                    <node concept="liA8E" id="1yfWS2nQF2D" role="2OqNvi">
+                                      <ref role="37wK5l" to="aqel:1yfWS2nPUdJ" resolve="getCommitedModels" />
+                                    </node>
+                                  </node>
+                                  <node concept="34oBXx" id="1yfWS2nR9ke" role="2OqNvi" />
+                                </node>
+                              </node>
+                              <node concept="Xl_RD" id="1yfWS2nQG4G" role="3uHU7w">
+                                <property role="Xl_RC" value=". Commit aborted" />
+                              </node>
+                            </node>
+                            <node concept="Rm8GO" id="1yfWS2nQFrz" role="37wK5m">
+                              <ref role="Rm8GQ" to="fnpx:~NotificationType.INFORMATION" resolve="INFORMATION" />
+                              <ref role="1Px2BO" to="fnpx:~NotificationType" resolve="NotificationType" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbF" id="1yfWS2nQyWh" role="3cqZAp">
+                      <node concept="2YIFZM" id="1yfWS2nQz$u" role="3clFbG">
+                        <ref role="37wK5l" to="fnpx:~Notifications$Bus.notify(com.intellij.notification.Notification)" resolve="notify" />
+                        <ref role="1Pybhc" to="fnpx:~Notifications$Bus" resolve="Bus" />
+                        <node concept="37vLTw" id="1yfWS2nQF2F" role="37wK5m">
+                          <ref role="3cqZAo" node="1yfWS2nQF2x" resolve="notification" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbH" id="P1Enn7$zFm" role="3cqZAp" />
+                    <node concept="3clFbF" id="1yfWS2nQEtL" role="3cqZAp">
+                      <node concept="Rm8GO" id="1yfWS2nQEx9" role="3clFbG">
+                        <ref role="Rm8GQ" to="18nx:~CheckinHandler$ReturnResult.CANCEL" resolve="CANCEL" />
+                        <ref role="1Px2BO" to="18nx:~CheckinHandler$ReturnResult" resolve="ReturnResult" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2AHcQZ" id="1yfWS2nQuNT" role="2AJF6D">
+                    <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                  </node>
+                </node>
+                <node concept="2YIFZM" id="2hNr1jFa9fw" role="37wK5m">
+                  <ref role="37wK5l" node="2hNr1jFa1hM" resolve="getKey" />
+                  <ref role="1Pybhc" node="2hNr1jFa0rr" resolve="KeyProvider" />
+                  <node concept="Xl_RD" id="2hNr1jFa9fx" role="37wK5m">
+                    <property role="Xl_RC" value="hello" />
+                  </node>
+                </node>
+                <node concept="3clFbT" id="1yfWS2nQxzD" role="37wK5m">
+                  <property role="3clFbU" value="true" />
+                </node>
+                <node concept="Xl_RD" id="1yfWS2nQxNw" role="37wK5m">
+                  <property role="Xl_RC" value="Demo action: Affected models" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="q3mfm" id="1yfWS2nOW3M" role="3clF45">
+        <ref role="q3mfh" to="90d:3zLwYDe0sv$" />
+        <ref role="1QQUv3" node="1yfWS2nOW3H" resolve="get" />
+      </node>
+    </node>
+  </node>
+  <node concept="2DaZZR" id="1yfWS2nNTDo" />
+  <node concept="312cEu" id="2hNr1jFa0rr">
+    <property role="TrG5h" value="KeyProvider" />
+    <node concept="Wx3nA" id="2hNr1jFa2DC" role="jymVt">
+      <property role="TrG5h" value="PREFIX" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm1VV" id="2hNr1jFa1QS" role="1B3o_S" />
+      <node concept="17QB3L" id="2hNr1jFa2Dt" role="1tU5fm" />
+      <node concept="Xl_RD" id="2hNr1jFa3eg" role="33vP2m">
+        <property role="Xl_RC" value="com.mbeddr.mpsutil.checkinHandler.demo" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="2hNr1jFa1$Y" role="jymVt" />
+    <node concept="2YIFZL" id="2hNr1jFa1hM" role="jymVt">
+      <property role="TrG5h" value="getKey" />
+      <node concept="3clFbS" id="2hNr1jFa1hP" role="3clF47">
+        <node concept="3clFbF" id="2hNr1jFa3r_" role="3cqZAp">
+          <node concept="3cpWs3" id="2hNr1jFa3Wf" role="3clFbG">
+            <node concept="37vLTw" id="2hNr1jFa3Xw" role="3uHU7w">
+              <ref role="3cqZAo" node="2hNr1jFa1zZ" resolve="name" />
+            </node>
+            <node concept="3cpWs3" id="2hNr1jFa3OV" role="3uHU7B">
+              <node concept="37vLTw" id="2hNr1jFa3r$" role="3uHU7B">
+                <ref role="3cqZAo" node="2hNr1jFa2DC" resolve="PREFIX" />
+              </node>
+              <node concept="Xl_RD" id="2hNr1jFa3Pp" role="3uHU7w">
+                <property role="Xl_RC" value="." />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="2hNr1jFa0HQ" role="1B3o_S" />
+      <node concept="17QB3L" id="2hNr1jFa1hC" role="3clF45" />
+      <node concept="37vLTG" id="2hNr1jFa1zZ" role="3clF46">
+        <property role="TrG5h" value="name" />
+        <node concept="17QB3L" id="2hNr1jFa1zY" role="1tU5fm" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="2hNr1jFoAly" role="jymVt" />
+    <node concept="2YIFZL" id="2hNr1jFoBi4" role="jymVt">
+      <property role="TrG5h" value="getNotificationKey" />
+      <node concept="3clFbS" id="2hNr1jFoBi7" role="3clF47">
+        <node concept="3clFbF" id="2hNr1jFoBmd" role="3cqZAp">
+          <node concept="3cpWs3" id="2hNr1jFoBJT" role="3clFbG">
+            <node concept="Xl_RD" id="2hNr1jFoBLj" role="3uHU7w">
+              <property role="Xl_RC" value=".notification" />
+            </node>
+            <node concept="37vLTw" id="2hNr1jFoBmc" role="3uHU7B">
+              <ref role="3cqZAo" node="2hNr1jFa2DC" resolve="PREFIX" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="2hNr1jFoAHK" role="1B3o_S" />
+      <node concept="17QB3L" id="2hNr1jFoBhN" role="3clF45" />
+    </node>
+    <node concept="3Tm1VV" id="2hNr1jFa0rs" role="1B3o_S" />
+  </node>
+</model>

--- a/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.checkinHandler/com.mbeddr.mpsutil.checkinHandler.msd
+++ b/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.checkinHandler/com.mbeddr.mpsutil.checkinHandler.msd
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<solution name="com.mbeddr.mpsutil.checkinHandler" uuid="5e43bd52-71f1-484a-90fa-e1e624f7e44b" moduleVersion="0" compileInMPS="true">
+  <models>
+    <modelRoot type="default" contentPath="${module}">
+      <sourceRoot location="models" />
+    </modelRoot>
+  </models>
+  <facets>
+    <facet compile="mps" classes="mps" ext="yes" type="java">
+      <classes generated="true" path="${module}/classes_gen" />
+    </facet>
+  </facets>
+  <sourcePath />
+  <dependencies>
+    <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
+    <dependency reexport="true">498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)</dependency>
+    <dependency reexport="false">3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)</dependency>
+    <dependency reexport="false">742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)</dependency>
+    <dependency reexport="false">6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)</dependency>
+    <dependency reexport="false">8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)</dependency>
+  </dependencies>
+  <languageVersions>
+    <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
+    <language slang="l:443f4c36-fcf5-4eb6-9500-8d06ed259e3e:jetbrains.mps.baseLanguage.classifiers" version="0" />
+    <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
+    <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
+    <language slang="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" version="0" />
+    <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
+    <language slang="l:c0080a47-7e37-4558-bee9-9ae18e690549:jetbrains.mps.lang.extension" version="2" />
+    <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
+    <language slang="l:28f9e497-3b42-4291-aeba-0a1039153ab1:jetbrains.mps.lang.plugin" version="5" />
+    <language slang="l:ef7bf5ac-d06c-4342-b11d-e42104eb9343:jetbrains.mps.lang.plugin.standalone" version="0" />
+    <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="19" />
+    <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
+    <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
+  </languageVersions>
+  <dependencyVersions>
+    <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
+    <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
+    <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
+    <module reference="1ed103c3-3aa6-49b7-9c21-6765ee11f224(MPS.Editor)" version="0" />
+    <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
+    <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
+    <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
+    <module reference="5e43bd52-71f1-484a-90fa-e1e624f7e44b(com.mbeddr.mpsutil.checkinHandler)" version="0" />
+  </dependencyVersions>
+</solution>

--- a/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.checkinHandler/models/com.mbeddr.mpsutil.checkinHandler.plugin.mps
+++ b/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.checkinHandler/models/com.mbeddr.mpsutil.checkinHandler.plugin.mps
@@ -1,0 +1,1165 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:ecd3c807-fa84-48be-b99b-f9c5f7f6cc51(com.mbeddr.mpsutil.checkinHandler.plugin)">
+  <persistence version="9" />
+  <languages>
+    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
+    <use id="760a0a8c-eabb-4521-8bfd-65db761a9ba3" name="jetbrains.mps.baseLanguage.logging" version="0" />
+    <use id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections" version="1" />
+    <use id="443f4c36-fcf5-4eb6-9500-8d06ed259e3e" name="jetbrains.mps.baseLanguage.classifiers" version="0" />
+    <use id="c0080a47-7e37-4558-bee9-9ae18e690549" name="jetbrains.mps.lang.extension" version="2" />
+    <use id="c7fb639f-be78-4307-89b0-b5959c3fa8c8" name="jetbrains.mps.lang.text" version="0" />
+    <use id="ef7bf5ac-d06c-4342-b11d-e42104eb9343" name="jetbrains.mps.lang.plugin.standalone" version="0" />
+    <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="12" />
+    <use id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures" version="0" />
+  </languages>
+  <imports>
+    <import index="dxuu" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:javax.swing(JDK/)" />
+    <import index="jmi8" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ide.util(MPS.IDEA/)" />
+    <import index="4zvo" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.vcs.ui(MPS.IDEA/)" />
+    <import index="jlff" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.vfs(MPS.IDEA/)" />
+    <import index="jlcu" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.vcs(MPS.IDEA/)" />
+    <import index="9ti4" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.extensions(MPS.IDEA/)" />
+    <import index="mhfm" ref="3f233e7f-b8a6-46d2-a57f-795d56775243/java:org.jetbrains.annotations(Annotations/)" />
+    <import index="z60i" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt(JDK/)" />
+    <import index="1037" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.vcs.changes(MPS.IDEA/)" />
+    <import index="4nm9" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.project(MPS.IDEA/)" />
+    <import index="18nx" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.vcs.checkin(MPS.IDEA/)" />
+    <import index="z1c3" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.project(MPS.Platform/)" />
+    <import index="z1c4" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.project(MPS.Core/)" />
+    <import index="lui2" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.module(MPS.OpenAPI/)" />
+    <import index="alof" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.ide.project(MPS.Platform/)" />
+    <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
+    <import index="4hrd" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.ide.vfs(MPS.Platform/)" />
+    <import index="w1kc" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel(MPS.Core/)" />
+    <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" />
+    <import index="v23q" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi(MPS.IDEA/)" />
+    <import index="zn9m" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.util(MPS.IDEA/)" />
+  </imports>
+  <registry>
+    <language id="ef7bf5ac-d06c-4342-b11d-e42104eb9343" name="jetbrains.mps.lang.plugin.standalone">
+      <concept id="481983775135178851" name="jetbrains.mps.lang.plugin.standalone.structure.ApplicationPluginInitBlock" flags="in" index="2uRRBj" />
+      <concept id="481983775135178840" name="jetbrains.mps.lang.plugin.standalone.structure.ApplicationPluginDeclaration" flags="ng" index="2uRRBC">
+        <child id="481983775135178842" name="initBlock" index="2uRRBE" />
+        <child id="481983775135178843" name="disposeBlock" index="2uRRBF" />
+        <child id="481983775135178844" name="fieldDeclaration" index="2uRRBG" />
+      </concept>
+      <concept id="481983775135178846" name="jetbrains.mps.lang.plugin.standalone.structure.ApplicationPluginDisposeBlock" flags="in" index="2uRRBI" />
+      <concept id="7520713872864775836" name="jetbrains.mps.lang.plugin.standalone.structure.StandalonePluginDescriptor" flags="ng" index="2DaZZR" />
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1082485599095" name="jetbrains.mps.baseLanguage.structure.BlockStatement" flags="nn" index="9aQIb">
+        <child id="1082485599096" name="statements" index="9aQI4" />
+      </concept>
+      <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
+        <child id="1068498886297" name="rValue" index="37vLTx" />
+        <child id="1068498886295" name="lValue" index="37vLTJ" />
+      </concept>
+      <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
+      <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="nn" index="2tJIrI" />
+      <concept id="1188207840427" name="jetbrains.mps.baseLanguage.structure.AnnotationInstance" flags="nn" index="2AHcQZ">
+        <reference id="1188208074048" name="annotation" index="2AI5Lk" />
+      </concept>
+      <concept id="1188208481402" name="jetbrains.mps.baseLanguage.structure.HasAnnotation" flags="ng" index="2AJDlI">
+        <child id="1188208488637" name="annotation" index="2AJF6D" />
+      </concept>
+      <concept id="1154032098014" name="jetbrains.mps.baseLanguage.structure.AbstractLoopStatement" flags="nn" index="2LF5Ji">
+        <child id="1154032183016" name="body" index="2LFqv$" />
+      </concept>
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1197029447546" name="jetbrains.mps.baseLanguage.structure.FieldReferenceOperation" flags="nn" index="2OwXpG">
+        <reference id="1197029500499" name="fieldDeclaration" index="2Oxat5" />
+      </concept>
+      <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
+        <child id="1145553007750" name="creator" index="2ShVmc" />
+      </concept>
+      <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
+        <child id="1137022507850" name="body" index="2VODD2" />
+      </concept>
+      <concept id="1070475354124" name="jetbrains.mps.baseLanguage.structure.ThisExpression" flags="nn" index="Xjq3P" />
+      <concept id="1182160077978" name="jetbrains.mps.baseLanguage.structure.AnonymousClassCreator" flags="nn" index="YeOm9">
+        <child id="1182160096073" name="cls" index="YeSDq" />
+      </concept>
+      <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
+        <reference id="1144433194310" name="classConcept" index="1Pybhc" />
+      </concept>
+      <concept id="1070533707846" name="jetbrains.mps.baseLanguage.structure.StaticFieldReference" flags="nn" index="10M0yZ">
+        <reference id="1144433057691" name="classifier" index="1PxDUh" />
+      </concept>
+      <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
+      <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
+      <concept id="1068390468200" name="jetbrains.mps.baseLanguage.structure.FieldDeclaration" flags="ig" index="312cEg" />
+      <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu">
+        <property id="1075300953594" name="abstractClass" index="1sVAO0" />
+        <child id="1165602531693" name="superclass" index="1zkMxy" />
+      </concept>
+      <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
+        <property id="1176718929932" name="isFinal" index="3TUv4t" />
+        <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
+        <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
+      </concept>
+      <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
+      <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
+      <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
+      <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
+        <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
+      <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
+        <child id="1068580123133" name="returnType" index="3clF45" />
+        <child id="1068580123134" name="parameter" index="3clF46" />
+        <child id="1068580123135" name="body" index="3clF47" />
+      </concept>
+      <concept id="1068580123165" name="jetbrains.mps.baseLanguage.structure.InstanceMethodDeclaration" flags="ig" index="3clFb_">
+        <property id="1178608670077" name="isAbstract" index="1EzhhJ" />
+      </concept>
+      <concept id="1068580123152" name="jetbrains.mps.baseLanguage.structure.EqualsExpression" flags="nn" index="3clFbC" />
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
+      <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
+        <child id="1082485599094" name="ifFalseStatement" index="9aQIa" />
+        <child id="1068580123160" name="condition" index="3clFbw" />
+        <child id="1068580123161" name="ifTrue" index="3clFbx" />
+      </concept>
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068580123140" name="jetbrains.mps.baseLanguage.structure.ConstructorDeclaration" flags="ig" index="3clFbW" />
+      <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
+        <property id="1068580320021" name="value" index="3cmrfH" />
+      </concept>
+      <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
+        <child id="1068581517676" name="expression" index="3cqZAk" />
+      </concept>
+      <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
+        <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
+      </concept>
+      <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
+      <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
+      </concept>
+      <concept id="1073063089578" name="jetbrains.mps.baseLanguage.structure.SuperMethodCall" flags="nn" index="3nyPlj" />
+      <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk" />
+      <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
+        <property id="521412098689998745" name="nonStatic" index="2bfB8j" />
+        <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
+      </concept>
+      <concept id="7812454656619025412" name="jetbrains.mps.baseLanguage.structure.LocalMethodCall" flags="nn" index="1rXfSq" />
+      <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
+        <reference id="1107535924139" name="classifier" index="3uigEE" />
+        <child id="1109201940907" name="parameter" index="11_B2D" />
+      </concept>
+      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
+        <child id="1081773367579" name="rightExpression" index="3uHU7w" />
+        <child id="1081773367580" name="leftExpression" index="3uHU7B" />
+      </concept>
+      <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
+        <child id="1178549979242" name="visibility" index="1B3o_S" />
+      </concept>
+      <concept id="1144226303539" name="jetbrains.mps.baseLanguage.structure.ForeachStatement" flags="nn" index="1DcWWT">
+        <child id="1144226360166" name="iterable" index="1DdaDG" />
+      </concept>
+      <concept id="1144230876926" name="jetbrains.mps.baseLanguage.structure.AbstractForStatement" flags="nn" index="1DupvO">
+        <child id="1144230900587" name="variable" index="1Duv9x" />
+      </concept>
+      <concept id="1082113931046" name="jetbrains.mps.baseLanguage.structure.ContinueStatement" flags="nn" index="3N13vt" />
+      <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="nn" index="3SKdUt">
+        <child id="8356039341262087992" name="line" index="1aUNEU" />
+      </concept>
+      <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
+      <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
+      <concept id="1146644641414" name="jetbrains.mps.baseLanguage.structure.ProtectedVisibility" flags="nn" index="3Tmbuc" />
+      <concept id="1170345865475" name="jetbrains.mps.baseLanguage.structure.AnonymousClass" flags="ig" index="1Y3b0j">
+        <reference id="1170346070688" name="classifier" index="1Y3XeK" />
+      </concept>
+    </language>
+    <language id="c0080a47-7e37-4558-bee9-9ae18e690549" name="jetbrains.mps.lang.extension">
+      <concept id="3729007189729192406" name="jetbrains.mps.lang.extension.structure.ExtensionPointDeclaration" flags="ng" index="vrV6u">
+        <child id="8029776554053057803" name="objectType" index="luc8K" />
+      </concept>
+      <concept id="6626851894249711936" name="jetbrains.mps.lang.extension.structure.ExtensionPointExpression" flags="nn" index="2O5UvJ">
+        <reference id="6626851894249712469" name="extensionPoint" index="2O5UnU" />
+      </concept>
+      <concept id="3175313036448560967" name="jetbrains.mps.lang.extension.structure.GetExtensionObjectsOperation" flags="nn" index="SfwO_" />
+    </language>
+    <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
+      <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
+        <child id="1199569906740" name="parameter" index="1bW2Oz" />
+        <child id="1199569916463" name="body" index="1bW5cS" />
+      </concept>
+    </language>
+    <language id="443f4c36-fcf5-4eb6-9500-8d06ed259e3e" name="jetbrains.mps.baseLanguage.classifiers">
+      <concept id="1213999088275" name="jetbrains.mps.baseLanguage.classifiers.structure.DefaultClassifierFieldDeclaration" flags="ig" index="2BZ0e9" />
+      <concept id="1213999117680" name="jetbrains.mps.baseLanguage.classifiers.structure.DefaultClassifierFieldAccessOperation" flags="nn" index="2BZ7hE" />
+      <concept id="1205752633985" name="jetbrains.mps.baseLanguage.classifiers.structure.ThisClassifierExpression" flags="nn" index="2WthIp" />
+      <concept id="1205756064662" name="jetbrains.mps.baseLanguage.classifiers.structure.IMemberOperation" flags="ng" index="2WEnae">
+        <reference id="1205756909548" name="member" index="2WH_rO" />
+      </concept>
+    </language>
+    <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1143226024141" name="jetbrains.mps.lang.smodel.structure.SModelType" flags="in" index="H_c77" />
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+    <language id="c7fb639f-be78-4307-89b0-b5959c3fa8c8" name="jetbrains.mps.lang.text">
+      <concept id="155656958578482948" name="jetbrains.mps.lang.text.structure.Word" flags="nn" index="3oM_SD">
+        <property id="155656958578482949" name="value" index="3oM_SC" />
+      </concept>
+      <concept id="2535923850359271782" name="jetbrains.mps.lang.text.structure.Line" flags="nn" index="1PaTwC">
+        <child id="2535923850359271783" name="elements" index="1PaTwD" />
+      </concept>
+    </language>
+    <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
+      <concept id="1204796164442" name="jetbrains.mps.baseLanguage.collections.structure.InternalSequenceOperation" flags="nn" index="23sCx2">
+        <child id="1204796294226" name="closure" index="23t8la" />
+      </concept>
+      <concept id="540871147943773365" name="jetbrains.mps.baseLanguage.collections.structure.SingleArgumentSequenceOperation" flags="nn" index="25WWJ4">
+        <child id="540871147943773366" name="argument" index="25WWJ7" />
+      </concept>
+      <concept id="1204980550705" name="jetbrains.mps.baseLanguage.collections.structure.VisitAllOperation" flags="nn" index="2es0OD" />
+      <concept id="1151688443754" name="jetbrains.mps.baseLanguage.collections.structure.ListType" flags="in" index="_YKpA">
+        <child id="1151688676805" name="elementType" index="_ZDj9" />
+      </concept>
+      <concept id="1237721394592" name="jetbrains.mps.baseLanguage.collections.structure.AbstractContainerCreator" flags="nn" index="HWqM0">
+        <child id="1237721435807" name="elementType" index="HW$YZ" />
+      </concept>
+      <concept id="1203518072036" name="jetbrains.mps.baseLanguage.collections.structure.SmartClosureParameterDeclaration" flags="ig" index="Rh6nW" />
+      <concept id="1160600644654" name="jetbrains.mps.baseLanguage.collections.structure.ListCreatorWithInit" flags="nn" index="Tc6Ow" />
+      <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="nn" index="TSZUe" />
+    </language>
+  </registry>
+  <node concept="312cEu" id="7uW9A9Lcnfm">
+    <property role="TrG5h" value="BaseCheckinHandler" />
+    <property role="1sVAO0" value="true" />
+    <node concept="312cEg" id="7uW9A9LcS0c" role="jymVt">
+      <property role="TrG5h" value="panel" />
+      <node concept="3Tmbuc" id="1yfWS2nO87U" role="1B3o_S" />
+      <node concept="3uibUv" id="7uW9A9LcRYn" role="1tU5fm">
+        <ref role="3uigEE" to="jlcu:~CheckinProjectPanel" resolve="CheckinProjectPanel" />
+      </node>
+    </node>
+    <node concept="312cEg" id="7uW9A9LcNXZ" role="jymVt">
+      <property role="TrG5h" value="ideaProject" />
+      <node concept="3Tmbuc" id="1yfWS2nO86W" role="1B3o_S" />
+      <node concept="3uibUv" id="7uW9A9LcNWa" role="1tU5fm">
+        <ref role="3uigEE" to="4nm9:~Project" resolve="Project" />
+      </node>
+    </node>
+    <node concept="312cEg" id="1yfWS2nOYbi" role="jymVt">
+      <property role="TrG5h" value="settingsKey" />
+      <node concept="3Tmbuc" id="1yfWS2nOY6v" role="1B3o_S" />
+      <node concept="17QB3L" id="1yfWS2nOYbf" role="1tU5fm" />
+    </node>
+    <node concept="312cEg" id="1yfWS2nP08P" role="jymVt">
+      <property role="TrG5h" value="perProjectSettings" />
+      <node concept="3Tmbuc" id="1yfWS2nOZTA" role="1B3o_S" />
+      <node concept="10P_77" id="1yfWS2nP06v" role="1tU5fm" />
+    </node>
+    <node concept="312cEg" id="1yfWS2nQrQ5" role="jymVt">
+      <property role="TrG5h" value="label" />
+      <node concept="3Tmbuc" id="1yfWS2nQr5b" role="1B3o_S" />
+      <node concept="17QB3L" id="1yfWS2nQrNY" role="1tU5fm" />
+    </node>
+    <node concept="2tJIrI" id="1yfWS2nOY1i" role="jymVt" />
+    <node concept="3clFbW" id="1yfWS2nOYu5" role="jymVt">
+      <node concept="3cqZAl" id="1yfWS2nOYu6" role="3clF45" />
+      <node concept="3clFbS" id="1yfWS2nOYu8" role="3clF47">
+        <node concept="3clFbF" id="1yfWS2nOYBw" role="3cqZAp">
+          <node concept="37vLTI" id="1yfWS2nOZ1F" role="3clFbG">
+            <node concept="37vLTw" id="1yfWS2nOZ3p" role="37vLTx">
+              <ref role="3cqZAo" node="1yfWS2nOYz5" resolve="settingsKey" />
+            </node>
+            <node concept="2OqwBi" id="1yfWS2nOYFe" role="37vLTJ">
+              <node concept="Xjq3P" id="1yfWS2nOYBv" role="2Oq$k0" />
+              <node concept="2OwXpG" id="1yfWS2nOYMm" role="2OqNvi">
+                <ref role="2Oxat5" node="1yfWS2nOYbi" resolve="settingsKey" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="1yfWS2nP0h6" role="3cqZAp">
+          <node concept="37vLTI" id="1yfWS2nP0MN" role="3clFbG">
+            <node concept="37vLTw" id="1yfWS2nP0PH" role="37vLTx">
+              <ref role="3cqZAo" node="1yfWS2nOZLX" resolve="perProjectSettings" />
+            </node>
+            <node concept="2OqwBi" id="1yfWS2nP0lT" role="37vLTJ">
+              <node concept="Xjq3P" id="1yfWS2nP0h4" role="2Oq$k0" />
+              <node concept="2OwXpG" id="1yfWS2nP0v5" role="2OqNvi">
+                <ref role="2Oxat5" node="1yfWS2nP08P" resolve="perProjectSettings" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="1yfWS2nQsUq" role="3cqZAp">
+          <node concept="37vLTI" id="1yfWS2nQtr_" role="3clFbG">
+            <node concept="37vLTw" id="1yfWS2nQtvb" role="37vLTx">
+              <ref role="3cqZAo" node="1yfWS2nQpVO" resolve="label" />
+            </node>
+            <node concept="2OqwBi" id="1yfWS2nQt0l" role="37vLTJ">
+              <node concept="Xjq3P" id="1yfWS2nQsUo" role="2Oq$k0" />
+              <node concept="2OwXpG" id="1yfWS2nQtao" role="2OqNvi">
+                <ref role="2Oxat5" node="1yfWS2nQrQ5" resolve="label" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="1yfWS2nOYu9" role="1B3o_S" />
+      <node concept="37vLTG" id="1yfWS2nOYz5" role="3clF46">
+        <property role="TrG5h" value="settingsKey" />
+        <node concept="17QB3L" id="1yfWS2nOYz4" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="1yfWS2nOZLX" role="3clF46">
+        <property role="TrG5h" value="perProjectSettings" />
+        <node concept="10P_77" id="1yfWS2nOZR8" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="1yfWS2nQpVO" role="3clF46">
+        <property role="TrG5h" value="label" />
+        <node concept="17QB3L" id="1yfWS2nQq4u" role="1tU5fm" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="1yfWS2nOZ8R" role="jymVt" />
+    <node concept="3clFb_" id="1yfWS2nO7Rr" role="jymVt">
+      <property role="TrG5h" value="initialize" />
+      <node concept="37vLTG" id="1yfWS2nO7Vp" role="3clF46">
+        <property role="TrG5h" value="panel" />
+        <node concept="3uibUv" id="1yfWS2nO7Vq" role="1tU5fm">
+          <ref role="3uigEE" to="jlcu:~CheckinProjectPanel" resolve="CheckinProjectPanel" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="1yfWS2nO7Ru" role="3clF47">
+        <node concept="3clFbF" id="7uW9A9LcTt1" role="3cqZAp">
+          <node concept="37vLTI" id="7uW9A9LcU3P" role="3clFbG">
+            <node concept="37vLTw" id="7uW9A9LcWSQ" role="37vLTx">
+              <ref role="3cqZAo" node="1yfWS2nO7Vp" resolve="panel" />
+            </node>
+            <node concept="2OqwBi" id="7uW9A9LcT_z" role="37vLTJ">
+              <node concept="Xjq3P" id="7uW9A9LcTsZ" role="2Oq$k0" />
+              <node concept="2OwXpG" id="7uW9A9LcTCT" role="2OqNvi">
+                <ref role="2Oxat5" node="7uW9A9LcS0c" resolve="panel" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7uW9A9LcSrK" role="3cqZAp">
+          <node concept="37vLTI" id="7uW9A9LcTjz" role="3clFbG">
+            <node concept="2OqwBi" id="7uW9A9LcS$4" role="37vLTJ">
+              <node concept="Xjq3P" id="7uW9A9LcSrJ" role="2Oq$k0" />
+              <node concept="2OwXpG" id="7uW9A9LcSRo" role="2OqNvi">
+                <ref role="2Oxat5" node="7uW9A9LcNXZ" resolve="ideaProject" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="1yfWS2nOavi" role="37vLTx">
+              <node concept="37vLTw" id="1yfWS2nOalP" role="2Oq$k0">
+                <ref role="3cqZAo" node="1yfWS2nO7Vp" resolve="panel" />
+              </node>
+              <node concept="liA8E" id="1yfWS2nOaV8" role="2OqNvi">
+                <ref role="37wK5l" to="jlcu:~CheckinProjectPanel.getProject()" resolve="getProject" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="1yfWS2nO9t1" role="3cqZAp">
+          <node concept="Xjq3P" id="1yfWS2nO9sZ" role="3clFbG" />
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="1yfWS2nO6lP" role="1B3o_S" />
+      <node concept="3uibUv" id="1yfWS2nO9hh" role="3clF45">
+        <ref role="3uigEE" node="7uW9A9Lcnfm" resolve="BaseCheckinHandler" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="1yfWS2nQd9J" role="jymVt" />
+    <node concept="3clFb_" id="1yfWS2nQf$_" role="jymVt">
+      <property role="TrG5h" value="actionBeforeCommit" />
+      <property role="1EzhhJ" value="true" />
+      <node concept="3clFbS" id="1yfWS2nQf$C" role="3clF47" />
+      <node concept="3Tmbuc" id="1yfWS2nQeQ$" role="1B3o_S" />
+      <node concept="3uibUv" id="1yfWS2nQfzk" role="3clF45">
+        <ref role="3uigEE" to="18nx:~CheckinHandler$ReturnResult" resolve="ReturnResult" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="1yfWS2nPS52" role="jymVt" />
+    <node concept="3clFb_" id="1yfWS2nOZjJ" role="jymVt">
+      <property role="TrG5h" value="getBeforeCheckinConfigurationPanel" />
+      <node concept="3Tm1VV" id="1yfWS2nOZjK" role="1B3o_S" />
+      <node concept="2AHcQZ" id="1yfWS2nOZjM" role="2AJF6D">
+        <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
+      </node>
+      <node concept="3uibUv" id="1yfWS2nOZjN" role="3clF45">
+        <ref role="3uigEE" to="4zvo:~RefreshableOnComponent" resolve="RefreshableOnComponent" />
+      </node>
+      <node concept="3clFbS" id="1yfWS2nOZjO" role="3clF47">
+        <node concept="3cpWs8" id="1yfWS2nP0Wb" role="3cqZAp">
+          <node concept="3cpWsn" id="1yfWS2nP0W9" role="3cpWs9">
+            <property role="3TUv4t" value="true" />
+            <property role="TrG5h" value="checkbox" />
+            <node concept="3uibUv" id="1yfWS2nP43o" role="1tU5fm">
+              <ref role="3uigEE" to="dxuu:~JCheckBox" resolve="JCheckBox" />
+            </node>
+            <node concept="2ShNRf" id="1yfWS2nP4jp" role="33vP2m">
+              <node concept="1pGfFk" id="1yfWS2nP4HV" role="2ShVmc">
+                <ref role="37wK5l" to="dxuu:~JCheckBox.&lt;init&gt;(java.lang.String)" resolve="JCheckBox" />
+                <node concept="37vLTw" id="1yfWS2nQtAF" role="37wK5m">
+                  <ref role="3cqZAo" node="1yfWS2nQrQ5" resolve="label" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="1yfWS2nP4Ri" role="3cqZAp">
+          <node concept="2ShNRf" id="1yfWS2nP4Uy" role="3cqZAk">
+            <node concept="YeOm9" id="1yfWS2nP5l7" role="2ShVmc">
+              <node concept="1Y3b0j" id="1yfWS2nP5la" role="YeSDq">
+                <property role="2bfB8j" value="true" />
+                <ref role="1Y3XeK" to="4zvo:~RefreshableOnComponent" resolve="RefreshableOnComponent" />
+                <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
+                <node concept="3clFb_" id="1yfWS2nP5lC" role="jymVt">
+                  <property role="TrG5h" value="getComponent" />
+                  <node concept="3Tm1VV" id="1yfWS2nP5lD" role="1B3o_S" />
+                  <node concept="3uibUv" id="1yfWS2nP5lF" role="3clF45">
+                    <ref role="3uigEE" to="dxuu:~JComponent" resolve="JComponent" />
+                  </node>
+                  <node concept="3clFbS" id="1yfWS2nP5lG" role="3clF47">
+                    <node concept="3cpWs8" id="1yfWS2nP7iW" role="3cqZAp">
+                      <node concept="3cpWsn" id="1yfWS2nP7iX" role="3cpWs9">
+                        <property role="TrG5h" value="panel" />
+                        <node concept="3uibUv" id="1yfWS2nP7iY" role="1tU5fm">
+                          <ref role="3uigEE" to="dxuu:~JPanel" resolve="JPanel" />
+                        </node>
+                        <node concept="2ShNRf" id="1yfWS2nP7Zn" role="33vP2m">
+                          <node concept="1pGfFk" id="1yfWS2nP8NJ" role="2ShVmc">
+                            <ref role="37wK5l" to="dxuu:~JPanel.&lt;init&gt;(java.awt.LayoutManager)" resolve="JPanel" />
+                            <node concept="2ShNRf" id="1yfWS2nP9fB" role="37wK5m">
+                              <node concept="1pGfFk" id="1yfWS2nPaI0" role="2ShVmc">
+                                <ref role="37wK5l" to="z60i:~GridLayout.&lt;init&gt;(int,int)" resolve="GridLayout" />
+                                <node concept="3cmrfG" id="1yfWS2nPbfE" role="37wK5m">
+                                  <property role="3cmrfH" value="1" />
+                                </node>
+                                <node concept="3cmrfG" id="1yfWS2nPcQ3" role="37wK5m">
+                                  <property role="3cmrfH" value="0" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbF" id="1yfWS2nPdqb" role="3cqZAp">
+                      <node concept="2OqwBi" id="1yfWS2nPe4R" role="3clFbG">
+                        <node concept="37vLTw" id="1yfWS2nPdq9" role="2Oq$k0">
+                          <ref role="3cqZAo" node="1yfWS2nP7iX" resolve="panel" />
+                        </node>
+                        <node concept="liA8E" id="1yfWS2nPfaa" role="2OqNvi">
+                          <ref role="37wK5l" to="z60i:~Container.add(java.awt.Component)" resolve="add" />
+                          <node concept="37vLTw" id="1yfWS2nPfx0" role="37wK5m">
+                            <ref role="3cqZAo" node="1yfWS2nP0W9" resolve="checkbox" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3cpWs6" id="1yfWS2nPgK5" role="3cqZAp">
+                      <node concept="37vLTw" id="1yfWS2nPhjR" role="3cqZAk">
+                        <ref role="3cqZAo" node="1yfWS2nP7iX" resolve="panel" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2AHcQZ" id="1yfWS2nP5lI" role="2AJF6D">
+                    <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                  </node>
+                </node>
+                <node concept="2tJIrI" id="1yfWS2nP6f5" role="jymVt" />
+                <node concept="3Tm1VV" id="1yfWS2nP5lb" role="1B3o_S" />
+                <node concept="3clFb_" id="1yfWS2nP5lg" role="jymVt">
+                  <property role="TrG5h" value="refresh" />
+                  <node concept="3Tm1VV" id="1yfWS2nP5lh" role="1B3o_S" />
+                  <node concept="3cqZAl" id="1yfWS2nP5lj" role="3clF45" />
+                  <node concept="3clFbS" id="1yfWS2nP5lk" role="3clF47" />
+                  <node concept="2AHcQZ" id="1yfWS2nP5lm" role="2AJF6D">
+                    <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                  </node>
+                </node>
+                <node concept="2tJIrI" id="1yfWS2nP5ln" role="jymVt" />
+                <node concept="3clFb_" id="1yfWS2nP5lo" role="jymVt">
+                  <property role="TrG5h" value="saveState" />
+                  <node concept="3Tm1VV" id="1yfWS2nP5lp" role="1B3o_S" />
+                  <node concept="3cqZAl" id="1yfWS2nP5lr" role="3clF45" />
+                  <node concept="3clFbS" id="1yfWS2nP5ls" role="3clF47">
+                    <node concept="3clFbJ" id="1yfWS2nP$1Z" role="3cqZAp">
+                      <node concept="37vLTw" id="1yfWS2nP$zQ" role="3clFbw">
+                        <ref role="3cqZAo" node="1yfWS2nP08P" resolve="perProjectSettings" />
+                      </node>
+                      <node concept="3clFbS" id="1yfWS2nP$21" role="3clFbx">
+                        <node concept="3clFbF" id="1yfWS2nP_xP" role="3cqZAp">
+                          <node concept="2OqwBi" id="1yfWS2nPBb0" role="3clFbG">
+                            <node concept="2YIFZM" id="1yfWS2nP_Nj" role="2Oq$k0">
+                              <ref role="1Pybhc" to="jmi8:~PropertiesComponent" resolve="PropertiesComponent" />
+                              <ref role="37wK5l" to="jmi8:~PropertiesComponent.getInstance(com.intellij.openapi.project.Project)" resolve="getInstance" />
+                              <node concept="37vLTw" id="1yfWS2nPAu2" role="37wK5m">
+                                <ref role="3cqZAo" node="7uW9A9LcNXZ" resolve="ideaProject" />
+                              </node>
+                            </node>
+                            <node concept="liA8E" id="1yfWS2nPBHD" role="2OqNvi">
+                              <ref role="37wK5l" to="jmi8:~PropertiesComponent.setValue(java.lang.String,boolean)" resolve="setValue" />
+                              <node concept="37vLTw" id="1yfWS2nPC7N" role="37wK5m">
+                                <ref role="3cqZAo" node="1yfWS2nOYbi" resolve="settingsKey" />
+                              </node>
+                              <node concept="2OqwBi" id="1yfWS2nPEpA" role="37wK5m">
+                                <node concept="37vLTw" id="1yfWS2nPD6L" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="1yfWS2nP0W9" resolve="checkbox" />
+                                </node>
+                                <node concept="liA8E" id="1yfWS2nPFA7" role="2OqNvi">
+                                  <ref role="37wK5l" to="dxuu:~AbstractButton.isSelected()" resolve="isSelected" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="9aQIb" id="1yfWS2nP$Pg" role="9aQIa">
+                        <node concept="3clFbS" id="1yfWS2nP$Ph" role="9aQI4">
+                          <node concept="3clFbF" id="1yfWS2nPGvl" role="3cqZAp">
+                            <node concept="2OqwBi" id="1yfWS2nPHuc" role="3clFbG">
+                              <node concept="2YIFZM" id="1yfWS2nPH3I" role="2Oq$k0">
+                                <ref role="37wK5l" to="jmi8:~PropertiesComponent.getInstance()" resolve="getInstance" />
+                                <ref role="1Pybhc" to="jmi8:~PropertiesComponent" resolve="PropertiesComponent" />
+                              </node>
+                              <node concept="liA8E" id="1yfWS2nPI2W" role="2OqNvi">
+                                <ref role="37wK5l" to="jmi8:~PropertiesComponent.setValue(java.lang.String,boolean)" resolve="setValue" />
+                                <node concept="37vLTw" id="1yfWS2nPIvD" role="37wK5m">
+                                  <ref role="3cqZAo" node="1yfWS2nOYbi" resolve="settingsKey" />
+                                </node>
+                                <node concept="2OqwBi" id="1yfWS2nPKC5" role="37wK5m">
+                                  <node concept="37vLTw" id="1yfWS2nPJiH" role="2Oq$k0">
+                                    <ref role="3cqZAo" node="1yfWS2nP0W9" resolve="checkbox" />
+                                  </node>
+                                  <node concept="liA8E" id="1yfWS2nPM7f" role="2OqNvi">
+                                    <ref role="37wK5l" to="dxuu:~AbstractButton.isSelected()" resolve="isSelected" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2AHcQZ" id="1yfWS2nP5lu" role="2AJF6D">
+                    <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                  </node>
+                </node>
+                <node concept="2tJIrI" id="1yfWS2nP5lv" role="jymVt" />
+                <node concept="3clFb_" id="1yfWS2nP5lw" role="jymVt">
+                  <property role="TrG5h" value="restoreState" />
+                  <node concept="3Tm1VV" id="1yfWS2nP5lx" role="1B3o_S" />
+                  <node concept="3cqZAl" id="1yfWS2nP5lz" role="3clF45" />
+                  <node concept="3clFbS" id="1yfWS2nP5l$" role="3clF47">
+                    <node concept="3clFbF" id="1yfWS2nPhVX" role="3cqZAp">
+                      <node concept="2OqwBi" id="1yfWS2nPiZZ" role="3clFbG">
+                        <node concept="37vLTw" id="1yfWS2nPhVW" role="2Oq$k0">
+                          <ref role="3cqZAo" node="1yfWS2nP0W9" resolve="checkbox" />
+                        </node>
+                        <node concept="liA8E" id="1yfWS2nPkfY" role="2OqNvi">
+                          <ref role="37wK5l" to="dxuu:~AbstractButton.setSelected(boolean)" resolve="setSelected" />
+                          <node concept="1rXfSq" id="2GzKrnbb3V" role="37wK5m">
+                            <ref role="37wK5l" node="2GzKrnb0Tt" resolve="getKeyValue" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2AHcQZ" id="1yfWS2nP5lA" role="2AJF6D">
+                    <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                  </node>
+                </node>
+                <node concept="2tJIrI" id="1yfWS2nP5lB" role="jymVt" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="1yfWS2nOZjP" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="eZmA2p4U4y" role="jymVt" />
+    <node concept="3clFb_" id="2GzKrnb0Tt" role="jymVt">
+      <property role="TrG5h" value="getKeyValue" />
+      <node concept="3clFbS" id="2GzKrnb0Tw" role="3clF47">
+        <node concept="3clFbJ" id="2GzKrnb1B9" role="3cqZAp">
+          <node concept="3clFbS" id="2GzKrnb1Ba" role="3clFbx">
+            <node concept="3cpWs6" id="2GzKrnb3xZ" role="3cqZAp">
+              <node concept="2OqwBi" id="2GzKrnb1Bd" role="3cqZAk">
+                <node concept="2YIFZM" id="2GzKrnb1Be" role="2Oq$k0">
+                  <ref role="1Pybhc" to="jmi8:~PropertiesComponent" resolve="PropertiesComponent" />
+                  <ref role="37wK5l" to="jmi8:~PropertiesComponent.getInstance(com.intellij.openapi.project.Project)" resolve="getInstance" />
+                  <node concept="37vLTw" id="2GzKrnb1Bf" role="37wK5m">
+                    <ref role="3cqZAo" node="7uW9A9LcNXZ" resolve="ideaProject" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="2GzKrnb1Bg" role="2OqNvi">
+                  <ref role="37wK5l" to="jmi8:~PropertiesComponent.getBoolean(java.lang.String)" resolve="getBoolean" />
+                  <node concept="37vLTw" id="2GzKrnb1Bh" role="37wK5m">
+                    <ref role="3cqZAo" node="1yfWS2nOYbi" resolve="settingsKey" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="37vLTw" id="2GzKrnb1Bj" role="3clFbw">
+            <ref role="3cqZAo" node="1yfWS2nP08P" resolve="perProjectSettings" />
+          </node>
+          <node concept="9aQIb" id="2GzKrnb1Bk" role="9aQIa">
+            <node concept="3clFbS" id="2GzKrnb1Bl" role="9aQI4">
+              <node concept="3cpWs6" id="2GzKrnb7Gi" role="3cqZAp">
+                <node concept="2OqwBi" id="2GzKrnb1Bo" role="3cqZAk">
+                  <node concept="2YIFZM" id="2GzKrnb1Bp" role="2Oq$k0">
+                    <ref role="37wK5l" to="jmi8:~PropertiesComponent.getInstance()" resolve="getInstance" />
+                    <ref role="1Pybhc" to="jmi8:~PropertiesComponent" resolve="PropertiesComponent" />
+                  </node>
+                  <node concept="liA8E" id="2GzKrnb1Bq" role="2OqNvi">
+                    <ref role="37wK5l" to="jmi8:~PropertiesComponent.getBoolean(java.lang.String)" resolve="getBoolean" />
+                    <node concept="37vLTw" id="2GzKrnb1Br" role="37wK5m">
+                      <ref role="3cqZAo" node="1yfWS2nOYbi" resolve="settingsKey" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="10P_77" id="2GzKrnaZLo" role="3clF45" />
+      <node concept="3Tm1VV" id="2GzKrnb8Z1" role="1B3o_S" />
+    </node>
+    <node concept="2tJIrI" id="2GzKrnaZ1_" role="jymVt" />
+    <node concept="3clFb_" id="1yfWS2nQiak" role="jymVt">
+      <property role="TrG5h" value="beforeCheckin" />
+      <node concept="3Tm1VV" id="1yfWS2nQial" role="1B3o_S" />
+      <node concept="3uibUv" id="1yfWS2nQian" role="3clF45">
+        <ref role="3uigEE" to="18nx:~CheckinHandler$ReturnResult" resolve="ReturnResult" />
+      </node>
+      <node concept="3clFbS" id="1yfWS2nQiao" role="3clF47">
+        <node concept="3clFbJ" id="2GzKrnbewM" role="3cqZAp">
+          <node concept="3clFbS" id="2GzKrnbewO" role="3clFbx">
+            <node concept="3cpWs6" id="2GzKrnbgT9" role="3cqZAp">
+              <node concept="1rXfSq" id="1yfWS2nQkr5" role="3cqZAk">
+                <ref role="37wK5l" node="1yfWS2nQf$_" resolve="actionBeforeCommit" />
+              </node>
+            </node>
+          </node>
+          <node concept="1rXfSq" id="2GzKrnbf9p" role="3clFbw">
+            <ref role="37wK5l" node="2GzKrnb0Tt" resolve="getKeyValue" />
+          </node>
+        </node>
+        <node concept="3clFbF" id="2GzKrnbj9_" role="3cqZAp">
+          <node concept="3nyPlj" id="2GzKrnbj9z" role="3clFbG">
+            <ref role="37wK5l" to="18nx:~CheckinHandler.beforeCheckin()" resolve="beforeCheckin" />
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="1yfWS2nQiap" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="1yfWS2nOY1M" role="jymVt" />
+    <node concept="3clFb_" id="1yfWS2nPWlQ" role="jymVt">
+      <property role="TrG5h" value="getMPSProject" />
+      <node concept="3clFbS" id="1yfWS2nPWlT" role="3clF47">
+        <node concept="3clFbF" id="1yfWS2nPXtE" role="3cqZAp">
+          <node concept="2YIFZM" id="1yfWS2nPXOS" role="3clFbG">
+            <ref role="37wK5l" to="alof:~ProjectHelper.fromIdeaProject(com.intellij.openapi.project.Project)" resolve="fromIdeaProject" />
+            <ref role="1Pybhc" to="alof:~ProjectHelper" resolve="ProjectHelper" />
+            <node concept="37vLTw" id="1yfWS2nPYca" role="37wK5m">
+              <ref role="3cqZAo" node="7uW9A9LcNXZ" resolve="ideaProject" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tmbuc" id="1yfWS2nPVS2" role="1B3o_S" />
+      <node concept="3uibUv" id="1yfWS2nPWkN" role="3clF45">
+        <ref role="3uigEE" to="z1c3:~MPSProject" resolve="MPSProject" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="1yfWS2nPWK_" role="jymVt" />
+    <node concept="3clFb_" id="1yfWS2nPUdJ" role="jymVt">
+      <property role="TrG5h" value="getCommitedModels" />
+      <node concept="3clFbS" id="1yfWS2nPUdM" role="3clF47">
+        <node concept="3cpWs8" id="1yfWS2nQ5Ki" role="3cqZAp">
+          <node concept="3cpWsn" id="1yfWS2nQ5Kj" role="3cpWs9">
+            <property role="TrG5h" value="mpsProject" />
+            <node concept="3uibUv" id="1yfWS2nQ5Kk" role="1tU5fm">
+              <ref role="3uigEE" to="z1c3:~MPSProject" resolve="MPSProject" />
+            </node>
+            <node concept="1rXfSq" id="1yfWS2nQ8m2" role="33vP2m">
+              <ref role="37wK5l" node="1yfWS2nPWlQ" resolve="getMPSProject" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="1yfWS2nQ4dM" role="3cqZAp" />
+        <node concept="3cpWs8" id="7uW9A9Ld3Za" role="3cqZAp">
+          <node concept="3cpWsn" id="7uW9A9Ld3Zb" role="3cpWs9">
+            <property role="TrG5h" value="repository" />
+            <property role="3TUv4t" value="true" />
+            <node concept="3uibUv" id="7uW9A9Ld3Zc" role="1tU5fm">
+              <ref role="3uigEE" to="lui2:~SRepository" resolve="SRepository" />
+            </node>
+            <node concept="2OqwBi" id="7uW9A9Ld5$L" role="33vP2m">
+              <node concept="liA8E" id="7uW9A9Ld6Bq" role="2OqNvi">
+                <ref role="37wK5l" to="z1c4:~Project.getRepository()" resolve="getRepository" />
+              </node>
+              <node concept="37vLTw" id="1yfWS2nQ9NL" role="2Oq$k0">
+                <ref role="3cqZAo" node="1yfWS2nQ5Kj" resolve="mpsProject" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="7naSPkSzoxV" role="3cqZAp">
+          <node concept="3cpWsn" id="7naSPkSzoxW" role="3cpWs9">
+            <property role="TrG5h" value="modelFileTracker" />
+            <node concept="3uibUv" id="7naSPkSzoxX" role="1tU5fm">
+              <ref role="3uigEE" to="w1kc:~SModelFileTracker" resolve="SModelFileTracker" />
+            </node>
+            <node concept="2YIFZM" id="7naSPkSzqCQ" role="33vP2m">
+              <ref role="37wK5l" to="w1kc:~SModelFileTracker.getInstance(org.jetbrains.mps.openapi.module.SRepository)" resolve="getInstance" />
+              <ref role="1Pybhc" to="w1kc:~SModelFileTracker" resolve="SModelFileTracker" />
+              <node concept="37vLTw" id="7naSPkSzr0P" role="37wK5m">
+                <ref role="3cqZAo" node="7uW9A9Ld3Zb" resolve="repository" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="7naSPkSzsJy" role="3cqZAp">
+          <node concept="3cpWsn" id="7naSPkSzsJx" role="3cpWs9">
+            <property role="TrG5h" value="affectedFiles" />
+            <node concept="3uibUv" id="7naSPkSzsJz" role="1tU5fm">
+              <ref role="3uigEE" to="33ny:~Collection" resolve="Collection" />
+              <node concept="3uibUv" id="7naSPkSzsJ$" role="11_B2D">
+                <ref role="3uigEE" to="jlff:~VirtualFile" resolve="VirtualFile" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="7naSPkSzu3I" role="33vP2m">
+              <node concept="liA8E" id="7naSPkSzu3J" role="2OqNvi">
+                <ref role="37wK5l" to="jlcu:~CheckinProjectPanel.getVirtualFiles()" resolve="getVirtualFiles" />
+              </node>
+              <node concept="37vLTw" id="1yfWS2nQ2IG" role="2Oq$k0">
+                <ref role="3cqZAo" node="7uW9A9LcS0c" resolve="panel" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3SKdUt" id="7naSPkSzsK5" role="3cqZAp">
+          <node concept="1PaTwC" id="7naSPkSzsK6" role="1aUNEU">
+            <node concept="3oM_SD" id="7naSPkSzsK7" role="1PaTwD">
+              <property role="3oM_SC" value="note," />
+            </node>
+            <node concept="3oM_SD" id="7naSPkSzsK8" role="1PaTwD">
+              <property role="3oM_SC" value="unlike" />
+            </node>
+            <node concept="3oM_SD" id="7naSPkSzsK9" role="1PaTwD">
+              <property role="3oM_SC" value="getVirtualFiles," />
+            </node>
+            <node concept="3oM_SD" id="7naSPkSzsKa" role="1PaTwD">
+              <property role="3oM_SC" value="getFiles" />
+            </node>
+            <node concept="3oM_SD" id="7naSPkSzsKb" role="1PaTwD">
+              <property role="3oM_SC" value="gives" />
+            </node>
+            <node concept="3oM_SD" id="7naSPkSzsKc" role="1PaTwD">
+              <property role="3oM_SC" value="deleted" />
+            </node>
+            <node concept="3oM_SD" id="7naSPkSzsKd" role="1PaTwD">
+              <property role="3oM_SC" value="files" />
+            </node>
+            <node concept="3oM_SD" id="7naSPkSzsKe" role="1PaTwD">
+              <property role="3oM_SC" value="as" />
+            </node>
+            <node concept="3oM_SD" id="7naSPkSzsKf" role="1PaTwD">
+              <property role="3oM_SC" value="well" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="7naSPkSzsJB" role="3cqZAp">
+          <node concept="3cpWsn" id="7naSPkSzsJA" role="3cpWs9">
+            <property role="3TUv4t" value="true" />
+            <property role="TrG5h" value="affectedModels" />
+            <node concept="_YKpA" id="7naSPkS$fQJ" role="1tU5fm">
+              <node concept="H_c77" id="7naSPkS$hJV" role="_ZDj9" />
+            </node>
+            <node concept="2ShNRf" id="7naSPkS$k4T" role="33vP2m">
+              <node concept="Tc6Ow" id="7naSPkS$rav" role="2ShVmc">
+                <node concept="H_c77" id="7naSPkS$tEj" role="HW$YZ" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1DcWWT" id="7naSPkSzsJG" role="3cqZAp">
+          <node concept="37vLTw" id="7naSPkSzsK4" role="1DdaDG">
+            <ref role="3cqZAo" node="7naSPkSzsJx" resolve="affectedFiles" />
+          </node>
+          <node concept="3cpWsn" id="7naSPkSzsK1" role="1Duv9x">
+            <property role="TrG5h" value="file" />
+            <node concept="3uibUv" id="7naSPkSzsK3" role="1tU5fm">
+              <ref role="3uigEE" to="jlff:~VirtualFile" resolve="VirtualFile" />
+            </node>
+          </node>
+          <node concept="3clFbS" id="7naSPkSzsJI" role="2LFqv$">
+            <node concept="3cpWs8" id="7naSPkSzsJK" role="3cqZAp">
+              <node concept="3cpWsn" id="7naSPkSzsJJ" role="3cpWs9">
+                <property role="TrG5h" value="model" />
+                <node concept="H_c77" id="7naSPkS$dkh" role="1tU5fm" />
+                <node concept="2OqwBi" id="7naSPkS$ASK" role="33vP2m">
+                  <node concept="37vLTw" id="7naSPkS$ASJ" role="2Oq$k0">
+                    <ref role="3cqZAo" node="7naSPkSzoxW" resolve="modelFileTracker" />
+                  </node>
+                  <node concept="liA8E" id="7naSPkS$ASL" role="2OqNvi">
+                    <ref role="37wK5l" to="w1kc:~SModelFileTracker.findModel(jetbrains.mps.vfs.IFile)" resolve="findModel" />
+                    <node concept="2OqwBi" id="7naSPkS$ASM" role="37wK5m">
+                      <node concept="2OqwBi" id="7naSPkS$ASN" role="2Oq$k0">
+                        <node concept="liA8E" id="7naSPkS$ASP" role="2OqNvi">
+                          <ref role="37wK5l" to="z1c3:~MPSProject.getFileSystem()" resolve="getFileSystem" />
+                        </node>
+                        <node concept="37vLTw" id="1yfWS2nQaph" role="2Oq$k0">
+                          <ref role="3cqZAo" node="1yfWS2nQ5Kj" resolve="mpsProject" />
+                        </node>
+                      </node>
+                      <node concept="liA8E" id="7naSPkS$ASQ" role="2OqNvi">
+                        <ref role="37wK5l" to="4hrd:~IdeaFileSystem.fromVirtualFile(com.intellij.openapi.vfs.VirtualFile)" resolve="fromVirtualFile" />
+                        <node concept="37vLTw" id="7naSPkS$ASR" role="37wK5m">
+                          <ref role="3cqZAo" node="7naSPkSzsK1" resolve="file" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbJ" id="7naSPkSzsJR" role="3cqZAp">
+              <node concept="3clFbC" id="7naSPkSzsJS" role="3clFbw">
+                <node concept="37vLTw" id="7naSPkSzsJT" role="3uHU7B">
+                  <ref role="3cqZAo" node="7naSPkSzsJJ" resolve="model" />
+                </node>
+                <node concept="10Nm6u" id="7naSPkSzsJU" role="3uHU7w" />
+              </node>
+              <node concept="3clFbS" id="7naSPkSzsJW" role="3clFbx">
+                <node concept="3N13vt" id="7naSPkSzsJX" role="3cqZAp" />
+              </node>
+            </node>
+            <node concept="3clFbF" id="7naSPkSzsJY" role="3cqZAp">
+              <node concept="2OqwBi" id="7naSPkSzu1X" role="3clFbG">
+                <node concept="37vLTw" id="7naSPkSzu1W" role="2Oq$k0">
+                  <ref role="3cqZAo" node="7naSPkSzsJA" resolve="affectedModels" />
+                </node>
+                <node concept="TSZUe" id="7naSPkS$zcE" role="2OqNvi">
+                  <node concept="37vLTw" id="7naSPkS$$6r" role="25WWJ7">
+                    <ref role="3cqZAo" node="7naSPkSzsJJ" resolve="model" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="1yfWS2nQaYN" role="3cqZAp" />
+        <node concept="3clFbF" id="1yfWS2nQcxv" role="3cqZAp">
+          <node concept="37vLTw" id="1yfWS2nQcxt" role="3clFbG">
+            <ref role="3cqZAo" node="7naSPkSzsJA" resolve="affectedModels" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tmbuc" id="1yfWS2nQDgO" role="1B3o_S" />
+      <node concept="_YKpA" id="1yfWS2nPU9u" role="3clF45">
+        <node concept="H_c77" id="1yfWS2nPUdG" role="_ZDj9" />
+      </node>
+    </node>
+    <node concept="3Tm1VV" id="7uW9A9Lcnfn" role="1B3o_S" />
+    <node concept="3uibUv" id="7uW9A9LcnhB" role="1zkMxy">
+      <ref role="3uigEE" to="18nx:~CheckinHandler" resolve="CheckinHandler" />
+    </node>
+  </node>
+  <node concept="vrV6u" id="1yfWS2nNO6t">
+    <property role="TrG5h" value="CheckinExtensionPoint" />
+    <node concept="3uibUv" id="1yfWS2nNS$v" role="luc8K">
+      <ref role="3uigEE" node="7uW9A9Lcnfm" resolve="BaseCheckinHandler" />
+    </node>
+  </node>
+  <node concept="2uRRBC" id="1yfWS2nNV4s">
+    <property role="TrG5h" value="CheckinPlugin" />
+    <node concept="2BZ0e9" id="1yfWS2nOhmX" role="2uRRBG">
+      <property role="TrG5h" value="factories" />
+      <node concept="3Tm6S6" id="1yfWS2nOhmY" role="1B3o_S" />
+      <node concept="_YKpA" id="1yfWS2nOlWn" role="1tU5fm">
+        <node concept="3uibUv" id="1yfWS2nOlWp" role="_ZDj9">
+          <ref role="3uigEE" to="18nx:~CheckinHandlerFactory" resolve="CheckinHandlerFactory" />
+        </node>
+      </node>
+      <node concept="2ShNRf" id="1yfWS2nOn3C" role="33vP2m">
+        <node concept="Tc6Ow" id="1yfWS2nOCjZ" role="2ShVmc">
+          <node concept="3uibUv" id="1yfWS2nOE27" role="HW$YZ">
+            <ref role="3uigEE" to="18nx:~CheckinHandlerFactory" resolve="CheckinHandlerFactory" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2BZ0e9" id="2hNr1jFo5wy" role="2uRRBG">
+      <property role="TrG5h" value="disposable" />
+      <node concept="3Tm6S6" id="2hNr1jFo5wz" role="1B3o_S" />
+      <node concept="3uibUv" id="2hNr1jFo6OQ" role="1tU5fm">
+        <ref role="3uigEE" to="v23q:~Disposable" resolve="Disposable" />
+      </node>
+      <node concept="2YIFZM" id="KzT7AlcHJm" role="33vP2m">
+        <ref role="1Pybhc" to="zn9m:~Disposer" resolve="Disposer" />
+        <ref role="37wK5l" to="zn9m:~Disposer.newDisposable(java.lang.String)" resolve="newDisposable" />
+        <node concept="2OqwBi" id="KzT7AlcIW5" role="37wK5m">
+          <node concept="2OqwBi" id="KzT7AlcHSN" role="2Oq$k0">
+            <node concept="2WthIp" id="KzT7AlcHJX" role="2Oq$k0" />
+            <node concept="liA8E" id="KzT7AlcI15" role="2OqNvi">
+              <ref role="37wK5l" to="wyt6:~Object.getClass()" resolve="getClass" />
+            </node>
+          </node>
+          <node concept="liA8E" id="KzT7AlcJyN" role="2OqNvi">
+            <ref role="37wK5l" to="wyt6:~Class.getName()" resolve="getName" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2uRRBj" id="1yfWS2nNV4t" role="2uRRBE">
+      <node concept="3clFbS" id="1yfWS2nNV4u" role="2VODD2">
+        <node concept="3cpWs8" id="1yfWS2nOg3T" role="3cqZAp">
+          <node concept="3cpWsn" id="1yfWS2nOg3U" role="3cpWs9">
+            <property role="TrG5h" value="extensionPoint" />
+            <node concept="3uibUv" id="1yfWS2nOfTb" role="1tU5fm">
+              <ref role="3uigEE" to="9ti4:~ExtensionPoint" resolve="ExtensionPoint" />
+              <node concept="3uibUv" id="1yfWS2nOfTe" role="11_B2D">
+                <ref role="3uigEE" to="18nx:~CheckinHandlerFactory" resolve="CheckinHandlerFactory" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="1yfWS2nOg3V" role="33vP2m">
+              <node concept="10M0yZ" id="1yfWS2nOg3W" role="2Oq$k0">
+                <ref role="1PxDUh" to="18nx:~CheckinHandlerFactory" resolve="CheckinHandlerFactory" />
+                <ref role="3cqZAo" to="18nx:~CheckinHandlerFactory.EP_NAME" resolve="EP_NAME" />
+              </node>
+              <node concept="liA8E" id="1yfWS2nOg3X" role="2OqNvi">
+                <ref role="37wK5l" to="9ti4:~ExtensionPointName.getPoint()" resolve="getPoint" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1DcWWT" id="1yfWS2nOFaI" role="3cqZAp">
+          <node concept="3clFbS" id="1yfWS2nOFaK" role="2LFqv$">
+            <node concept="3cpWs8" id="1yfWS2nOMj9" role="3cqZAp">
+              <node concept="3cpWsn" id="1yfWS2nOMja" role="3cpWs9">
+                <property role="TrG5h" value="handlerFactory" />
+                <node concept="3uibUv" id="1yfWS2nOMj8" role="1tU5fm">
+                  <ref role="3uigEE" to="18nx:~CheckinHandlerFactory" resolve="CheckinHandlerFactory" />
+                </node>
+                <node concept="2ShNRf" id="1yfWS2nOMjb" role="33vP2m">
+                  <node concept="YeOm9" id="1yfWS2nOMjc" role="2ShVmc">
+                    <node concept="1Y3b0j" id="1yfWS2nOMjd" role="YeSDq">
+                      <property role="2bfB8j" value="true" />
+                      <ref role="1Y3XeK" to="18nx:~CheckinHandlerFactory" resolve="CheckinHandlerFactory" />
+                      <ref role="37wK5l" to="18nx:~CheckinHandlerFactory.&lt;init&gt;()" resolve="CheckinHandlerFactory" />
+                      <node concept="3Tm1VV" id="1yfWS2nOMje" role="1B3o_S" />
+                      <node concept="3clFb_" id="1yfWS2nOMjf" role="jymVt">
+                        <property role="TrG5h" value="createHandler" />
+                        <node concept="3Tm1VV" id="1yfWS2nOMjg" role="1B3o_S" />
+                        <node concept="2AHcQZ" id="1yfWS2nOMjh" role="2AJF6D">
+                          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+                        </node>
+                        <node concept="3uibUv" id="1yfWS2nOMji" role="3clF45">
+                          <ref role="3uigEE" to="18nx:~CheckinHandler" resolve="CheckinHandler" />
+                        </node>
+                        <node concept="37vLTG" id="1yfWS2nOMjj" role="3clF46">
+                          <property role="TrG5h" value="panel" />
+                          <node concept="3uibUv" id="1yfWS2nOMjk" role="1tU5fm">
+                            <ref role="3uigEE" to="jlcu:~CheckinProjectPanel" resolve="CheckinProjectPanel" />
+                          </node>
+                          <node concept="2AHcQZ" id="1yfWS2nOMjl" role="2AJF6D">
+                            <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+                          </node>
+                        </node>
+                        <node concept="37vLTG" id="1yfWS2nOMjm" role="3clF46">
+                          <property role="TrG5h" value="context" />
+                          <node concept="3uibUv" id="1yfWS2nOMjn" role="1tU5fm">
+                            <ref role="3uigEE" to="1037:~CommitContext" resolve="CommitContext" />
+                          </node>
+                          <node concept="2AHcQZ" id="1yfWS2nOMjo" role="2AJF6D">
+                            <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+                          </node>
+                        </node>
+                        <node concept="3clFbS" id="1yfWS2nOMjp" role="3clF47">
+                          <node concept="3clFbF" id="1yfWS2nOMjq" role="3cqZAp">
+                            <node concept="2OqwBi" id="1yfWS2nOMjr" role="3clFbG">
+                              <node concept="37vLTw" id="1yfWS2nOMjs" role="2Oq$k0">
+                                <ref role="3cqZAo" node="1yfWS2nOFaL" resolve="handler" />
+                              </node>
+                              <node concept="liA8E" id="1yfWS2nOMjt" role="2OqNvi">
+                                <ref role="37wK5l" node="1yfWS2nO7Rr" resolve="initialize" />
+                                <node concept="37vLTw" id="1yfWS2nOMju" role="37wK5m">
+                                  <ref role="3cqZAo" node="1yfWS2nOMjj" resolve="panel" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="2AHcQZ" id="1yfWS2nOMjv" role="2AJF6D">
+                          <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="1yfWS2nOOwP" role="3cqZAp">
+              <node concept="2OqwBi" id="1yfWS2nOOGJ" role="3clFbG">
+                <node concept="37vLTw" id="1yfWS2nOOwN" role="2Oq$k0">
+                  <ref role="3cqZAo" node="1yfWS2nOg3U" resolve="extensionPoint" />
+                </node>
+                <node concept="liA8E" id="1yfWS2nOOZ6" role="2OqNvi">
+                  <ref role="37wK5l" to="9ti4:~ExtensionPoint.registerExtension(java.lang.Object,com.intellij.openapi.Disposable)" resolve="registerExtension" />
+                  <node concept="37vLTw" id="1yfWS2nOP1$" role="37wK5m">
+                    <ref role="3cqZAo" node="1yfWS2nOMja" resolve="handlerFactory" />
+                  </node>
+                  <node concept="2OqwBi" id="2hNr1jFo7qI" role="37wK5m">
+                    <node concept="2WthIp" id="2hNr1jFo7qL" role="2Oq$k0" />
+                    <node concept="2BZ7hE" id="2hNr1jFo7qN" role="2OqNvi">
+                      <ref role="2WH_rO" node="2hNr1jFo5wy" resolve="disposable" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="1yfWS2nOGEC" role="3cqZAp">
+              <node concept="2OqwBi" id="1yfWS2nOHko" role="3clFbG">
+                <node concept="2OqwBi" id="1yfWS2nOGEy" role="2Oq$k0">
+                  <node concept="2WthIp" id="1yfWS2nOGE_" role="2Oq$k0" />
+                  <node concept="2BZ7hE" id="1yfWS2nOGEB" role="2OqNvi">
+                    <ref role="2WH_rO" node="1yfWS2nOhmX" resolve="factories" />
+                  </node>
+                </node>
+                <node concept="TSZUe" id="1yfWS2nOIjk" role="2OqNvi">
+                  <node concept="37vLTw" id="1yfWS2nOMjw" role="25WWJ7">
+                    <ref role="3cqZAo" node="1yfWS2nOMja" resolve="handlerFactory" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWsn" id="1yfWS2nOFaL" role="1Duv9x">
+            <property role="TrG5h" value="handler" />
+            <property role="3TUv4t" value="true" />
+            <node concept="3uibUv" id="1yfWS2nOFWs" role="1tU5fm">
+              <ref role="3uigEE" node="7uW9A9Lcnfm" resolve="BaseCheckinHandler" />
+            </node>
+          </node>
+          <node concept="2OqwBi" id="1yfWS2nOGcz" role="1DdaDG">
+            <node concept="2O5UvJ" id="1yfWS2nOGc$" role="2Oq$k0">
+              <ref role="2O5UnU" node="1yfWS2nNO6t" resolve="CheckinExtensionPoint" />
+            </node>
+            <node concept="SfwO_" id="1yfWS2nOGc_" role="2OqNvi" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2uRRBI" id="1yfWS2nNV4L" role="2uRRBF">
+      <node concept="3clFbS" id="1yfWS2nNV4M" role="2VODD2">
+        <node concept="3cpWs8" id="1yfWS2nOh92" role="3cqZAp">
+          <node concept="3cpWsn" id="1yfWS2nOh93" role="3cpWs9">
+            <property role="TrG5h" value="extensionPoint" />
+            <node concept="3uibUv" id="1yfWS2nOh94" role="1tU5fm">
+              <ref role="3uigEE" to="9ti4:~ExtensionPoint" resolve="ExtensionPoint" />
+              <node concept="3uibUv" id="1yfWS2nOh95" role="11_B2D">
+                <ref role="3uigEE" to="18nx:~CheckinHandlerFactory" resolve="CheckinHandlerFactory" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="1yfWS2nOh96" role="33vP2m">
+              <node concept="10M0yZ" id="1yfWS2nOh97" role="2Oq$k0">
+                <ref role="3cqZAo" to="18nx:~CheckinHandlerFactory.EP_NAME" resolve="EP_NAME" />
+                <ref role="1PxDUh" to="18nx:~CheckinHandlerFactory" resolve="CheckinHandlerFactory" />
+              </node>
+              <node concept="liA8E" id="1yfWS2nOh98" role="2OqNvi">
+                <ref role="37wK5l" to="9ti4:~ExtensionPointName.getPoint()" resolve="getPoint" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="KzT7AlffR6" role="3cqZAp">
+          <node concept="3clFbS" id="KzT7AlffR8" role="3clFbx">
+            <node concept="3clFbF" id="KzT7AlcKuH" role="3cqZAp">
+              <node concept="2YIFZM" id="KzT7AlcKRG" role="3clFbG">
+                <ref role="37wK5l" to="zn9m:~Disposer.dispose(com.intellij.openapi.Disposable)" resolve="dispose" />
+                <ref role="1Pybhc" to="zn9m:~Disposer" resolve="Disposer" />
+                <node concept="2OqwBi" id="KzT7AlcL6p" role="37wK5m">
+                  <node concept="2WthIp" id="KzT7AlcL6s" role="2Oq$k0" />
+                  <node concept="2BZ7hE" id="2hNr1jFobgJ" role="2OqNvi">
+                    <ref role="2WH_rO" node="2hNr1jFo5wy" resolve="disposable" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3y3z36" id="KzT7Alfgrx" role="3clFbw">
+            <node concept="10Nm6u" id="KzT7Alfgwh" role="3uHU7w" />
+            <node concept="2OqwBi" id="KzT7Alfgbp" role="3uHU7B">
+              <node concept="2WthIp" id="KzT7Alfgbs" role="2Oq$k0" />
+              <node concept="2BZ7hE" id="2hNr1jFo9jo" role="2OqNvi">
+                <ref role="2WH_rO" node="2hNr1jFo5wy" resolve="disposable" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="2hNr1jFo8cE" role="3cqZAp" />
+        <node concept="3clFbF" id="1yfWS2nOPno" role="3cqZAp">
+          <node concept="2OqwBi" id="1yfWS2nOQ8P" role="3clFbG">
+            <node concept="2OqwBi" id="1yfWS2nOPni" role="2Oq$k0">
+              <node concept="2WthIp" id="1yfWS2nOPnl" role="2Oq$k0" />
+              <node concept="2BZ7hE" id="1yfWS2nOPnn" role="2OqNvi">
+                <ref role="2WH_rO" node="1yfWS2nOhmX" resolve="factories" />
+              </node>
+            </node>
+            <node concept="2es0OD" id="1yfWS2nOR5N" role="2OqNvi">
+              <node concept="1bVj0M" id="1yfWS2nOR5P" role="23t8la">
+                <node concept="3clFbS" id="1yfWS2nOR5Q" role="1bW5cS">
+                  <node concept="3clFbF" id="1yfWS2nORc_" role="3cqZAp">
+                    <node concept="2OqwBi" id="1yfWS2nORlt" role="3clFbG">
+                      <node concept="37vLTw" id="1yfWS2nORc$" role="2Oq$k0">
+                        <ref role="3cqZAo" node="1yfWS2nOh93" resolve="extensionPoint" />
+                      </node>
+                      <node concept="liA8E" id="1yfWS2nORDb" role="2OqNvi">
+                        <ref role="37wK5l" to="9ti4:~ExtensionPoint.unregisterExtension(java.lang.Class)" resolve="unregisterExtension" />
+                        <node concept="2OqwBi" id="2hNr1jFocgn" role="37wK5m">
+                          <node concept="37vLTw" id="1yfWS2nORHM" role="2Oq$k0">
+                            <ref role="3cqZAo" node="1yfWS2nOR5R" resolve="it" />
+                          </node>
+                          <node concept="liA8E" id="2hNr1jFocDz" role="2OqNvi">
+                            <ref role="37wK5l" to="wyt6:~Object.getClass()" resolve="getClass" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="Rh6nW" id="1yfWS2nOR5R" role="1bW2Oz">
+                  <property role="TrG5h" value="it" />
+                  <node concept="2jxLKc" id="1yfWS2nOR5S" role="1tU5fm" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="2DaZZR" id="1yfWS2nNLUx" />
+</model>

--- a/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.checkinHandler/models/com.mbeddr.mpsutil.checkinHandler.plugin.mps
+++ b/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.checkinHandler/models/com.mbeddr.mpsutil.checkinHandler.plugin.mps
@@ -238,6 +238,10 @@
       <concept id="1203518072036" name="jetbrains.mps.baseLanguage.collections.structure.SmartClosureParameterDeclaration" flags="ig" index="Rh6nW" />
       <concept id="1160600644654" name="jetbrains.mps.baseLanguage.collections.structure.ListCreatorWithInit" flags="nn" index="Tc6Ow" />
       <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="nn" index="TSZUe" />
+      <concept id="7125221305512719026" name="jetbrains.mps.baseLanguage.collections.structure.CollectionType" flags="in" index="3vKaQO" />
+      <concept id="5686963296372573083" name="jetbrains.mps.baseLanguage.collections.structure.AbstractContainerType" flags="in" index="3O5elB">
+        <child id="5686963296372573084" name="elementType" index="3O5elw" />
+      </concept>
     </language>
   </registry>
   <node concept="312cEu" id="7uW9A9Lcnfm">
@@ -882,6 +886,28 @@
         <node concept="H_c77" id="1yfWS2nPUdG" role="_ZDj9" />
       </node>
     </node>
+    <node concept="2tJIrI" id="32CFzTqVbQe" role="jymVt" />
+    <node concept="3clFb_" id="32CFzTqVg78" role="jymVt">
+      <property role="TrG5h" value="getAffectedFiles" />
+      <node concept="3clFbS" id="32CFzTqVg7b" role="3clF47">
+        <node concept="3clFbF" id="32CFzTqVkaM" role="3cqZAp">
+          <node concept="2OqwBi" id="32CFzTqVh2b" role="3clFbG">
+            <node concept="liA8E" id="32CFzTqVh2c" role="2OqNvi">
+              <ref role="37wK5l" to="jlcu:~CheckinProjectPanel.getVirtualFiles()" resolve="getVirtualFiles" />
+            </node>
+            <node concept="37vLTw" id="32CFzTqVh2d" role="2Oq$k0">
+              <ref role="3cqZAo" node="7uW9A9LcS0c" resolve="panel" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tmbuc" id="32CFzTqVduA" role="1B3o_S" />
+      <node concept="3vKaQO" id="32CFzTqVg4S" role="3clF45">
+        <node concept="3uibUv" id="32CFzTqVg4U" role="3O5elw">
+          <ref role="3uigEE" to="jlff:~VirtualFile" resolve="VirtualFile" />
+        </node>
+      </node>
+    </node>
     <node concept="3Tm1VV" id="7uW9A9Lcnfn" role="1B3o_S" />
     <node concept="3uibUv" id="7uW9A9LcnhB" role="1zkMxy">
       <ref role="3uigEE" to="18nx:~CheckinHandler" resolve="CheckinHandler" />
@@ -1163,3 +1189,4 @@
   </node>
   <node concept="2DaZZR" id="1yfWS2nNLUx" />
 </model>
+


### PR DESCRIPTION
Create a new extension for CheckinExtensionPoint to add a new handler. You can find some example handlers in `com.mbeddr.mpsutil.checkinHandler.demo.plugin`. The handlers can accept a commit, reject it or execute arbitrary actions.