### PR TITLE
build: Remove unused jdk_home variable

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,27 +29,7 @@ ext.artifactsDir = new File(rootDir, 'artifacts')
 ext.ciBuild = project.findProperty("forceCI") ?: !project.findProperty('mpsHomeDir') && project.hasProperty("teamcity")
 
 afterEvaluate {
-
     ext["itemis.mps.gradle.ant.defaultJavaExecutable"] = tasks.getByName('downloadJbr').javaExecutable
-
-    def jdk_home = null
-
-    if (ext.has('java17_home')) {
-        jdk_home = ext.get('java17_home')
-    } else if (System.getenv('JB_JAVA17_HOME') != null) {
-        jdk_home = System.getenv('JB_JAVA17_HOME')
-    }
-
-    if(jdk_home != null) {
-        // Check JDK location
-        if (!new File(jdk_home, "lib").exists()) {
-            throw new GradleException("Unable to locate JDK home folder. Detected folder is: $jdk_home")
-        } else {
-            ext.jdk_home = jdk_home
-            logger.info 'Using JDK at {}', jdk_home
-            ext["itemis.mps.gradle.ant.defaultJavaExecutable"] = new File(jdk_home, 'bin/java')
-	}
-    }
 }
 
 def hasNonEmptyProperty(property) {

--- a/build/com.mbeddr/build.gradle
+++ b/build/com.mbeddr/build.gradle
@@ -39,18 +39,6 @@ task install() {
 
 logger.info "skipresolve_mps: {}, mpsHomeDir: {}", ext.skipresolve_mps, ext.mpsHomeDir
 
-// JDK_HOME required for adding tools.jar into classpath of the forked ant process
-if (!hasProperty("jdk_home")) {
-    def java_home = System.properties['java.home']
-    def jdk_home = java_home
-    if (!file("$jdk_home/lib").exists()) {
-        throw new GradleException("Was not able to locate jdk home folder. Use 'jdk_home' project variable to specify JDK location explicitly. Current JAVA_HOME is: $java_home")
-    }
-    ext.jdk_home = jdk_home
-}
-
-logger.info "jdk_home: $jdk_home"
-
 ext.artifactsDir = file(rootProject.projectDir.absolutePath + "/artifacts")
 
 ext.mps_home = '-Dmps.home=' + mpsHomeDir.getAbsolutePath()


### PR DESCRIPTION
We use the downloaded JBR to run Ant.