### PR TITLE
build_mbeddr: add dependency on copy_allScripts

### DIFF
--- a/build/com.mbeddr/languages/build.gradle
+++ b/build/com.mbeddr/languages/build.gradle
@@ -50,18 +50,18 @@ ant.taskdef(name: 'junit', classname: 'org.apache.tools.ant.taskdefs.optional.ju
 ant.taskdef(name: 'junitreport', classname: 'org.apache.tools.ant.taskdefs.optional.junit.XMLResultAggregator',
         classpath: configurations.junitAnt.asPath)
 
-def mbeddrDependencies
+def mbeddrPlatformDependency
 
 def usePrebuiltPlatform = ciBuild && !project.hasProperty('forceBuildPlatform')
 
 //on teamcity we don't build the platform we take it from the nexus. Locally we want to build it
 if (usePrebuiltPlatform) {
-    mbeddrDependencies = [resolve_mbeddr_platform]
+    mbeddrPlatformDependency = resolve_mbeddr_platform
 } else {
-    mbeddrDependencies = [':com.mbeddr:platform:build_platform']
+    mbeddrPlatformDependency = ':com.mbeddr:platform:build_platform'
 }
 
-task build_mbeddr(type: BuildLanguages, dependsOn: mbeddrDependencies) {
+task build_mbeddr(type: BuildLanguages, dependsOn: [':com.mbeddr:platform:copy_allScripts', mbeddrPlatformDependency]) {
     script script_build_mbeddr
     outputs.dir("$artifactsDir/mbeddr")
 }


### PR DESCRIPTION
The dependency was transitive via the spawner before but has to be added directly now.