### PR TITLE
core.base: autolayout diagrams before taking a screenshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Semantic Versioning and the changes are simply documented in reverse chronologic
 
 # October 2024
 
+## com.mbeddr.core.base
+
+- Diagrams are not auto-layouted before taking a screenshot.
+
 ## com.mbeddr.mpsutil.ecore
 
 ### Fixed

--- a/code/languages/com.mbeddr.build/solutions/com.mbeddr.platform/models/com/mbeddr/platform/build.mps
+++ b/code/languages/com.mbeddr.build/solutions/com.mbeddr.platform/models/com/mbeddr/platform/build.mps
@@ -1286,6 +1286,9 @@
       <node concept="m$_yC" id="1l1Xn9JkgoT" role="m$_yJ">
         <ref role="m$_y1" node="2wdbvPWDGd4" resolve="com.mbeddr.mpsutil.infrastructure.misc" />
       </node>
+      <node concept="m$_yC" id="ZhAg9Tj4d0" role="m$_yJ">
+        <ref role="m$_y1" to="90a9:4be$WTb1MZD" resolve="de.itemis.mps.editor.diagram" />
+      </node>
       <node concept="3_J27D" id="$bJ0jguQdt" role="m_cZH">
         <node concept="3Mxwew" id="$bJ0jguQdu" role="3MwsjC">
           <property role="3MwjfP" value="mbeddr.platform" />
@@ -15162,6 +15165,11 @@
             <ref role="3bR37D" to="ffeo:HHlBn9$wJ2" resolve="org.jdom" />
           </node>
         </node>
+        <node concept="1SiIV0" id="3AVU87RT5z6" role="3bR37C">
+          <node concept="3bR9La" id="3AVU87RT5z7" role="1SiIV1">
+            <ref role="3bR37D" to="90a9:4be$WTb1AQa" resolve="de.itemis.mps.editor.diagram.runtime" />
+          </node>
+        </node>
       </node>
       <node concept="1E1JtD" id="$bJ0jguQfr" role="2G$12L">
         <property role="BnDLt" value="true" />
@@ -16774,101 +16782,6 @@
             <ref role="1Busuk" node="$bJ0jguQfr" resolve="com.mbeddr.core.base" />
           </node>
         </node>
-        <node concept="1SiIV0" id="6qrqamSa6l9" role="3bR37C">
-          <node concept="1BurEX" id="6qrqamSa6la" role="1SiIV1">
-            <node concept="398BVA" id="6qrqamSa6kW" role="1BurEY">
-              <ref role="398BVh" node="1m4fy7Kxwst" resolve="mbeddr.doc" />
-              <node concept="2Ry0Ak" id="6qrqamSa6kX" role="iGT6I">
-                <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="6qrqamSa6kY" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mbeddr.spreadsheat" />
-                  <node concept="2Ry0Ak" id="6qrqamSa6kZ" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="6qrqamSa6l0" role="2Ry0An">
-                      <property role="2Ry0Am" value="commons-codec-1.10.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="6qrqamSa6lQ" role="3bR37C">
-          <node concept="1BurEX" id="6qrqamSa6lR" role="1SiIV1">
-            <node concept="398BVA" id="6qrqamSa6lD" role="1BurEY">
-              <ref role="398BVh" node="1m4fy7Kxwst" resolve="mbeddr.doc" />
-              <node concept="2Ry0Ak" id="6qrqamSa6lE" role="iGT6I">
-                <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="6qrqamSa6lF" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mbeddr.spreadsheat" />
-                  <node concept="2Ry0Ak" id="6qrqamSa6lG" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="6qrqamSa6lH" role="2Ry0An">
-                      <property role="2Ry0Am" value="poi-5.0.0.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="6qrqamSa6m5" role="3bR37C">
-          <node concept="1BurEX" id="6qrqamSa6m6" role="1SiIV1">
-            <node concept="398BVA" id="6qrqamSa6lS" role="1BurEY">
-              <ref role="398BVh" node="1m4fy7Kxwst" resolve="mbeddr.doc" />
-              <node concept="2Ry0Ak" id="6qrqamSa6lT" role="iGT6I">
-                <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="6qrqamSa6lU" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mbeddr.spreadsheat" />
-                  <node concept="2Ry0Ak" id="6qrqamSa6lV" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="6qrqamSa6lW" role="2Ry0An">
-                      <property role="2Ry0Am" value="poi-ooxml-5.0.0.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2tOXMOy_0rv" role="3bR37C">
-          <node concept="1BurEX" id="2tOXMOy_0rw" role="1SiIV1">
-            <node concept="398BVA" id="2tOXMOy_0ri" role="1BurEY">
-              <ref role="398BVh" node="1m4fy7Kxwst" resolve="mbeddr.doc" />
-              <node concept="2Ry0Ak" id="2tOXMOy_0rj" role="iGT6I">
-                <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="2tOXMOy_0rk" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mbeddr.spreadsheat" />
-                  <node concept="2Ry0Ak" id="2tOXMOy_0rl" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="2tOXMOy_0rm" role="2Ry0An">
-                      <property role="2Ry0Am" value="poi-ooxml-lite-5.0.0.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="BNROLcYFVv" role="3bR37C">
-          <node concept="1BurEX" id="BNROLcYFVw" role="1SiIV1">
-            <node concept="398BVA" id="BNROLcYFVi" role="1BurEY">
-              <ref role="398BVh" node="1m4fy7Kxwst" resolve="mbeddr.doc" />
-              <node concept="2Ry0Ak" id="BNROLcYFVj" role="iGT6I">
-                <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="BNROLcYFVk" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mbeddr.spreadsheat" />
-                  <node concept="2Ry0Ak" id="BNROLcYFVl" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="BNROLcYFVm" role="2Ry0An">
-                      <property role="2Ry0Am" value="xmlbeans-4.0.0.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
         <node concept="1yeLz9" id="4aKYPQyrdec" role="1TViLv">
           <property role="TrG5h" value="com.mbeddr.spreadsheat#4354378109086982931" />
           <property role="3LESm3" value="7986ede4-bb02-4e5d-8e13-03458d393ab7" />
@@ -16930,17 +16843,17 @@
             </node>
           </node>
         </node>
-        <node concept="1SiIV0" id="7nFSfz7_8Iv" role="3bR37C">
-          <node concept="1BurEX" id="7nFSfz7_8Iw" role="1SiIV1">
-            <node concept="398BVA" id="7nFSfz7_8Ii" role="1BurEY">
+        <node concept="1SiIV0" id="77lUErj8BEx" role="3bR37C">
+          <node concept="1BurEX" id="77lUErj8BEy" role="1SiIV1">
+            <node concept="398BVA" id="77lUErj8BEk" role="1BurEY">
               <ref role="398BVh" node="1m4fy7Kxwst" resolve="mbeddr.doc" />
-              <node concept="2Ry0Ak" id="7nFSfz7_8Ij" role="iGT6I">
+              <node concept="2Ry0Ak" id="77lUErj8BEl" role="iGT6I">
                 <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="7nFSfz7_8Ik" role="2Ry0An">
+                <node concept="2Ry0Ak" id="77lUErj8BEm" role="2Ry0An">
                   <property role="2Ry0Am" value="com.mbeddr.spreadsheat" />
-                  <node concept="2Ry0Ak" id="7nFSfz7_8Il" role="2Ry0An">
+                  <node concept="2Ry0Ak" id="77lUErj8BEn" role="2Ry0An">
                     <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="7nFSfz7_8Im" role="2Ry0An">
+                    <node concept="2Ry0Ak" id="77lUErj8BEo" role="2Ry0An">
                       <property role="2Ry0Am" value="commons-collections4-4.1.jar" />
                     </node>
                   </node>
@@ -16949,17 +16862,17 @@
             </node>
           </node>
         </node>
-        <node concept="1SiIV0" id="7nFSfz7_8II" role="3bR37C">
-          <node concept="1BurEX" id="7nFSfz7_8IJ" role="1SiIV1">
-            <node concept="398BVA" id="7nFSfz7_8Ix" role="1BurEY">
+        <node concept="1SiIV0" id="77lUErj8BEK" role="3bR37C">
+          <node concept="1BurEX" id="77lUErj8BEL" role="1SiIV1">
+            <node concept="398BVA" id="77lUErj8BEz" role="1BurEY">
               <ref role="398BVh" node="1m4fy7Kxwst" resolve="mbeddr.doc" />
-              <node concept="2Ry0Ak" id="7nFSfz7_8Iy" role="iGT6I">
+              <node concept="2Ry0Ak" id="77lUErj8BE$" role="iGT6I">
                 <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="7nFSfz7_8Iz" role="2Ry0An">
+                <node concept="2Ry0Ak" id="77lUErj8BE_" role="2Ry0An">
                   <property role="2Ry0Am" value="com.mbeddr.spreadsheat" />
-                  <node concept="2Ry0Ak" id="7nFSfz7_8I$" role="2Ry0An">
+                  <node concept="2Ry0Ak" id="77lUErj8BEA" role="2Ry0An">
                     <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="7nFSfz7_8I_" role="2Ry0An">
+                    <node concept="2Ry0Ak" id="77lUErj8BEB" role="2Ry0An">
                       <property role="2Ry0Am" value="curvesapi-1.04.jar" />
                     </node>
                   </node>
@@ -16968,17 +16881,17 @@
             </node>
           </node>
         </node>
-        <node concept="1SiIV0" id="1C4$Mxwyfej" role="3bR37C">
-          <node concept="1BurEX" id="1C4$Mxwyfek" role="1SiIV1">
-            <node concept="398BVA" id="1C4$Mxwyfe6" role="1BurEY">
+        <node concept="1SiIV0" id="77lUErj8BEZ" role="3bR37C">
+          <node concept="1BurEX" id="77lUErj8BF0" role="1SiIV1">
+            <node concept="398BVA" id="77lUErj8BEM" role="1BurEY">
               <ref role="398BVh" node="1m4fy7Kxwst" resolve="mbeddr.doc" />
-              <node concept="2Ry0Ak" id="1C4$Mxwyfe7" role="iGT6I">
+              <node concept="2Ry0Ak" id="77lUErj8BEN" role="iGT6I">
                 <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="1C4$Mxwyfe8" role="2Ry0An">
+                <node concept="2Ry0Ak" id="77lUErj8BEO" role="2Ry0An">
                   <property role="2Ry0Am" value="com.mbeddr.spreadsheat" />
-                  <node concept="2Ry0Ak" id="1C4$Mxwyfe9" role="2Ry0An">
+                  <node concept="2Ry0Ak" id="77lUErj8BEP" role="2Ry0An">
                     <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="1C4$Mxwyfea" role="2Ry0An">
+                    <node concept="2Ry0Ak" id="77lUErj8BEQ" role="2Ry0An">
                       <property role="2Ry0Am" value="commons-codec-1.10.jar" />
                     </node>
                   </node>
@@ -16987,55 +16900,17 @@
             </node>
           </node>
         </node>
-        <node concept="1SiIV0" id="1C4$Mxwyfey" role="3bR37C">
-          <node concept="1BurEX" id="1C4$Mxwyfez" role="1SiIV1">
-            <node concept="398BVA" id="1C4$Mxwyfel" role="1BurEY">
+        <node concept="1SiIV0" id="77lUErj8BFe" role="3bR37C">
+          <node concept="1BurEX" id="77lUErj8BFf" role="1SiIV1">
+            <node concept="398BVA" id="77lUErj8BF1" role="1BurEY">
               <ref role="398BVh" node="1m4fy7Kxwst" resolve="mbeddr.doc" />
-              <node concept="2Ry0Ak" id="1C4$Mxwyfem" role="iGT6I">
+              <node concept="2Ry0Ak" id="77lUErj8BF2" role="iGT6I">
                 <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="1C4$Mxwyfen" role="2Ry0An">
+                <node concept="2Ry0Ak" id="77lUErj8BF3" role="2Ry0An">
                   <property role="2Ry0Am" value="com.mbeddr.spreadsheat" />
-                  <node concept="2Ry0Ak" id="1C4$Mxwyfeo" role="2Ry0An">
+                  <node concept="2Ry0Ak" id="77lUErj8BF4" role="2Ry0An">
                     <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="1C4$Mxwyfep" role="2Ry0An">
-                      <property role="2Ry0Am" value="commons-collections4-4.1.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="1C4$MxwyfeL" role="3bR37C">
-          <node concept="1BurEX" id="1C4$MxwyfeM" role="1SiIV1">
-            <node concept="398BVA" id="1C4$Mxwyfe$" role="1BurEY">
-              <ref role="398BVh" node="1m4fy7Kxwst" resolve="mbeddr.doc" />
-              <node concept="2Ry0Ak" id="1C4$Mxwyfe_" role="iGT6I">
-                <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="1C4$MxwyfeA" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mbeddr.spreadsheat" />
-                  <node concept="2Ry0Ak" id="1C4$MxwyfeB" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="1C4$MxwyfeC" role="2Ry0An">
-                      <property role="2Ry0Am" value="curvesapi-1.04.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="1C4$Mxwyff0" role="3bR37C">
-          <node concept="1BurEX" id="1C4$Mxwyff1" role="1SiIV1">
-            <node concept="398BVA" id="1C4$MxwyfeN" role="1BurEY">
-              <ref role="398BVh" node="1m4fy7Kxwst" resolve="mbeddr.doc" />
-              <node concept="2Ry0Ak" id="1C4$MxwyfeO" role="iGT6I">
-                <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="1C4$MxwyfeP" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mbeddr.spreadsheat" />
-                  <node concept="2Ry0Ak" id="1C4$MxwyfeQ" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="1C4$MxwyfeR" role="2Ry0An">
+                    <node concept="2Ry0Ak" id="77lUErj8BF5" role="2Ry0An">
                       <property role="2Ry0Am" value="poi-5.0.0.jar" />
                     </node>
                   </node>
@@ -17044,17 +16919,17 @@
             </node>
           </node>
         </node>
-        <node concept="1SiIV0" id="1C4$Mxwyfff" role="3bR37C">
-          <node concept="1BurEX" id="1C4$Mxwyffg" role="1SiIV1">
-            <node concept="398BVA" id="1C4$Mxwyff2" role="1BurEY">
+        <node concept="1SiIV0" id="77lUErj8BFt" role="3bR37C">
+          <node concept="1BurEX" id="77lUErj8BFu" role="1SiIV1">
+            <node concept="398BVA" id="77lUErj8BFg" role="1BurEY">
               <ref role="398BVh" node="1m4fy7Kxwst" resolve="mbeddr.doc" />
-              <node concept="2Ry0Ak" id="1C4$Mxwyff3" role="iGT6I">
+              <node concept="2Ry0Ak" id="77lUErj8BFh" role="iGT6I">
                 <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="1C4$Mxwyff4" role="2Ry0An">
+                <node concept="2Ry0Ak" id="77lUErj8BFi" role="2Ry0An">
                   <property role="2Ry0Am" value="com.mbeddr.spreadsheat" />
-                  <node concept="2Ry0Ak" id="1C4$Mxwyff5" role="2Ry0An">
+                  <node concept="2Ry0Ak" id="77lUErj8BFj" role="2Ry0An">
                     <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="1C4$Mxwyff6" role="2Ry0An">
+                    <node concept="2Ry0Ak" id="77lUErj8BFk" role="2Ry0An">
                       <property role="2Ry0Am" value="poi-ooxml-5.0.0.jar" />
                     </node>
                   </node>
@@ -17063,17 +16938,17 @@
             </node>
           </node>
         </node>
-        <node concept="1SiIV0" id="1C4$Mxwyffu" role="3bR37C">
-          <node concept="1BurEX" id="1C4$Mxwyffv" role="1SiIV1">
-            <node concept="398BVA" id="1C4$Mxwyffh" role="1BurEY">
+        <node concept="1SiIV0" id="77lUErj8BFG" role="3bR37C">
+          <node concept="1BurEX" id="77lUErj8BFH" role="1SiIV1">
+            <node concept="398BVA" id="77lUErj8BFv" role="1BurEY">
               <ref role="398BVh" node="1m4fy7Kxwst" resolve="mbeddr.doc" />
-              <node concept="2Ry0Ak" id="1C4$Mxwyffi" role="iGT6I">
+              <node concept="2Ry0Ak" id="77lUErj8BFw" role="iGT6I">
                 <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="1C4$Mxwyffj" role="2Ry0An">
+                <node concept="2Ry0Ak" id="77lUErj8BFx" role="2Ry0An">
                   <property role="2Ry0Am" value="com.mbeddr.spreadsheat" />
-                  <node concept="2Ry0Ak" id="1C4$Mxwyffk" role="2Ry0An">
+                  <node concept="2Ry0Ak" id="77lUErj8BFy" role="2Ry0An">
                     <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="1C4$Mxwyffl" role="2Ry0An">
+                    <node concept="2Ry0Ak" id="77lUErj8BFz" role="2Ry0An">
                       <property role="2Ry0Am" value="xmlbeans-4.0.0.jar" />
                     </node>
                   </node>
@@ -17082,17 +16957,17 @@
             </node>
           </node>
         </node>
-        <node concept="1SiIV0" id="1C4$MxwyffH" role="3bR37C">
-          <node concept="1BurEX" id="1C4$MxwyffI" role="1SiIV1">
-            <node concept="398BVA" id="1C4$Mxwyffw" role="1BurEY">
+        <node concept="1SiIV0" id="77lUErj8BFV" role="3bR37C">
+          <node concept="1BurEX" id="77lUErj8BFW" role="1SiIV1">
+            <node concept="398BVA" id="77lUErj8BFI" role="1BurEY">
               <ref role="398BVh" node="1m4fy7Kxwst" resolve="mbeddr.doc" />
-              <node concept="2Ry0Ak" id="1C4$Mxwyffx" role="iGT6I">
+              <node concept="2Ry0Ak" id="77lUErj8BFJ" role="iGT6I">
                 <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="1C4$Mxwyffy" role="2Ry0An">
+                <node concept="2Ry0Ak" id="77lUErj8BFK" role="2Ry0An">
                   <property role="2Ry0Am" value="com.mbeddr.spreadsheat" />
-                  <node concept="2Ry0Ak" id="1C4$Mxwyffz" role="2Ry0An">
+                  <node concept="2Ry0Ak" id="77lUErj8BFL" role="2Ry0An">
                     <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="1C4$Mxwyff$" role="2Ry0An">
+                    <node concept="2Ry0Ak" id="77lUErj8BFM" role="2Ry0An">
                       <property role="2Ry0Am" value="poi-ooxml-lite-5.0.0.jar" />
                     </node>
                   </node>
@@ -17101,17 +16976,17 @@
             </node>
           </node>
         </node>
-        <node concept="1SiIV0" id="1C4$MxwyffW" role="3bR37C">
-          <node concept="1BurEX" id="1C4$MxwyffX" role="1SiIV1">
-            <node concept="398BVA" id="1C4$MxwyffJ" role="1BurEY">
+        <node concept="1SiIV0" id="77lUErj8BGa" role="3bR37C">
+          <node concept="1BurEX" id="77lUErj8BGb" role="1SiIV1">
+            <node concept="398BVA" id="77lUErj8BFX" role="1BurEY">
               <ref role="398BVh" node="1m4fy7Kxwst" resolve="mbeddr.doc" />
-              <node concept="2Ry0Ak" id="1C4$MxwyffK" role="iGT6I">
+              <node concept="2Ry0Ak" id="77lUErj8BFY" role="iGT6I">
                 <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="1C4$MxwyffL" role="2Ry0An">
+                <node concept="2Ry0Ak" id="77lUErj8BFZ" role="2Ry0An">
                   <property role="2Ry0Am" value="com.mbeddr.spreadsheat" />
-                  <node concept="2Ry0Ak" id="1C4$MxwyffM" role="2Ry0An">
+                  <node concept="2Ry0Ak" id="77lUErj8BG0" role="2Ry0An">
                     <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="1C4$MxwyffN" role="2Ry0An">
+                    <node concept="2Ry0Ak" id="77lUErj8BG1" role="2Ry0An">
                       <property role="2Ry0Am" value="commons-codec-1.10.jar" />
                     </node>
                   </node>
@@ -17120,17 +16995,17 @@
             </node>
           </node>
         </node>
-        <node concept="1SiIV0" id="1C4$Mxwyfgb" role="3bR37C">
-          <node concept="1BurEX" id="1C4$Mxwyfgc" role="1SiIV1">
-            <node concept="398BVA" id="1C4$MxwyffY" role="1BurEY">
+        <node concept="1SiIV0" id="77lUErj8BGp" role="3bR37C">
+          <node concept="1BurEX" id="77lUErj8BGq" role="1SiIV1">
+            <node concept="398BVA" id="77lUErj8BGc" role="1BurEY">
               <ref role="398BVh" node="1m4fy7Kxwst" resolve="mbeddr.doc" />
-              <node concept="2Ry0Ak" id="1C4$MxwyffZ" role="iGT6I">
+              <node concept="2Ry0Ak" id="77lUErj8BGd" role="iGT6I">
                 <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="1C4$Mxwyfg0" role="2Ry0An">
+                <node concept="2Ry0Ak" id="77lUErj8BGe" role="2Ry0An">
                   <property role="2Ry0Am" value="com.mbeddr.spreadsheat" />
-                  <node concept="2Ry0Ak" id="1C4$Mxwyfg1" role="2Ry0An">
+                  <node concept="2Ry0Ak" id="77lUErj8BGf" role="2Ry0An">
                     <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="1C4$Mxwyfg2" role="2Ry0An">
+                    <node concept="2Ry0Ak" id="77lUErj8BGg" role="2Ry0An">
                       <property role="2Ry0Am" value="commons-collections4-4.1.jar" />
                     </node>
                   </node>
@@ -17139,17 +17014,17 @@
             </node>
           </node>
         </node>
-        <node concept="1SiIV0" id="1C4$Mxwyfgq" role="3bR37C">
-          <node concept="1BurEX" id="1C4$Mxwyfgr" role="1SiIV1">
-            <node concept="398BVA" id="1C4$Mxwyfgd" role="1BurEY">
+        <node concept="1SiIV0" id="77lUErj8BGC" role="3bR37C">
+          <node concept="1BurEX" id="77lUErj8BGD" role="1SiIV1">
+            <node concept="398BVA" id="77lUErj8BGr" role="1BurEY">
               <ref role="398BVh" node="1m4fy7Kxwst" resolve="mbeddr.doc" />
-              <node concept="2Ry0Ak" id="1C4$Mxwyfge" role="iGT6I">
+              <node concept="2Ry0Ak" id="77lUErj8BGs" role="iGT6I">
                 <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="1C4$Mxwyfgf" role="2Ry0An">
+                <node concept="2Ry0Ak" id="77lUErj8BGt" role="2Ry0An">
                   <property role="2Ry0Am" value="com.mbeddr.spreadsheat" />
-                  <node concept="2Ry0Ak" id="1C4$Mxwyfgg" role="2Ry0An">
+                  <node concept="2Ry0Ak" id="77lUErj8BGu" role="2Ry0An">
                     <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="1C4$Mxwyfgh" role="2Ry0An">
+                    <node concept="2Ry0Ak" id="77lUErj8BGv" role="2Ry0An">
                       <property role="2Ry0Am" value="curvesapi-1.04.jar" />
                     </node>
                   </node>
@@ -17158,17 +17033,17 @@
             </node>
           </node>
         </node>
-        <node concept="1SiIV0" id="1C4$MxwyfgD" role="3bR37C">
-          <node concept="1BurEX" id="1C4$MxwyfgE" role="1SiIV1">
-            <node concept="398BVA" id="1C4$Mxwyfgs" role="1BurEY">
+        <node concept="1SiIV0" id="77lUErj8BGR" role="3bR37C">
+          <node concept="1BurEX" id="77lUErj8BGS" role="1SiIV1">
+            <node concept="398BVA" id="77lUErj8BGE" role="1BurEY">
               <ref role="398BVh" node="1m4fy7Kxwst" resolve="mbeddr.doc" />
-              <node concept="2Ry0Ak" id="1C4$Mxwyfgt" role="iGT6I">
+              <node concept="2Ry0Ak" id="77lUErj8BGF" role="iGT6I">
                 <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="1C4$Mxwyfgu" role="2Ry0An">
+                <node concept="2Ry0Ak" id="77lUErj8BGG" role="2Ry0An">
                   <property role="2Ry0Am" value="com.mbeddr.spreadsheat" />
-                  <node concept="2Ry0Ak" id="1C4$Mxwyfgv" role="2Ry0An">
+                  <node concept="2Ry0Ak" id="77lUErj8BGH" role="2Ry0An">
                     <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="1C4$Mxwyfgw" role="2Ry0An">
+                    <node concept="2Ry0Ak" id="77lUErj8BGI" role="2Ry0An">
                       <property role="2Ry0Am" value="poi-5.0.0.jar" />
                     </node>
                   </node>
@@ -17177,17 +17052,17 @@
             </node>
           </node>
         </node>
-        <node concept="1SiIV0" id="1C4$MxwyfgS" role="3bR37C">
-          <node concept="1BurEX" id="1C4$MxwyfgT" role="1SiIV1">
-            <node concept="398BVA" id="1C4$MxwyfgF" role="1BurEY">
+        <node concept="1SiIV0" id="77lUErj8BH6" role="3bR37C">
+          <node concept="1BurEX" id="77lUErj8BH7" role="1SiIV1">
+            <node concept="398BVA" id="77lUErj8BGT" role="1BurEY">
               <ref role="398BVh" node="1m4fy7Kxwst" resolve="mbeddr.doc" />
-              <node concept="2Ry0Ak" id="1C4$MxwyfgG" role="iGT6I">
+              <node concept="2Ry0Ak" id="77lUErj8BGU" role="iGT6I">
                 <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="1C4$MxwyfgH" role="2Ry0An">
+                <node concept="2Ry0Ak" id="77lUErj8BGV" role="2Ry0An">
                   <property role="2Ry0Am" value="com.mbeddr.spreadsheat" />
-                  <node concept="2Ry0Ak" id="1C4$MxwyfgI" role="2Ry0An">
+                  <node concept="2Ry0Ak" id="77lUErj8BGW" role="2Ry0An">
                     <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="1C4$MxwyfgJ" role="2Ry0An">
+                    <node concept="2Ry0Ak" id="77lUErj8BGX" role="2Ry0An">
                       <property role="2Ry0Am" value="poi-ooxml-5.0.0.jar" />
                     </node>
                   </node>
@@ -17196,17 +17071,17 @@
             </node>
           </node>
         </node>
-        <node concept="1SiIV0" id="1C4$Mxwyfh7" role="3bR37C">
-          <node concept="1BurEX" id="1C4$Mxwyfh8" role="1SiIV1">
-            <node concept="398BVA" id="1C4$MxwyfgU" role="1BurEY">
+        <node concept="1SiIV0" id="77lUErj8BHl" role="3bR37C">
+          <node concept="1BurEX" id="77lUErj8BHm" role="1SiIV1">
+            <node concept="398BVA" id="77lUErj8BH8" role="1BurEY">
               <ref role="398BVh" node="1m4fy7Kxwst" resolve="mbeddr.doc" />
-              <node concept="2Ry0Ak" id="1C4$MxwyfgV" role="iGT6I">
+              <node concept="2Ry0Ak" id="77lUErj8BH9" role="iGT6I">
                 <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="1C4$MxwyfgW" role="2Ry0An">
+                <node concept="2Ry0Ak" id="77lUErj8BHa" role="2Ry0An">
                   <property role="2Ry0Am" value="com.mbeddr.spreadsheat" />
-                  <node concept="2Ry0Ak" id="1C4$MxwyfgX" role="2Ry0An">
+                  <node concept="2Ry0Ak" id="77lUErj8BHb" role="2Ry0An">
                     <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="1C4$MxwyfgY" role="2Ry0An">
+                    <node concept="2Ry0Ak" id="77lUErj8BHc" role="2Ry0An">
                       <property role="2Ry0Am" value="xmlbeans-4.0.0.jar" />
                     </node>
                   </node>
@@ -17215,17 +17090,549 @@
             </node>
           </node>
         </node>
-        <node concept="1SiIV0" id="1C4$Mxwyfhm" role="3bR37C">
-          <node concept="1BurEX" id="1C4$Mxwyfhn" role="1SiIV1">
-            <node concept="398BVA" id="1C4$Mxwyfh9" role="1BurEY">
+        <node concept="1SiIV0" id="77lUErj8BH$" role="3bR37C">
+          <node concept="1BurEX" id="77lUErj8BH_" role="1SiIV1">
+            <node concept="398BVA" id="77lUErj8BHn" role="1BurEY">
               <ref role="398BVh" node="1m4fy7Kxwst" resolve="mbeddr.doc" />
-              <node concept="2Ry0Ak" id="1C4$Mxwyfha" role="iGT6I">
+              <node concept="2Ry0Ak" id="77lUErj8BHo" role="iGT6I">
                 <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="1C4$Mxwyfhb" role="2Ry0An">
+                <node concept="2Ry0Ak" id="77lUErj8BHp" role="2Ry0An">
                   <property role="2Ry0Am" value="com.mbeddr.spreadsheat" />
-                  <node concept="2Ry0Ak" id="1C4$Mxwyfhc" role="2Ry0An">
+                  <node concept="2Ry0Ak" id="77lUErj8BHq" role="2Ry0An">
                     <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="1C4$Mxwyfhd" role="2Ry0An">
+                    <node concept="2Ry0Ak" id="77lUErj8BHr" role="2Ry0An">
+                      <property role="2Ry0Am" value="poi-ooxml-lite-5.0.0.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="77lUErj8BHN" role="3bR37C">
+          <node concept="1BurEX" id="77lUErj8BHO" role="1SiIV1">
+            <node concept="398BVA" id="77lUErj8BHA" role="1BurEY">
+              <ref role="398BVh" node="1m4fy7Kxwst" resolve="mbeddr.doc" />
+              <node concept="2Ry0Ak" id="77lUErj8BHB" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="77lUErj8BHC" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mbeddr.spreadsheat" />
+                  <node concept="2Ry0Ak" id="77lUErj8BHD" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                    <node concept="2Ry0Ak" id="77lUErj8BHE" role="2Ry0An">
+                      <property role="2Ry0Am" value="commons-codec-1.10.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="77lUErj8BI2" role="3bR37C">
+          <node concept="1BurEX" id="77lUErj8BI3" role="1SiIV1">
+            <node concept="398BVA" id="77lUErj8BHP" role="1BurEY">
+              <ref role="398BVh" node="1m4fy7Kxwst" resolve="mbeddr.doc" />
+              <node concept="2Ry0Ak" id="77lUErj8BHQ" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="77lUErj8BHR" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mbeddr.spreadsheat" />
+                  <node concept="2Ry0Ak" id="77lUErj8BHS" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                    <node concept="2Ry0Ak" id="77lUErj8BHT" role="2Ry0An">
+                      <property role="2Ry0Am" value="commons-collections4-4.1.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="77lUErj8BIh" role="3bR37C">
+          <node concept="1BurEX" id="77lUErj8BIi" role="1SiIV1">
+            <node concept="398BVA" id="77lUErj8BI4" role="1BurEY">
+              <ref role="398BVh" node="1m4fy7Kxwst" resolve="mbeddr.doc" />
+              <node concept="2Ry0Ak" id="77lUErj8BI5" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="77lUErj8BI6" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mbeddr.spreadsheat" />
+                  <node concept="2Ry0Ak" id="77lUErj8BI7" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                    <node concept="2Ry0Ak" id="77lUErj8BI8" role="2Ry0An">
+                      <property role="2Ry0Am" value="curvesapi-1.04.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="77lUErj8BIw" role="3bR37C">
+          <node concept="1BurEX" id="77lUErj8BIx" role="1SiIV1">
+            <node concept="398BVA" id="77lUErj8BIj" role="1BurEY">
+              <ref role="398BVh" node="1m4fy7Kxwst" resolve="mbeddr.doc" />
+              <node concept="2Ry0Ak" id="77lUErj8BIk" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="77lUErj8BIl" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mbeddr.spreadsheat" />
+                  <node concept="2Ry0Ak" id="77lUErj8BIm" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                    <node concept="2Ry0Ak" id="77lUErj8BIn" role="2Ry0An">
+                      <property role="2Ry0Am" value="poi-5.0.0.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="77lUErj8BIJ" role="3bR37C">
+          <node concept="1BurEX" id="77lUErj8BIK" role="1SiIV1">
+            <node concept="398BVA" id="77lUErj8BIy" role="1BurEY">
+              <ref role="398BVh" node="1m4fy7Kxwst" resolve="mbeddr.doc" />
+              <node concept="2Ry0Ak" id="77lUErj8BIz" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="77lUErj8BI$" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mbeddr.spreadsheat" />
+                  <node concept="2Ry0Ak" id="77lUErj8BI_" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                    <node concept="2Ry0Ak" id="77lUErj8BIA" role="2Ry0An">
+                      <property role="2Ry0Am" value="poi-ooxml-5.0.0.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="77lUErj8BIY" role="3bR37C">
+          <node concept="1BurEX" id="77lUErj8BIZ" role="1SiIV1">
+            <node concept="398BVA" id="77lUErj8BIL" role="1BurEY">
+              <ref role="398BVh" node="1m4fy7Kxwst" resolve="mbeddr.doc" />
+              <node concept="2Ry0Ak" id="77lUErj8BIM" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="77lUErj8BIN" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mbeddr.spreadsheat" />
+                  <node concept="2Ry0Ak" id="77lUErj8BIO" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                    <node concept="2Ry0Ak" id="77lUErj8BIP" role="2Ry0An">
+                      <property role="2Ry0Am" value="xmlbeans-4.0.0.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="77lUErj8BJd" role="3bR37C">
+          <node concept="1BurEX" id="77lUErj8BJe" role="1SiIV1">
+            <node concept="398BVA" id="77lUErj8BJ0" role="1BurEY">
+              <ref role="398BVh" node="1m4fy7Kxwst" resolve="mbeddr.doc" />
+              <node concept="2Ry0Ak" id="77lUErj8BJ1" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="77lUErj8BJ2" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mbeddr.spreadsheat" />
+                  <node concept="2Ry0Ak" id="77lUErj8BJ3" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                    <node concept="2Ry0Ak" id="77lUErj8BJ4" role="2Ry0An">
+                      <property role="2Ry0Am" value="poi-ooxml-lite-5.0.0.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="77lUErj8BJs" role="3bR37C">
+          <node concept="1BurEX" id="77lUErj8BJt" role="1SiIV1">
+            <node concept="398BVA" id="77lUErj8BJf" role="1BurEY">
+              <ref role="398BVh" node="1m4fy7Kxwst" resolve="mbeddr.doc" />
+              <node concept="2Ry0Ak" id="77lUErj8BJg" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="77lUErj8BJh" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mbeddr.spreadsheat" />
+                  <node concept="2Ry0Ak" id="77lUErj8BJi" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                    <node concept="2Ry0Ak" id="77lUErj8BJj" role="2Ry0An">
+                      <property role="2Ry0Am" value="commons-codec-1.10.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="77lUErj8BJF" role="3bR37C">
+          <node concept="1BurEX" id="77lUErj8BJG" role="1SiIV1">
+            <node concept="398BVA" id="77lUErj8BJu" role="1BurEY">
+              <ref role="398BVh" node="1m4fy7Kxwst" resolve="mbeddr.doc" />
+              <node concept="2Ry0Ak" id="77lUErj8BJv" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="77lUErj8BJw" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mbeddr.spreadsheat" />
+                  <node concept="2Ry0Ak" id="77lUErj8BJx" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                    <node concept="2Ry0Ak" id="77lUErj8BJy" role="2Ry0An">
+                      <property role="2Ry0Am" value="commons-collections4-4.1.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="77lUErj8BJU" role="3bR37C">
+          <node concept="1BurEX" id="77lUErj8BJV" role="1SiIV1">
+            <node concept="398BVA" id="77lUErj8BJH" role="1BurEY">
+              <ref role="398BVh" node="1m4fy7Kxwst" resolve="mbeddr.doc" />
+              <node concept="2Ry0Ak" id="77lUErj8BJI" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="77lUErj8BJJ" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mbeddr.spreadsheat" />
+                  <node concept="2Ry0Ak" id="77lUErj8BJK" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                    <node concept="2Ry0Ak" id="77lUErj8BJL" role="2Ry0An">
+                      <property role="2Ry0Am" value="curvesapi-1.04.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="77lUErj8BK9" role="3bR37C">
+          <node concept="1BurEX" id="77lUErj8BKa" role="1SiIV1">
+            <node concept="398BVA" id="77lUErj8BJW" role="1BurEY">
+              <ref role="398BVh" node="1m4fy7Kxwst" resolve="mbeddr.doc" />
+              <node concept="2Ry0Ak" id="77lUErj8BJX" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="77lUErj8BJY" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mbeddr.spreadsheat" />
+                  <node concept="2Ry0Ak" id="77lUErj8BJZ" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                    <node concept="2Ry0Ak" id="77lUErj8BK0" role="2Ry0An">
+                      <property role="2Ry0Am" value="poi-5.0.0.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="77lUErj8BKo" role="3bR37C">
+          <node concept="1BurEX" id="77lUErj8BKp" role="1SiIV1">
+            <node concept="398BVA" id="77lUErj8BKb" role="1BurEY">
+              <ref role="398BVh" node="1m4fy7Kxwst" resolve="mbeddr.doc" />
+              <node concept="2Ry0Ak" id="77lUErj8BKc" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="77lUErj8BKd" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mbeddr.spreadsheat" />
+                  <node concept="2Ry0Ak" id="77lUErj8BKe" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                    <node concept="2Ry0Ak" id="77lUErj8BKf" role="2Ry0An">
+                      <property role="2Ry0Am" value="poi-ooxml-5.0.0.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="77lUErj8BKB" role="3bR37C">
+          <node concept="1BurEX" id="77lUErj8BKC" role="1SiIV1">
+            <node concept="398BVA" id="77lUErj8BKq" role="1BurEY">
+              <ref role="398BVh" node="1m4fy7Kxwst" resolve="mbeddr.doc" />
+              <node concept="2Ry0Ak" id="77lUErj8BKr" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="77lUErj8BKs" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mbeddr.spreadsheat" />
+                  <node concept="2Ry0Ak" id="77lUErj8BKt" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                    <node concept="2Ry0Ak" id="77lUErj8BKu" role="2Ry0An">
+                      <property role="2Ry0Am" value="xmlbeans-4.0.0.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="77lUErj8BKQ" role="3bR37C">
+          <node concept="1BurEX" id="77lUErj8BKR" role="1SiIV1">
+            <node concept="398BVA" id="77lUErj8BKD" role="1BurEY">
+              <ref role="398BVh" node="1m4fy7Kxwst" resolve="mbeddr.doc" />
+              <node concept="2Ry0Ak" id="77lUErj8BKE" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="77lUErj8BKF" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mbeddr.spreadsheat" />
+                  <node concept="2Ry0Ak" id="77lUErj8BKG" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                    <node concept="2Ry0Ak" id="77lUErj8BKH" role="2Ry0An">
+                      <property role="2Ry0Am" value="poi-ooxml-lite-5.0.0.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="77lUErj8BL5" role="3bR37C">
+          <node concept="1BurEX" id="77lUErj8BL6" role="1SiIV1">
+            <node concept="398BVA" id="77lUErj8BKS" role="1BurEY">
+              <ref role="398BVh" node="1m4fy7Kxwst" resolve="mbeddr.doc" />
+              <node concept="2Ry0Ak" id="77lUErj8BKT" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="77lUErj8BKU" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mbeddr.spreadsheat" />
+                  <node concept="2Ry0Ak" id="77lUErj8BKV" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                    <node concept="2Ry0Ak" id="77lUErj8BKW" role="2Ry0An">
+                      <property role="2Ry0Am" value="commons-codec-1.10.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="77lUErj8BLk" role="3bR37C">
+          <node concept="1BurEX" id="77lUErj8BLl" role="1SiIV1">
+            <node concept="398BVA" id="77lUErj8BL7" role="1BurEY">
+              <ref role="398BVh" node="1m4fy7Kxwst" resolve="mbeddr.doc" />
+              <node concept="2Ry0Ak" id="77lUErj8BL8" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="77lUErj8BL9" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mbeddr.spreadsheat" />
+                  <node concept="2Ry0Ak" id="77lUErj8BLa" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                    <node concept="2Ry0Ak" id="77lUErj8BLb" role="2Ry0An">
+                      <property role="2Ry0Am" value="commons-collections4-4.1.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="77lUErj8BLz" role="3bR37C">
+          <node concept="1BurEX" id="77lUErj8BL$" role="1SiIV1">
+            <node concept="398BVA" id="77lUErj8BLm" role="1BurEY">
+              <ref role="398BVh" node="1m4fy7Kxwst" resolve="mbeddr.doc" />
+              <node concept="2Ry0Ak" id="77lUErj8BLn" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="77lUErj8BLo" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mbeddr.spreadsheat" />
+                  <node concept="2Ry0Ak" id="77lUErj8BLp" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                    <node concept="2Ry0Ak" id="77lUErj8BLq" role="2Ry0An">
+                      <property role="2Ry0Am" value="curvesapi-1.04.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="77lUErj8BLM" role="3bR37C">
+          <node concept="1BurEX" id="77lUErj8BLN" role="1SiIV1">
+            <node concept="398BVA" id="77lUErj8BL_" role="1BurEY">
+              <ref role="398BVh" node="1m4fy7Kxwst" resolve="mbeddr.doc" />
+              <node concept="2Ry0Ak" id="77lUErj8BLA" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="77lUErj8BLB" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mbeddr.spreadsheat" />
+                  <node concept="2Ry0Ak" id="77lUErj8BLC" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                    <node concept="2Ry0Ak" id="77lUErj8BLD" role="2Ry0An">
+                      <property role="2Ry0Am" value="poi-5.0.0.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="77lUErj8BM1" role="3bR37C">
+          <node concept="1BurEX" id="77lUErj8BM2" role="1SiIV1">
+            <node concept="398BVA" id="77lUErj8BLO" role="1BurEY">
+              <ref role="398BVh" node="1m4fy7Kxwst" resolve="mbeddr.doc" />
+              <node concept="2Ry0Ak" id="77lUErj8BLP" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="77lUErj8BLQ" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mbeddr.spreadsheat" />
+                  <node concept="2Ry0Ak" id="77lUErj8BLR" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                    <node concept="2Ry0Ak" id="77lUErj8BLS" role="2Ry0An">
+                      <property role="2Ry0Am" value="poi-ooxml-5.0.0.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="77lUErj8BMg" role="3bR37C">
+          <node concept="1BurEX" id="77lUErj8BMh" role="1SiIV1">
+            <node concept="398BVA" id="77lUErj8BM3" role="1BurEY">
+              <ref role="398BVh" node="1m4fy7Kxwst" resolve="mbeddr.doc" />
+              <node concept="2Ry0Ak" id="77lUErj8BM4" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="77lUErj8BM5" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mbeddr.spreadsheat" />
+                  <node concept="2Ry0Ak" id="77lUErj8BM6" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                    <node concept="2Ry0Ak" id="77lUErj8BM7" role="2Ry0An">
+                      <property role="2Ry0Am" value="xmlbeans-4.0.0.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="77lUErj8BMv" role="3bR37C">
+          <node concept="1BurEX" id="77lUErj8BMw" role="1SiIV1">
+            <node concept="398BVA" id="77lUErj8BMi" role="1BurEY">
+              <ref role="398BVh" node="1m4fy7Kxwst" resolve="mbeddr.doc" />
+              <node concept="2Ry0Ak" id="77lUErj8BMj" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="77lUErj8BMk" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mbeddr.spreadsheat" />
+                  <node concept="2Ry0Ak" id="77lUErj8BMl" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                    <node concept="2Ry0Ak" id="77lUErj8BMm" role="2Ry0An">
+                      <property role="2Ry0Am" value="poi-ooxml-lite-5.0.0.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="77lUErj8BMI" role="3bR37C">
+          <node concept="1BurEX" id="77lUErj8BMJ" role="1SiIV1">
+            <node concept="398BVA" id="77lUErj8BMx" role="1BurEY">
+              <ref role="398BVh" node="1m4fy7Kxwst" resolve="mbeddr.doc" />
+              <node concept="2Ry0Ak" id="77lUErj8BMy" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="77lUErj8BMz" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mbeddr.spreadsheat" />
+                  <node concept="2Ry0Ak" id="77lUErj8BM$" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                    <node concept="2Ry0Ak" id="77lUErj8BM_" role="2Ry0An">
+                      <property role="2Ry0Am" value="commons-codec-1.10.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="77lUErj8BMX" role="3bR37C">
+          <node concept="1BurEX" id="77lUErj8BMY" role="1SiIV1">
+            <node concept="398BVA" id="77lUErj8BMK" role="1BurEY">
+              <ref role="398BVh" node="1m4fy7Kxwst" resolve="mbeddr.doc" />
+              <node concept="2Ry0Ak" id="77lUErj8BML" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="77lUErj8BMM" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mbeddr.spreadsheat" />
+                  <node concept="2Ry0Ak" id="77lUErj8BMN" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                    <node concept="2Ry0Ak" id="77lUErj8BMO" role="2Ry0An">
+                      <property role="2Ry0Am" value="commons-collections4-4.1.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="77lUErj8BNc" role="3bR37C">
+          <node concept="1BurEX" id="77lUErj8BNd" role="1SiIV1">
+            <node concept="398BVA" id="77lUErj8BMZ" role="1BurEY">
+              <ref role="398BVh" node="1m4fy7Kxwst" resolve="mbeddr.doc" />
+              <node concept="2Ry0Ak" id="77lUErj8BN0" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="77lUErj8BN1" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mbeddr.spreadsheat" />
+                  <node concept="2Ry0Ak" id="77lUErj8BN2" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                    <node concept="2Ry0Ak" id="77lUErj8BN3" role="2Ry0An">
+                      <property role="2Ry0Am" value="curvesapi-1.04.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="77lUErj8BNr" role="3bR37C">
+          <node concept="1BurEX" id="77lUErj8BNs" role="1SiIV1">
+            <node concept="398BVA" id="77lUErj8BNe" role="1BurEY">
+              <ref role="398BVh" node="1m4fy7Kxwst" resolve="mbeddr.doc" />
+              <node concept="2Ry0Ak" id="77lUErj8BNf" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="77lUErj8BNg" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mbeddr.spreadsheat" />
+                  <node concept="2Ry0Ak" id="77lUErj8BNh" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                    <node concept="2Ry0Ak" id="77lUErj8BNi" role="2Ry0An">
+                      <property role="2Ry0Am" value="poi-5.0.0.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="77lUErj8BNE" role="3bR37C">
+          <node concept="1BurEX" id="77lUErj8BNF" role="1SiIV1">
+            <node concept="398BVA" id="77lUErj8BNt" role="1BurEY">
+              <ref role="398BVh" node="1m4fy7Kxwst" resolve="mbeddr.doc" />
+              <node concept="2Ry0Ak" id="77lUErj8BNu" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="77lUErj8BNv" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mbeddr.spreadsheat" />
+                  <node concept="2Ry0Ak" id="77lUErj8BNw" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                    <node concept="2Ry0Ak" id="77lUErj8BNx" role="2Ry0An">
+                      <property role="2Ry0Am" value="poi-ooxml-5.0.0.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="77lUErj8BNT" role="3bR37C">
+          <node concept="1BurEX" id="77lUErj8BNU" role="1SiIV1">
+            <node concept="398BVA" id="77lUErj8BNG" role="1BurEY">
+              <ref role="398BVh" node="1m4fy7Kxwst" resolve="mbeddr.doc" />
+              <node concept="2Ry0Ak" id="77lUErj8BNH" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="77lUErj8BNI" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mbeddr.spreadsheat" />
+                  <node concept="2Ry0Ak" id="77lUErj8BNJ" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                    <node concept="2Ry0Ak" id="77lUErj8BNK" role="2Ry0An">
+                      <property role="2Ry0Am" value="xmlbeans-4.0.0.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="77lUErj8BO8" role="3bR37C">
+          <node concept="1BurEX" id="77lUErj8BO9" role="1SiIV1">
+            <node concept="398BVA" id="77lUErj8BNV" role="1BurEY">
+              <ref role="398BVh" node="1m4fy7Kxwst" resolve="mbeddr.doc" />
+              <node concept="2Ry0Ak" id="77lUErj8BNW" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="77lUErj8BNX" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mbeddr.spreadsheat" />
+                  <node concept="2Ry0Ak" id="77lUErj8BNY" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                    <node concept="2Ry0Ak" id="77lUErj8BNZ" role="2Ry0An">
                       <property role="2Ry0Am" value="poi-ooxml-lite-5.0.0.jar" />
                     </node>
                   </node>

--- a/code/languages/com.mbeddr.core/languages/com.mbeddr.core.base/solutions/pluginSolution/models/com/mbeddr/core/base/pluginSolution/plugin.mps
+++ b/code/languages/com.mbeddr.core/languages/com.mbeddr.core.base/solutions/pluginSolution/models/com/mbeddr/core/base/pluginSolution/plugin.mps
@@ -11,18 +11,12 @@
     <use id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections" version="2" />
     <use id="63650c59-16c8-498a-99c8-005c7ee9515d" name="jetbrains.mps.lang.access" version="-1" />
     <use id="63e0e566-5131-447e-90e3-12ea330e1a00" name="com.mbeddr.mpsutil.blutil" version="3" />
-    <use id="c3bfea76-7bba-4f0e-b5a2-ff4e7a8d7cf1" name="com.mbeddr.mpsutil.spreferences" version="-1" />
-    <use id="fe9d76d7-5809-45c9-ae28-a40915b4d6ff" name="jetbrains.mps.lang.checkedName" version="1" />
     <use id="760a0a8c-eabb-4521-8bfd-65db761a9ba3" name="jetbrains.mps.baseLanguage.logging" version="-1" />
     <use id="58e731a3-6aaa-444a-bf40-801b91c15878" name="com.mbeddr.mpsutil.lang.plugin.extensions" version="-1" />
     <use id="aee9cad2-acd4-4608-aef2-0004f6a1cdbd" name="jetbrains.mps.lang.actions" version="-1" />
-    <use id="13744753-c81f-424a-9c1b-cf8943bf4e86" name="jetbrains.mps.lang.sharedConcepts" version="-1" />
-    <use id="ed6d7656-532c-4bc2-81d1-af945aeb8280" name="jetbrains.mps.baseLanguage.blTypes" version="-1" />
-    <use id="9ded098b-ad6a-4657-bfd9-48636cfe8bc3" name="jetbrains.mps.lang.traceable" version="-1" />
     <use id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core" version="2" />
     <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
     <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="12" />
-    <use id="c72da2b9-7cce-4447-8389-f407dc1158b7" name="jetbrains.mps.lang.structure" version="9" />
     <use id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc" version="-1" />
     <use id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor" version="14" />
     <use id="774bf8a0-62e5-41e1-af63-f4812e60e48b" name="jetbrains.mps.baseLanguage.checkedDots" version="0" />
@@ -34,20 +28,15 @@
     <import index="k3nr" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.ide.editor(MPS.Editor/)" />
     <import index="exr9" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor(MPS.Editor/)" />
     <import index="71xd" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.ide.tools(MPS.Platform/)" />
-    <import index="k4i4" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.ide.findusages.findalgorithm.finders(MPS.Core/)" />
     <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
     <import index="dxuu" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:javax.swing(JDK/)" />
     <import index="z1c3" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.project(MPS.Core/)" />
     <import index="hyam" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt.event(JDK/)" />
     <import index="w1kc" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel(MPS.Core/)" />
-    <import index="ngmm" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.ide.findusages.view(MPS.Core/)" />
     <import index="z60i" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt(JDK/)" />
-    <import index="xnls" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.ide.icons(MPS.Platform/)" />
     <import index="z1c4" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.project(MPS.Platform/)" />
     <import index="mk8z" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.progress(MPS.Core/)" />
     <import index="18ew" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.util(MPS.Core/)" />
-    <import index="9erk" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.ide.findusages.model(MPS.Core/)" />
-    <import index="ogzp" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.ide.findusages(MPS.Core/)" />
     <import index="alof" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.ide.project(MPS.Platform/)" />
     <import index="vs0r" ref="r:f7764ca4-8c75-4049-922b-08516400a727(com.mbeddr.core.base.structure)" />
     <import index="hwgx" ref="r:fd2980c8-676c-4b19-b524-18c70e02f8b7(com.mbeddr.core.base.behavior)" />
@@ -60,19 +49,15 @@
     <import index="c8ee" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:javax.swing.table(JDK/)" />
     <import index="mk90" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.progress(MPS.Platform/)" />
     <import index="r791" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:javax.swing.text(JDK/)" />
-    <import index="ngmn" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.ide.findusages.view(MPS.Platform/)" />
-    <import index="gkle" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.ide.findusages.view.treeholder.tree(MPS.Platform/)" />
     <import index="xygl" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.progress(MPS.IDEA/)" />
     <import index="jkm4" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.ui(MPS.IDEA/)" />
     <import index="mhfm" ref="3f233e7f-b8a6-46d2-a57f-795d56775243/java:org.jetbrains.annotations(Annotations/)" />
-    <import index="dsdj" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.ide.findusages.view.treeholder.treeview(MPS.Platform/)" />
     <import index="mhbf" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.model(MPS.OpenAPI/)" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" />
     <import index="guwi" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.io(JDK/)" />
     <import index="4nm9" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.project(MPS.IDEA/)" />
     <import index="lui2" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.module(MPS.OpenAPI/)" />
     <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" />
-    <import index="yyf4" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.util(MPS.OpenAPI/)" />
     <import index="qkt" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.actionSystem(MPS.IDEA/)" />
     <import index="qbve" ref="r:35e808a0-0758-4b03-9053-4675a7ced44c(jetbrains.mps.baseLanguage.closures.runtime)" />
     <import index="rvbb" ref="86441d7a-e194-42da-81a5-2161ec62a379/java:jetbrains.mps.ide.projectPane(MPS.Workbench/)" />
@@ -97,19 +82,13 @@
     <import index="9oh" ref="r:de82dfab-9448-49ba-813e-2b0579f7fb15(jetbrains.mps.ide.platform.actions)" />
     <import index="8rsk" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.actionSystem.ex(MPS.IDEA/)" />
     <import index="r4b4" ref="r:1784e088-20fd-4fdb-96b8-bc57f0056d94(com.mbeddr.core.base.editor)" />
-    <import index="z2i8" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.icons(MPS.IDEA/)" />
-    <import index="mklf" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui.content.tabs(MPS.IDEA/)" />
     <import index="f4zo" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.cells(MPS.Editor/)" />
     <import index="y49u" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.util(MPS.OpenAPI/)" />
     <import index="jan3" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt.image(JDK/)" />
     <import index="oqcp" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:javax.imageio(JDK/)" />
-    <import index="ykok" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel.constraints(MPS.Core/)" />
-    <import index="pjrh" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel.adapter(MPS.Core/)" />
     <import index="7a0s" ref="r:2af017c2-293f-4ebb-99f3-81e353b3d6e6(jetbrains.mps.editor.runtime)" />
     <import index="22ra" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.update(MPS.Editor/)" />
     <import index="g51k" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor.cells(MPS.Editor/)" />
-    <import index="f061" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.application.ex(MPS.IDEA/)" />
-    <import index="5zyv" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util.concurrent(JDK/)" />
     <import index="kt01" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt.datatransfer(JDK/)" />
     <import index="sn11" ref="r:836426ab-a6f4-4fa3-9a9c-34c02ed6ab5d(jetbrains.mps.ide.icons)" />
     <import index="lwvz" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.selection(MPS.Editor/)" />
@@ -121,11 +100,13 @@
     <import index="3a50" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.ide(MPS.Platform/)" />
     <import index="o2jy" ref="r:5a764b6f-e05f-4050-b22c-cbcad1577f1b(jetbrains.mps.ide.refactoring)" />
     <import index="pdwk" ref="8e98f4e2-decf-4e97-bf80-9109e8b759ee/java:jetbrains.mps.core.aspects.constraints.rules.kinds(jetbrains.mps.lang.constraints.rules.runtime/)" />
-    <import index="wvnl" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.extensions(MPS.Editor/)" />
     <import index="zyr2" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor.inspector(MPS.Editor/)" />
     <import index="7oz1" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor.configuration(MPS.Editor/)" />
-    <import index="mmaq" ref="f647e48e-4568-4f4c-b48a-1546492c6a2e/java:org.jdom(org.jdom/)" />
-    <import index="ykol" ref="8e98f4e2-decf-4e97-bf80-9109e8b759ee/java:jetbrains.mps.smodel.constraints(jetbrains.mps.lang.constraints.rules.runtime/)" />
+    <import index="wvnl" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.extensions(MPS.Editor/)" />
+    <import index="ykok" ref="8e98f4e2-decf-4e97-bf80-9109e8b759ee/java:jetbrains.mps.smodel.constraints(jetbrains.mps.lang.constraints.rules.runtime/)" />
+    <import index="r3rm" ref="r:7fc96130-6279-4a55-aeeb-422a6879539d(de.itemis.mps.editor.diagram.runtime.jgraph)" />
+    <import index="nkm5" ref="r:095345ad-6627-42ca-9d3f-fc1b2d9fbd61(de.itemis.mps.editor.diagram.runtime.model)" />
+    <import index="1njx" ref="1144260c-e9a5-49a2-9add-39a1a1a7077e/java:com.mxgraph.view(de.itemis.mps.editor.diagram.runtime/)" />
     <import index="68mc" ref="r:2a10821d-612f-4a73-b7b0-ed6b57106321(com.mbeddr.mpsutil.filepicker.structure)" implicit="true" />
   </imports>
   <registry>
@@ -565,6 +546,7 @@
       </concept>
       <concept id="8974276187400348181" name="jetbrains.mps.lang.access.structure.ExecuteLightweightCommandStatement" flags="nn" index="1QHqEK" />
       <concept id="8974276187400348183" name="jetbrains.mps.lang.access.structure.ExecuteWriteActionStatement" flags="nn" index="1QHqEM" />
+      <concept id="8974276187400348177" name="jetbrains.mps.lang.access.structure.ExecuteCommandStatement" flags="nn" index="1QHqEO" />
     </language>
     <language id="774bf8a0-62e5-41e1-af63-f4812e60e48b" name="jetbrains.mps.baseLanguage.checkedDots">
       <concept id="4079382982702596667" name="jetbrains.mps.baseLanguage.checkedDots.structure.CheckedDotExpression" flags="nn" index="2EnYce" />
@@ -7200,8 +7182,8 @@
                                 </node>
                                 <node concept="2OqwBi" id="6g_o1CJDXKQ" role="3uHU7B">
                                   <node concept="2YIFZM" id="6g_o1CJDWBz" role="2Oq$k0">
-                                    <ref role="37wK5l" to="ykol:~ConstraintsCanBeFacade.checkCanBeRoot(jetbrains.mps.core.aspects.constraints.rules.kinds.CanBeRootContext)" resolve="checkCanBeRoot" />
-                                    <ref role="1Pybhc" to="ykol:~ConstraintsCanBeFacade" resolve="ConstraintsCanBeFacade" />
+                                    <ref role="37wK5l" to="ykok:~ConstraintsCanBeFacade.checkCanBeRoot(jetbrains.mps.core.aspects.constraints.rules.kinds.CanBeRootContext)" resolve="checkCanBeRoot" />
+                                    <ref role="1Pybhc" to="ykok:~ConstraintsCanBeFacade" resolve="ConstraintsCanBeFacade" />
                                     <node concept="2ShNRf" id="6g_o1CJDWB$" role="37wK5m">
                                       <node concept="1pGfFk" id="6g_o1CJDWB_" role="2ShVmc">
                                         <ref role="37wK5l" to="pdwk:~CanBeRootContext.&lt;init&gt;(org.jetbrains.mps.openapi.language.SAbstractConcept,org.jetbrains.mps.openapi.model.SModel)" resolve="CanBeRootContext" />
@@ -20499,18 +20481,19 @@
                     </node>
                   </node>
                 </node>
-                <node concept="1QHqEK" id="5Pb2U$k6TNB" role="3cqZAp">
-                  <node concept="1QHqEC" id="5Pb2U$k6TNC" role="1QHqEI">
-                    <node concept="3clFbS" id="5Pb2U$k6TND" role="1bW5cS">
+                <node concept="1QHqEO" id="26a4BNiAbMI" role="3cqZAp">
+                  <node concept="1QHqEC" id="26a4BNiAbMK" role="1QHqEI">
+                    <node concept="3clFbS" id="26a4BNiAbMM" role="1bW5cS">
+                      <node concept="3clFbH" id="26a4BNiE1IE" role="3cqZAp" />
                       <node concept="3cpWs8" id="2hPErkZEtBK" role="3cqZAp">
                         <node concept="3cpWsn" id="2hPErkZEtBL" role="3cpWs9">
                           <property role="TrG5h" value="options" />
                           <node concept="3uibUv" id="2hPErkZEtBM" role="1tU5fm">
-                            <ref role="3uigEE" node="2hPErkZEgVS" resolve="CellEditorScreenshooter.ScreenshotOptions" />
+                            <ref role="3uigEE" node="2hPErkZEgVS" resolve="ScreenshotOptions" />
                           </node>
                           <node concept="2ShNRf" id="2hPErkZEub4" role="33vP2m">
                             <node concept="HV5vD" id="2hPErkZF270" role="2ShVmc">
-                              <ref role="HV5vE" node="2hPErkZEgVS" resolve="CellEditorScreenshooter.ScreenshotOptions" />
+                              <ref role="HV5vE" node="2hPErkZEgVS" resolve="ScreenshotOptions" />
                             </node>
                           </node>
                         </node>
@@ -20580,7 +20563,7 @@
                       </node>
                     </node>
                   </node>
-                  <node concept="37vLTw" id="2pIr2f0y3nC" role="ukAjM">
+                  <node concept="37vLTw" id="26a4BNiAcdr" role="ukAjM">
                     <ref role="3cqZAo" node="2pIr2f0y3nx" resolve="repository" />
                   </node>
                 </node>
@@ -20983,15 +20966,141 @@
                 </node>
               </node>
             </node>
-            <node concept="3clFbF" id="2hPErkZAv7K" role="3cqZAp">
-              <node concept="1rXfSq" id="2hPErkZAv7L" role="3clFbG">
+            <node concept="3clFbH" id="56GB2t_BJBI" role="3cqZAp" />
+            <node concept="3cpWs8" id="5OnCad3K$NA" role="3cqZAp">
+              <node concept="3cpWsn" id="5OnCad3K$NB" role="3cpWs9">
+                <property role="3TUv4t" value="false" />
+                <property role="TrG5h" value="descendants" />
+                <node concept="A3Dl8" id="5OnCad3K$NC" role="1tU5fm">
+                  <node concept="3uibUv" id="5OnCad3K$ND" role="A3Ik2">
+                    <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
+                  </node>
+                </node>
+                <node concept="2YIFZM" id="5OnCad3K$NE" role="33vP2m">
+                  <ref role="1Pybhc" to="f4zo:~CellTraversalUtil" resolve="CellTraversalUtil" />
+                  <ref role="37wK5l" to="f4zo:~CellTraversalUtil.iterateTree(jetbrains.mps.openapi.editor.cells.EditorCell,jetbrains.mps.openapi.editor.cells.EditorCell,boolean)" resolve="iterateTree" />
+                  <node concept="2OqwBi" id="5OnCad3KDw7" role="37wK5m">
+                    <node concept="37vLTw" id="5OnCad3K$NF" role="2Oq$k0">
+                      <ref role="3cqZAo" node="2hPErkZAv65" resolve="editorComp" />
+                    </node>
+                    <node concept="liA8E" id="5OnCad3KFg8" role="2OqNvi">
+                      <ref role="37wK5l" to="exr9:~EditorComponent.getRootCell()" resolve="getRootCell" />
+                    </node>
+                  </node>
+                  <node concept="2OqwBi" id="5OnCad3KJWk" role="37wK5m">
+                    <node concept="37vLTw" id="5OnCad3KIcX" role="2Oq$k0">
+                      <ref role="3cqZAo" node="2hPErkZAv65" resolve="editorComp" />
+                    </node>
+                    <node concept="liA8E" id="5OnCad3KLJ0" role="2OqNvi">
+                      <ref role="37wK5l" to="exr9:~EditorComponent.getRootCell()" resolve="getRootCell" />
+                    </node>
+                  </node>
+                  <node concept="3clFbT" id="5OnCad3K$NH" role="37wK5m">
+                    <property role="3clFbU" value="true" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="3AVU87RRLpe" role="3cqZAp">
+              <node concept="2OqwBi" id="3AVU87RRMH4" role="3clFbG">
+                <node concept="2OqwBi" id="3AVU87RRLpg" role="2Oq$k0">
+                  <node concept="37vLTw" id="3AVU87RRLph" role="2Oq$k0">
+                    <ref role="3cqZAo" node="5OnCad3K$NB" resolve="descendants" />
+                  </node>
+                  <node concept="UnYns" id="3AVU87RRLpi" role="2OqNvi">
+                    <node concept="3uibUv" id="3AVU87RRLpj" role="UnYnz">
+                      <ref role="3uigEE" to="r3rm:4KKQOHIOe6F" resolve="RootDiagramECell" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2es0OD" id="3AVU87RRPK7" role="2OqNvi">
+                  <node concept="1bVj0M" id="3AVU87RRPK9" role="23t8la">
+                    <node concept="3clFbS" id="3AVU87RRPKa" role="1bW5cS">
+                      <node concept="3cpWs8" id="26a4BNiQNhz" role="3cqZAp">
+                        <node concept="3cpWsn" id="26a4BNiQNh$" role="3cpWs9">
+                          <property role="TrG5h" value="rootCell" />
+                          <node concept="3uibUv" id="26a4BNiQNh_" role="1tU5fm">
+                            <ref role="3uigEE" to="r3rm:1yAlWL_Ah1Z" resolve="BaseDiagramDCell" />
+                          </node>
+                          <node concept="10QFUN" id="26a4BNiQNhA" role="33vP2m">
+                            <node concept="3uibUv" id="26a4BNiQNhB" role="10QFUM">
+                              <ref role="3uigEE" to="r3rm:1yAlWL_Ah1Z" resolve="BaseDiagramDCell" />
+                            </node>
+                            <node concept="2OqwBi" id="26a4BNiQNhC" role="10QFUP">
+                              <node concept="37vLTw" id="26a4BNiQNhD" role="2Oq$k0">
+                                <ref role="3cqZAo" node="3AVU87RRPKb" resolve="it" />
+                              </node>
+                              <node concept="liA8E" id="26a4BNiQNhE" role="2OqNvi">
+                                <ref role="37wK5l" to="r3rm:1wCaMthvUVe" resolve="getDCell" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3cpWs8" id="3AVU87RIM2n" role="3cqZAp">
+                        <node concept="3cpWsn" id="3AVU87RIM2o" role="3cpWs9">
+                          <property role="TrG5h" value="model" />
+                          <node concept="3uibUv" id="3AVU87RIKXw" role="1tU5fm">
+                            <ref role="3uigEE" to="nkm5:27djZ8_ZBps" resolve="DiagramModel" />
+                          </node>
+                          <node concept="2OqwBi" id="3AVU87RIM2p" role="33vP2m">
+                            <node concept="37vLTw" id="3AVU87RIM2q" role="2Oq$k0">
+                              <ref role="3cqZAo" node="26a4BNiQNh$" resolve="rootCell" />
+                            </node>
+                            <node concept="liA8E" id="3AVU87RIM2r" role="2OqNvi">
+                              <ref role="37wK5l" to="r3rm:3SIh5TTmBYg" resolve="getDiagramModel" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbF" id="26a4BNiQNhF" role="3cqZAp">
+                        <node concept="2OqwBi" id="26a4BNiQNhG" role="3clFbG">
+                          <node concept="2OqwBi" id="26a4BNiQNhH" role="2Oq$k0">
+                            <node concept="liA8E" id="26a4BNiQNhI" role="2OqNvi">
+                              <ref role="37wK5l" to="nkm5:7k8PWDQhok1" resolve="getLayouter" />
+                            </node>
+                            <node concept="37vLTw" id="3AVU87RIM2s" role="2Oq$k0">
+                              <ref role="3cqZAo" node="3AVU87RIM2o" resolve="model" />
+                            </node>
+                          </node>
+                          <node concept="liA8E" id="26a4BNiQNhM" role="2OqNvi">
+                            <ref role="37wK5l" to="r3rm:xqQxwstVRr" resolve="layout" />
+                            <node concept="2OqwBi" id="26a4BNiQNhN" role="37wK5m">
+                              <node concept="37vLTw" id="26a4BNiQNhO" role="2Oq$k0">
+                                <ref role="3cqZAo" node="3AVU87RRPKb" resolve="it" />
+                              </node>
+                              <node concept="liA8E" id="26a4BNiQNhP" role="2OqNvi">
+                                <ref role="37wK5l" to="r3rm:4HMzb$XPdI$" resolve="getContextGraph" />
+                              </node>
+                            </node>
+                            <node concept="2ShNRf" id="26a4BNiQNhQ" role="37wK5m">
+                              <node concept="1pGfFk" id="26a4BNiQNhR" role="2ShVmc">
+                                <property role="373rjd" value="true" />
+                                <ref role="37wK5l" to="xygl:~EmptyProgressIndicator.&lt;init&gt;()" resolve="EmptyProgressIndicator" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="gl6BB" id="3AVU87RRPKb" role="1bW2Oz">
+                      <property role="TrG5h" value="it" />
+                      <node concept="2jxLKc" id="3AVU87RRPKc" role="1tU5fm" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbH" id="56GB2t_6f9r" role="3cqZAp" />
+            <node concept="3clFbF" id="5OnCad3Wx7N" role="3cqZAp">
+              <node concept="1rXfSq" id="5OnCad3Wx7O" role="3clFbG">
                 <ref role="37wK5l" node="7tcNvKILDLs" resolve="layoutAll" />
-                <node concept="37vLTw" id="2hPErkZAv7M" role="37wK5m">
+                <node concept="37vLTw" id="5OnCad3Wx7P" role="37wK5m">
                   <ref role="3cqZAo" node="2hPErkZAv65" resolve="editorComp" />
                 </node>
               </node>
             </node>
-            <node concept="3clFbH" id="2hPErkZAv7N" role="3cqZAp" />
+            <node concept="3clFbH" id="77lUErj4xz3" role="3cqZAp" />
             <node concept="3cpWs8" id="2hPErkZAv7O" role="3cqZAp">
               <node concept="3cpWsn" id="2hPErkZAv7P" role="3cpWs9">
                 <property role="TrG5h" value="cell" />

--- a/code/languages/com.mbeddr.core/languages/com.mbeddr.core.base/solutions/pluginSolution/pluginSolution.msd
+++ b/code/languages/com.mbeddr.core/languages/com.mbeddr.core.base/solutions/pluginSolution/pluginSolution.msd
@@ -29,14 +29,13 @@
     <dependency reexport="false">5474e4cd-6621-4b33-a39a-75552543ba57(de.slisson.mps.conditionalEditor.hints)</dependency>
     <dependency reexport="false">8e98f4e2-decf-4e97-bf80-9109e8b759ee(jetbrains.mps.lang.constraints.rules.runtime)</dependency>
     <dependency reexport="false">f647e48e-4568-4f4c-b48a-1546492c6a2e(org.jdom)</dependency>
+    <dependency reexport="false">1144260c-e9a5-49a2-9add-39a1a1a7077e(de.itemis.mps.editor.diagram.runtime)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:63e0e566-5131-447e-90e3-12ea330e1a00:com.mbeddr.mpsutil.blutil" version="3" />
     <language slang="l:58e731a3-6aaa-444a-bf40-801b91c15878:com.mbeddr.mpsutil.lang.plugin.extensions" version="0" />
     <language slang="l:1fc20ffe-f35b-4791-a0b7-d706bad5c49a:com.mbeddr.mpsutil.refactoring" version="0" />
-    <language slang="l:c3bfea76-7bba-4f0e-b5a2-ff4e7a8d7cf1:com.mbeddr.mpsutil.spreferences" version="0" />
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
-    <language slang="l:ed6d7656-532c-4bc2-81d1-af945aeb8280:jetbrains.mps.baseLanguage.blTypes" version="0" />
     <language slang="l:774bf8a0-62e5-41e1-af63-f4812e60e48b:jetbrains.mps.baseLanguage.checkedDots" version="0" />
     <language slang="l:443f4c36-fcf5-4eb6-9500-8d06ed259e3e:jetbrains.mps.baseLanguage.classifiers" version="0" />
     <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
@@ -46,7 +45,6 @@
     <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
     <language slang="l:63650c59-16c8-498a-99c8-005c7ee9515d:jetbrains.mps.lang.access" version="0" />
     <language slang="l:aee9cad2-acd4-4608-aef2-0004f6a1cdbd:jetbrains.mps.lang.actions" version="4" />
-    <language slang="l:fe9d76d7-5809-45c9-ae28-a40915b4d6ff:jetbrains.mps.lang.checkedName" version="1" />
     <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
     <language slang="l:18bc6592-03a6-4e29-a83a-7ff23bde13ba:jetbrains.mps.lang.editor" version="14" />
     <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
@@ -54,7 +52,6 @@
     <language slang="l:ef7bf5ac-d06c-4342-b11d-e42104eb9343:jetbrains.mps.lang.plugin.standalone" version="0" />
     <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="5" />
     <language slang="l:982eb8df-2c96-4bd7-9963-11712ea622e5:jetbrains.mps.lang.resources" version="2" />
-    <language slang="l:13744753-c81f-424a-9c1b-cf8943bf4e86:jetbrains.mps.lang.sharedConcepts" version="0" />
     <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="19" />
     <language slang="l:c72da2b9-7cce-4447-8389-f407dc1158b7:jetbrains.mps.lang.structure" version="9" />
     <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
@@ -78,7 +75,12 @@
     <module reference="b4d28e19-7d2d-47e9-943e-3a41f97a0e52(com.mbeddr.mpsutil.plantuml.node)" version="0" />
     <module reference="848ef45d-e560-4e35-853c-f35a64cc135c(de.itemis.mps.editor.celllayout.runtime)" version="0" />
     <module reference="24c96a96-b7a1-4f30-82da-0f8e279a2661(de.itemis.mps.editor.celllayout.styles)" version="0" />
+    <module reference="7b45fa94-2707-4a1a-9e6a-ce40c4aaf35a(de.itemis.mps.editor.collapsible.runtime)" version="0" />
+    <module reference="1144260c-e9a5-49a2-9add-39a1a1a7077e(de.itemis.mps.editor.diagram.runtime)" version="0" />
+    <module reference="56c81845-acaf-48a7-bcd8-e29b36c98dd7(de.itemis.mps.editor.diagram.styles)" version="0" />
+    <module reference="5c13c612-0f7b-4f0a-ab8b-565186b418de(de.itemis.mps.mouselistener.runtime)" version="0" />
     <module reference="cce85e64-7b37-4ad5-b0e6-9d18324cdfb3(de.itemis.mps.selection.runtime)" version="0" />
+    <module reference="0022e9df-2136-4ef8-81b2-08650aeb1dc7(de.itemis.mps.tooltips.runtime)" version="0" />
     <module reference="5474e4cd-6621-4b33-a39a-75552543ba57(de.slisson.mps.conditionalEditor.hints)" version="0" />
     <module reference="dc038ceb-b7ea-4fea-ac12-55f7400e97ba(de.slisson.mps.editor.multiline.runtime)" version="0" />
     <module reference="f0fff802-6d26-4d2e-b89d-391357265626(de.slisson.mps.hacks.editor)" version="0" />

--- a/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/languageModels/plugin.mps
+++ b/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/languageModels/plugin.mps
@@ -2,9 +2,9 @@
 <model ref="r:07597124-beb3-41b7-beb1-a882af3ded40(com.mbeddr.doc.plugin)">
   <persistence version="9" />
   <languages>
-    <use id="28f9e497-3b42-4291-aeba-0a1039153ab1" name="jetbrains.mps.lang.plugin" version="6" />
+    <use id="28f9e497-3b42-4291-aeba-0a1039153ab1" name="jetbrains.mps.lang.plugin" version="5" />
     <use id="443f4c36-fcf5-4eb6-9500-8d06ed259e3e" name="jetbrains.mps.baseLanguage.classifiers" version="-1" />
-    <use id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections" version="2" />
+    <use id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections" version="-1" />
     <use id="ef7bf5ac-d06c-4342-b11d-e42104eb9343" name="jetbrains.mps.lang.plugin.standalone" version="-1" />
     <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="12" />
     <use id="696c1165-4a59-463b-bc5d-902caab85dd0" name="jetbrains.mps.make.facet" version="-1" />
@@ -3571,7 +3571,7 @@
                                   </node>
                                 </node>
                                 <node concept="liA8E" id="5IFGh_MNLfR" role="2OqNvi">
-                                  <ref role="37wK5l" to="lui2:~ModelAccess.runReadAction(java.lang.Runnable)" resolve="runReadAction" />
+                                  <ref role="37wK5l" to="lui2:~ModelAccess.runWriteAction(java.lang.Runnable)" resolve="runWriteAction" />
                                   <node concept="2GrUjf" id="5IFGh_MNLgT" role="37wK5m">
                                     <ref role="2Gs0qQ" node="3kcKtVhLbkt" resolve="currentRunnable" />
                                   </node>
@@ -3596,7 +3596,7 @@
                                     </node>
                                   </node>
                                   <node concept="liA8E" id="3kcKtVhN2Ge" role="2OqNvi">
-                                    <ref role="37wK5l" to="lui2:~ModelAccess.runReadInEDT(java.lang.Runnable)" resolve="runReadInEDT" />
+                                    <ref role="37wK5l" to="lui2:~ModelAccess.runWriteInEDT(java.lang.Runnable)" resolve="runWriteInEDT" />
                                     <node concept="2GrUjf" id="1cBwqeL3E8b" role="37wK5m">
                                       <ref role="2Gs0qQ" node="3kcKtVhLbkt" resolve="currentRunnable" />
                                     </node>


### PR DESCRIPTION
The access was changed to command because the auto-layouter of the diagrams language needs command access and not only read acess to the model.