### PR TITLE
build: Use Gradle lifecycle tasks

### DIFF
--- a/build/com.mbeddr/languages/build.gradle
+++ b/build/com.mbeddr/languages/build.gradle
@@ -1,5 +1,9 @@
 import de.itemis.mps.gradle.*
 
+plugins {
+    id 'lifecycle-base'
+}
+
 // :com.mbeddr.build
 def script_build_mbeddr = new File(scriptsBasePath + "/com.mbeddr.build/" + "build.xml")
 
@@ -157,6 +161,15 @@ task test_mbeddr_xmodel(dependsOn: []) {}
 
 task test_mbeddr(dependsOn: [test_mbeddr_core, test_mbeddr_performance, test_mbeddr_cc, test_mbeddr_ext, test_mbeddr_xmodel]) {}
 
+tasks.register('test') {
+    dependsOn(test_mbeddr)
+}
+
+tasks.named('check') {
+    dependsOn 'test'
+}
+
+
 def pubDeb
 if (ciBuild) {
     pubDeb = test_mbeddr
@@ -220,5 +233,3 @@ if({project.mbeddrBuild}() == "master") {
        */
     tasks.findByName("publishMbeddrPublicationToMavenRepository").dependsOn("publishMbeddrPublicationToGitHubPackagesRepository")
 }
-
-check.dependsOn test_mbeddr

--- a/build/com.mbeddr/languages/build.gradle
+++ b/build/com.mbeddr/languages/build.gradle
@@ -21,6 +21,8 @@ configurations {
     mbeddrPlatform
 }
 
+def usePrebuiltPlatform = ciBuild && !project.hasProperty('forceBuildPlatform')
+
 dependencies {
     junitAnt 'junit:junit:4.12'
     junitAnt('org.apache.ant:ant-junit:1.9.7') {
@@ -29,9 +31,18 @@ dependencies {
     junitAnt('org.apache.ant:ant-junit4:1.9.7') {
         transitive = false
     }
-    mbeddrPlatform "com.mbeddr:platform:$mbeddrPlatformBuildNumber"
-}
 
+    def mbeddrPlatformDependency
+
+    if (usePrebuiltPlatform) {
+        // By default, on CI we don't build the platform but take it from Nexus, unless overridden by `-PforceBuildPlatform`.
+        mbeddrPlatformDependency = "com.mbeddr:platform:$mbeddrPlatformBuildNumber"
+    } else {
+        mbeddrPlatformDependency = project(':com.mbeddr:platform')
+    }
+
+    mbeddrPlatform mbeddrPlatformDependency
+}
 
 task resolve_mbeddr_platform() {
     doLast {
@@ -56,16 +67,7 @@ ant.taskdef(name: 'junitreport', classname: 'org.apache.tools.ant.taskdefs.optio
 
 def mbeddrPlatformDependency
 
-def usePrebuiltPlatform = ciBuild && !project.hasProperty('forceBuildPlatform')
-
-//on teamcity we don't build the platform we take it from the nexus. Locally we want to build it
-if (usePrebuiltPlatform) {
-    mbeddrPlatformDependency = resolve_mbeddr_platform
-} else {
-    mbeddrPlatformDependency = ':com.mbeddr:platform:build_platform'
-}
-
-task build_mbeddr(type: BuildLanguages, dependsOn: [':com.mbeddr:platform:copy_allScripts', mbeddrPlatformDependency]) {
+task build_mbeddr(type: BuildLanguages, dependsOn: [':com.mbeddr:platform:copy_allScripts', configurations.mbeddrPlatform]) {
     script script_build_mbeddr
     outputs.dir("$artifactsDir/mbeddr")
 }

--- a/build/com.mbeddr/languages/build.gradle
+++ b/build/com.mbeddr/languages/build.gradle
@@ -171,18 +171,14 @@ tasks.named('check') {
     dependsOn 'test'
 }
 
-
-def pubDeb
-if (ciBuild) {
-    pubDeb = test_mbeddr
-} else {
-    pubDeb = build_mbeddr
-}
-
-task package_mbeddr(type: Zip, dependsOn: pubDeb) {
+task package_mbeddr(type: Zip, dependsOn: build_mbeddr) {
     archiveFileName = 'com.mbeddr.zip'
     from artifactsDir
     include "mbeddr/**"
+}
+
+artifacts {
+    'default'(package_mbeddr)
 }
 
 publishing {

--- a/build/com.mbeddr/platform/build.gradle
+++ b/build/com.mbeddr/platform/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'lifecycle-base'
+    id 'base'
 }
 
 import de.itemis.mps.gradle.*
@@ -114,6 +114,11 @@ task package_mbeddrPlatform(type: Zip, dependsOn: test_mbeddr_platform) {
     from artifactsDir
     include "com.mbeddr.platform/**"
 }
+
+artifacts {
+    'default'(package_mbeddrPlatform)
+}
+
 
 task defaultWrapper(dependsOn: build_platform) {
     doFirst {

--- a/build/com.mbeddr/platform/build.gradle
+++ b/build/com.mbeddr/platform/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id 'lifecycle-base'
+}
+
 import de.itemis.mps.gradle.*
 
 def script_test_mbeddrPlatform = new File(scriptsBasePath + "/com.mbeddr.platform/" + "build-ts-tests.xml")
@@ -91,6 +95,14 @@ tasks.getByPath(':com.mbeddr:install').dependsOn install_actionsfilter
 task test_mbeddr_platform(type: TestLanguages, dependsOn: build_platform) {
     script script_test_mbeddrPlatform
     description "execute typesystem and generator tests for the plaform"
+}
+
+tasks.register('test') {
+    dependsOn(test_mbeddr_platform)
+}
+
+tasks.named('check') {
+    dependsOn('test')
 }
 
 task build_platform_distribution(type: BuildLanguages, dependsOn: [build_platform, test_mbeddr_platform]) {

--- a/build/com.mbeddr/platform/build.gradle
+++ b/build/com.mbeddr/platform/build.gradle
@@ -109,7 +109,7 @@ task build_platform_distribution(type: BuildLanguages, dependsOn: [build_platfor
     script scriptFile('com.mbeddr.platform/build-distribution.xml')
 }
 
-task package_mbeddrPlatform(type: Zip, dependsOn: test_mbeddr_platform) {
+task package_mbeddrPlatform(type: Zip, dependsOn: build_platform) {
     archiveFileName = 'com.mbeddr.platform.zip'
     from artifactsDir
     include "com.mbeddr.platform/**"


### PR DESCRIPTION
The Gradle convention (as implemented by the built-in [`lifecycle-base` and `base` plugins](https://docs.gradle.org/current/userguide/base_plugin.html)) is to have a `build` task which runs `assemble` and `check`, where `assemble` builds the package and `check` runs tests (by depending on a `test` task) or any further checks such as linting, or in our case potentially model checks.

This PR implements this convention. As a prerequisite, it also decouples `package_*` tasks from `test_*` tasks so that tests only run when explicitly requested.

It should now be possible to simply run `build` or `check` to build and test the whole project.