### PR TITLE
Fix CI build

### DIFF
--- a/subprojects/com.mbeddr/languages/build.gradle
+++ b/subprojects/com.mbeddr/languages/build.gradle
@@ -55,18 +55,18 @@ ant.taskdef(name: 'junit', classname: 'org.apache.tools.ant.taskdefs.optional.ju
 ant.taskdef(name: 'junitreport', classname: 'org.apache.tools.ant.taskdefs.optional.junit.XMLResultAggregator',
         classpath: configurations.junitAnt.asPath)
 
-def mbeddrDependencies
+def mbeddrPlatformDependency
 
 def usePrebuiltPlatform = ciBuild && !project.hasProperty('forceBuildPlatform')
 
 //on teamcity we don't build the platform we take it from the nexus. Locally we want to build it
 if (usePrebuiltPlatform) {
-    mbeddrDependencies = [resolve_mbeddr_platform]
+    mbeddrPlatformDependency = resolve_mbeddr_platform
 } else {
-    mbeddrDependencies = [':com.mbeddr:platform:build_platform']
+    mbeddrPlatformDependency = ':com.mbeddr:platform:build_platform'
 }
 
-task build_mbeddr(type: BuildLanguages, dependsOn: mbeddrDependencies) {
+task build_mbeddr(type: BuildLanguages, dependsOn: [':com.mbeddr:platform:copy_allScripts', mbeddrPlatformDependency]) {
     script script_build_mbeddr
     outputs.dir("$artifactsDir/mbeddr")
 }

--- a/subprojects/com.mbeddr/platform/build.gradle
+++ b/subprojects/com.mbeddr/platform/build.gradle
@@ -52,6 +52,11 @@ task build_allScripts(type: BuildLanguages, dependsOn: [resolve_mps, resolve_mps
 
     // Need to override basedir until https://github.com/JetBrains/MPS/pull/73 is merged or otherwise fixed.
     scriptArgs = ["-Dbasedir=${rootProject.file('code/languages/com.mbeddr.build')}"]
+
+    // Workaround for https://github.com/gradle/gradle/issues/24368 -- provide outputs but disable up-to-date checks
+    // since we don't provide inputs.
+    outputs.dir(new File(artifactsDir, 'com.mbeddr.allScripts.build'))
+    outputs.upToDateWhen { false }
 }
 
 task copy_allScripts(type: Copy, dependsOn: build_allScripts) {
@@ -82,6 +87,7 @@ task build_platform(type: BuildLanguages, dependsOn: copy_allScripts) {
     // see comment in build_allScripts, above, for reasons we need to explicitly state task output
     // to address NO-SOURCE failure for package_mbeddrPlatform
     outputs.dir(new File(artifactsDir, 'com.mbeddr.platform/'))
+    outputs.upToDateWhen { false }
 }
 
 task install_actionsfilter(type: Copy, dependsOn: build_platform) {


### PR DESCRIPTION
Dependency on `copy_allScripts` must now be added explicitly to the mbeddr C build.