### PR TITLE
Upgrade to MPS 2023.2.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ ext.defaultReleaseRepository = 'https://artifacts.itemis.cloud/repository/maven-
 
 //MPS version
 ext.mpsMajor = "2023.2"
-ext.mpsBuild = "2023.2"
+ext.mpsBuild = "2023.2.1"
 
 //MPS-extensions version
 ext.mpsExtensionsVersion = findNonEmptyProperty('mpsExtensionsVersion') ?: "$mpsMajor.+"


### PR DESCRIPTION
2023.2 does not load project libraries in the IDEA environment (which is important for our migration tasks), 2023.2.1 fixes that.