### PR TITLE
Strip `:build` prefix from project names

### DIFF
--- a/build/com.mbeddr/analyses.test/build.gradle
+++ b/build/com.mbeddr/analyses.test/build.gradle
@@ -41,7 +41,7 @@ task resolve_mbeddr() {
 }
 
 
-task test_mbeddr_analysis_ts(type: TestLanguages, dependsOn: [resolve_mbeddr, ':build:com.mbeddr:platform:copy_allScripts']) {
+task test_mbeddr_analysis_ts(type: TestLanguages, dependsOn: [resolve_mbeddr, ':com.mbeddr:platform:copy_allScripts']) {
     script script_test_mbeddrAnalysisTs
 }
 task test_mbeddr_analysis_ex {
@@ -54,6 +54,6 @@ task build_mbeddr_analysis_ex(type: BuildLanguages, dependsOn: resolve_mbeddr) {
     script script_test_mbeddrAnalysisEx
 }
 
-build_mbeddr_analysis_ex.dependsOn ':build:com.mbeddr:platform:copy_allScripts'
-test_mbeddr_analysis_ex.dependsOn ':build:com.mbeddr:platform:copy_allScripts'
+build_mbeddr_analysis_ex.dependsOn ':com.mbeddr:platform:copy_allScripts'
+test_mbeddr_analysis_ex.dependsOn ':com.mbeddr:platform:copy_allScripts'
 task test_mbeddr_analysis(dependsOn: [test_mbeddr_analysis_ts, build_mbeddr_analysis_ex, test_mbeddr_analysis_ex]) { }

--- a/build/com.mbeddr/distribution/build.gradle
+++ b/build/com.mbeddr/distribution/build.gradle
@@ -25,11 +25,11 @@ task resolve_mbeddr() {
 
 def script_build_mbeddrAllInOne = new File(scriptsBasePath + "/com.mbeddr.allInOne/" + "build.xml")
 
-task build_all_in_one(type: BuildLanguages, dependsOn: [':build:com.mbeddr:platform:copy_allScripts', resolve_mbeddr]) {
+task build_all_in_one(type: BuildLanguages, dependsOn: [':com.mbeddr:platform:copy_allScripts', resolve_mbeddr]) {
     script script_build_mbeddrAllInOne
 }
 
-task build_platform_distribution(type: BuildLanguages, dependsOn: [':build:com.mbeddr:platform:copy_allScripts', resolve_mbeddr]) {
+task build_platform_distribution(type: BuildLanguages, dependsOn: [':com.mbeddr:platform:copy_allScripts', resolve_mbeddr]) {
     script scriptFile('com.mbeddr.platform/build-distribution.xml')
     // Support incremental build
     inputs.file(script)

--- a/build/com.mbeddr/everythingElse/build.gradle
+++ b/build/com.mbeddr/everythingElse/build.gradle
@@ -49,7 +49,7 @@ configurations {
 
 
 
-// :build:com.mbeddr.tests
+// :com.mbeddr.tests
 
 import org.apache.tools.ant.taskdefs.condition.Os
 
@@ -113,7 +113,7 @@ task unzip_cbmcWinZip(type: Copy, dependsOn: resolve_cbmcWin)  {
 
 
 
-// :build:com.mbeddr.rcp
+// :com.mbeddr.rcp
 publishing {
     publications {
         mbeddrJre(MavenPublication) {
@@ -141,7 +141,7 @@ task package_JRE(type: Zip, dependsOn: download_JRE) {
     include "jdk..tar.gz"
 }
 
-// :build:com.mbeddr.analyses.cbmc
+// :com.mbeddr.analyses.cbmc
 publishing {
     publications {
         cbmcMac(MavenPublication) {

--- a/build/com.mbeddr/languages/build.gradle
+++ b/build/com.mbeddr/languages/build.gradle
@@ -1,6 +1,6 @@
 import de.itemis.mps.gradle.*
 
-// :build:com.mbeddr.build
+// :com.mbeddr.build
 def script_build_mbeddr = new File(scriptsBasePath + "/com.mbeddr.build/" + "build.xml")
 
 ant.taskdef(name: "makeTests",
@@ -40,7 +40,7 @@ task resolve_mbeddr_platform() {
     }
 }
 
-task copy_logConfig(type: Copy, dependsOn: ':build:com.mbeddr:platform:copy_allScripts') {
+task copy_logConfig(type: Copy, dependsOn: ':com.mbeddr:platform:copy_allScripts') {
     from "$rootDir/debug"
     into "$mpsHomeDir/bin"
 }
@@ -58,7 +58,7 @@ def usePrebuiltPlatform = ciBuild && !project.hasProperty('forceBuildPlatform')
 if (usePrebuiltPlatform) {
     mbeddrDependencies = [resolve_mbeddr_platform]
 } else {
-    mbeddrDependencies = [':build:com.mbeddr:platform:build_platform']
+    mbeddrDependencies = [':com.mbeddr:platform:build_platform']
 }
 
 task build_mbeddr(type: BuildLanguages, dependsOn: mbeddrDependencies) {
@@ -195,7 +195,7 @@ publishing {
 
 
 task publishMbeddrToLocal (dependsOn: ['publishMbeddrPublicationToMavenLocal',
-':build:com.mbeddr:platform:publishMbeddrPlatformToLocal']) {}
+':com.mbeddr:platform:publishMbeddrPlatformToLocal']) {}
 
 //mbeddr build is "master" also for maintenance branches
 //using the closure to delay evaluate from configuration to execution phase is important because the

--- a/build/com.mbeddr/platform/build.gradle
+++ b/build/com.mbeddr/platform/build.gradle
@@ -71,7 +71,7 @@ task install_nativelibs_loader(type: Copy, dependsOn: resolve_extensions) {
     include "de.itemis.mps.nativelibs.loader/"
     into "$mpsPluginsDir"
 }
-tasks.getByPath(':build:com.mbeddr:install').dependsOn install_nativelibs_loader
+tasks.getByPath(':com.mbeddr:install').dependsOn install_nativelibs_loader
 */
 
 task build_platform(type: BuildLanguages, dependsOn: copy_allScripts) {
@@ -86,7 +86,7 @@ task install_actionsfilter(type: Copy, dependsOn: build_platform) {
     include "com.mbeddr.mpsutil.actionsfilter/"
     into "$mpsPluginsDir"
 }
-tasks.getByPath(':build:com.mbeddr:install').dependsOn install_actionsfilter
+tasks.getByPath(':com.mbeddr:install').dependsOn install_actionsfilter
 
 task test_mbeddr_platform(type: TestLanguages, dependsOn: build_platform) {
     script script_test_mbeddrPlatform

--- a/build/publishing/build.gradle
+++ b/build/publishing/build.gradle
@@ -63,21 +63,21 @@ task renameMacosFile(type: Copy) {
 		rename ('mbeddr-macos.dmg', macosFileName)
 }
 
-task renameAllInOne(type: Copy, dependsOn: ':build:com.mbeddr:distribution:build_all_in_one') {
+task renameAllInOne(type: Copy, dependsOn: ':com.mbeddr:distribution:build_all_in_one') {
     from(artifactsRoot + "/com.mbeddr.allInOne/")
     into(artifactsRoot + "/com.mbeddr.allInOne/")
     include("com.mbeddr.allInOne.zip")
     rename("com.mbeddr.allInOne.zip", allInOneFileName)
 }
 
-task renameTutorial(type: Copy, dependsOn: ':build:com.mbeddr:distribution:package_tutorial') {
+task renameTutorial(type: Copy, dependsOn: ':com.mbeddr:distribution:package_tutorial') {
     from(artifactsRoot + "/com.mbeddr.tutorial/")
     into(artifactsRoot + "/com.mbeddr.tutorial/")
     include("com.mbeddr.tutorial.zip")
     rename("com.mbeddr.tutorial.zip", tutorialFileName)
 }
 
-task renamePlarform(type: Copy, dependsOn: ':build:com.mbeddr:distribution:build_platform_distribution') {
+task renamePlarform(type: Copy, dependsOn: ':com.mbeddr:distribution:build_platform_distribution') {
     from(artifactsRoot + "/com.mbeddr.platform.distribution/")
     into(artifactsRoot + "/com.mbeddr.platform.distribution/")
     include("platform-distribution.zip")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -5,15 +5,24 @@ pluginManagement {
     }
 }
 
-include(":build:com.mbeddr",
-        ":build:com.mbeddr:platform",
-        ":build:com.mbeddr:languages",
-        ":build:com.mbeddr:distribution",
-        ":build:com.mbeddr:analyses.test",
-        ":build:thirdparty",
-        ":build:thirdparty:graphviz",
-        ":build:thirdparty:jdk",
-        ":build:publishing")
+val subprojectPaths = listOf("com.mbeddr",
+    "com.mbeddr:platform",
+    "com.mbeddr:languages",
+    "com.mbeddr:distribution",
+    "com.mbeddr:analyses.test",
+    "thirdparty",
+    "thirdparty:graphviz",
+    "thirdparty:jdk",
+    "publishing")
+
+fun fqpath(path: String) = ":$path"
+fun dir(path: String) = file("build/" + path.replace(':', '/'))
+
+include(*subprojectPaths.map(::fqpath).toTypedArray())
+
+for (path in subprojectPaths) {
+    project(fqpath(path)).projectDir = dir(path)
+}
 
 include(":BigProject")
 project(":BigProject").projectDir = file("tools/BigProject")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,11 +1,11 @@
 pluginManagement {
     repositories {
-        maven { url 'https://artifacts.itemis.cloud/repository/maven-mps/' }
+        maven("https://artifacts.itemis.cloud/repository/maven-mps/")
         gradlePluginPortal()
     }
 }
 
-include ":build:com.mbeddr",
+include(":build:com.mbeddr",
         ":build:com.mbeddr:platform",
         ":build:com.mbeddr:languages",
         ":build:com.mbeddr:distribution",
@@ -13,9 +13,9 @@ include ":build:com.mbeddr",
         ":build:thirdparty",
         ":build:thirdparty:graphviz",
         ":build:thirdparty:jdk",
-        ":build:publishing"
+        ":build:publishing")
 
-include ":BigProject"
-project(":BigProject").projectDir = file('tools/BigProject')
+include(":BigProject")
+project(":BigProject").projectDir = file("tools/BigProject")
 
-rootProject.name = 'mbeddr.core'
+rootProject.name = "mbeddr.core"


### PR DESCRIPTION
Part of #2500 applied to the 2022.2 branch to fix the CI build.