### PR TITLE
`migrate` and `remigrate` tasks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,8 +3,8 @@ import de.itemis.mps.gradle.RunAntScript
 
 
 plugins {
-    id 'de.itemis.mps.gradle.common' version '1.16.+'
-    id 'download-jbr' version '1.16.+'
+    id 'de.itemis.mps.gradle.common' version '1.28.+'
+    id 'download-jbr' version '1.28.+'
 }
 
 repositories {

--- a/code/languages/com.mbeddr.build/.mps/libraries.xml
+++ b/code/languages/com.mbeddr.build/.mps/libraries.xml
@@ -3,14 +3,6 @@
   <component name="ProjectLibraryManager">
     <option name="libraries">
       <map>
-        <entry key="mbeddr.core">
-          <value>
-            <Library>
-              <option name="name" value="mbeddr.core" />
-              <option name="path" value="${mbeddr.github.core.home}/code/languages" />
-            </Library>
-          </value>
-        </entry>
         <entry key="mps.extensions">
           <value>
             <Library>

--- a/code/languages/com.mbeddr.build/.mps/vcs.xml
+++ b/code/languages/com.mbeddr.build/.mps/vcs.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="VcsDirectoryMappings">
-    <mapping directory="$mbeddr.github.core.home$" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/../../.." vcs="Git" />
   </component>
 </project>

--- a/code/languages/com.mbeddr.build/solutions/com.mbeddr.core.tests.build/models/com/mbeddr/core/tests/build/build.mps
+++ b/code/languages/com.mbeddr.build/solutions/com.mbeddr.core.tests.build/models/com/mbeddr/core/tests/build/build.mps
@@ -1051,6 +1051,22 @@
             <ref role="3bR37D" node="5Z2CJwRopt8" resolve="test.assessments.testlang" />
           </node>
         </node>
+        <node concept="3rtmxn" id="3xUpIvHHZkn" role="3bR31x">
+          <node concept="3LXTmp" id="3xUpIvHHZko" role="3rtmxm">
+            <node concept="3qWCbU" id="3xUpIvHHZkp" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+            <node concept="398BVA" id="3xUpIvHHZkq" role="3LXTmr">
+              <ref role="398BVh" node="7eF9rfAuuux" resolve="mbeddr.core" />
+              <node concept="2Ry0Ak" id="3xUpIvHHZkr" role="iGT6I">
+                <property role="2Ry0Am" value="tests" />
+                <node concept="2Ry0Ak" id="3xUpIvHHZks" role="2Ry0An">
+                  <property role="2Ry0Am" value="test.assessments" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
       </node>
     </node>
     <node concept="398rNT" id="7eF9rfAuuuc" role="1l3spd">

--- a/code/languages/com.mbeddr.build/solutions/com.mbeddr.platform.tests.build/models/com.mbeddr.platform.tests.build.mps
+++ b/code/languages/com.mbeddr.build/solutions/com.mbeddr.platform.tests.build/models/com.mbeddr.platform.tests.build.mps
@@ -477,6 +477,22 @@
             <ref role="3bR37D" to="ffeo:rD7wKO5Iy" resolve="MPS.TextGen" />
           </node>
         </node>
+        <node concept="3rtmxn" id="3xUpIvHHZkB" role="3bR31x">
+          <node concept="3LXTmp" id="3xUpIvHHZkC" role="3rtmxm">
+            <node concept="3qWCbU" id="3xUpIvHHZkD" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+            <node concept="398BVA" id="3xUpIvHHZkE" role="3LXTmr">
+              <ref role="398BVh" node="7hVsScEQJ6E" resolve="mbeddr.mpsutil" />
+              <node concept="2Ry0Ak" id="3xUpIvHHZkF" role="iGT6I">
+                <property role="2Ry0Am" value="tests" />
+                <node concept="2Ry0Ak" id="3xUpIvHHZkG" role="2Ry0An">
+                  <property role="2Ry0Am" value="tests.com.mbeddr.mpsutil.json" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
       </node>
       <node concept="1E1JtA" id="4BxzwLdy2a8" role="2G$12L">
         <property role="BnDLt" value="true" />
@@ -535,6 +551,22 @@
         <node concept="1SiIV0" id="2lpmVPSkCqT" role="3bR37C">
           <node concept="3bR9La" id="2lpmVPSkCqU" role="1SiIV1">
             <ref role="3bR37D" to="ffeo:3MI1gu0QouH" resolve="jetbrains.mps.editor.runtime" />
+          </node>
+        </node>
+        <node concept="3rtmxn" id="3xUpIvHHZkI" role="3bR31x">
+          <node concept="3LXTmp" id="3xUpIvHHZkJ" role="3rtmxm">
+            <node concept="3qWCbU" id="3xUpIvHHZkK" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+            <node concept="398BVA" id="3xUpIvHHZkL" role="3LXTmr">
+              <ref role="398BVh" node="7hVsScEQJ6E" resolve="mbeddr.mpsutil" />
+              <node concept="2Ry0Ak" id="3xUpIvHHZkM" role="iGT6I">
+                <property role="2Ry0Am" value="tests" />
+                <node concept="2Ry0Ak" id="3xUpIvHHZkN" role="2Ry0An">
+                  <property role="2Ry0Am" value="test.com.mbeddr.mpsutil.contextactions" />
+                </node>
+              </node>
+            </node>
           </node>
         </node>
       </node>
@@ -4043,6 +4075,126 @@
           </node>
           <node concept="3qWCbU" id="E0fxGqltzq" role="3LXTna">
             <property role="3qWCbO" value="icons/**, resources/**" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1E1JtD" id="1KdUzjFvDYJ" role="3989C9">
+      <property role="BnDLt" value="true" />
+      <property role="TrG5h" value="com.mbeddr.mpsutil.conceptdiagram.sandbox" />
+      <property role="3LESm3" value="685601d2-5d91-4ffb-8283-5aefff4a2ce9" />
+      <node concept="398BVA" id="1KdUzjFvDYM" role="3LF7KH">
+        <ref role="398BVh" node="E0fxGqls7k" resolve="mbeddr.mpsutil" />
+        <node concept="2Ry0Ak" id="1KdUzjFvDYQ" role="iGT6I">
+          <property role="2Ry0Am" value="languages" />
+          <node concept="2Ry0Ak" id="1KdUzjFvDYT" role="2Ry0An">
+            <property role="2Ry0Am" value="com.mbeddr.mpsutil.conceptdiagram.sandbox" />
+            <node concept="2Ry0Ak" id="1KdUzjFvDYW" role="2Ry0An">
+              <property role="2Ry0Am" value="com.mbeddr.mpsutil.conceptdiagram.sandbox.mpl" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1SiIV0" id="1KdUzjFvE3J" role="3bR37C">
+        <node concept="3bR9La" id="1KdUzjFvE3K" role="1SiIV1">
+          <ref role="3bR37D" to="ffeo:7Kfy9QB6KYb" resolve="jetbrains.mps.baseLanguage" />
+        </node>
+      </node>
+      <node concept="1SiIV0" id="1KdUzjFvE3L" role="3bR37C">
+        <node concept="3bR9La" id="1KdUzjFvE3M" role="1SiIV1">
+          <ref role="3bR37D" to="ffeo:7Kfy9QB6L0h" resolve="jetbrains.mps.baseLanguage.collections" />
+        </node>
+      </node>
+      <node concept="1BupzO" id="1KdUzjFvE3Y" role="3bR31x">
+        <property role="3ZfqAx" value="languageModels" />
+        <property role="1Hdu6h" value="true" />
+        <property role="1HemKv" value="true" />
+        <node concept="3LXTmp" id="1KdUzjFvE3Z" role="1HemKq">
+          <node concept="398BVA" id="1KdUzjFvE3N" role="3LXTmr">
+            <ref role="398BVh" node="E0fxGqls7k" resolve="mbeddr.mpsutil" />
+            <node concept="2Ry0Ak" id="1KdUzjFvE3O" role="iGT6I">
+              <property role="2Ry0Am" value="languages" />
+              <node concept="2Ry0Ak" id="1KdUzjFvE3P" role="2Ry0An">
+                <property role="2Ry0Am" value="com.mbeddr.mpsutil.conceptdiagram.sandbox" />
+                <node concept="2Ry0Ak" id="1KdUzjFvE3Q" role="2Ry0An">
+                  <property role="2Ry0Am" value="languageModels" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3qWCbU" id="1KdUzjFvE40" role="3LXTna">
+            <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+          </node>
+        </node>
+      </node>
+      <node concept="3rtmxn" id="1KdUzjFvE41" role="3bR31x">
+        <node concept="3LXTmp" id="1KdUzjFvE42" role="3rtmxm">
+          <node concept="398BVA" id="1KdUzjFvE43" role="3LXTmr">
+            <ref role="398BVh" node="E0fxGqls7k" resolve="mbeddr.mpsutil" />
+            <node concept="2Ry0Ak" id="1KdUzjFvE44" role="iGT6I">
+              <property role="2Ry0Am" value="languages" />
+              <node concept="2Ry0Ak" id="1KdUzjFvE45" role="2Ry0An">
+                <property role="2Ry0Am" value="com.mbeddr.mpsutil.conceptdiagram.sandbox" />
+              </node>
+            </node>
+          </node>
+          <node concept="3qWCbU" id="1KdUzjFvE47" role="3LXTna">
+            <property role="3qWCbO" value="icons/**, resources/**" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1E1JtD" id="1KdUzjFvE49" role="3989C9">
+      <property role="BnDLt" value="true" />
+      <property role="TrG5h" value="com.mbeddr.mpsutil.ecoretransofmation.sandbox" />
+      <property role="3LESm3" value="54f1ebf8-c32c-4cb5-b811-0a5d6af7bbe7" />
+      <node concept="398BVA" id="1KdUzjFvE4c" role="3LF7KH">
+        <ref role="398BVh" node="E0fxGqls7k" resolve="mbeddr.mpsutil" />
+        <node concept="2Ry0Ak" id="1KdUzjFvE4g" role="iGT6I">
+          <property role="2Ry0Am" value="languages" />
+          <node concept="2Ry0Ak" id="1KdUzjFvE4j" role="2Ry0An">
+            <property role="2Ry0Am" value="com.mbeddr.mpsutil.ecoretransofmation.sandbox" />
+            <node concept="2Ry0Ak" id="1KdUzjFvE4m" role="2Ry0An">
+              <property role="2Ry0Am" value="com.mbeddr.mpsutil.ecoretransofmation.sandbox.mpl" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1BupzO" id="1KdUzjFvE9v" role="3bR31x">
+        <property role="3ZfqAx" value="models" />
+        <property role="1Hdu6h" value="true" />
+        <property role="1HemKv" value="true" />
+        <node concept="3LXTmp" id="1KdUzjFvE9w" role="1HemKq">
+          <node concept="398BVA" id="1KdUzjFvE9k" role="3LXTmr">
+            <ref role="398BVh" node="E0fxGqls7k" resolve="mbeddr.mpsutil" />
+            <node concept="2Ry0Ak" id="1KdUzjFvE9l" role="iGT6I">
+              <property role="2Ry0Am" value="languages" />
+              <node concept="2Ry0Ak" id="1KdUzjFvE9m" role="2Ry0An">
+                <property role="2Ry0Am" value="com.mbeddr.mpsutil.ecoretransofmation.sandbox" />
+                <node concept="2Ry0Ak" id="1KdUzjFvE9n" role="2Ry0An">
+                  <property role="2Ry0Am" value="models" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3qWCbU" id="1KdUzjFvE9x" role="3LXTna">
+            <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+          </node>
+        </node>
+      </node>
+      <node concept="3rtmxn" id="3xUpIvHHZkP" role="3bR31x">
+        <node concept="3LXTmp" id="3xUpIvHHZkQ" role="3rtmxm">
+          <node concept="3qWCbU" id="3xUpIvHHZkR" role="3LXTna">
+            <property role="3qWCbO" value="icons/**, resources/**" />
+          </node>
+          <node concept="398BVA" id="3xUpIvHHZkS" role="3LXTmr">
+            <ref role="398BVh" node="E0fxGqls7k" resolve="mbeddr.mpsutil" />
+            <node concept="2Ry0Ak" id="3xUpIvHHZkT" role="iGT6I">
+              <property role="2Ry0Am" value="languages" />
+              <node concept="2Ry0Ak" id="3xUpIvHHZkU" role="2Ry0An">
+                <property role="2Ry0Am" value="com.mbeddr.mpsutil.ecoretransofmation.sandbox" />
+              </node>
+            </node>
           </node>
         </node>
       </node>

--- a/code/languages/com.mbeddr.build/solutions/com.mbeddr.platform.tests.build/models/com.mbeddr.platform.tests.build.mps
+++ b/code/languages/com.mbeddr.build/solutions/com.mbeddr.platform.tests.build/models/com.mbeddr.platform.tests.build.mps
@@ -144,10 +144,14 @@
       <concept id="4278635856200794926" name="jetbrains.mps.build.mps.structure.BuildMps_ModuleDependencyExtendLanguage" flags="ng" index="1Busua">
         <reference id="4278635856200794928" name="language" index="1Busuk" />
       </concept>
+      <concept id="3189788309731981027" name="jetbrains.mps.build.mps.structure.BuildMps_ModuleSolutionRuntime" flags="ng" index="1E0d5M">
+        <reference id="3189788309731981028" name="solution" index="1E0d5P" />
+      </concept>
       <concept id="3189788309731840247" name="jetbrains.mps.build.mps.structure.BuildMps_Solution" flags="ng" index="1E1JtA">
         <property id="269707337715731330" name="sourcesKind" index="aoJFB" />
       </concept>
       <concept id="3189788309731840248" name="jetbrains.mps.build.mps.structure.BuildMps_Language" flags="ng" index="1E1JtD">
+        <child id="3189788309731917348" name="runtime" index="1E1XAP" />
         <child id="9200313594498201639" name="generator" index="1TViLv" />
       </concept>
       <concept id="322010710375871467" name="jetbrains.mps.build.mps.structure.BuildMps_AbstractModule" flags="ng" index="3LEN3z">
@@ -1508,34 +1512,6 @@
         <property role="TrG5h" value="test.com.mbeddr.mpsutil.ecore.metaModelImport" />
         <property role="3LESm3" value="5da3f266-d744-4554-a337-854f76f37e5f" />
         <property role="aoJFB" value="eYcmk9QOlj/sources_and_tests" />
-        <node concept="398BVA" id="bHMJKhDAXY" role="3LF7KH">
-          <ref role="398BVh" node="7hVsScEQJ6E" resolve="mbeddr.mpsutil" />
-          <node concept="2Ry0Ak" id="bHMJKhDAYF" role="iGT6I">
-            <property role="2Ry0Am" value="tests" />
-            <node concept="2Ry0Ak" id="bHMJKhDD69" role="2Ry0An">
-              <property role="2Ry0Am" value="test.com.mbeddr.mpsutil.ecore.metaModelImport" />
-              <node concept="2Ry0Ak" id="5Ap$XSqW8M_" role="2Ry0An">
-                <property role="2Ry0Am" value="test.com.mbeddr.mpsutil.ecore.metaModelImport.msd" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3rtmxn" id="bHMJKhDD8P" role="3bR31x">
-          <node concept="3LXTmp" id="bHMJKhDD8Q" role="3rtmxm">
-            <node concept="398BVA" id="bHMJKhDD8R" role="3LXTmr">
-              <ref role="398BVh" node="7hVsScEQJ6E" resolve="mbeddr.mpsutil" />
-              <node concept="2Ry0Ak" id="bHMJKhDD8S" role="iGT6I">
-                <property role="2Ry0Am" value="tests" />
-                <node concept="2Ry0Ak" id="5Ap$XSqWAMk" role="2Ry0An">
-                  <property role="2Ry0Am" value="test.com.mbeddr.mpsutil.ecore.metaModelImport" />
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="bHMJKhDD8V" role="3LXTna">
-              <property role="3qWCbO" value="icons/**" />
-            </node>
-          </node>
-        </node>
         <node concept="1SiIV0" id="bHMJKhDDf5" role="3bR37C">
           <node concept="3bR9La" id="bHMJKhDDf6" role="1SiIV1">
             <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
@@ -1564,6 +1540,34 @@
         <node concept="1SiIV0" id="bHMJKhDDff" role="3bR37C">
           <node concept="3bR9La" id="bHMJKhDDfg" role="1SiIV1">
             <ref role="3bR37D" to="ffeo:7Kfy9QB6LaO" resolve="jetbrains.mps.lang.structure" />
+          </node>
+        </node>
+        <node concept="398BVA" id="bHMJKhDAXY" role="3LF7KH">
+          <ref role="398BVh" node="7hVsScEQJ6E" resolve="mbeddr.mpsutil" />
+          <node concept="2Ry0Ak" id="bHMJKhDAYF" role="iGT6I">
+            <property role="2Ry0Am" value="tests" />
+            <node concept="2Ry0Ak" id="bHMJKhDD69" role="2Ry0An">
+              <property role="2Ry0Am" value="test.com.mbeddr.mpsutil.ecore.metaModelImport" />
+              <node concept="2Ry0Ak" id="5Ap$XSqW8M_" role="2Ry0An">
+                <property role="2Ry0Am" value="test.com.mbeddr.mpsutil.ecore.metaModelImport.msd" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3rtmxn" id="bHMJKhDD8P" role="3bR31x">
+          <node concept="3LXTmp" id="bHMJKhDD8Q" role="3rtmxm">
+            <node concept="398BVA" id="bHMJKhDD8R" role="3LXTmr">
+              <ref role="398BVh" node="7hVsScEQJ6E" resolve="mbeddr.mpsutil" />
+              <node concept="2Ry0Ak" id="bHMJKhDD8S" role="iGT6I">
+                <property role="2Ry0Am" value="tests" />
+                <node concept="2Ry0Ak" id="5Ap$XSqWAMk" role="2Ry0An">
+                  <property role="2Ry0Am" value="test.com.mbeddr.mpsutil.ecore.metaModelImport" />
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="bHMJKhDD8V" role="3LXTna">
+              <property role="3qWCbO" value="icons/**" />
+            </node>
           </node>
         </node>
         <node concept="1BupzO" id="bHMJKhDDfz" role="3bR31x">
@@ -4195,6 +4199,366 @@
                 <property role="2Ry0Am" value="com.mbeddr.mpsutil.ecoretransofmation.sandbox" />
               </node>
             </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1E1JtA" id="3SrAMjiLmZZ" role="3989C9">
+      <property role="BnDLt" value="true" />
+      <property role="TrG5h" value="com.mbeddr.mpsutil.graphstream.runtime" />
+      <property role="3LESm3" value="ab71436a-a7d1-4689-ac02-b5fde2ec681f" />
+      <node concept="398BVA" id="3SrAMjiLn02" role="3LF7KH">
+        <ref role="398BVh" node="E0fxGqls7k" resolve="mbeddr.mpsutil" />
+        <node concept="2Ry0Ak" id="3SrAMjiLn0b" role="iGT6I">
+          <property role="2Ry0Am" value="languages" />
+          <node concept="2Ry0Ak" id="3SrAMjiLn0e" role="2Ry0An">
+            <property role="2Ry0Am" value="com.mbeddr.mpsutil.graphstream" />
+            <node concept="2Ry0Ak" id="3SrAMjiLn0h" role="2Ry0An">
+              <property role="2Ry0Am" value="runtime" />
+              <node concept="2Ry0Ak" id="3SrAMjiLn0k" role="2Ry0An">
+                <property role="2Ry0Am" value="com.mbeddr.mpsutil.graphstream.runtime.msd" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1SiIV0" id="3SrAMjiLn5t" role="3bR37C">
+        <node concept="3bR9La" id="3SrAMjiLn5u" role="1SiIV1">
+          <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
+        </node>
+      </node>
+      <node concept="1SiIV0" id="3SrAMjiLn5v" role="3bR37C">
+        <node concept="3bR9La" id="3SrAMjiLn5w" role="1SiIV1">
+          <ref role="3bR37D" to="ffeo:1ia2VB5guYy" resolve="MPS.IDEA" />
+        </node>
+      </node>
+      <node concept="1SiIV0" id="3SrAMjiLn5x" role="3bR37C">
+        <node concept="3bR9La" id="3SrAMjiLn5y" role="1SiIV1">
+          <ref role="3bR37D" to="ffeo:1TaHNgiIbJ$" resolve="jetbrains.mps.ide.editor" />
+        </node>
+      </node>
+      <node concept="1SiIV0" id="3SrAMjiLn5z" role="3bR37C">
+        <node concept="3bR9La" id="3SrAMjiLn5$" role="1SiIV1">
+          <ref role="3bR37D" node="3SrAMjiLmUj" resolve="com.mbeddr.mpsutil.graphstream" />
+        </node>
+      </node>
+      <node concept="1SiIV0" id="3SrAMjiLn5_" role="3bR37C">
+        <node concept="3bR9La" id="3SrAMjiLn5A" role="1SiIV1">
+          <ref role="3bR37D" to="ffeo:1TaHNgiIbJb" resolve="MPS.Platform" />
+        </node>
+      </node>
+      <node concept="1SiIV0" id="3SrAMjiLn5B" role="3bR37C">
+        <node concept="3bR9La" id="3SrAMjiLn5C" role="1SiIV1">
+          <ref role="3bR37D" to="al5i:2N1CSrzSJt4" resolve="com.mbeddr.mpsutil.plantuml.pluginSolution" />
+        </node>
+      </node>
+      <node concept="1SiIV0" id="3SrAMjiLn5S" role="3bR37C">
+        <node concept="1BurEX" id="3SrAMjiLn5T" role="1SiIV1">
+          <node concept="398BVA" id="3SrAMjiLn5D" role="1BurEY">
+            <ref role="398BVh" node="E0fxGqls7k" resolve="mbeddr.mpsutil" />
+            <node concept="2Ry0Ak" id="3SrAMjiLn5E" role="iGT6I">
+              <property role="2Ry0Am" value="languages" />
+              <node concept="2Ry0Ak" id="3SrAMjiLn5F" role="2Ry0An">
+                <property role="2Ry0Am" value="com.mbeddr.mpsutil.graphstream" />
+                <node concept="2Ry0Ak" id="3SrAMjiLn5G" role="2Ry0An">
+                  <property role="2Ry0Am" value="runtime" />
+                  <node concept="2Ry0Ak" id="3SrAMjiLn5H" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                    <node concept="2Ry0Ak" id="3SrAMjiLn5I" role="2Ry0An">
+                      <property role="2Ry0Am" value="gs-algo-1.3.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1SiIV0" id="3SrAMjiLn69" role="3bR37C">
+        <node concept="1BurEX" id="3SrAMjiLn6a" role="1SiIV1">
+          <node concept="398BVA" id="3SrAMjiLn5U" role="1BurEY">
+            <ref role="398BVh" node="E0fxGqls7k" resolve="mbeddr.mpsutil" />
+            <node concept="2Ry0Ak" id="3SrAMjiLn5V" role="iGT6I">
+              <property role="2Ry0Am" value="languages" />
+              <node concept="2Ry0Ak" id="3SrAMjiLn5W" role="2Ry0An">
+                <property role="2Ry0Am" value="com.mbeddr.mpsutil.graphstream" />
+                <node concept="2Ry0Ak" id="3SrAMjiLn5X" role="2Ry0An">
+                  <property role="2Ry0Am" value="runtime" />
+                  <node concept="2Ry0Ak" id="3SrAMjiLn5Y" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                    <node concept="2Ry0Ak" id="3SrAMjiLn5Z" role="2Ry0An">
+                      <property role="2Ry0Am" value="gs-core-1.3.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1SiIV0" id="3SrAMjiLn6q" role="3bR37C">
+        <node concept="1BurEX" id="3SrAMjiLn6r" role="1SiIV1">
+          <node concept="398BVA" id="3SrAMjiLn6b" role="1BurEY">
+            <ref role="398BVh" node="E0fxGqls7k" resolve="mbeddr.mpsutil" />
+            <node concept="2Ry0Ak" id="3SrAMjiLn6c" role="iGT6I">
+              <property role="2Ry0Am" value="languages" />
+              <node concept="2Ry0Ak" id="3SrAMjiLn6d" role="2Ry0An">
+                <property role="2Ry0Am" value="com.mbeddr.mpsutil.graphstream" />
+                <node concept="2Ry0Ak" id="3SrAMjiLn6e" role="2Ry0An">
+                  <property role="2Ry0Am" value="runtime" />
+                  <node concept="2Ry0Ak" id="3SrAMjiLn6f" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                    <node concept="2Ry0Ak" id="3SrAMjiLn6g" role="2Ry0An">
+                      <property role="2Ry0Am" value="gs-ui-1.3.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1SiIV0" id="3SrAMjiLn6F" role="3bR37C">
+        <node concept="1BurEX" id="3SrAMjiLn6G" role="1SiIV1">
+          <node concept="398BVA" id="3SrAMjiLn6s" role="1BurEY">
+            <ref role="398BVh" node="E0fxGqls7k" resolve="mbeddr.mpsutil" />
+            <node concept="2Ry0Ak" id="3SrAMjiLn6t" role="iGT6I">
+              <property role="2Ry0Am" value="languages" />
+              <node concept="2Ry0Ak" id="3SrAMjiLn6u" role="2Ry0An">
+                <property role="2Ry0Am" value="com.mbeddr.mpsutil.graphstream" />
+                <node concept="2Ry0Ak" id="3SrAMjiLn6v" role="2Ry0An">
+                  <property role="2Ry0Am" value="runtime" />
+                  <node concept="2Ry0Ak" id="3SrAMjiLn6w" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                    <node concept="2Ry0Ak" id="3SrAMjiLn6x" role="2Ry0An">
+                      <property role="2Ry0Am" value="jgraphx-3.7.4.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1SiIV0" id="3SrAMjiLn6W" role="3bR37C">
+        <node concept="1BurEX" id="3SrAMjiLn6X" role="1SiIV1">
+          <node concept="398BVA" id="3SrAMjiLn6H" role="1BurEY">
+            <ref role="398BVh" node="E0fxGqls7k" resolve="mbeddr.mpsutil" />
+            <node concept="2Ry0Ak" id="3SrAMjiLn6I" role="iGT6I">
+              <property role="2Ry0Am" value="languages" />
+              <node concept="2Ry0Ak" id="3SrAMjiLn6J" role="2Ry0An">
+                <property role="2Ry0Am" value="com.mbeddr.mpsutil.graphstream" />
+                <node concept="2Ry0Ak" id="3SrAMjiLn6K" role="2Ry0An">
+                  <property role="2Ry0Am" value="runtime" />
+                  <node concept="2Ry0Ak" id="3SrAMjiLn6L" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                    <node concept="2Ry0Ak" id="3SrAMjiLn6M" role="2Ry0An">
+                      <property role="2Ry0Am" value="abego-treelayout-1.0.3.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1SiIV0" id="3SrAMjiLn7d" role="3bR37C">
+        <node concept="1BurEX" id="3SrAMjiLn7e" role="1SiIV1">
+          <node concept="398BVA" id="3SrAMjiLn6Y" role="1BurEY">
+            <ref role="398BVh" node="E0fxGqls7k" resolve="mbeddr.mpsutil" />
+            <node concept="2Ry0Ak" id="3SrAMjiLn6Z" role="iGT6I">
+              <property role="2Ry0Am" value="languages" />
+              <node concept="2Ry0Ak" id="3SrAMjiLn70" role="2Ry0An">
+                <property role="2Ry0Am" value="com.mbeddr.mpsutil.graphstream" />
+                <node concept="2Ry0Ak" id="3SrAMjiLn71" role="2Ry0An">
+                  <property role="2Ry0Am" value="runtime" />
+                  <node concept="2Ry0Ak" id="3SrAMjiLn72" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                    <node concept="2Ry0Ak" id="3SrAMjiLn73" role="2Ry0An">
+                      <property role="2Ry0Am" value="de.itemis.graphing.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1BupzO" id="3SrAMjiLn7s" role="3bR31x">
+        <property role="3ZfqAx" value="models" />
+        <property role="1Hdu6h" value="true" />
+        <property role="1HemKv" value="true" />
+        <node concept="3LXTmp" id="3SrAMjiLn7t" role="1HemKq">
+          <node concept="398BVA" id="3SrAMjiLn7f" role="3LXTmr">
+            <ref role="398BVh" node="E0fxGqls7k" resolve="mbeddr.mpsutil" />
+            <node concept="2Ry0Ak" id="3SrAMjiLn7g" role="iGT6I">
+              <property role="2Ry0Am" value="languages" />
+              <node concept="2Ry0Ak" id="3SrAMjiLn7h" role="2Ry0An">
+                <property role="2Ry0Am" value="com.mbeddr.mpsutil.graphstream" />
+                <node concept="2Ry0Ak" id="3SrAMjiLn7i" role="2Ry0An">
+                  <property role="2Ry0Am" value="runtime" />
+                  <node concept="2Ry0Ak" id="3SrAMjiLn7j" role="2Ry0An">
+                    <property role="2Ry0Am" value="models" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3qWCbU" id="3SrAMjiLn7u" role="3LXTna">
+            <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+          </node>
+        </node>
+      </node>
+      <node concept="3rtmxn" id="3SrAMjiLnc0" role="3bR31x">
+        <node concept="3LXTmp" id="3SrAMjiLnc1" role="3rtmxm">
+          <node concept="398BVA" id="3SrAMjiLnc2" role="3LXTmr">
+            <ref role="398BVh" node="E0fxGqls7k" resolve="mbeddr.mpsutil" />
+            <node concept="2Ry0Ak" id="3SrAMjiLnc3" role="iGT6I">
+              <property role="2Ry0Am" value="languages" />
+              <node concept="2Ry0Ak" id="3SrAMjiLnc4" role="2Ry0An">
+                <property role="2Ry0Am" value="com.mbeddr.mpsutil.graphstream" />
+                <node concept="2Ry0Ak" id="3SrAMjiLnc5" role="2Ry0An">
+                  <property role="2Ry0Am" value="runtime" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3qWCbU" id="3SrAMjiLnc7" role="3LXTna">
+            <property role="3qWCbO" value="icons/**, resources/**" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1E1JtD" id="3SrAMjiLmUj" role="3989C9">
+      <property role="BnDLt" value="true" />
+      <property role="TrG5h" value="com.mbeddr.mpsutil.graphstream" />
+      <property role="3LESm3" value="5787a8ed-1486-4469-94b0-fa3fc6c8538d" />
+      <node concept="398BVA" id="3SrAMjiLmUm" role="3LF7KH">
+        <ref role="398BVh" node="E0fxGqls7k" resolve="mbeddr.mpsutil" />
+        <node concept="2Ry0Ak" id="3SrAMjiLmUq" role="iGT6I">
+          <property role="2Ry0Am" value="languages" />
+          <node concept="2Ry0Ak" id="3SrAMjiLmUt" role="2Ry0An">
+            <property role="2Ry0Am" value="com.mbeddr.mpsutil.graphstream" />
+            <node concept="2Ry0Ak" id="3SrAMjiLmUw" role="2Ry0An">
+              <property role="2Ry0Am" value="com.mbeddr.mpsutil.graphstream.mpl" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1BupzO" id="3SrAMjiLmZO" role="3bR31x">
+        <property role="3ZfqAx" value="models" />
+        <property role="1Hdu6h" value="true" />
+        <property role="1HemKv" value="true" />
+        <node concept="3LXTmp" id="3SrAMjiLmZP" role="1HemKq">
+          <node concept="398BVA" id="3SrAMjiLmZD" role="3LXTmr">
+            <ref role="398BVh" node="E0fxGqls7k" resolve="mbeddr.mpsutil" />
+            <node concept="2Ry0Ak" id="3SrAMjiLmZE" role="iGT6I">
+              <property role="2Ry0Am" value="languages" />
+              <node concept="2Ry0Ak" id="3SrAMjiLmZF" role="2Ry0An">
+                <property role="2Ry0Am" value="com.mbeddr.mpsutil.graphstream" />
+                <node concept="2Ry0Ak" id="3SrAMjiLmZG" role="2Ry0An">
+                  <property role="2Ry0Am" value="models" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3qWCbU" id="3SrAMjiLmZQ" role="3LXTna">
+            <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+          </node>
+        </node>
+      </node>
+      <node concept="3rtmxn" id="3SrAMjiLmZR" role="3bR31x">
+        <node concept="3LXTmp" id="3SrAMjiLmZS" role="3rtmxm">
+          <node concept="398BVA" id="3SrAMjiLmZT" role="3LXTmr">
+            <ref role="398BVh" node="E0fxGqls7k" resolve="mbeddr.mpsutil" />
+            <node concept="2Ry0Ak" id="3SrAMjiLmZU" role="iGT6I">
+              <property role="2Ry0Am" value="languages" />
+              <node concept="2Ry0Ak" id="3SrAMjiLmZV" role="2Ry0An">
+                <property role="2Ry0Am" value="com.mbeddr.mpsutil.graphstream" />
+              </node>
+            </node>
+          </node>
+          <node concept="3qWCbU" id="3SrAMjiLmZX" role="3LXTna">
+            <property role="3qWCbO" value="icons/**, resources/**" />
+          </node>
+        </node>
+      </node>
+      <node concept="1SiIV0" id="3SrAMjiLnkh" role="3bR37C">
+        <node concept="3bR9La" id="3SrAMjiLnki" role="1SiIV1">
+          <ref role="3bR37D" node="3SrAMjiLmZZ" resolve="com.mbeddr.mpsutil.graphstream.runtime" />
+        </node>
+      </node>
+      <node concept="1E0d5M" id="3SrAMjiLnku" role="1E1XAP">
+        <ref role="1E0d5P" node="3SrAMjiLmZZ" resolve="com.mbeddr.mpsutil.graphstream.runtime" />
+      </node>
+    </node>
+    <node concept="1E1JtD" id="3SrAMjiLnlU" role="3989C9">
+      <property role="BnDLt" value="true" />
+      <property role="TrG5h" value="com.mbeddr.mpsutil.graphstream.example" />
+      <property role="3LESm3" value="72fa8b44-393c-4983-99aa-868cd899b005" />
+      <node concept="398BVA" id="3SrAMjiLnnn" role="3LF7KH">
+        <ref role="398BVh" node="E0fxGqls7k" resolve="mbeddr.mpsutil" />
+        <node concept="2Ry0Ak" id="3SrAMjiLnqf" role="iGT6I">
+          <property role="2Ry0Am" value="languages" />
+          <node concept="2Ry0Ak" id="3SrAMjiLnt6" role="2Ry0An">
+            <property role="2Ry0Am" value="com.mbeddr.mpsutil.graphstream.example" />
+            <node concept="2Ry0Ak" id="3SrAMjiLnvX" role="2Ry0An">
+              <property role="2Ry0Am" value="com.mbeddr.mpsutil.graphstream.example.mpl" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1SiIV0" id="3SrAMjiLnCi" role="3bR37C">
+        <node concept="3bR9La" id="3SrAMjiLnCj" role="1SiIV1">
+          <ref role="3bR37D" to="ffeo:1ia2VB5guYy" resolve="MPS.IDEA" />
+        </node>
+      </node>
+      <node concept="1SiIV0" id="3SrAMjiLnCk" role="3bR37C">
+        <node concept="3bR9La" id="3SrAMjiLnCl" role="1SiIV1">
+          <property role="3bR36h" value="true" />
+          <ref role="3bR37D" node="3SrAMjiLmZZ" resolve="com.mbeddr.mpsutil.graphstream.runtime" />
+        </node>
+      </node>
+      <node concept="1BupzO" id="3SrAMjiLnCx" role="3bR31x">
+        <property role="3ZfqAx" value="models" />
+        <property role="1Hdu6h" value="true" />
+        <property role="1HemKv" value="true" />
+        <node concept="3LXTmp" id="3SrAMjiLnCy" role="1HemKq">
+          <node concept="398BVA" id="3SrAMjiLnCm" role="3LXTmr">
+            <ref role="398BVh" node="E0fxGqls7k" resolve="mbeddr.mpsutil" />
+            <node concept="2Ry0Ak" id="3SrAMjiLnCn" role="iGT6I">
+              <property role="2Ry0Am" value="languages" />
+              <node concept="2Ry0Ak" id="3SrAMjiLnCo" role="2Ry0An">
+                <property role="2Ry0Am" value="com.mbeddr.mpsutil.graphstream.example" />
+                <node concept="2Ry0Ak" id="3SrAMjiLnCp" role="2Ry0An">
+                  <property role="2Ry0Am" value="models" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3qWCbU" id="3SrAMjiLnCz" role="3LXTna">
+            <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+          </node>
+        </node>
+      </node>
+      <node concept="1SiIV0" id="3SrAMjiLnC$" role="3bR37C">
+        <node concept="1Busua" id="3SrAMjiLnC_" role="1SiIV1">
+          <ref role="1Busuk" node="3SrAMjiLmUj" resolve="com.mbeddr.mpsutil.graphstream" />
+        </node>
+      </node>
+      <node concept="3rtmxn" id="3SrAMjiLnE0" role="3bR31x">
+        <node concept="3LXTmp" id="3SrAMjiLnE1" role="3rtmxm">
+          <node concept="398BVA" id="3SrAMjiLnE2" role="3LXTmr">
+            <ref role="398BVh" node="E0fxGqls7k" resolve="mbeddr.mpsutil" />
+            <node concept="2Ry0Ak" id="3SrAMjiLnE3" role="iGT6I">
+              <property role="2Ry0Am" value="languages" />
+              <node concept="2Ry0Ak" id="3SrAMjiLnE4" role="2Ry0An">
+                <property role="2Ry0Am" value="com.mbeddr.mpsutil.graphstream.example" />
+              </node>
+            </node>
+          </node>
+          <node concept="3qWCbU" id="3SrAMjiLnE6" role="3LXTna">
+            <property role="3qWCbO" value="icons/**, resources/**" />
           </node>
         </node>
       </node>

--- a/code/languages/com.mbeddr.build/solutions/com.mbeddr.platform.tests.build/models/com.mbeddr.platform.tests.build.mps
+++ b/code/languages/com.mbeddr.build/solutions/com.mbeddr.platform.tests.build/models/com.mbeddr.platform.tests.build.mps
@@ -1476,6 +1476,34 @@
         <property role="TrG5h" value="test.com.mbeddr.mpsutil.ecore.metaModelImport" />
         <property role="3LESm3" value="5da3f266-d744-4554-a337-854f76f37e5f" />
         <property role="aoJFB" value="eYcmk9QOlj/sources_and_tests" />
+        <node concept="398BVA" id="bHMJKhDAXY" role="3LF7KH">
+          <ref role="398BVh" node="7hVsScEQJ6E" resolve="mbeddr.mpsutil" />
+          <node concept="2Ry0Ak" id="bHMJKhDAYF" role="iGT6I">
+            <property role="2Ry0Am" value="tests" />
+            <node concept="2Ry0Ak" id="bHMJKhDD69" role="2Ry0An">
+              <property role="2Ry0Am" value="test.com.mbeddr.mpsutil.ecore.metaModelImport" />
+              <node concept="2Ry0Ak" id="5Ap$XSqW8M_" role="2Ry0An">
+                <property role="2Ry0Am" value="test.com.mbeddr.mpsutil.ecore.metaModelImport.msd" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3rtmxn" id="bHMJKhDD8P" role="3bR31x">
+          <node concept="3LXTmp" id="bHMJKhDD8Q" role="3rtmxm">
+            <node concept="398BVA" id="bHMJKhDD8R" role="3LXTmr">
+              <ref role="398BVh" node="7hVsScEQJ6E" resolve="mbeddr.mpsutil" />
+              <node concept="2Ry0Ak" id="bHMJKhDD8S" role="iGT6I">
+                <property role="2Ry0Am" value="tests" />
+                <node concept="2Ry0Ak" id="5Ap$XSqWAMk" role="2Ry0An">
+                  <property role="2Ry0Am" value="test.com.mbeddr.mpsutil.ecore.metaModelImport" />
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="bHMJKhDD8V" role="3LXTna">
+              <property role="3qWCbO" value="icons/**" />
+            </node>
+          </node>
+        </node>
         <node concept="1SiIV0" id="bHMJKhDDf5" role="3bR37C">
           <node concept="3bR9La" id="bHMJKhDDf6" role="1SiIV1">
             <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
@@ -1504,34 +1532,6 @@
         <node concept="1SiIV0" id="bHMJKhDDff" role="3bR37C">
           <node concept="3bR9La" id="bHMJKhDDfg" role="1SiIV1">
             <ref role="3bR37D" to="ffeo:7Kfy9QB6LaO" resolve="jetbrains.mps.lang.structure" />
-          </node>
-        </node>
-        <node concept="398BVA" id="bHMJKhDAXY" role="3LF7KH">
-          <ref role="398BVh" node="7hVsScEQJ6E" resolve="mbeddr.mpsutil" />
-          <node concept="2Ry0Ak" id="bHMJKhDAYF" role="iGT6I">
-            <property role="2Ry0Am" value="tests" />
-            <node concept="2Ry0Ak" id="bHMJKhDD69" role="2Ry0An">
-              <property role="2Ry0Am" value="test.com.mbeddr.mpsutil.ecore.metaModelImport" />
-              <node concept="2Ry0Ak" id="5Ap$XSqW8M_" role="2Ry0An">
-                <property role="2Ry0Am" value="test.com.mbeddr.mpsutil.ecore.metaModelImport.msd" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3rtmxn" id="bHMJKhDD8P" role="3bR31x">
-          <node concept="3LXTmp" id="bHMJKhDD8Q" role="3rtmxm">
-            <node concept="398BVA" id="bHMJKhDD8R" role="3LXTmr">
-              <ref role="398BVh" node="7hVsScEQJ6E" resolve="mbeddr.mpsutil" />
-              <node concept="2Ry0Ak" id="bHMJKhDD8S" role="iGT6I">
-                <property role="2Ry0Am" value="tests" />
-                <node concept="2Ry0Ak" id="5Ap$XSqWAMk" role="2Ry0An">
-                  <property role="2Ry0Am" value="test.com.mbeddr.mpsutil.ecore.metaModelImport" />
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="bHMJKhDD8V" role="3LXTna">
-              <property role="3qWCbO" value="icons/**" />
-            </node>
           </node>
         </node>
         <node concept="1BupzO" id="bHMJKhDDfz" role="3bR31x">
@@ -2853,6 +2853,1199 @@
     <node concept="2igEWh" id="3HpWboH_Z$G" role="1hWBAP">
       <property role="2igJW4" value="true" />
       <property role="3UIfUI" value="4096" />
+    </node>
+  </node>
+  <node concept="1l3spW" id="E0fxGqls4q">
+    <property role="2DA0ip" value="../../../../../build/com.mbeddr.platform" />
+    <property role="TrG5h" value="com.mbeddr.platform.sandboxes" />
+    <property role="turDy" value="build-sandboxes.xml" />
+    <node concept="398rNT" id="E0fxGqls69" role="1l3spd">
+      <property role="TrG5h" value="mps.home" />
+    </node>
+    <node concept="398rNT" id="E0fxGqls73" role="1l3spd">
+      <property role="TrG5h" value="artifacts.root" />
+    </node>
+    <node concept="398rNT" id="E0fxGqls7d" role="1l3spd">
+      <property role="TrG5h" value="mbeddr.github.core.home" />
+      <node concept="55IIr" id="E0fxGqls7e" role="398pKh">
+        <node concept="2Ry0Ak" id="E0fxGqls7f" role="iGT6I">
+          <property role="2Ry0Am" value=".." />
+          <node concept="2Ry0Ak" id="E0fxGqls7g" role="2Ry0An">
+            <property role="2Ry0Am" value=".." />
+            <node concept="2Ry0Ak" id="E0fxGqls7h" role="2Ry0An">
+              <property role="2Ry0Am" value="" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="398rNT" id="E0fxGqls7k" role="1l3spd">
+      <property role="TrG5h" value="mbeddr.mpsutil" />
+      <node concept="398BVA" id="E0fxGqls7l" role="398pKh">
+        <ref role="398BVh" node="E0fxGqls7d" resolve="mbeddr.github.core.home" />
+        <node concept="2Ry0Ak" id="E0fxGqls7m" role="iGT6I">
+          <property role="2Ry0Am" value="code" />
+          <node concept="2Ry0Ak" id="E0fxGqls7n" role="2Ry0An">
+            <property role="2Ry0Am" value="languages" />
+            <node concept="2Ry0Ak" id="E0fxGqls7o" role="2Ry0An">
+              <property role="2Ry0Am" value="com.mbeddr.mpsutil" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2sgV4H" id="E0fxGqls5p" role="1l3spa">
+      <ref role="1l3spb" to="ffeo:3IKDaVZmzS6" resolve="mps" />
+      <node concept="398BVA" id="E0fxGqls5q" role="2JcizS">
+        <ref role="398BVh" node="E0fxGqls69" resolve="mps.home" />
+      </node>
+    </node>
+    <node concept="2sgV4H" id="E0fxGqls5r" role="1l3spa">
+      <ref role="1l3spb" to="al5i:3AVJcIMlF8l" resolve="com.mbeddr.platform" />
+      <node concept="398BVA" id="4xZxQlOFM87" role="2JcizS">
+        <ref role="398BVh" node="E0fxGqls73" resolve="artifacts.root" />
+        <node concept="2Ry0Ak" id="4xZxQlOFM88" role="iGT6I">
+          <property role="2Ry0Am" value="com.mbeddr.platform" />
+        </node>
+      </node>
+    </node>
+    <node concept="2sgV4H" id="E0fxGqls5t" role="1l3spa">
+      <ref role="1l3spb" to="90a9:2Xjt3l56m0V" resolve="de.itemis.mps.extensions" />
+      <node concept="398BVA" id="E0fxGqls6j" role="2JcizS">
+        <ref role="398BVh" node="E0fxGqls73" resolve="artifacts.root" />
+        <node concept="2Ry0Ak" id="E0fxGqls6k" role="iGT6I">
+          <property role="2Ry0Am" value="de.itemis.mps.extensions" />
+        </node>
+      </node>
+    </node>
+    <node concept="1l3spV" id="E0fxGqls4s" role="1l3spN" />
+    <node concept="3b7kt6" id="E0fxGqls5l" role="10PD9s" />
+    <node concept="10PD9b" id="E0fxGqls5n" role="10PD9s" />
+    <node concept="1E1JtD" id="E0fxGqls74" role="3989C9">
+      <property role="BnDLt" value="true" />
+      <property role="TrG5h" value="com.mbeddr.mpsutil.editor.displayControl.sandbox" />
+      <property role="3LESm3" value="c3a9b5df-25f0-466c-a31c-0da4314af7d1" />
+      <node concept="398BVA" id="E0fxGqls7p" role="3LF7KH">
+        <ref role="398BVh" node="E0fxGqls7k" resolve="mbeddr.mpsutil" />
+        <node concept="2Ry0Ak" id="E0fxGqls7t" role="iGT6I">
+          <property role="2Ry0Am" value="languages" />
+          <node concept="2Ry0Ak" id="E0fxGqls7w" role="2Ry0An">
+            <property role="2Ry0Am" value="com.mbeddr.mpsutil.editor.displayControl.sandbox" />
+            <node concept="2Ry0Ak" id="E0fxGqls7z" role="2Ry0An">
+              <property role="2Ry0Am" value="com.mbeddr.mpsutil.editor.displayControl.sandbox.mpl" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1SiIV0" id="E0fxGqls7$" role="3bR37C">
+        <node concept="3bR9La" id="E0fxGqls7_" role="1SiIV1">
+          <ref role="3bR37D" to="ffeo:1TaHNgiIbIZ" resolve="MPS.Editor" />
+        </node>
+      </node>
+      <node concept="1BupzO" id="E0fxGqls7L" role="3bR31x">
+        <property role="3ZfqAx" value="models" />
+        <property role="1Hdu6h" value="true" />
+        <property role="1HemKv" value="true" />
+        <node concept="3LXTmp" id="E0fxGqls7M" role="1HemKq">
+          <node concept="398BVA" id="E0fxGqls7A" role="3LXTmr">
+            <ref role="398BVh" node="E0fxGqls7k" resolve="mbeddr.mpsutil" />
+            <node concept="2Ry0Ak" id="E0fxGqls7B" role="iGT6I">
+              <property role="2Ry0Am" value="languages" />
+              <node concept="2Ry0Ak" id="E0fxGqls7C" role="2Ry0An">
+                <property role="2Ry0Am" value="com.mbeddr.mpsutil.editor.displayControl.sandbox" />
+                <node concept="2Ry0Ak" id="E0fxGqls7D" role="2Ry0An">
+                  <property role="2Ry0Am" value="models" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3qWCbU" id="E0fxGqls7N" role="3LXTna">
+            <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+          </node>
+        </node>
+      </node>
+      <node concept="1SiIV0" id="E0fxGqls7O" role="3bR37C">
+        <node concept="1Busua" id="E0fxGqls7P" role="1SiIV1">
+          <ref role="1Busuk" to="al5i:3uPnK4iE1MQ" resolve="com.mbeddr.mpsutil.editor.displayControl" />
+        </node>
+      </node>
+      <node concept="3rtmxn" id="E0fxGqls8Q" role="3bR31x">
+        <node concept="3LXTmp" id="E0fxGqls8R" role="3rtmxm">
+          <node concept="398BVA" id="E0fxGqls8S" role="3LXTmr">
+            <ref role="398BVh" node="E0fxGqls7k" resolve="mbeddr.mpsutil" />
+            <node concept="2Ry0Ak" id="E0fxGqls8T" role="iGT6I">
+              <property role="2Ry0Am" value="languages" />
+              <node concept="2Ry0Ak" id="E0fxGqls8U" role="2Ry0An">
+                <property role="2Ry0Am" value="com.mbeddr.mpsutil.editor.displayControl.sandbox" />
+              </node>
+            </node>
+          </node>
+          <node concept="3qWCbU" id="E0fxGqls8W" role="3LXTna">
+            <property role="3qWCbO" value="icons/**, resources/**" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1E1JtD" id="E0fxGqls7R" role="3989C9">
+      <property role="BnDLt" value="true" />
+      <property role="TrG5h" value="com.mbeddr.demo.comparator.diff" />
+      <property role="3LESm3" value="e0989c7a-8149-4be7-97b6-0b78561af099" />
+      <node concept="398BVA" id="E0fxGqls7U" role="3LF7KH">
+        <ref role="398BVh" node="E0fxGqls7k" resolve="mbeddr.mpsutil" />
+        <node concept="2Ry0Ak" id="E0fxGqls7Y" role="iGT6I">
+          <property role="2Ry0Am" value="languages" />
+          <node concept="2Ry0Ak" id="E0fxGqls81" role="2Ry0An">
+            <property role="2Ry0Am" value="com.mbeddr.demo.comparator.diff" />
+            <node concept="2Ry0Ak" id="E0fxGqls84" role="2Ry0An">
+              <property role="2Ry0Am" value="com.mbeddr.demo.comparator.diff.mpl" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1BupzO" id="E0fxGqls8r" role="3bR31x">
+        <property role="3ZfqAx" value="models" />
+        <property role="1Hdu6h" value="true" />
+        <property role="1HemKv" value="true" />
+        <node concept="3LXTmp" id="E0fxGqls8s" role="1HemKq">
+          <node concept="398BVA" id="E0fxGqls8g" role="3LXTmr">
+            <ref role="398BVh" node="E0fxGqls7k" resolve="mbeddr.mpsutil" />
+            <node concept="2Ry0Ak" id="E0fxGqls8h" role="iGT6I">
+              <property role="2Ry0Am" value="languages" />
+              <node concept="2Ry0Ak" id="E0fxGqls8i" role="2Ry0An">
+                <property role="2Ry0Am" value="com.mbeddr.demo.comparator.diff" />
+                <node concept="2Ry0Ak" id="E0fxGqls8j" role="2Ry0An">
+                  <property role="2Ry0Am" value="models" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3qWCbU" id="E0fxGqls8t" role="3LXTna">
+            <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+          </node>
+        </node>
+      </node>
+      <node concept="1yeLz9" id="E0fxGqls8u" role="1TViLv">
+        <property role="TrG5h" value="com.mbeddr.demo.comparator.diff.generator" />
+        <property role="3LESm3" value="03d01fc4-0150-47ac-8aad-110e89f7ad8a" />
+        <node concept="1BupzO" id="E0fxGqls8G" role="3bR31x">
+          <property role="3ZfqAx" value="generator/templates" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="E0fxGqls8H" role="1HemKq">
+            <node concept="398BVA" id="E0fxGqls8v" role="3LXTmr">
+              <ref role="398BVh" node="E0fxGqls7k" resolve="mbeddr.mpsutil" />
+              <node concept="2Ry0Ak" id="E0fxGqls8w" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="E0fxGqls8x" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mbeddr.demo.comparator.diff" />
+                  <node concept="2Ry0Ak" id="E0fxGqls8y" role="2Ry0An">
+                    <property role="2Ry0Am" value="generator" />
+                    <node concept="2Ry0Ak" id="E0fxGqls8z" role="2Ry0An">
+                      <property role="2Ry0Am" value="templates" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="E0fxGqls8I" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3rtmxn" id="E0fxGqls8J" role="3bR31x">
+        <node concept="3LXTmp" id="E0fxGqls8K" role="3rtmxm">
+          <node concept="398BVA" id="E0fxGqls8L" role="3LXTmr">
+            <ref role="398BVh" node="E0fxGqls7k" resolve="mbeddr.mpsutil" />
+            <node concept="2Ry0Ak" id="E0fxGqls8M" role="iGT6I">
+              <property role="2Ry0Am" value="languages" />
+              <node concept="2Ry0Ak" id="E0fxGqls8N" role="2Ry0An">
+                <property role="2Ry0Am" value="com.mbeddr.demo.comparator.diff" />
+              </node>
+            </node>
+          </node>
+          <node concept="3qWCbU" id="E0fxGqls8P" role="3LXTna">
+            <property role="3qWCbO" value="icons/**, resources/**" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1E1JtD" id="E0fxGqltmf" role="3989C9">
+      <property role="BnDLt" value="true" />
+      <property role="TrG5h" value="com.mbeddr.mpsutil.ccmenu.sandboxlang" />
+      <property role="3LESm3" value="7369078b-42c2-46a1-a2d6-4e4224650944" />
+      <node concept="398BVA" id="E0fxGqltmi" role="3LF7KH">
+        <ref role="398BVh" node="E0fxGqls7k" resolve="mbeddr.mpsutil" />
+        <node concept="2Ry0Ak" id="E0fxGqltmm" role="iGT6I">
+          <property role="2Ry0Am" value="languages" />
+          <node concept="2Ry0Ak" id="E0fxGqltmp" role="2Ry0An">
+            <property role="2Ry0Am" value="com.mbeddr.mpsutil.ccmenu.sandboxlang" />
+            <node concept="2Ry0Ak" id="E0fxGqltms" role="2Ry0An">
+              <property role="2Ry0Am" value="com.mbeddr.mpsutil.ccmenu.sandboxlang.mpl" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1SiIV0" id="E0fxGqltnb" role="3bR37C">
+        <node concept="3bR9La" id="E0fxGqltnc" role="1SiIV1">
+          <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
+        </node>
+      </node>
+      <node concept="1SiIV0" id="E0fxGqltnd" role="3bR37C">
+        <node concept="3bR9La" id="E0fxGqltne" role="1SiIV1">
+          <ref role="3bR37D" to="ffeo:7Kfy9QB6KYb" resolve="jetbrains.mps.baseLanguage" />
+        </node>
+      </node>
+      <node concept="1SiIV0" id="E0fxGqltnf" role="3bR37C">
+        <node concept="3bR9La" id="E0fxGqltng" role="1SiIV1">
+          <ref role="3bR37D" to="al5i:3n7Foehtmt5" resolve="com.mbeddr.mpsutil.ccmenu.runtime" />
+        </node>
+      </node>
+      <node concept="1BupzO" id="E0fxGqltns" role="3bR31x">
+        <property role="3ZfqAx" value="models" />
+        <property role="1Hdu6h" value="true" />
+        <property role="1HemKv" value="true" />
+        <node concept="3LXTmp" id="E0fxGqltnt" role="1HemKq">
+          <node concept="398BVA" id="E0fxGqltnh" role="3LXTmr">
+            <ref role="398BVh" node="E0fxGqls7k" resolve="mbeddr.mpsutil" />
+            <node concept="2Ry0Ak" id="E0fxGqltni" role="iGT6I">
+              <property role="2Ry0Am" value="languages" />
+              <node concept="2Ry0Ak" id="E0fxGqltnj" role="2Ry0An">
+                <property role="2Ry0Am" value="com.mbeddr.mpsutil.ccmenu.sandboxlang" />
+                <node concept="2Ry0Ak" id="E0fxGqltnk" role="2Ry0An">
+                  <property role="2Ry0Am" value="models" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3qWCbU" id="E0fxGqltnu" role="3LXTna">
+            <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+          </node>
+        </node>
+      </node>
+      <node concept="1yeLz9" id="E0fxGqltnv" role="1TViLv">
+        <property role="TrG5h" value="com.mbeddr.mpsutil.ccmenu.sandboxlang#7020116223055682704" />
+        <property role="3LESm3" value="ae79b18e-559b-4aaa-9903-57560e48dcbd" />
+        <node concept="1BupzO" id="E0fxGqltnH" role="3bR31x">
+          <property role="3ZfqAx" value="generator/template" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="E0fxGqltnI" role="1HemKq">
+            <node concept="398BVA" id="E0fxGqltnw" role="3LXTmr">
+              <ref role="398BVh" node="E0fxGqls7k" resolve="mbeddr.mpsutil" />
+              <node concept="2Ry0Ak" id="E0fxGqltnx" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="E0fxGqltny" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mbeddr.mpsutil.ccmenu.sandboxlang" />
+                  <node concept="2Ry0Ak" id="E0fxGqltnz" role="2Ry0An">
+                    <property role="2Ry0Am" value="generator" />
+                    <node concept="2Ry0Ak" id="E0fxGqltn$" role="2Ry0An">
+                      <property role="2Ry0Am" value="template" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="E0fxGqltnJ" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3rtmxn" id="E0fxGqltnK" role="3bR31x">
+        <node concept="3LXTmp" id="E0fxGqltnL" role="3rtmxm">
+          <node concept="398BVA" id="E0fxGqltnM" role="3LXTmr">
+            <ref role="398BVh" node="E0fxGqls7k" resolve="mbeddr.mpsutil" />
+            <node concept="2Ry0Ak" id="E0fxGqltnN" role="iGT6I">
+              <property role="2Ry0Am" value="languages" />
+              <node concept="2Ry0Ak" id="E0fxGqltnO" role="2Ry0An">
+                <property role="2Ry0Am" value="com.mbeddr.mpsutil.ccmenu.sandboxlang" />
+              </node>
+            </node>
+          </node>
+          <node concept="3qWCbU" id="E0fxGqltnQ" role="3LXTna">
+            <property role="3qWCbO" value="icons/**, resources/**" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1E1JtD" id="E0fxGqluGE" role="3989C9">
+      <property role="BnDLt" value="true" />
+      <property role="TrG5h" value="com.mbeddr.mpsutil.datepicker.sandbox" />
+      <property role="3LESm3" value="27e888f7-20c7-4b89-9a66-3c9207e0608b" />
+      <node concept="398BVA" id="E0fxGqluGH" role="3LF7KH">
+        <ref role="398BVh" node="E0fxGqls7k" resolve="mbeddr.mpsutil" />
+        <node concept="2Ry0Ak" id="E0fxGqluGL" role="iGT6I">
+          <property role="2Ry0Am" value="languages" />
+          <node concept="2Ry0Ak" id="E0fxGqluGO" role="2Ry0An">
+            <property role="2Ry0Am" value="com.mbeddr.mpsutil.datepicker.sandbox" />
+            <node concept="2Ry0Ak" id="E0fxGqluGR" role="2Ry0An">
+              <property role="2Ry0Am" value="com.mbeddr.mpsutil.datepicker.sandbox.mpl" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1SiIV0" id="E0fxGqluHN" role="3bR37C">
+        <node concept="3bR9La" id="E0fxGqluHO" role="1SiIV1">
+          <ref role="3bR37D" to="al5i:35WzcHe4_iF" resolve="com.mbeddr.mpsutil.datepicker.runtime" />
+        </node>
+      </node>
+      <node concept="1BupzO" id="E0fxGqluI0" role="3bR31x">
+        <property role="3ZfqAx" value="languageModels" />
+        <property role="1Hdu6h" value="true" />
+        <property role="1HemKv" value="true" />
+        <node concept="3LXTmp" id="E0fxGqluI1" role="1HemKq">
+          <node concept="398BVA" id="E0fxGqluHP" role="3LXTmr">
+            <ref role="398BVh" node="E0fxGqls7k" resolve="mbeddr.mpsutil" />
+            <node concept="2Ry0Ak" id="E0fxGqluHQ" role="iGT6I">
+              <property role="2Ry0Am" value="languages" />
+              <node concept="2Ry0Ak" id="E0fxGqluHR" role="2Ry0An">
+                <property role="2Ry0Am" value="com.mbeddr.mpsutil.datepicker.sandbox" />
+                <node concept="2Ry0Ak" id="E0fxGqluHS" role="2Ry0An">
+                  <property role="2Ry0Am" value="languageModels" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3qWCbU" id="E0fxGqluI2" role="3LXTna">
+            <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+          </node>
+        </node>
+      </node>
+      <node concept="1SiIV0" id="E0fxGqluI3" role="3bR37C">
+        <node concept="1Busua" id="E0fxGqluI4" role="1SiIV1">
+          <ref role="1Busuk" to="ffeo:7Kfy9QB6KXW" resolve="jetbrains.mps.lang.core" />
+        </node>
+      </node>
+      <node concept="1yeLz9" id="E0fxGqluI5" role="1TViLv">
+        <property role="TrG5h" value="com.mbeddr.mpsutil.datepicker.sandbox#2733170341479301653" />
+        <property role="3LESm3" value="1bc7e48c-d288-4fdd-83c3-72668cca4896" />
+        <node concept="1BupzO" id="E0fxGqluIj" role="3bR31x">
+          <property role="3ZfqAx" value="generator/template" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="E0fxGqluIk" role="1HemKq">
+            <node concept="398BVA" id="E0fxGqluI6" role="3LXTmr">
+              <ref role="398BVh" node="E0fxGqls7k" resolve="mbeddr.mpsutil" />
+              <node concept="2Ry0Ak" id="E0fxGqluI7" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="E0fxGqluI8" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mbeddr.mpsutil.datepicker.sandbox" />
+                  <node concept="2Ry0Ak" id="E0fxGqluI9" role="2Ry0An">
+                    <property role="2Ry0Am" value="generator" />
+                    <node concept="2Ry0Ak" id="E0fxGqluIa" role="2Ry0An">
+                      <property role="2Ry0Am" value="template" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="E0fxGqluIl" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3rtmxn" id="E0fxGqluKa" role="3bR31x">
+        <node concept="3LXTmp" id="E0fxGqluKb" role="3rtmxm">
+          <node concept="398BVA" id="E0fxGqluKc" role="3LXTmr">
+            <ref role="398BVh" node="E0fxGqls7k" resolve="mbeddr.mpsutil" />
+            <node concept="2Ry0Ak" id="E0fxGqluKd" role="iGT6I">
+              <property role="2Ry0Am" value="languages" />
+              <node concept="2Ry0Ak" id="E0fxGqluKe" role="2Ry0An">
+                <property role="2Ry0Am" value="com.mbeddr.mpsutil.datepicker.sandbox" />
+              </node>
+            </node>
+          </node>
+          <node concept="3qWCbU" id="E0fxGqluKg" role="3LXTna">
+            <property role="3qWCbO" value="icons/**, resources/**" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1E1JtD" id="E0fxGqluKi" role="3989C9">
+      <property role="BnDLt" value="true" />
+      <property role="TrG5h" value="com.mbeddr.mpsutil.hyperlink.sandbox" />
+      <property role="3LESm3" value="2d90dfd2-4b63-4216-b74d-8e16508c4961" />
+      <node concept="398BVA" id="E0fxGqluKl" role="3LF7KH">
+        <ref role="398BVh" node="E0fxGqls7k" resolve="mbeddr.mpsutil" />
+        <node concept="2Ry0Ak" id="E0fxGqluKp" role="iGT6I">
+          <property role="2Ry0Am" value="languages" />
+          <node concept="2Ry0Ak" id="E0fxGqluKs" role="2Ry0An">
+            <property role="2Ry0Am" value="com.mbeddr.mpsutil.hyperlink.sandbox" />
+            <node concept="2Ry0Ak" id="E0fxGqluKv" role="2Ry0An">
+              <property role="2Ry0Am" value="com.mbeddr.mpsutil.hyperlink.sandbox.mpl" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1SiIV0" id="E0fxGqluLN" role="3bR37C">
+        <node concept="3bR9La" id="E0fxGqluLO" role="1SiIV1">
+          <ref role="3bR37D" to="ffeo:1ia2VB5guYy" resolve="MPS.IDEA" />
+        </node>
+      </node>
+      <node concept="1SiIV0" id="E0fxGqluLP" role="3bR37C">
+        <node concept="3bR9La" id="E0fxGqluLQ" role="1SiIV1">
+          <ref role="3bR37D" to="ffeo:1TaHNgiIbIZ" resolve="MPS.Editor" />
+        </node>
+      </node>
+      <node concept="1SiIV0" id="E0fxGqluLR" role="3bR37C">
+        <node concept="3bR9La" id="E0fxGqluLS" role="1SiIV1">
+          <ref role="3bR37D" to="ffeo:1TaHNgiIbJb" resolve="MPS.Platform" />
+        </node>
+      </node>
+      <node concept="1SiIV0" id="E0fxGqluLT" role="3bR37C">
+        <node concept="3bR9La" id="E0fxGqluLU" role="1SiIV1">
+          <ref role="3bR37D" to="ffeo:1TaHNgiIbIQ" resolve="MPS.Core" />
+        </node>
+      </node>
+      <node concept="1SiIV0" id="E0fxGqluLV" role="3bR37C">
+        <node concept="3bR9La" id="E0fxGqluLW" role="1SiIV1">
+          <ref role="3bR37D" to="al5i:5A_Zlt6CRir" resolve="com.mbeddr.mpsutil.hyperlink" />
+        </node>
+      </node>
+      <node concept="1BupzO" id="E0fxGqluM8" role="3bR31x">
+        <property role="3ZfqAx" value="models" />
+        <property role="1Hdu6h" value="true" />
+        <property role="1HemKv" value="true" />
+        <node concept="3LXTmp" id="E0fxGqluM9" role="1HemKq">
+          <node concept="398BVA" id="E0fxGqluLX" role="3LXTmr">
+            <ref role="398BVh" node="E0fxGqls7k" resolve="mbeddr.mpsutil" />
+            <node concept="2Ry0Ak" id="E0fxGqluLY" role="iGT6I">
+              <property role="2Ry0Am" value="languages" />
+              <node concept="2Ry0Ak" id="E0fxGqluLZ" role="2Ry0An">
+                <property role="2Ry0Am" value="com.mbeddr.mpsutil.hyperlink.sandbox" />
+                <node concept="2Ry0Ak" id="E0fxGqluM0" role="2Ry0An">
+                  <property role="2Ry0Am" value="models" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3qWCbU" id="E0fxGqluMa" role="3LXTna">
+            <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+          </node>
+        </node>
+      </node>
+      <node concept="3rtmxn" id="E0fxGqluNZ" role="3bR31x">
+        <node concept="3LXTmp" id="E0fxGqluO0" role="3rtmxm">
+          <node concept="398BVA" id="E0fxGqluO1" role="3LXTmr">
+            <ref role="398BVh" node="E0fxGqls7k" resolve="mbeddr.mpsutil" />
+            <node concept="2Ry0Ak" id="E0fxGqluO2" role="iGT6I">
+              <property role="2Ry0Am" value="languages" />
+              <node concept="2Ry0Ak" id="E0fxGqluO3" role="2Ry0An">
+                <property role="2Ry0Am" value="com.mbeddr.mpsutil.hyperlink.sandbox" />
+              </node>
+            </node>
+          </node>
+          <node concept="3qWCbU" id="E0fxGqluO5" role="3LXTna">
+            <property role="3qWCbO" value="icons/**, resources/**" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1E1JtD" id="E0fxGqls9C" role="3989C9">
+      <property role="BnDLt" value="true" />
+      <property role="TrG5h" value="com.mbeddr.mpsutil.incrementalcomputation.example" />
+      <property role="3LESm3" value="8ecfd3b5-385b-43fc-ace0-9babcff50bdb" />
+      <node concept="398BVA" id="E0fxGqls9F" role="3LF7KH">
+        <ref role="398BVh" node="E0fxGqls7k" resolve="mbeddr.mpsutil" />
+        <node concept="2Ry0Ak" id="E0fxGqls9J" role="iGT6I">
+          <property role="2Ry0Am" value="languages" />
+          <node concept="2Ry0Ak" id="E0fxGqls9M" role="2Ry0An">
+            <property role="2Ry0Am" value="com.mbeddr.mpsutil.incrementalcomputation.example" />
+            <node concept="2Ry0Ak" id="E0fxGqls9P" role="2Ry0An">
+              <property role="2Ry0Am" value="com.mbeddr.mpsutil.incrementalcomputation.example.mpl" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1SiIV0" id="E0fxGqlsap" role="3bR37C">
+        <node concept="3bR9La" id="E0fxGqlsaq" role="1SiIV1">
+          <ref role="3bR37D" to="ffeo:1H905DlDUSw" resolve="MPS.OpenAPI" />
+        </node>
+      </node>
+      <node concept="1SiIV0" id="E0fxGqlsar" role="3bR37C">
+        <node concept="3bR9La" id="E0fxGqlsas" role="1SiIV1">
+          <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
+        </node>
+      </node>
+      <node concept="1SiIV0" id="E0fxGqlsat" role="3bR37C">
+        <node concept="3bR9La" id="E0fxGqlsau" role="1SiIV1">
+          <ref role="3bR37D" to="al5i:3bCcKqaUIpY" resolve="com.mbeddr.mpsutil.incrementalcomputation.runtime" />
+        </node>
+      </node>
+      <node concept="1BupzO" id="E0fxGqlsaE" role="3bR31x">
+        <property role="3ZfqAx" value="models" />
+        <property role="1Hdu6h" value="true" />
+        <property role="1HemKv" value="true" />
+        <node concept="3LXTmp" id="E0fxGqlsaF" role="1HemKq">
+          <node concept="398BVA" id="E0fxGqlsav" role="3LXTmr">
+            <ref role="398BVh" node="E0fxGqls7k" resolve="mbeddr.mpsutil" />
+            <node concept="2Ry0Ak" id="E0fxGqlsaw" role="iGT6I">
+              <property role="2Ry0Am" value="languages" />
+              <node concept="2Ry0Ak" id="E0fxGqlsax" role="2Ry0An">
+                <property role="2Ry0Am" value="com.mbeddr.mpsutil.incrementalcomputation.example" />
+                <node concept="2Ry0Ak" id="E0fxGqlsay" role="2Ry0An">
+                  <property role="2Ry0Am" value="models" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3qWCbU" id="E0fxGqlsaG" role="3LXTna">
+            <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+          </node>
+        </node>
+      </node>
+      <node concept="1SiIV0" id="E0fxGqlsaH" role="3bR37C">
+        <node concept="1Busua" id="E0fxGqlsaI" role="1SiIV1">
+          <ref role="1Busuk" to="al5i:3bCcKqaUnoh" resolve="com.mbeddr.mpsutil.incrementalcomputation" />
+        </node>
+      </node>
+      <node concept="3rtmxn" id="E0fxGqlsaJ" role="3bR31x">
+        <node concept="3LXTmp" id="E0fxGqlsaK" role="3rtmxm">
+          <node concept="398BVA" id="E0fxGqlsaL" role="3LXTmr">
+            <ref role="398BVh" node="E0fxGqls7k" resolve="mbeddr.mpsutil" />
+            <node concept="2Ry0Ak" id="E0fxGqlsaM" role="iGT6I">
+              <property role="2Ry0Am" value="languages" />
+              <node concept="2Ry0Ak" id="E0fxGqlsaN" role="2Ry0An">
+                <property role="2Ry0Am" value="com.mbeddr.mpsutil.incrementalcomputation.example" />
+              </node>
+            </node>
+          </node>
+          <node concept="3qWCbU" id="E0fxGqlsaP" role="3LXTna">
+            <property role="3qWCbO" value="icons/**, resources/**" />
+          </node>
+        </node>
+      </node>
+      <node concept="1SiIV0" id="E0fxGqlsbp" role="3bR37C">
+        <node concept="3bR9La" id="E0fxGqlsbq" role="1SiIV1">
+          <ref role="3bR37D" node="E0fxGqls9C" resolve="com.mbeddr.mpsutil.incrementalcomputation.example" />
+        </node>
+      </node>
+    </node>
+    <node concept="1E1JtD" id="E0fxGqltnS" role="3989C9">
+      <property role="BnDLt" value="true" />
+      <property role="TrG5h" value="com.mbeddr.mpsutil.jfreechart.sandboxlang" />
+      <property role="3LESm3" value="032e4d4e-a71c-4d57-826e-d354d35582f1" />
+      <node concept="398BVA" id="E0fxGqltnV" role="3LF7KH">
+        <ref role="398BVh" node="E0fxGqls7k" resolve="mbeddr.mpsutil" />
+        <node concept="2Ry0Ak" id="E0fxGqltnZ" role="iGT6I">
+          <property role="2Ry0Am" value="languages" />
+          <node concept="2Ry0Ak" id="E0fxGqlto2" role="2Ry0An">
+            <property role="2Ry0Am" value="com.mbeddr.mpsutil.jfreechart.sandboxlang" />
+            <node concept="2Ry0Ak" id="E0fxGqlto5" role="2Ry0An">
+              <property role="2Ry0Am" value="com.mbeddr.mpsutil.jfreechart.sandboxlang.mpl" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1SiIV0" id="E0fxGqltpc" role="3bR37C">
+        <node concept="3bR9La" id="E0fxGqltpd" role="1SiIV1">
+          <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
+        </node>
+      </node>
+      <node concept="1SiIV0" id="E0fxGqltpe" role="3bR37C">
+        <node concept="3bR9La" id="E0fxGqltpf" role="1SiIV1">
+          <ref role="3bR37D" to="ffeo:7Kfy9QB6KYb" resolve="jetbrains.mps.baseLanguage" />
+        </node>
+      </node>
+      <node concept="1SiIV0" id="E0fxGqltpg" role="3bR37C">
+        <node concept="3bR9La" id="E0fxGqltph" role="1SiIV1">
+          <ref role="3bR37D" to="ffeo:1TaHNgiIbIZ" resolve="MPS.Editor" />
+        </node>
+      </node>
+      <node concept="1SiIV0" id="E0fxGqltpi" role="3bR37C">
+        <node concept="3bR9La" id="E0fxGqltpj" role="1SiIV1">
+          <ref role="3bR37D" to="al5i:7uOgiTahf8" resolve="com.mbeddr.mpsutil.jfreechart.runtime" />
+        </node>
+      </node>
+      <node concept="1BupzO" id="E0fxGqltpv" role="3bR31x">
+        <property role="3ZfqAx" value="models" />
+        <property role="1Hdu6h" value="true" />
+        <property role="1HemKv" value="true" />
+        <node concept="3LXTmp" id="E0fxGqltpw" role="1HemKq">
+          <node concept="398BVA" id="E0fxGqltpk" role="3LXTmr">
+            <ref role="398BVh" node="E0fxGqls7k" resolve="mbeddr.mpsutil" />
+            <node concept="2Ry0Ak" id="E0fxGqltpl" role="iGT6I">
+              <property role="2Ry0Am" value="languages" />
+              <node concept="2Ry0Ak" id="E0fxGqltpm" role="2Ry0An">
+                <property role="2Ry0Am" value="com.mbeddr.mpsutil.jfreechart.sandboxlang" />
+                <node concept="2Ry0Ak" id="E0fxGqltpn" role="2Ry0An">
+                  <property role="2Ry0Am" value="models" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3qWCbU" id="E0fxGqltpx" role="3LXTna">
+            <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+          </node>
+        </node>
+      </node>
+      <node concept="3rtmxn" id="E0fxGqltpy" role="3bR31x">
+        <node concept="3LXTmp" id="E0fxGqltpz" role="3rtmxm">
+          <node concept="398BVA" id="E0fxGqltp$" role="3LXTmr">
+            <ref role="398BVh" node="E0fxGqls7k" resolve="mbeddr.mpsutil" />
+            <node concept="2Ry0Ak" id="E0fxGqltp_" role="iGT6I">
+              <property role="2Ry0Am" value="languages" />
+              <node concept="2Ry0Ak" id="E0fxGqltpA" role="2Ry0An">
+                <property role="2Ry0Am" value="com.mbeddr.mpsutil.jfreechart.sandboxlang" />
+              </node>
+            </node>
+          </node>
+          <node concept="3qWCbU" id="E0fxGqltpC" role="3LXTna">
+            <property role="3qWCbO" value="icons/**, resources/**" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1E1JtD" id="E0fxGqluDq" role="3989C9">
+      <property role="BnDLt" value="true" />
+      <property role="TrG5h" value="com.mbeddr.mpsutil.logicalChild.sandbox" />
+      <property role="3LESm3" value="286e2375-00e3-4042-b083-84873dd623be" />
+      <node concept="398BVA" id="E0fxGqluDt" role="3LF7KH">
+        <ref role="398BVh" node="E0fxGqls7k" resolve="mbeddr.mpsutil" />
+        <node concept="2Ry0Ak" id="E0fxGqluDx" role="iGT6I">
+          <property role="2Ry0Am" value="languages" />
+          <node concept="2Ry0Ak" id="E0fxGqluD$" role="2Ry0An">
+            <property role="2Ry0Am" value="com.mbeddr.mpsutil.logicalChild.sandbox" />
+            <node concept="2Ry0Ak" id="E0fxGqluDB" role="2Ry0An">
+              <property role="2Ry0Am" value="com.mbeddr.mpsutil.logicalChild.sandbox.mpl" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1SiIV0" id="E0fxGqluET" role="3bR37C">
+        <node concept="3bR9La" id="E0fxGqluEU" role="1SiIV1">
+          <ref role="3bR37D" to="ffeo:1ia2VB5guYy" resolve="MPS.IDEA" />
+        </node>
+      </node>
+      <node concept="1SiIV0" id="E0fxGqluEV" role="3bR37C">
+        <node concept="3bR9La" id="E0fxGqluEW" role="1SiIV1">
+          <ref role="3bR37D" to="ffeo:7Kfy9QB6KYb" resolve="jetbrains.mps.baseLanguage" />
+        </node>
+      </node>
+      <node concept="1SiIV0" id="E0fxGqluEX" role="3bR37C">
+        <node concept="3bR9La" id="E0fxGqluEY" role="1SiIV1">
+          <ref role="3bR37D" to="ffeo:1TaHNgiIbIZ" resolve="MPS.Editor" />
+        </node>
+      </node>
+      <node concept="1BupzO" id="E0fxGqluFa" role="3bR31x">
+        <property role="3ZfqAx" value="models" />
+        <property role="1Hdu6h" value="true" />
+        <property role="1HemKv" value="true" />
+        <node concept="3LXTmp" id="E0fxGqluFb" role="1HemKq">
+          <node concept="398BVA" id="E0fxGqluEZ" role="3LXTmr">
+            <ref role="398BVh" node="E0fxGqls7k" resolve="mbeddr.mpsutil" />
+            <node concept="2Ry0Ak" id="E0fxGqluF0" role="iGT6I">
+              <property role="2Ry0Am" value="languages" />
+              <node concept="2Ry0Ak" id="E0fxGqluF1" role="2Ry0An">
+                <property role="2Ry0Am" value="com.mbeddr.mpsutil.logicalChild.sandbox" />
+                <node concept="2Ry0Ak" id="E0fxGqluF2" role="2Ry0An">
+                  <property role="2Ry0Am" value="models" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3qWCbU" id="E0fxGqluFc" role="3LXTna">
+            <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+          </node>
+        </node>
+      </node>
+      <node concept="1SiIV0" id="E0fxGqluFd" role="3bR37C">
+        <node concept="1Busua" id="E0fxGqluFe" role="1SiIV1">
+          <ref role="1Busuk" to="al5i:3lcj7hzsmpl" resolve="com.mbeddr.mpsutil.logicalChild" />
+        </node>
+      </node>
+      <node concept="3rtmxn" id="E0fxGqluGy" role="3bR31x">
+        <node concept="3LXTmp" id="E0fxGqluGz" role="3rtmxm">
+          <node concept="398BVA" id="E0fxGqluG$" role="3LXTmr">
+            <ref role="398BVh" node="E0fxGqls7k" resolve="mbeddr.mpsutil" />
+            <node concept="2Ry0Ak" id="E0fxGqluG_" role="iGT6I">
+              <property role="2Ry0Am" value="languages" />
+              <node concept="2Ry0Ak" id="E0fxGqluGA" role="2Ry0An">
+                <property role="2Ry0Am" value="com.mbeddr.mpsutil.logicalChild.sandbox" />
+              </node>
+            </node>
+          </node>
+          <node concept="3qWCbU" id="E0fxGqluGC" role="3LXTna">
+            <property role="3qWCbO" value="icons/**, resources/**" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1E1JtD" id="E0fxGqltpE" role="3989C9">
+      <property role="BnDLt" value="true" />
+      <property role="TrG5h" value="com.mbeddr.mpsutil.ecoretransformation.amaltheametamodel" />
+      <property role="3LESm3" value="ad8b5993-1cc2-49c0-b7a0-0283da231703" />
+      <node concept="398BVA" id="E0fxGqltpH" role="3LF7KH">
+        <ref role="398BVh" node="E0fxGqls7k" resolve="mbeddr.mpsutil" />
+        <node concept="2Ry0Ak" id="E0fxGqltpL" role="iGT6I">
+          <property role="2Ry0Am" value="languages" />
+          <node concept="2Ry0Ak" id="E0fxGqltpO" role="2Ry0An">
+            <property role="2Ry0Am" value="com.mbeddr.mpsutil.ecoretransformation.amaltheametamodel" />
+            <node concept="2Ry0Ak" id="E0fxGqltpR" role="2Ry0An">
+              <property role="2Ry0Am" value="com.mbeddr.mpsutil.ecoretransformation.amaltheametamodel.mpl" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1SiIV0" id="E0fxGqltr9" role="3bR37C">
+        <node concept="3bR9La" id="E0fxGqltra" role="1SiIV1">
+          <ref role="3bR37D" to="al5i:vOGyTeKHIn" resolve="com.mbeddr.mpsutil.ecore" />
+        </node>
+      </node>
+      <node concept="1BupzO" id="E0fxGqltrm" role="3bR31x">
+        <property role="3ZfqAx" value="models" />
+        <property role="1Hdu6h" value="true" />
+        <property role="1HemKv" value="true" />
+        <node concept="3LXTmp" id="E0fxGqltrn" role="1HemKq">
+          <node concept="398BVA" id="E0fxGqltrb" role="3LXTmr">
+            <ref role="398BVh" node="E0fxGqls7k" resolve="mbeddr.mpsutil" />
+            <node concept="2Ry0Ak" id="E0fxGqltrc" role="iGT6I">
+              <property role="2Ry0Am" value="languages" />
+              <node concept="2Ry0Ak" id="E0fxGqltrd" role="2Ry0An">
+                <property role="2Ry0Am" value="com.mbeddr.mpsutil.ecoretransformation.amaltheametamodel" />
+                <node concept="2Ry0Ak" id="E0fxGqltre" role="2Ry0An">
+                  <property role="2Ry0Am" value="models" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3qWCbU" id="E0fxGqltro" role="3LXTna">
+            <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+          </node>
+        </node>
+      </node>
+      <node concept="3rtmxn" id="E0fxGqltrp" role="3bR31x">
+        <node concept="3LXTmp" id="E0fxGqltrq" role="3rtmxm">
+          <node concept="398BVA" id="E0fxGqltrr" role="3LXTmr">
+            <ref role="398BVh" node="E0fxGqls7k" resolve="mbeddr.mpsutil" />
+            <node concept="2Ry0Ak" id="E0fxGqltrs" role="iGT6I">
+              <property role="2Ry0Am" value="languages" />
+              <node concept="2Ry0Ak" id="E0fxGqltrt" role="2Ry0An">
+                <property role="2Ry0Am" value="com.mbeddr.mpsutil.ecoretransformation.amaltheametamodel" />
+              </node>
+            </node>
+          </node>
+          <node concept="3qWCbU" id="E0fxGqltrv" role="3LXTna">
+            <property role="3qWCbO" value="icons/**, resources/**" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1E1JtD" id="E0fxGqluO7" role="3989C9">
+      <property role="BnDLt" value="true" />
+      <property role="TrG5h" value="com.mbeddr.mpsutil.userstyles.sandboxlang" />
+      <property role="3LESm3" value="33745ab7-37dd-4c72-914d-eee6d52b9b33" />
+      <node concept="398BVA" id="E0fxGqluOa" role="3LF7KH">
+        <ref role="398BVh" node="E0fxGqls7k" resolve="mbeddr.mpsutil" />
+        <node concept="2Ry0Ak" id="E0fxGqluOe" role="iGT6I">
+          <property role="2Ry0Am" value="languages" />
+          <node concept="2Ry0Ak" id="E0fxGqluOh" role="2Ry0An">
+            <property role="2Ry0Am" value="com.mbeddr.mpsutil.userstyles.sandboxlang" />
+            <node concept="2Ry0Ak" id="E0fxGqluOk" role="2Ry0An">
+              <property role="2Ry0Am" value="com.mbeddr.mpsutil.userstyles.sandboxlang.mpl" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1BupzO" id="E0fxGqluQE" role="3bR31x">
+        <property role="3ZfqAx" value="models" />
+        <property role="1Hdu6h" value="true" />
+        <property role="1HemKv" value="true" />
+        <node concept="3LXTmp" id="E0fxGqluQF" role="1HemKq">
+          <node concept="398BVA" id="E0fxGqluQv" role="3LXTmr">
+            <ref role="398BVh" node="E0fxGqls7k" resolve="mbeddr.mpsutil" />
+            <node concept="2Ry0Ak" id="E0fxGqluQw" role="iGT6I">
+              <property role="2Ry0Am" value="languages" />
+              <node concept="2Ry0Ak" id="E0fxGqluQx" role="2Ry0An">
+                <property role="2Ry0Am" value="com.mbeddr.mpsutil.userstyles.sandboxlang" />
+                <node concept="2Ry0Ak" id="E0fxGqluQy" role="2Ry0An">
+                  <property role="2Ry0Am" value="models" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3qWCbU" id="E0fxGqluQG" role="3LXTna">
+            <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+          </node>
+        </node>
+      </node>
+      <node concept="1yeLz9" id="E0fxGqluQH" role="1TViLv">
+        <property role="TrG5h" value="com.mbeddr.mpsutil.userstyles.sandboxlang#8170319964140879799" />
+        <property role="3LESm3" value="a06cadbc-43ed-4f6a-8a1b-5df13e51844b" />
+        <node concept="1BupzO" id="E0fxGqluQV" role="3bR31x">
+          <property role="3ZfqAx" value="generator/template" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="E0fxGqluQW" role="1HemKq">
+            <node concept="398BVA" id="E0fxGqluQI" role="3LXTmr">
+              <ref role="398BVh" node="E0fxGqls7k" resolve="mbeddr.mpsutil" />
+              <node concept="2Ry0Ak" id="E0fxGqluQJ" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="E0fxGqluQK" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mbeddr.mpsutil.userstyles.sandboxlang" />
+                  <node concept="2Ry0Ak" id="E0fxGqluQL" role="2Ry0An">
+                    <property role="2Ry0Am" value="generator" />
+                    <node concept="2Ry0Ak" id="E0fxGqluQM" role="2Ry0An">
+                      <property role="2Ry0Am" value="template" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="E0fxGqluQX" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3rtmxn" id="E0fxGqluS6" role="3bR31x">
+        <node concept="3LXTmp" id="E0fxGqluS7" role="3rtmxm">
+          <node concept="398BVA" id="E0fxGqluS8" role="3LXTmr">
+            <ref role="398BVh" node="E0fxGqls7k" resolve="mbeddr.mpsutil" />
+            <node concept="2Ry0Ak" id="E0fxGqluS9" role="iGT6I">
+              <property role="2Ry0Am" value="languages" />
+              <node concept="2Ry0Ak" id="E0fxGqluSa" role="2Ry0An">
+                <property role="2Ry0Am" value="com.mbeddr.mpsutil.userstyles.sandboxlang" />
+              </node>
+            </node>
+          </node>
+          <node concept="3qWCbU" id="E0fxGqluSc" role="3LXTna">
+            <property role="3qWCbO" value="icons/**, resources/**" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1E1JtD" id="E0fxGqltrx" role="3989C9">
+      <property role="BnDLt" value="true" />
+      <property role="TrG5h" value="test.com.mbeddr.mpsutil.ecoretransformation.modelImportExport.testLanguage1" />
+      <property role="3LESm3" value="98309aa4-0aee-4c83-b79a-2ab22ee75043" />
+      <node concept="398BVA" id="E0fxGqltr$" role="3LF7KH">
+        <ref role="398BVh" node="E0fxGqls7k" resolve="mbeddr.mpsutil" />
+        <node concept="2Ry0Ak" id="E0fxGqltrC" role="iGT6I">
+          <property role="2Ry0Am" value="languages" />
+          <node concept="2Ry0Ak" id="E0fxGqltrF" role="2Ry0An">
+            <property role="2Ry0Am" value="test.com.mbeddr.mpsutil.ecoretransformation.modelImportExport.testLanguage1" />
+            <node concept="2Ry0Ak" id="E0fxGqltrI" role="2Ry0An">
+              <property role="2Ry0Am" value="test.com.mbeddr.mpsutil.ecoretransformation.modelImportExport.testLanguage1.mpl" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1BupzO" id="E0fxGqlttm" role="3bR31x">
+        <property role="3ZfqAx" value="models" />
+        <property role="1Hdu6h" value="true" />
+        <property role="1HemKv" value="true" />
+        <node concept="3LXTmp" id="E0fxGqlttn" role="1HemKq">
+          <node concept="398BVA" id="E0fxGqlttb" role="3LXTmr">
+            <ref role="398BVh" node="E0fxGqls7k" resolve="mbeddr.mpsutil" />
+            <node concept="2Ry0Ak" id="E0fxGqlttc" role="iGT6I">
+              <property role="2Ry0Am" value="languages" />
+              <node concept="2Ry0Ak" id="E0fxGqlttd" role="2Ry0An">
+                <property role="2Ry0Am" value="test.com.mbeddr.mpsutil.ecoretransformation.modelImportExport.testLanguage1" />
+                <node concept="2Ry0Ak" id="E0fxGqltte" role="2Ry0An">
+                  <property role="2Ry0Am" value="models" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3qWCbU" id="E0fxGqltto" role="3LXTna">
+            <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+          </node>
+        </node>
+      </node>
+      <node concept="3rtmxn" id="E0fxGqlttE" role="3bR31x">
+        <node concept="3LXTmp" id="E0fxGqlttF" role="3rtmxm">
+          <node concept="398BVA" id="E0fxGqlttG" role="3LXTmr">
+            <ref role="398BVh" node="E0fxGqls7k" resolve="mbeddr.mpsutil" />
+            <node concept="2Ry0Ak" id="E0fxGqlttH" role="iGT6I">
+              <property role="2Ry0Am" value="languages" />
+              <node concept="2Ry0Ak" id="E0fxGqlttI" role="2Ry0An">
+                <property role="2Ry0Am" value="test.com.mbeddr.mpsutil.ecoretransformation.modelImportExport.testLanguage1" />
+              </node>
+            </node>
+          </node>
+          <node concept="3qWCbU" id="E0fxGqlttK" role="3LXTna">
+            <property role="3qWCbO" value="icons/**, resources/**" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1E1JtD" id="E0fxGqlttM" role="3989C9">
+      <property role="BnDLt" value="true" />
+      <property role="TrG5h" value="test.com.mbeddr.mpsutil.ecoretransformation.modelImportExport.testLanguage2" />
+      <property role="3LESm3" value="8cff051b-53c3-4e5f-bf0a-6688f069e505" />
+      <node concept="398BVA" id="E0fxGqlttP" role="3LF7KH">
+        <ref role="398BVh" node="E0fxGqls7k" resolve="mbeddr.mpsutil" />
+        <node concept="2Ry0Ak" id="E0fxGqlttT" role="iGT6I">
+          <property role="2Ry0Am" value="languages" />
+          <node concept="2Ry0Ak" id="E0fxGqlttW" role="2Ry0An">
+            <property role="2Ry0Am" value="test.com.mbeddr.mpsutil.ecoretransformation.modelImportExport.testLanguage2" />
+            <node concept="2Ry0Ak" id="E0fxGqlttZ" role="2Ry0An">
+              <property role="2Ry0Am" value="test.com.mbeddr.mpsutil.ecoretransformation.modelImportExport.testLanguage2.mpl" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1BupzO" id="E0fxGqltvZ" role="3bR31x">
+        <property role="3ZfqAx" value="models" />
+        <property role="1Hdu6h" value="true" />
+        <property role="1HemKv" value="true" />
+        <node concept="3LXTmp" id="E0fxGqltw0" role="1HemKq">
+          <node concept="398BVA" id="E0fxGqltvO" role="3LXTmr">
+            <ref role="398BVh" node="E0fxGqls7k" resolve="mbeddr.mpsutil" />
+            <node concept="2Ry0Ak" id="E0fxGqltvP" role="iGT6I">
+              <property role="2Ry0Am" value="languages" />
+              <node concept="2Ry0Ak" id="E0fxGqltvQ" role="2Ry0An">
+                <property role="2Ry0Am" value="test.com.mbeddr.mpsutil.ecoretransformation.modelImportExport.testLanguage2" />
+                <node concept="2Ry0Ak" id="E0fxGqltvR" role="2Ry0An">
+                  <property role="2Ry0Am" value="models" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3qWCbU" id="E0fxGqltw1" role="3LXTna">
+            <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+          </node>
+        </node>
+      </node>
+      <node concept="3rtmxn" id="E0fxGqltwj" role="3bR31x">
+        <node concept="3LXTmp" id="E0fxGqltwk" role="3rtmxm">
+          <node concept="398BVA" id="E0fxGqltwl" role="3LXTmr">
+            <ref role="398BVh" node="E0fxGqls7k" resolve="mbeddr.mpsutil" />
+            <node concept="2Ry0Ak" id="E0fxGqltwm" role="iGT6I">
+              <property role="2Ry0Am" value="languages" />
+              <node concept="2Ry0Ak" id="E0fxGqltwn" role="2Ry0An">
+                <property role="2Ry0Am" value="test.com.mbeddr.mpsutil.ecoretransformation.modelImportExport.testLanguage2" />
+              </node>
+            </node>
+          </node>
+          <node concept="3qWCbU" id="E0fxGqltwp" role="3LXTna">
+            <property role="3qWCbO" value="icons/**, resources/**" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1E1JtD" id="E0fxGqluSe" role="3989C9">
+      <property role="BnDLt" value="true" />
+      <property role="TrG5h" value="test.com.mbeddr.mpsutil.ecoretransformation.modelImportExport.testLanguage3" />
+      <property role="3LESm3" value="028d5289-4615-4ec1-9058-1fdf1373966c" />
+      <node concept="398BVA" id="E0fxGqluSq" role="3LF7KH">
+        <ref role="398BVh" node="E0fxGqls7k" resolve="mbeddr.mpsutil" />
+        <node concept="2Ry0Ak" id="E0fxGqluSr" role="iGT6I">
+          <property role="2Ry0Am" value="languages" />
+          <node concept="2Ry0Ak" id="E0fxGqluSs" role="2Ry0An">
+            <property role="2Ry0Am" value="test.com.mbeddr.mpsutil.ecoretransformation.modelImportExport.testLanguage3" />
+            <node concept="2Ry0Ak" id="E0fxGqluSA" role="2Ry0An">
+              <property role="2Ry0Am" value="test.com.mbeddr.mpsutil.ecoretransformation.modelImportExport.testLanguage3.mpl" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1BupzO" id="E0fxGqluW6" role="3bR31x">
+        <property role="3ZfqAx" value="models" />
+        <property role="1Hdu6h" value="true" />
+        <property role="1HemKv" value="true" />
+        <node concept="3LXTmp" id="E0fxGqluW7" role="1HemKq">
+          <node concept="398BVA" id="E0fxGqluVV" role="3LXTmr">
+            <ref role="398BVh" node="E0fxGqls7k" resolve="mbeddr.mpsutil" />
+            <node concept="2Ry0Ak" id="E0fxGqluVW" role="iGT6I">
+              <property role="2Ry0Am" value="languages" />
+              <node concept="2Ry0Ak" id="E0fxGqluVX" role="2Ry0An">
+                <property role="2Ry0Am" value="test.com.mbeddr.mpsutil.ecoretransformation.modelImportExport.testLanguage3" />
+                <node concept="2Ry0Ak" id="E0fxGqluVY" role="2Ry0An">
+                  <property role="2Ry0Am" value="models" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3qWCbU" id="E0fxGqluW8" role="3LXTna">
+            <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+          </node>
+        </node>
+      </node>
+      <node concept="3rtmxn" id="E0fxGqluXK" role="3bR31x">
+        <node concept="3LXTmp" id="E0fxGqluXL" role="3rtmxm">
+          <node concept="398BVA" id="E0fxGqluXM" role="3LXTmr">
+            <ref role="398BVh" node="E0fxGqls7k" resolve="mbeddr.mpsutil" />
+            <node concept="2Ry0Ak" id="E0fxGqluXN" role="iGT6I">
+              <property role="2Ry0Am" value="languages" />
+              <node concept="2Ry0Ak" id="E0fxGqluXO" role="2Ry0An">
+                <property role="2Ry0Am" value="test.com.mbeddr.mpsutil.ecoretransformation.modelImportExport.testLanguage3" />
+              </node>
+            </node>
+          </node>
+          <node concept="3qWCbU" id="E0fxGqluXQ" role="3LXTna">
+            <property role="3qWCbO" value="icons/**, resources/**" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1E1JtD" id="E0fxGqluSj" role="3989C9">
+      <property role="BnDLt" value="true" />
+      <property role="TrG5h" value="test.com.mbeddr.mpsutil.ecoretransformation.modelImportExport.testLanguage4" />
+      <property role="3LESm3" value="42b42fb4-1209-425a-8ff3-87a670a3a5b5" />
+      <node concept="398BVA" id="E0fxGqluSu" role="3LF7KH">
+        <ref role="398BVh" node="E0fxGqls7k" resolve="mbeddr.mpsutil" />
+        <node concept="2Ry0Ak" id="E0fxGqluSv" role="iGT6I">
+          <property role="2Ry0Am" value="languages" />
+          <node concept="2Ry0Ak" id="E0fxGqluSw" role="2Ry0An">
+            <property role="2Ry0Am" value="test.com.mbeddr.mpsutil.ecoretransformation.modelImportExport.testLanguage4" />
+            <node concept="2Ry0Ak" id="E0fxGqluSB" role="2Ry0An">
+              <property role="2Ry0Am" value="test.com.mbeddr.mpsutil.ecoretransformation.modelImportExport.testLanguage4.mpl" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1BupzO" id="E0fxGqluW_" role="3bR31x">
+        <property role="3ZfqAx" value="models" />
+        <property role="1Hdu6h" value="true" />
+        <property role="1HemKv" value="true" />
+        <node concept="3LXTmp" id="E0fxGqluWA" role="1HemKq">
+          <node concept="398BVA" id="E0fxGqluWq" role="3LXTmr">
+            <ref role="398BVh" node="E0fxGqls7k" resolve="mbeddr.mpsutil" />
+            <node concept="2Ry0Ak" id="E0fxGqluWr" role="iGT6I">
+              <property role="2Ry0Am" value="languages" />
+              <node concept="2Ry0Ak" id="E0fxGqluWs" role="2Ry0An">
+                <property role="2Ry0Am" value="test.com.mbeddr.mpsutil.ecoretransformation.modelImportExport.testLanguage4" />
+                <node concept="2Ry0Ak" id="E0fxGqluWt" role="2Ry0An">
+                  <property role="2Ry0Am" value="models" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3qWCbU" id="E0fxGqluWB" role="3LXTna">
+            <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+          </node>
+        </node>
+      </node>
+      <node concept="3rtmxn" id="E0fxGqluXR" role="3bR31x">
+        <node concept="3LXTmp" id="E0fxGqluXS" role="3rtmxm">
+          <node concept="398BVA" id="E0fxGqluXT" role="3LXTmr">
+            <ref role="398BVh" node="E0fxGqls7k" resolve="mbeddr.mpsutil" />
+            <node concept="2Ry0Ak" id="E0fxGqluXU" role="iGT6I">
+              <property role="2Ry0Am" value="languages" />
+              <node concept="2Ry0Ak" id="E0fxGqluXV" role="2Ry0An">
+                <property role="2Ry0Am" value="test.com.mbeddr.mpsutil.ecoretransformation.modelImportExport.testLanguage4" />
+              </node>
+            </node>
+          </node>
+          <node concept="3qWCbU" id="E0fxGqluXX" role="3LXTna">
+            <property role="3qWCbO" value="icons/**, resources/**" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1E1JtD" id="E0fxGqluSn" role="3989C9">
+      <property role="BnDLt" value="true" />
+      <property role="TrG5h" value="test.com.mbeddr.mpsutil.ecoretransformation.modelImportExport.testLanguage5" />
+      <property role="3LESm3" value="b883f758-9a65-4140-ac15-f5b95052c219" />
+      <node concept="398BVA" id="E0fxGqluSy" role="3LF7KH">
+        <ref role="398BVh" node="E0fxGqls7k" resolve="mbeddr.mpsutil" />
+        <node concept="2Ry0Ak" id="E0fxGqluSz" role="iGT6I">
+          <property role="2Ry0Am" value="languages" />
+          <node concept="2Ry0Ak" id="E0fxGqluS$" role="2Ry0An">
+            <property role="2Ry0Am" value="test.com.mbeddr.mpsutil.ecoretransformation.modelImportExport.testLanguage5" />
+            <node concept="2Ry0Ak" id="E0fxGqluSC" role="2Ry0An">
+              <property role="2Ry0Am" value="test.com.mbeddr.mpsutil.ecoretransformation.modelImportExport.testLanguage5.mpl" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1BupzO" id="E0fxGqluX4" role="3bR31x">
+        <property role="3ZfqAx" value="models" />
+        <property role="1Hdu6h" value="true" />
+        <property role="1HemKv" value="true" />
+        <node concept="3LXTmp" id="E0fxGqluX5" role="1HemKq">
+          <node concept="398BVA" id="E0fxGqluWT" role="3LXTmr">
+            <ref role="398BVh" node="E0fxGqls7k" resolve="mbeddr.mpsutil" />
+            <node concept="2Ry0Ak" id="E0fxGqluWU" role="iGT6I">
+              <property role="2Ry0Am" value="languages" />
+              <node concept="2Ry0Ak" id="E0fxGqluWV" role="2Ry0An">
+                <property role="2Ry0Am" value="test.com.mbeddr.mpsutil.ecoretransformation.modelImportExport.testLanguage5" />
+                <node concept="2Ry0Ak" id="E0fxGqluWW" role="2Ry0An">
+                  <property role="2Ry0Am" value="models" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3qWCbU" id="E0fxGqluX6" role="3LXTna">
+            <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+          </node>
+        </node>
+      </node>
+      <node concept="3rtmxn" id="E0fxGqluXY" role="3bR31x">
+        <node concept="3LXTmp" id="E0fxGqluXZ" role="3rtmxm">
+          <node concept="398BVA" id="E0fxGqluY0" role="3LXTmr">
+            <ref role="398BVh" node="E0fxGqls7k" resolve="mbeddr.mpsutil" />
+            <node concept="2Ry0Ak" id="E0fxGqluY1" role="iGT6I">
+              <property role="2Ry0Am" value="languages" />
+              <node concept="2Ry0Ak" id="E0fxGqluY2" role="2Ry0An">
+                <property role="2Ry0Am" value="test.com.mbeddr.mpsutil.ecoretransformation.modelImportExport.testLanguage5" />
+              </node>
+            </node>
+          </node>
+          <node concept="3qWCbU" id="E0fxGqluY4" role="3LXTna">
+            <property role="3qWCbO" value="icons/**, resources/**" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1E1JtD" id="E0fxGqltwr" role="3989C9">
+      <property role="BnDLt" value="true" />
+      <property role="TrG5h" value="test.com.mbeddr.mpsutil.ecoretransformation.modelImportExport.testLanguage6" />
+      <property role="3LESm3" value="36dc6740-50ca-47a8-b44f-4cf0c584b822" />
+      <node concept="398BVA" id="E0fxGqltwu" role="3LF7KH">
+        <ref role="398BVh" node="E0fxGqls7k" resolve="mbeddr.mpsutil" />
+        <node concept="2Ry0Ak" id="E0fxGqltwy" role="iGT6I">
+          <property role="2Ry0Am" value="languages" />
+          <node concept="2Ry0Ak" id="E0fxGqltw_" role="2Ry0An">
+            <property role="2Ry0Am" value="test.com.mbeddr.mpsutil.ecoretransformation.modelImportExport.testLanguage6" />
+            <node concept="2Ry0Ak" id="E0fxGqltwC" role="2Ry0An">
+              <property role="2Ry0Am" value="test.com.mbeddr.mpsutil.ecoretransformation.modelImportExport.testLanguage6.mpl" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1BupzO" id="E0fxGqltz0" role="3bR31x">
+        <property role="3ZfqAx" value="models" />
+        <property role="1Hdu6h" value="true" />
+        <property role="1HemKv" value="true" />
+        <node concept="3LXTmp" id="E0fxGqltz1" role="1HemKq">
+          <node concept="398BVA" id="E0fxGqltyP" role="3LXTmr">
+            <ref role="398BVh" node="E0fxGqls7k" resolve="mbeddr.mpsutil" />
+            <node concept="2Ry0Ak" id="E0fxGqltyQ" role="iGT6I">
+              <property role="2Ry0Am" value="languages" />
+              <node concept="2Ry0Ak" id="E0fxGqltyR" role="2Ry0An">
+                <property role="2Ry0Am" value="test.com.mbeddr.mpsutil.ecoretransformation.modelImportExport.testLanguage6" />
+                <node concept="2Ry0Ak" id="E0fxGqltyS" role="2Ry0An">
+                  <property role="2Ry0Am" value="models" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3qWCbU" id="E0fxGqltz2" role="3LXTna">
+            <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+          </node>
+        </node>
+      </node>
+      <node concept="3rtmxn" id="E0fxGqltzk" role="3bR31x">
+        <node concept="3LXTmp" id="E0fxGqltzl" role="3rtmxm">
+          <node concept="398BVA" id="E0fxGqltzm" role="3LXTmr">
+            <ref role="398BVh" node="E0fxGqls7k" resolve="mbeddr.mpsutil" />
+            <node concept="2Ry0Ak" id="E0fxGqltzn" role="iGT6I">
+              <property role="2Ry0Am" value="languages" />
+              <node concept="2Ry0Ak" id="E0fxGqltzo" role="2Ry0An">
+                <property role="2Ry0Am" value="test.com.mbeddr.mpsutil.ecoretransformation.modelImportExport.testLanguage6" />
+              </node>
+            </node>
+          </node>
+          <node concept="3qWCbU" id="E0fxGqltzq" role="3LXTna">
+            <property role="3qWCbO" value="icons/**, resources/**" />
+          </node>
+        </node>
+      </node>
     </node>
   </node>
 </model>

--- a/code/languages/com.mbeddr.build/solutions/com.mbeddr.platform/models/com/mbeddr/platform/build.mps
+++ b/code/languages/com.mbeddr.build/solutions/com.mbeddr.platform/models/com/mbeddr/platform/build.mps
@@ -1790,6 +1790,12 @@
             </node>
           </node>
         </node>
+        <node concept="1SiIV0" id="46XBvPMFwgD" role="3bR37C">
+          <node concept="3bR9La" id="46XBvPMFwgE" role="1SiIV1">
+            <property role="3bR36h" value="true" />
+            <ref role="3bR37D" to="ffeo:1ia2VB5guYy" resolve="MPS.IDEA" />
+          </node>
+        </node>
         <node concept="1BupzO" id="4PRpvcZJN7E" role="3bR31x">
           <property role="3ZfqAx" value="models" />
           <property role="1Hdu6h" value="true" />
@@ -1810,12 +1816,6 @@
             <node concept="3qWCbU" id="4PRpvcZJN7G" role="3LXTna">
               <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
             </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="46XBvPMFwgD" role="3bR37C">
-          <node concept="3bR9La" id="46XBvPMFwgE" role="1SiIV1">
-            <property role="3bR36h" value="true" />
-            <ref role="3bR37D" to="ffeo:1ia2VB5guYy" resolve="MPS.IDEA" />
           </node>
         </node>
       </node>
@@ -17215,6 +17215,130 @@
         <node concept="1SiIV0" id="1sNMMH9l$3l" role="3bR37C">
           <node concept="3bR9La" id="1sNMMH9l$3m" role="1SiIV1">
             <ref role="3bR37D" to="90a9:6SVXTgIel8z" resolve="de.itemis.mps.editor.celllayout.styles" />
+          </node>
+        </node>
+      </node>
+      <node concept="1E1JtD" id="4WMvu6msufV" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="com.mbeddr.slides" />
+        <property role="3LESm3" value="94daa6eb-e6a4-4b9f-90b6-4b23682ca120" />
+        <node concept="398BVA" id="4WMvu6msuzA" role="3LF7KH">
+          <ref role="398BVh" node="1m4fy7Kxwst" resolve="mbeddr.doc" />
+          <node concept="2Ry0Ak" id="4WMvu6mswpk" role="iGT6I">
+            <property role="2Ry0Am" value="languages" />
+            <node concept="2Ry0Ak" id="4WMvu6msx0_" role="2Ry0An">
+              <property role="2Ry0Am" value="com.mbeddr.slides" />
+              <node concept="2Ry0Ak" id="4WMvu6msxBQ" role="2Ry0An">
+                <property role="2Ry0Am" value="com.mbeddr.slides.mpl" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="4WMvu6msyJw" role="3bR37C">
+          <node concept="3bR9La" id="4WMvu6msyJx" role="1SiIV1">
+            <ref role="3bR37D" node="$bJ0jguQfr" resolve="com.mbeddr.core.base" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="4WMvu6msyJy" role="3bR37C">
+          <node concept="3bR9La" id="4WMvu6msyJz" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="4WMvu6msyJ$" role="3bR37C">
+          <node concept="3bR9La" id="4WMvu6msyJ_" role="1SiIV1">
+            <ref role="3bR37D" node="1YMM4SJ2m0" resolve="com.mbeddr.doc" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="4WMvu6msyJA" role="3bR37C">
+          <node concept="3bR9La" id="4WMvu6msyJB" role="1SiIV1">
+            <ref role="3bR37D" node="5A_Zlt6CRir" resolve="com.mbeddr.mpsutil.hyperlink" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="4WMvu6msyJC" role="3bR37C">
+          <node concept="3bR9La" id="4WMvu6msyJD" role="1SiIV1">
+            <ref role="3bR37D" to="90a9:1sO539bGQvB" resolve="de.slisson.mps.richtext" />
+          </node>
+        </node>
+        <node concept="1BupzO" id="4WMvu6msyJP" role="3bR31x">
+          <property role="3ZfqAx" value="languageModels" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="4WMvu6msyJQ" role="1HemKq">
+            <node concept="398BVA" id="4WMvu6msyJE" role="3LXTmr">
+              <ref role="398BVh" node="1m4fy7Kxwst" resolve="mbeddr.doc" />
+              <node concept="2Ry0Ak" id="4WMvu6msyJF" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="4WMvu6msyJG" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mbeddr.slides" />
+                  <node concept="2Ry0Ak" id="4WMvu6msyJH" role="2Ry0An">
+                    <property role="2Ry0Am" value="languageModels" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="4WMvu6msyJR" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="4WMvu6msyJS" role="3bR37C">
+          <node concept="1Busua" id="4WMvu6msyJT" role="1SiIV1">
+            <ref role="1Busuk" node="1YMM4SJ2m0" resolve="com.mbeddr.doc" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="4WMvu6msyJU" role="3bR37C">
+          <node concept="1Busua" id="4WMvu6msyJV" role="1SiIV1">
+            <ref role="1Busuk" to="90a9:1sO539bGQvB" resolve="de.slisson.mps.richtext" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="4WMvu6msyJW" role="3bR37C">
+          <node concept="1Busua" id="4WMvu6msyJX" role="1SiIV1">
+            <ref role="1Busuk" to="ffeo:568PkTlOK5Q" resolve="jetbrains.mps.core.xml" />
+          </node>
+        </node>
+        <node concept="1yeLz9" id="4WMvu6msyJY" role="1TViLv">
+          <property role="TrG5h" value="com.mbeddr.slides#5455967284188432063" />
+          <property role="3LESm3" value="7276fe27-ac58-4bed-89ee-66e00d2b7581" />
+          <node concept="1BupzO" id="4WMvu6msyKc" role="3bR31x">
+            <property role="3ZfqAx" value="generator/template" />
+            <property role="1Hdu6h" value="true" />
+            <property role="1HemKv" value="true" />
+            <node concept="3LXTmp" id="4WMvu6msyKd" role="1HemKq">
+              <node concept="398BVA" id="4WMvu6msyJZ" role="3LXTmr">
+                <ref role="398BVh" node="1m4fy7Kxwst" resolve="mbeddr.doc" />
+                <node concept="2Ry0Ak" id="4WMvu6msyK0" role="iGT6I">
+                  <property role="2Ry0Am" value="languages" />
+                  <node concept="2Ry0Ak" id="4WMvu6msyK1" role="2Ry0An">
+                    <property role="2Ry0Am" value="com.mbeddr.slides" />
+                    <node concept="2Ry0Ak" id="4WMvu6msyK2" role="2Ry0An">
+                      <property role="2Ry0Am" value="generator" />
+                      <node concept="2Ry0Ak" id="4WMvu6msyK3" role="2Ry0An">
+                        <property role="2Ry0Am" value="template" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3qWCbU" id="4WMvu6msyKe" role="3LXTna">
+                <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3rtmxn" id="4WMvu6msz8e" role="3bR31x">
+          <node concept="3LXTmp" id="4WMvu6msz8f" role="3rtmxm">
+            <node concept="398BVA" id="4WMvu6msz8g" role="3LXTmr">
+              <ref role="398BVh" node="1m4fy7Kxwst" resolve="mbeddr.doc" />
+              <node concept="2Ry0Ak" id="4WMvu6msz8h" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="4WMvu6msz8i" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mbeddr.slides" />
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="4WMvu6msz8k" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
           </node>
         </node>
       </node>

--- a/code/languages/com.mbeddr.build/solutions/com.mbeddr.platform/models/com/mbeddr/platform/build.mps
+++ b/code/languages/com.mbeddr.build/solutions/com.mbeddr.platform/models/com/mbeddr/platform/build.mps
@@ -1790,12 +1790,6 @@
             </node>
           </node>
         </node>
-        <node concept="1SiIV0" id="46XBvPMFwgD" role="3bR37C">
-          <node concept="3bR9La" id="46XBvPMFwgE" role="1SiIV1">
-            <property role="3bR36h" value="true" />
-            <ref role="3bR37D" to="ffeo:1ia2VB5guYy" resolve="MPS.IDEA" />
-          </node>
-        </node>
         <node concept="1BupzO" id="4PRpvcZJN7E" role="3bR31x">
           <property role="3ZfqAx" value="models" />
           <property role="1Hdu6h" value="true" />
@@ -1816,6 +1810,12 @@
             <node concept="3qWCbU" id="4PRpvcZJN7G" role="3LXTna">
               <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
             </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="46XBvPMFwgD" role="3bR37C">
+          <node concept="3bR9La" id="46XBvPMFwgE" role="1SiIV1">
+            <property role="3bR36h" value="true" />
+            <ref role="3bR37D" to="ffeo:1ia2VB5guYy" resolve="MPS.IDEA" />
           </node>
         </node>
       </node>
@@ -20099,6 +20099,22 @@
             </node>
           </node>
         </node>
+        <node concept="3rtmxn" id="3xUpIvHHZl6" role="3bR31x">
+          <node concept="3LXTmp" id="3xUpIvHHZl7" role="3rtmxm">
+            <node concept="3qWCbU" id="3xUpIvHHZl8" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+            <node concept="398BVA" id="3xUpIvHHZl9" role="3LXTmr">
+              <ref role="398BVh" node="7uZw0yZ2_Lj" resolve="mpsutil" />
+              <node concept="2Ry0Ak" id="3xUpIvHHZla" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="3xUpIvHHZlb" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mbeddr.mpsutil.editor.displayControl" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
       </node>
     </node>
     <node concept="m$_wf" id="3Ol24ijlxoL" role="3989C9">
@@ -20176,6 +20192,22 @@
             </node>
             <node concept="3qWCbU" id="3lcj7hzsBO2" role="3LXTna">
               <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+        <node concept="3rtmxn" id="3xUpIvHHZld" role="3bR31x">
+          <node concept="3LXTmp" id="3xUpIvHHZle" role="3rtmxm">
+            <node concept="3qWCbU" id="3xUpIvHHZlf" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+            <node concept="398BVA" id="3xUpIvHHZlg" role="3LXTmr">
+              <ref role="398BVh" node="7uZw0yZ2_Lj" resolve="mpsutil" />
+              <node concept="2Ry0Ak" id="3xUpIvHHZlh" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="3xUpIvHHZli" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mbeddr.mpsutil.logicalChild" />
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -20288,6 +20320,22 @@
         <node concept="1SiIV0" id="4LY$CIohIRF" role="3bR37C">
           <node concept="3bR9La" id="4LY$CIohIRG" role="1SiIV1">
             <ref role="3bR37D" to="ffeo:1ACpgrwmP7U" resolve="jetbrains.mps.kotlin.stdlib" />
+          </node>
+        </node>
+        <node concept="3rtmxn" id="3xUpIvHHZkZ" role="3bR31x">
+          <node concept="3LXTmp" id="3xUpIvHHZl0" role="3rtmxm">
+            <node concept="3qWCbU" id="3xUpIvHHZl1" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+            <node concept="398BVA" id="3xUpIvHHZl2" role="3LXTmr">
+              <ref role="398BVh" node="7uZw0yZ2_Lj" resolve="mpsutil" />
+              <node concept="2Ry0Ak" id="3xUpIvHHZl3" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="3xUpIvHHZl4" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mbeddr.mpsutil.checkinHandler" />
+                </node>
+              </node>
+            </node>
           </node>
         </node>
       </node>

--- a/code/languages/com.mbeddr.mpsutil/.mps/libraries.xml
+++ b/code/languages/com.mbeddr.mpsutil/.mps/libraries.xml
@@ -3,14 +3,6 @@
   <component name="ProjectLibraryManager">
     <option name="libraries">
       <map>
-        <entry key="mbeddr">
-          <value>
-            <Library>
-              <option name="name" value="mbeddr" />
-              <option name="path" value="${mbeddr.github.core.home}/code" />
-            </Library>
-          </value>
-        </entry>
         <entry key="mps.extensions">
           <value>
             <Library>

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.demo.comparator.diff/com.mbeddr.demo.comparator.diff.mpl
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.demo.comparator.diff/com.mbeddr.demo.comparator.diff.mpl
@@ -6,7 +6,7 @@
     </modelRoot>
   </models>
   <facets>
-    <facet type="java">
+    <facet type="java" compile="mps" classes="mps" ext="yes">
       <classes generated="true" path="${module}/classes_gen" />
     </facet>
   </facets>
@@ -19,7 +19,7 @@
         </modelRoot>
       </models>
       <facets>
-        <facet type="java">
+        <facet type="java" compile="mps" classes="mps" ext="no">
           <classes generated="true" path="${module}/generator/classes_gen" />
         </facet>
       </facets>

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.asynccell.sandbox/models/behavior.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.asynccell.sandbox/models/behavior.mps
@@ -243,7 +243,7 @@
                     <ref role="3cqZAo" node="2YOONxNStSE" resolve="exception" />
                   </node>
                   <node concept="liA8E" id="2YOONxNSz1I" role="2OqNvi">
-                    <ref role="37wK5l" to="wyt6:~Throwable.getMessage():java.lang.String" resolve="getMessage" />
+                    <ref role="37wK5l" to="wyt6:~Throwable.getMessage()" resolve="getMessage" />
                   </node>
                 </node>
               </node>
@@ -475,7 +475,7 @@
                   </node>
                 </node>
                 <node concept="liA8E" id="2YOONxNRGtC" role="2OqNvi">
-                  <ref role="37wK5l" to="dxuu:~Timer.stop():void" resolve="stop" />
+                  <ref role="37wK5l" to="dxuu:~Timer.stop()" resolve="stop" />
                 </node>
               </node>
             </node>
@@ -518,7 +518,7 @@
               <ref role="3cqZAo" node="17HIJlL0Ew$" resolve="timer" />
             </node>
             <node concept="liA8E" id="2YOONxNRGu7" role="2OqNvi">
-              <ref role="37wK5l" to="dxuu:~Timer.setRepeats(boolean):void" resolve="setRepeats" />
+              <ref role="37wK5l" to="dxuu:~Timer.setRepeats(boolean)" resolve="setRepeats" />
               <node concept="3clFbT" id="2YOONxNRGu8" role="37wK5m">
                 <property role="3clFbU" value="false" />
               </node>
@@ -531,7 +531,7 @@
               <ref role="3cqZAo" node="17HIJlL0Ew$" resolve="timer" />
             </node>
             <node concept="liA8E" id="2YOONxNRGuc" role="2OqNvi">
-              <ref role="37wK5l" to="dxuu:~Timer.start():void" resolve="start" />
+              <ref role="37wK5l" to="dxuu:~Timer.start()" resolve="start" />
             </node>
           </node>
         </node>

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.asynccell.sandbox/models/editor.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.asynccell.sandbox/models/editor.mps
@@ -193,7 +193,7 @@
                     <ref role="3cqZAo" node="17HIJlKZU71" resolve="button" />
                   </node>
                   <node concept="liA8E" id="17HIJlKZWfd" role="2OqNvi">
-                    <ref role="37wK5l" to="dxuu:~AbstractButton.addActionListener(java.awt.event.ActionListener):void" resolve="addActionListener" />
+                    <ref role="37wK5l" to="dxuu:~AbstractButton.addActionListener(java.awt.event.ActionListener)" resolve="addActionListener" />
                     <node concept="1bVj0M" id="2YOONxNRT5i" role="37wK5m">
                       <node concept="3clFbS" id="2YOONxNRT5j" role="1bW5cS">
                         <node concept="3clFbF" id="17HIJlL0gGV" role="3cqZAp">
@@ -218,11 +218,11 @@
                             <node concept="2OqwBi" id="2u$73V9t9yn" role="2Oq$k0">
                               <node concept="1Q80Hx" id="2u$73V9t9yo" role="2Oq$k0" />
                               <node concept="liA8E" id="2u$73V9t9yp" role="2OqNvi">
-                                <ref role="37wK5l" to="cj4x:~EditorContext.getEditorComponent():jetbrains.mps.openapi.editor.EditorComponent" resolve="getEditorComponent" />
+                                <ref role="37wK5l" to="cj4x:~EditorContext.getEditorComponent()" resolve="getEditorComponent" />
                               </node>
                             </node>
                             <node concept="liA8E" id="2u$73V9t9yq" role="2OqNvi">
-                              <ref role="37wK5l" to="cj4x:~EditorComponent.update():void" resolve="update" />
+                              <ref role="37wK5l" to="cj4x:~EditorComponent.update()" resolve="update" />
                             </node>
                           </node>
                         </node>
@@ -270,7 +270,7 @@
                     <ref role="3cqZAo" node="2YOONxNRDtr" resolve="button" />
                   </node>
                   <node concept="liA8E" id="2YOONxNRDtz" role="2OqNvi">
-                    <ref role="37wK5l" to="dxuu:~AbstractButton.addActionListener(java.awt.event.ActionListener):void" resolve="addActionListener" />
+                    <ref role="37wK5l" to="dxuu:~AbstractButton.addActionListener(java.awt.event.ActionListener)" resolve="addActionListener" />
                     <node concept="1bVj0M" id="2YOONxNRQT4" role="37wK5m">
                       <node concept="3clFbS" id="2YOONxNRQT5" role="1bW5cS">
                         <node concept="3clFbF" id="2YOONxNRQqV" role="3cqZAp">
@@ -300,11 +300,11 @@
                             <node concept="2OqwBi" id="2YOONxNRDtQ" role="2Oq$k0">
                               <node concept="1Q80Hx" id="2YOONxNRDtR" role="2Oq$k0" />
                               <node concept="liA8E" id="2YOONxNRDtS" role="2OqNvi">
-                                <ref role="37wK5l" to="cj4x:~EditorContext.getEditorComponent():jetbrains.mps.openapi.editor.EditorComponent" resolve="getEditorComponent" />
+                                <ref role="37wK5l" to="cj4x:~EditorContext.getEditorComponent()" resolve="getEditorComponent" />
                               </node>
                             </node>
                             <node concept="liA8E" id="2YOONxNRDtT" role="2OqNvi">
-                              <ref role="37wK5l" to="cj4x:~EditorComponent.update():void" resolve="update" />
+                              <ref role="37wK5l" to="cj4x:~EditorComponent.update()" resolve="update" />
                             </node>
                           </node>
                         </node>
@@ -358,7 +358,7 @@
                     <ref role="3cqZAo" node="2u$73V9r4da" resolve="button" />
                   </node>
                   <node concept="liA8E" id="2u$73V9r4di" role="2OqNvi">
-                    <ref role="37wK5l" to="dxuu:~AbstractButton.addActionListener(java.awt.event.ActionListener):void" resolve="addActionListener" />
+                    <ref role="37wK5l" to="dxuu:~AbstractButton.addActionListener(java.awt.event.ActionListener)" resolve="addActionListener" />
                     <node concept="2ShNRf" id="2u$73V9r4dj" role="37wK5m">
                       <node concept="YeOm9" id="2u$73V9r4dk" role="2ShVmc">
                         <node concept="1Y3b0j" id="2u$73V9r4dl" role="YeSDq">
@@ -397,11 +397,11 @@
                                   <node concept="2OqwBi" id="2u$73V9t9pz" role="2Oq$k0">
                                     <node concept="1Q80Hx" id="2u$73V9t9p$" role="2Oq$k0" />
                                     <node concept="liA8E" id="2u$73V9t9p_" role="2OqNvi">
-                                      <ref role="37wK5l" to="cj4x:~EditorContext.getEditorComponent():jetbrains.mps.openapi.editor.EditorComponent" resolve="getEditorComponent" />
+                                      <ref role="37wK5l" to="cj4x:~EditorContext.getEditorComponent()" resolve="getEditorComponent" />
                                     </node>
                                   </node>
                                   <node concept="liA8E" id="2u$73V9t9pA" role="2OqNvi">
-                                    <ref role="37wK5l" to="cj4x:~EditorComponent.update():void" resolve="update" />
+                                    <ref role="37wK5l" to="cj4x:~EditorComponent.update()" resolve="update" />
                                   </node>
                                 </node>
                               </node>
@@ -446,7 +446,7 @@
                     <ref role="3cqZAo" node="2u$73V9r4Bu" resolve="button" />
                   </node>
                   <node concept="liA8E" id="2u$73V9r4BA" role="2OqNvi">
-                    <ref role="37wK5l" to="dxuu:~AbstractButton.addActionListener(java.awt.event.ActionListener):void" resolve="addActionListener" />
+                    <ref role="37wK5l" to="dxuu:~AbstractButton.addActionListener(java.awt.event.ActionListener)" resolve="addActionListener" />
                     <node concept="2ShNRf" id="2u$73V9r4BB" role="37wK5m">
                       <node concept="YeOm9" id="2u$73V9r4BC" role="2ShVmc">
                         <node concept="1Y3b0j" id="2u$73V9r4BD" role="YeSDq">
@@ -487,11 +487,11 @@
                                   <node concept="2OqwBi" id="2u$73V9r4BN" role="2Oq$k0">
                                     <node concept="1Q80Hx" id="2u$73V9r4BO" role="2Oq$k0" />
                                     <node concept="liA8E" id="2u$73V9r4BP" role="2OqNvi">
-                                      <ref role="37wK5l" to="cj4x:~EditorContext.getEditorComponent():jetbrains.mps.openapi.editor.EditorComponent" resolve="getEditorComponent" />
+                                      <ref role="37wK5l" to="cj4x:~EditorContext.getEditorComponent()" resolve="getEditorComponent" />
                                     </node>
                                   </node>
                                   <node concept="liA8E" id="2u$73V9r4BQ" role="2OqNvi">
-                                    <ref role="37wK5l" to="cj4x:~EditorComponent.update():void" resolve="update" />
+                                    <ref role="37wK5l" to="cj4x:~EditorComponent.update()" resolve="update" />
                                   </node>
                                 </node>
                               </node>
@@ -564,11 +564,11 @@
                             <node concept="2EnYce" id="2u$73V9uyfS" role="2Oq$k0">
                               <node concept="1Q80Hx" id="2u$73V9uwFY" role="2Oq$k0" />
                               <node concept="liA8E" id="2u$73V9uwFZ" role="2OqNvi">
-                                <ref role="37wK5l" to="cj4x:~EditorContext.getContextCell():jetbrains.mps.openapi.editor.cells.EditorCell" resolve="getContextCell" />
+                                <ref role="37wK5l" to="cj4x:~EditorContext.getContextCell()" resolve="getContextCell" />
                               </node>
                             </node>
                             <node concept="liA8E" id="2u$73V9uwG0" role="2OqNvi">
-                              <ref role="37wK5l" to="f4zo:~EditorCell.getStyle():jetbrains.mps.openapi.editor.style.Style" resolve="getStyle" />
+                              <ref role="37wK5l" to="f4zo:~EditorCell.getStyle()" resolve="getStyle" />
                             </node>
                           </node>
                         </node>

--- a/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.actionsfilter.runtime/com.mbeddr.mpsutil.actionsfilter.runtime.msd
+++ b/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.actionsfilter.runtime/com.mbeddr.mpsutil.actionsfilter.runtime.msd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <solution name="com.mbeddr.mpsutil.actionsfilter.runtime" uuid="436eb984-d162-4543-a347-2601ff5bb2a0" moduleVersion="0" compileInMPS="true">
   <models>
-    <modelRoot contentPath="${module}" type="default">
+    <modelRoot type="default" contentPath="${module}">
       <sourceRoot location="models" />
     </modelRoot>
   </models>
@@ -22,6 +22,7 @@
   <languageVersions>
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
     <language slang="l:774bf8a0-62e5-41e1-af63-f4812e60e48b:jetbrains.mps.baseLanguage.checkedDots" version="0" />
+    <language slang="l:443f4c36-fcf5-4eb6-9500-8d06ed259e3e:jetbrains.mps.baseLanguage.classifiers" version="0" />
     <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
     <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
     <language slang="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" version="2" />
@@ -30,6 +31,8 @@
     <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
     <language slang="l:c0080a47-7e37-4558-bee9-9ae18e690549:jetbrains.mps.lang.extension" version="2" />
     <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
+    <language slang="l:28f9e497-3b42-4291-aeba-0a1039153ab1:jetbrains.mps.lang.plugin" version="5" />
+    <language slang="l:ef7bf5ac-d06c-4342-b11d-e42104eb9343:jetbrains.mps.lang.plugin.standalone" version="0" />
     <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="5" />
     <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="19" />
     <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />

--- a/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.actionsfilter.runtime/models/com/mbeddr/mpsutil/actionsfilter/runtime.mps
+++ b/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.actionsfilter.runtime/models/com/mbeddr/mpsutil/actionsfilter/runtime.mps
@@ -7,6 +7,8 @@
     <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="12" />
     <use id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc" version="2" />
     <use id="c0080a47-7e37-4558-bee9-9ae18e690549" name="jetbrains.mps.lang.extension" version="2" />
+    <use id="28f9e497-3b42-4291-aeba-0a1039153ab1" name="jetbrains.mps.lang.plugin" version="5" />
+    <use id="ef7bf5ac-d06c-4342-b11d-e42104eb9343" name="jetbrains.mps.lang.plugin.standalone" version="0" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
@@ -24,7 +26,6 @@
     <import index="q7tw" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:org.apache.log4j(MPS.Core/)" />
     <import index="mpcv" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang.ref(JDK/)" />
     <import index="rgfa" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:javax.swing.tree(JDK/)" />
-    <import index="xnls" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.ide.icons(MPS.Platform/)" />
     <import index="obo9" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.plugins.actions(MPS.Platform/)" />
     <import index="hq8m" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.options(MPS.IDEA/)" />
     <import index="mnlj" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.beans(JDK/)" />
@@ -35,15 +36,10 @@
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" />
     <import index="bd8o" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.application(MPS.IDEA/)" />
     <import index="8fb" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ide.ui.customization(MPS.IDEA/)" />
-    <import index="ctgy" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ide.plugins(MPS.IDEA/)" />
-    <import index="69r2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ide.macro(MPS.IDEA/)" />
     <import index="18ew" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.util(MPS.Core/)" />
-    <import index="jlff" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.vfs(MPS.IDEA/)" />
-    <import index="4hrd" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.ide.vfs(MPS.Platform/)" />
     <import index="z2i8" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.icons(MPS.IDEA/)" />
     <import index="qq03" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.ide.actions(MPS.Platform/)" />
     <import index="qq04" ref="86441d7a-e194-42da-81a5-2161ec62a379/java:jetbrains.mps.ide.actions(MPS.Workbench/)" />
-    <import index="zdfu" ref="cac2fef0-41a6-4fcd-923f-f893d536b2ab/java:jetbrains.mps.ide.devkit.actions(jetbrains.mps.ide.mpsdevkit/)" implicit="true" />
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
@@ -4962,115 +4958,6 @@
                     <property role="Xl_RC" value="Generator" />
                   </node>
                 </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3SKdUt" id="6_xeB7oXnWU" role="3cqZAp">
-          <node concept="1PaTwC" id="6_xeB7oXnWV" role="1aUNEU">
-            <node concept="3oM_SD" id="6_xeB7oXnWX" role="1PaTwD">
-              <property role="3oM_SC" value="FIXME:" />
-            </node>
-            <node concept="3oM_SD" id="6_xeB7oXooT" role="1PaTwD">
-              <property role="3oM_SC" value="with" />
-            </node>
-            <node concept="3oM_SD" id="6_xeB7oXo4n" role="1PaTwD">
-              <property role="3oM_SC" value="MPS" />
-            </node>
-            <node concept="3oM_SD" id="6_xeB7oXo6u" role="1PaTwD">
-              <property role="3oM_SC" value="2019.2.4" />
-            </node>
-            <node concept="3oM_SD" id="7knwKBVubK_" role="1PaTwD">
-              <property role="3oM_SC" value="referencing" />
-            </node>
-            <node concept="3oM_SD" id="6_xeB7oXoeg" role="1PaTwD">
-              <property role="3oM_SC" value="this" />
-            </node>
-            <node concept="3oM_SD" id="6_xeB7oXoeV" role="1PaTwD">
-              <property role="3oM_SC" value="action" />
-            </node>
-            <node concept="3oM_SD" id="6_xeB7oXofl" role="1PaTwD">
-              <property role="3oM_SC" value="group" />
-            </node>
-            <node concept="3oM_SD" id="6_xeB7oXozA" role="1PaTwD">
-              <property role="3oM_SC" value="causes" />
-            </node>
-            <node concept="3oM_SD" id="6_xeB7oXogB" role="1PaTwD">
-              <property role="3oM_SC" value="broken" />
-            </node>
-            <node concept="3oM_SD" id="6_xeB7oXoh5" role="1PaTwD">
-              <property role="3oM_SC" value="ref" />
-            </node>
-            <node concept="3oM_SD" id="6_xeB7oXoi6" role="1PaTwD">
-              <property role="3oM_SC" value="in" />
-            </node>
-            <node concept="3oM_SD" id="6_xeB7oXo$K" role="1PaTwD">
-              <property role="3oM_SC" value="the" />
-            </node>
-            <node concept="3oM_SD" id="6_xeB7oXo_j" role="1PaTwD">
-              <property role="3oM_SC" value="generated" />
-            </node>
-            <node concept="3oM_SD" id="6_xeB7oXoA7" role="1PaTwD">
-              <property role="3oM_SC" value="code" />
-            </node>
-            <node concept="3oM_SD" id="6_xeB7oXoiI" role="1PaTwD">
-              <property role="3oM_SC" value="of" />
-            </node>
-            <node concept="3oM_SD" id="6_xeB7oXoAQ" role="1PaTwD">
-              <property role="3oM_SC" value="the" />
-            </node>
-            <node concept="3oM_SD" id="6_xeB7oXojV" role="1PaTwD">
-              <property role="3oM_SC" value="ant" />
-            </node>
-            <node concept="3oM_SD" id="6_xeB7oXok_" role="1PaTwD">
-              <property role="3oM_SC" value="build" />
-            </node>
-          </node>
-        </node>
-        <node concept="3SKdUt" id="27yO7ubg8CM" role="3cqZAp">
-          <node concept="1PaTwC" id="1N2UgSJHHvT" role="1aUNEU">
-            <node concept="3oM_SD" id="1N2UgSJHHvS" role="1PaTwD">
-              <property role="3oM_SC" value="see" />
-            </node>
-            <node concept="3oM_SD" id="7knwKBVuf09" role="1PaTwD">
-              <property role="3oM_SC" value="https://youtrack.jetbrains.com/issue/MPS-31865" />
-            </node>
-            <node concept="3oM_SD" id="7knwKBVubLb" role="1PaTwD">
-              <property role="3oM_SC" value="" />
-            </node>
-            <node concept="3oM_SD" id="1N2UgSJMvWX" role="1PaTwD">
-              <property role="3oM_SC" value="" />
-            </node>
-            <node concept="3oM_SD" id="1N2UgSJMvFx" role="1PaTwD">
-              <property role="3oM_SC" value="" />
-            </node>
-            <node concept="3oM_SD" id="1N2UgSJMv$q" role="1PaTwD">
-              <property role="3oM_SC" value="" />
-            </node>
-            <node concept="3oM_SD" id="1N2UgSJMvwK" role="1PaTwD">
-              <property role="3oM_SC" value="" />
-            </node>
-            <node concept="3oM_SD" id="1N2UgSJMuX_" role="1PaTwD">
-              <property role="3oM_SC" value="" />
-            </node>
-            <node concept="3oM_SD" id="1N2UgSJMvt7" role="1PaTwD">
-              <property role="3oM_SC" value="" />
-            </node>
-            <node concept="3oM_SD" id="1N2UgSJHHzW" role="1PaTwD">
-              <property role="3oM_SC" value="" />
-            </node>
-          </node>
-        </node>
-        <node concept="1X3_iC" id="6_xeB7oXnzc" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3cpWs8" id="6_xeB7oXmVH" role="8Wnug">
-            <node concept="3cpWsn" id="6_xeB7oXmVI" role="3cpWs9">
-              <property role="TrG5h" value="id" />
-              <node concept="17QB3L" id="6_xeB7oXneC" role="1tU5fm" />
-              <node concept="10M0yZ" id="6_xeB7oXmVJ" role="33vP2m">
-                <ref role="1PxDUh" to="zdfu:~RuntimeFolderActions_ActionGroup" resolve="RuntimeFolderActions_ActionGroup" />
-                <ref role="3cqZAo" to="zdfu:~RuntimeFolderActions_ActionGroup.ID" resolve="ID" />
               </node>
             </node>
           </node>

--- a/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.comparator.diff.demo.genplan/com.mbeddr.mpsutil.comparator.diff.demo.genplan.msd
+++ b/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.comparator.diff.demo.genplan/com.mbeddr.mpsutil.comparator.diff.demo.genplan.msd
@@ -6,7 +6,7 @@
     </modelRoot>
   </models>
   <facets>
-    <facet type="java">
+    <facet type="java" compile="mps" classes="mps" ext="no">
       <classes generated="true" path="${module}/classes_gen" />
     </facet>
   </facets>

--- a/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.comparator.diff.demo.tests/com.mbeddr.mpsutil.comparator.diff.demo.tests.msd
+++ b/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.comparator.diff.demo.tests/com.mbeddr.mpsutil.comparator.diff.demo.tests.msd
@@ -6,9 +6,10 @@
     </modelRoot>
   </models>
   <facets>
-    <facet type="java">
+    <facet type="java" compile="mps" classes="mps" ext="no">
       <classes generated="true" path="${module}/classes_gen" />
     </facet>
+    <facet type="tests" />
   </facets>
   <sourcePath />
   <dependencies>

--- a/code/languages/com.mbeddr.mpsutil/tests/test.com.mbeddr.mpsutil.common/test.com.mbeddr.mpsutil.common.msd
+++ b/code/languages/com.mbeddr.mpsutil/tests/test.com.mbeddr.mpsutil.common/test.com.mbeddr.mpsutil.common.msd
@@ -6,9 +6,10 @@
     </modelRoot>
   </models>
   <facets>
-    <facet type="java">
+    <facet type="java" compile="mps" classes="mps" ext="no">
       <classes generated="true" path="${module}/classes_gen" />
     </facet>
+    <facet type="tests" />
   </facets>
   <sourcePath />
   <dependencies>

--- a/code/languages/com.mbeddr.mpsutil/tests/test.com.mbeddr.mpsutil.ecore.metaModelImport/models/test/com/mbeddr/mpsutil/ecoreimporter/testFailDifferentPropertyName.mps
+++ b/code/languages/com.mbeddr.mpsutil/tests/test.com.mbeddr.mpsutil.ecore.metaModelImport/models/test/com/mbeddr/mpsutil/ecoreimporter/testFailDifferentPropertyName.mps
@@ -24,9 +24,6 @@
       <concept id="3348158742936976479" name="jetbrains.mps.lang.structure.structure.EnumerationDeclaration" flags="ng" index="25R3W">
         <child id="3348158742936976577" name="members" index="25R1y" />
       </concept>
-      <concept id="6491077959632463275" name="jetbrains.mps.lang.structure.structure.EnumPropertyMigrationInfo" flags="ng" index="3l_iC">
-        <child id="6491077959632463286" name="oldProperty" index="3l_iP" />
-      </concept>
       <concept id="1169125787135" name="jetbrains.mps.lang.structure.structure.AbstractConceptDeclaration" flags="ig" index="PkWjJ">
         <property id="6714410169261853888" name="conceptId" index="EcuMT" />
         <property id="4628067390765956802" name="abstract" index="R5$K7" />
@@ -158,24 +155,10 @@
     <node concept="1TJgyi" id="17qUVvSZm9G" role="1TKVEl">
       <property role="TrG5h" value="prop1" />
       <property role="IQ2nx" value="8807858324542504720" />
-      <node concept="3l_iC" id="17qUVvSZm9H" role="lGtFl">
-        <node concept="1TJgyi" id="7CVN7FEkFWg" role="3l_iP">
-          <property role="IQ2nx" value="8807858324542504720" />
-          <property role="TrG5h" value="prop1" />
-          <ref role="AX2Wp" node="7CVN7FEkFWt" resolve="enumTest" />
-        </node>
-      </node>
     </node>
     <node concept="1TJgyi" id="17qUVvSZm9I" role="1TKVEl">
       <property role="TrG5h" value="prop2" />
       <property role="IQ2nx" value="8807858324542504721" />
-      <node concept="3l_iC" id="17qUVvSZm9J" role="lGtFl">
-        <node concept="1TJgyi" id="7CVN7FEkFWh" role="3l_iP">
-          <property role="IQ2nx" value="8807858324542504721" />
-          <property role="TrG5h" value="prop2" />
-          <ref role="AX2Wp" node="7CVN7FEkFWi" resolve="enumTest2" />
-        </node>
-      </node>
     </node>
   </node>
   <node concept="25R3W" id="apJ4OR7VSv">

--- a/subprojects/com.mbeddr/build.gradle
+++ b/subprojects/com.mbeddr/build.gradle
@@ -160,14 +160,14 @@ private static void configureRepositories(Project project) {
 }
 
 
-task printVersions {
+tasks.register('printVersions') {
     doLast {
         println "mbeddrBuildNumber: $project.mbeddrBuildNumber"
         println "mbeddrPlatformBuildNumber: $project.mbeddrPlatformBuildNumber"
     }
 }
 
-task printRepositories {
+tasks.register('printRepositories') {
     doLast {
         println "snapshotRepository: $snapshotRepository"
         println "releaseRepository: $releaseRepository"

--- a/subprojects/com.mbeddr/build.gradle
+++ b/subprojects/com.mbeddr/build.gradle
@@ -1,3 +1,10 @@
+import de.itemis.mps.gradle.tasks.MpsMigrate
+import de.itemis.mps.gradle.tasks.Remigrate
+
+plugins {
+    id 'de.itemis.mps.gradle.common'
+}
+
 // path variables
 // If mpsHomeDir is set explicitly, skip the MPS resolution step and use the explicit path (which may be relative from
 // the root directory).
@@ -168,10 +175,44 @@ task printRepositories {
     }
 }
 
-tasks.register('migrate') {
-    // No-op in this version
+List<String> projectsInDependencyOrder = [
+        'com.mbeddr.mpsutil',
+//        'com.mbeddr.doc',
+//        'com.mbeddr.doc.aspect',
+//        'com.mbeddr.core',
+//        'com.mbeddr.ext',
+//        'com.mbeddr.cc',
+//        'com.mbeddr.xmodel',
+        'com.mbeddr.build',
+]
+
+List<File> projectDirectoriesInDependencyOrder = projectsInDependencyOrder.collect {
+    new File(rootProject.file('code/languages'), it)
 }
 
-tasks.register('remigrate') {
-    // No-op in this version
+tasks.register('migrate', MpsMigrate) {
+    dependsOn(':com.mbeddr:platform:generate_platform_languages')
+    mpsHome = mpsHomeDir
+    projectDirectories.from(projectDirectoriesInDependencyOrder)
+
+    folderMacros['mbeddr.github.core.home'] = rootProject.layout.projectDirectory
+
+    pluginRoots.from(new File(mpsHomeDir, 'plugins'))
+
+    maxHeapSize = "4G"
 }
+
+tasks.register('remigrate', Remigrate) {
+    dependsOn(':com.mbeddr:platform:generate_platform_languages')
+    mpsHome = mpsHomeDir
+    projectDirectories.from(projectDirectoriesInDependencyOrder)
+
+    folderMacros['mbeddr.github.core.home'] = rootProject.layout.projectDirectory
+
+    pluginRoots.from(new File(mpsHomeDir, 'plugins'))
+
+    maxHeapSize = "4G"
+}
+
+// For the remigrate backend
+configureRepositories(project)

--- a/subprojects/com.mbeddr/platform/build.gradle
+++ b/subprojects/com.mbeddr/platform/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 import de.itemis.mps.gradle.*
 
-def script_test_mbeddrPlatform = new File(scriptsBasePath + "/com.mbeddr.platform/" + "build-ts-tests.xml")
+def script_test_mbeddrPlatform = new File(scriptsBasePath, "com.mbeddr.platform/build-ts-tests.xml")
 def script_mbeddrPlatform_sandboxes = new File(scriptsBasePath, "com.mbeddr.platform/build-sandboxes.xml")
 
 if (project.skipresolve_mps) {
@@ -104,6 +104,13 @@ task install_actionsfilter(type: Copy, dependsOn: build_actionsfilter) {
 }
 tasks.getByPath(':com.mbeddr:install').dependsOn install_actionsfilter
 
+tasks.register('generate_mbeddr_platform_tests', RunAntScript) {
+    dependsOn build_platform
+    script script_test_mbeddrPlatform
+    description "build mbeddr platform tests"
+    targets 'generate'
+}
+
 tasks.register('generate_platform_sandboxes', RunAntScript) {
     dependsOn build_platform
     script script_mbeddrPlatform_sandboxes
@@ -111,9 +118,14 @@ tasks.register('generate_platform_sandboxes', RunAntScript) {
     targets 'generate'
 }
 
-task test_mbeddr_platform(type: TestLanguages, dependsOn: build_platform) {
+tasks.register('generate_platform_languages') {
+    dependsOn build_platform, generate_mbeddr_platform_tests, generate_platform_sandboxes
+}
+
+task test_mbeddr_platform(type: TestLanguages, dependsOn: [build_platform, generate_mbeddr_platform_tests]) {
     script script_test_mbeddrPlatform
     description "execute typesystem and generator tests for the plaform"
+    targets 'check'
 }
 
 task build_platform_distribution(type: BuildLanguages, dependsOn: [build_platform, test_mbeddr_platform]) {

--- a/subprojects/com.mbeddr/platform/build.gradle
+++ b/subprojects/com.mbeddr/platform/build.gradle
@@ -6,6 +6,7 @@ plugins {
 import de.itemis.mps.gradle.*
 
 def script_test_mbeddrPlatform = new File(scriptsBasePath + "/com.mbeddr.platform/" + "build-ts-tests.xml")
+def script_mbeddrPlatform_sandboxes = new File(scriptsBasePath, "com.mbeddr.platform/build-sandboxes.xml")
 
 if (project.skipresolve_mps) {
     task resolve_mps {
@@ -102,6 +103,13 @@ task install_actionsfilter(type: Copy, dependsOn: build_actionsfilter) {
     into "$mpsPluginsDir"
 }
 tasks.getByPath(':com.mbeddr:install').dependsOn install_actionsfilter
+
+tasks.register('generate_platform_sandboxes', RunAntScript) {
+    dependsOn build_platform
+    script script_mbeddrPlatform_sandboxes
+    description "build mbeddr platform sandboxes"
+    targets 'generate'
+}
 
 task test_mbeddr_platform(type: TestLanguages, dependsOn: build_platform) {
     script script_test_mbeddrPlatform


### PR DESCRIPTION
New migration tasks, only migrating com.mbeddr.mpsutil and com.mbeddr.build for now, with more projects to follow.

Since migration will fail if an non-built language is encountered in a project, a new build script was added (sandboxes) to build all languages that were not built by other build scripts.