### PR TITLE
mbeddr.doc: clear created words in initialized TextParagraph

### DIFF
--- a/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/languageModels/behavior.mps
+++ b/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/languageModels/behavior.mps
@@ -555,6 +555,22 @@
             </node>
           </node>
         </node>
+        <node concept="3clFbF" id="7eEYhG5G4p6" role="3cqZAp">
+          <node concept="2OqwBi" id="7eEYhG5G7N1" role="3clFbG">
+            <node concept="2OqwBi" id="7eEYhG5G5ly" role="2Oq$k0">
+              <node concept="2OqwBi" id="7eEYhG5G4FD" role="2Oq$k0">
+                <node concept="13iPFW" id="7eEYhG5G4p4" role="2Oq$k0" />
+                <node concept="3TrEf2" id="7eEYhG5G5aM" role="2OqNvi">
+                  <ref role="3Tt5mk" to="2c95:2TZO3DbvcWd" resolve="text" />
+                </node>
+              </node>
+              <node concept="3Tsc0h" id="7eEYhG5G5zU" role="2OqNvi">
+                <ref role="3TtcxE" to="87nw:2dWzqxEBBFI" resolve="words" />
+              </node>
+            </node>
+            <node concept="2Kehj3" id="7eEYhG5GcqX" role="2OqNvi" />
+          </node>
+        </node>
       </node>
     </node>
     <node concept="13i0hz" id="jpyKDg34b8" role="13h7CS">


### PR DESCRIPTION
Otherwise, the created word steals the focus, and it is also not necessary to have a blank word at the beginning of the paragraph.