### PR TITLE
build: depend on resolve_mbeddr_platform

### DIFF
--- a/build/com.mbeddr/languages/build.gradle
+++ b/build/com.mbeddr/languages/build.gradle
@@ -45,6 +45,7 @@ dependencies {
 }
 
 task resolve_mbeddr_platform() {
+    dependsOn(configurations.mbeddrPlatform)
     doLast {
         copy {
             from {
@@ -65,9 +66,7 @@ ant.taskdef(name: 'junit', classname: 'org.apache.tools.ant.taskdefs.optional.ju
 ant.taskdef(name: 'junitreport', classname: 'org.apache.tools.ant.taskdefs.optional.junit.XMLResultAggregator',
         classpath: configurations.junitAnt.asPath)
 
-def mbeddrPlatformDependency
-
-task build_mbeddr(type: BuildLanguages, dependsOn: [':com.mbeddr:platform:copy_allScripts', configurations.mbeddrPlatform]) {
+task build_mbeddr(type: BuildLanguages, dependsOn: [':com.mbeddr:platform:copy_allScripts', 'resolve_mbeddr_platform']) {
     script script_build_mbeddr
     outputs.dir("$artifactsDir/mbeddr")
 }


### PR DESCRIPTION
Because we always need the platform zip unzipped.

In case of a local build we zip the platform first and then unzip it again later, but we keep the projects more independent, and we can fix this later with more Gradle modelling.