### PR TITLE
Fix broken build

### DIFF
--- a/subprojects/com.mbeddr/build.gradle
+++ b/subprojects/com.mbeddr/build.gradle
@@ -1,8 +1,3 @@
-plugins {
-    id 'base'
-    id 'maven-publish'
-}
-
 // path variables
 // If mpsHomeDir is set explicitly, skip the MPS resolution step and use the explicit path (which may be relative from
 // the root directory).
@@ -103,30 +98,32 @@ File scriptFile(String relativePath) {
 }
 
 private static void configureRepositories(Project project) {
-    project.publishing {
-        repositories {
-            maven {
-                url project.mbeddrBuildNumber.endsWith('-SNAPSHOT') ? project.snapshotRepository : project.releaseRepository
-                if (project.hasProperty('artifacts.itemis.cloud.user') && project.hasProperty('artifacts.itemis.cloud.pw')) {
-                    credentials {
-                        username project.getProperty('artifacts.itemis.cloud.user')
-                        password project.getProperty('artifacts.itemis.cloud.pw')
+    project.pluginManager.withPlugin('maven-publish') {
+        project.publishing {
+            repositories {
+                maven {
+                    url project.mbeddrBuildNumber.endsWith('-SNAPSHOT') ? project.snapshotRepository : project.releaseRepository
+                    if (project.hasProperty('artifacts.itemis.cloud.user') && project.hasProperty('artifacts.itemis.cloud.pw')) {
+                        credentials {
+                            username project.getProperty('artifacts.itemis.cloud.user')
+                            password project.getProperty('artifacts.itemis.cloud.pw')
+                        }
                     }
                 }
-            }
 
-            //mbeddr build is "master" also for maintenance branches
-            //using the closure to delay evaluate from configuration to execution phase is important because the
-            //mbeddrBuild property is created by a "subproject" block which is executed after this script is configured.
-            //if no closure is used the build script won't compile.
-            if({project.mbeddrBuild}() == "master") {
-                maven {
-                    name = "GitHubPackages"
-                    url = "https://maven.pkg.github.com/mbeddr/mbeddr.core"
-                    if (project.hasProperty("gpr.token")) {
-                        credentials {
-                            username = project.findProperty("gpr.user")
-                            password = project.findProperty("gpr.token")
+                //mbeddr build is "master" also for maintenance branches
+                //using the closure to delay evaluate from configuration to execution phase is important because the
+                //mbeddrBuild property is created by a "subproject" block which is executed after this script is configured.
+                //if no closure is used the build script won't compile.
+                if({project.mbeddrBuild}() == "master") {
+                    maven {
+                        name = "GitHubPackages"
+                        url = "https://maven.pkg.github.com/mbeddr/mbeddr.core"
+                        if (project.hasProperty("gpr.token")) {
+                            credentials {
+                                username = project.findProperty("gpr.user")
+                                password = project.findProperty("gpr.token")
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Due to some inexplicable Gradle behavior (probably a bug), when `maven-publish` plugin is applied to `com.mbeddr` project, it causes the subproject configuration in `subprojects` block to misbehave. Instead of adding a repository to each subproject, the repository is added multiple times to the parent.

Removing the `plugins` block from `com.mbeddr` fixes this.

Since `com.mbeddr:distribution` does not apply these plugins, publishing repositories are now configured only when the `maven-publish` plugin is applied.