### PR TITLE
Add migration tasks

### DIFF
--- a/build/com.mbeddr/build.gradle
+++ b/build/com.mbeddr/build.gradle
@@ -171,3 +171,11 @@ task printRepositories {
         println "dependencyRepositories: $dependencyRepositories"
     }
 }
+
+tasks.register('migrate') {
+    // No-op in this version
+}
+
+tasks.register('remigrate') {
+    // No-op in this version
+}


### PR DESCRIPTION
The tasks are no-op in 2022.2 but are executed on CI for every pull request. Proper implementation will be added in maintenance/mps20223 and above.