### PR TITLE
mbeddr.mpsutil: add a new language com.mbeddr.mpsutil.collections that provides an nset type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is _loosely_ based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). The project does _not_ follow
 Semantic Versioning and the changes are simply documented in reverse chronological order, grouped by calendar month.
 
+# November 2024
+
+## com.mbeddr.mpsutil
+
+### Feature
+
+- A new language `com.mbeddr.mpsutil.collections` was added that adds support for a set type `nset` that use nodes as the values of the set. Equivalence of nodes is checked structurally. The hash code calculation is done for all properties and children and the first level of references. The runtime solution also contains a more general class `EquivalenceHashSet` to implement hashsets with arbitrary `equals` and `hashcode` methods.
+
 # October 2024
 
 ## com.mbeddr.mpsutil

--- a/code/languages/com.mbeddr.build/solutions/com.mbeddr.platform.tests.build/models/com.mbeddr.platform.tests.build.mps
+++ b/code/languages/com.mbeddr.build/solutions/com.mbeddr.platform.tests.build/models/com.mbeddr.platform.tests.build.mps
@@ -1533,6 +1533,21 @@
             <ref role="3bR37D" to="ffeo:7Kfy9QB6KXW" resolve="jetbrains.mps.lang.core" />
           </node>
         </node>
+        <node concept="1SiIV0" id="bHMJKhDDfb" role="3bR37C">
+          <node concept="3bR9La" id="bHMJKhDDfc" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:7Kfy9QB6L9O" resolve="jetbrains.mps.lang.smodel" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="bHMJKhDDfd" role="3bR37C">
+          <node concept="3bR9La" id="bHMJKhDDfe" role="1SiIV1">
+            <ref role="3bR37D" to="al5i:vOGyTeKPEA" resolve="com.mbeddr.mpsutil.ecore.testing" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="bHMJKhDDff" role="3bR37C">
+          <node concept="3bR9La" id="bHMJKhDDfg" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:7Kfy9QB6LaO" resolve="jetbrains.mps.lang.structure" />
+          </node>
+        </node>
         <node concept="398BVA" id="bHMJKhDAXY" role="3LF7KH">
           <ref role="398BVh" node="7hVsScEQJ6E" resolve="mbeddr.mpsutil" />
           <node concept="2Ry0Ak" id="bHMJKhDAYF" role="iGT6I">
@@ -1581,21 +1596,6 @@
             <node concept="3qWCbU" id="5Ap$XSqW8TG" role="3LXTna">
               <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
             </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="bHMJKhDDfb" role="3bR37C">
-          <node concept="3bR9La" id="bHMJKhDDfc" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:7Kfy9QB6L9O" resolve="jetbrains.mps.lang.smodel" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="bHMJKhDDfd" role="3bR37C">
-          <node concept="3bR9La" id="bHMJKhDDfe" role="1SiIV1">
-            <ref role="3bR37D" to="al5i:vOGyTeKPEA" resolve="com.mbeddr.mpsutil.ecore.testing" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="bHMJKhDDff" role="3bR37C">
-          <node concept="3bR9La" id="bHMJKhDDfg" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:7Kfy9QB6LaO" resolve="jetbrains.mps.lang.structure" />
           </node>
         </node>
       </node>
@@ -2878,6 +2878,101 @@
                 <property role="2Ry0Am" value="languages" />
                 <node concept="2Ry0Ak" id="3WyAxHbtRd0" role="2Ry0An">
                   <property role="2Ry0Am" value="com.mbeddr.mpsutil.logicalChild.sandbox" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1E1JtA" id="4JmsWjEwl1e" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="test.com.mbeddr.mpsutil.collections.runtime" />
+        <property role="3LESm3" value="f88d18b6-41df-491c-ad99-c292037bf751" />
+        <node concept="398BVA" id="4JmsWjEwl1W" role="3LF7KH">
+          <ref role="398BVh" node="7hVsScEQJ6E" resolve="mbeddr.mpsutil" />
+          <node concept="2Ry0Ak" id="4JmsWjEwl3k" role="iGT6I">
+            <property role="2Ry0Am" value="solutions" />
+            <node concept="2Ry0Ak" id="4JmsWjEwl4F" role="2Ry0An">
+              <property role="2Ry0Am" value="test.com.mbeddr.mpsutil.collections.runtime" />
+              <node concept="2Ry0Ak" id="4JmsWjEwl62" role="2Ry0An">
+                <property role="2Ry0Am" value="test.com.mbeddr.mpsutil.collections.runtime.msd" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="4JmsWjEwli6" role="3bR37C">
+          <node concept="3bR9La" id="4JmsWjEwli7" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:1H905DlDUSw" resolve="MPS.OpenAPI" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="4JmsWjEwli8" role="3bR37C">
+          <node concept="3bR9La" id="4JmsWjEwli9" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:7Kfy9QB6KXW" resolve="jetbrains.mps.lang.core" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="4JmsWjEwlia" role="3bR37C">
+          <node concept="3bR9La" id="4JmsWjEwlib" role="1SiIV1">
+            <ref role="3bR37D" to="al5i:13oTmDlqC$D" resolve="com.mbeddr.mpsutil.collections" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="4JmsWjEwlic" role="3bR37C">
+          <node concept="3bR9La" id="4JmsWjEwlid" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:7Kfy9QB6KYb" resolve="jetbrains.mps.baseLanguage" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="4JmsWjEwlie" role="3bR37C">
+          <node concept="3bR9La" id="4JmsWjEwlif" role="1SiIV1">
+            <ref role="3bR37D" to="al5i:13oTmDlqAt2" resolve="com.mbeddr.mpsutil.collections.runtime" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="4JmsWjEwlig" role="3bR37C">
+          <node concept="3bR9La" id="4JmsWjEwlih" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:ymnOULAU0H" resolve="jetbrains.mps.lang.test" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="4JmsWjEwlii" role="3bR37C">
+          <node concept="3bR9La" id="4JmsWjEwlij" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:7Kfy9QB6L0h" resolve="jetbrains.mps.baseLanguage.collections" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="4JmsWjEwlik" role="3bR37C">
+          <node concept="3bR9La" id="4JmsWjEwlil" role="1SiIV1">
+            <ref role="3bR37D" to="90a9:6fQhGuklQWU" resolve="de.q60.mps.collections.libs" />
+          </node>
+        </node>
+        <node concept="1BupzO" id="4JmsWjEwliC" role="3bR31x">
+          <property role="3ZfqAx" value="models" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="4JmsWjEwliD" role="1HemKq">
+            <node concept="398BVA" id="4JmsWjEwlim" role="3LXTmr">
+              <ref role="398BVh" node="7hVsScEQJ6E" resolve="mbeddr.mpsutil" />
+              <node concept="2Ry0Ak" id="4JmsWjEwlin" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="4JmsWjEwlio" role="2Ry0An">
+                  <property role="2Ry0Am" value="test.com.mbeddr.mpsutil.collections.runtime" />
+                  <node concept="2Ry0Ak" id="4JmsWjEwlip" role="2Ry0An">
+                    <property role="2Ry0Am" value="models" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="4JmsWjEwliE" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+        <node concept="3rtmxn" id="7MFd5ixyTnb" role="3bR31x">
+          <node concept="3LXTmp" id="7MFd5ixyTnc" role="3rtmxm">
+            <node concept="3qWCbU" id="7MFd5ixyTnd" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+            <node concept="398BVA" id="7MFd5ixyTne" role="3LXTmr">
+              <ref role="398BVh" node="7hVsScEQJ6E" resolve="mbeddr.mpsutil" />
+              <node concept="2Ry0Ak" id="7MFd5ixyTnf" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="7MFd5ixyTng" role="2Ry0An">
+                  <property role="2Ry0Am" value="test.com.mbeddr.mpsutil.collections.runtime" />
                 </node>
               </node>
             </node>

--- a/code/languages/com.mbeddr.build/solutions/com.mbeddr.platform/models/com/mbeddr/platform/build.mps
+++ b/code/languages/com.mbeddr.build/solutions/com.mbeddr.platform/models/com/mbeddr/platform/build.mps
@@ -19924,6 +19924,10 @@
         <ref role="m_rDy" node="2hNr1jFzOYG" resolve="com.mbeddr.mpsutil.checkinHandler" />
         <node concept="pUk6x" id="SUkpD3Rllc" role="pUk7w" />
       </node>
+      <node concept="m$_wl" id="13oTmDlqIT0" role="39821P">
+        <ref role="m_rDy" node="13oTmDlqFtC" resolve="com.mbeddr.mpsutil.collections" />
+        <node concept="pUk6x" id="13oTmDlqJhE" role="pUk7w" />
+      </node>
       <node concept="3_I8Xc" id="1vIw1eCEpcn" role="39821P">
         <ref role="3_I8Xa" node="4SMNYR2Zl4L" resolve="com.mbeddr.mpsutil.actionsfilter" />
       </node>
@@ -20343,6 +20347,288 @@
             </node>
           </node>
         </node>
+      </node>
+    </node>
+    <node concept="2G$12M" id="13oTmDlqAt1" role="3989C9">
+      <property role="TrG5h" value="com.mbeddr.mpsutil.collections" />
+      <node concept="1E1JtA" id="13oTmDlqAt2" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="com.mbeddr.mpsutil.collections.runtime" />
+        <property role="3LESm3" value="3f2dbc2e-ad41-470f-b5f1-2869513d2b58" />
+        <node concept="398BVA" id="13oTmDlqAt3" role="3LF7KH">
+          <ref role="398BVh" node="7uZw0yZ2_Lj" resolve="mpsutil" />
+          <node concept="2Ry0Ak" id="13oTmDlqAt4" role="iGT6I">
+            <property role="2Ry0Am" value="solutions" />
+            <node concept="2Ry0Ak" id="13oTmDlqAt5" role="2Ry0An">
+              <property role="2Ry0Am" value="com.mbeddr.mpsutil.collections.runtime" />
+              <node concept="2Ry0Ak" id="13oTmDlqB2t" role="2Ry0An">
+                <property role="2Ry0Am" value="com.mbeddr.mpsutil.collections.runtime.msd" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="13oTmDlqAt7" role="3bR37C">
+          <node concept="3bR9La" id="13oTmDlqAt8" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:1H905DlDUSw" resolve="MPS.OpenAPI" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="13oTmDlqAt9" role="3bR37C">
+          <node concept="3bR9La" id="13oTmDlqAta" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="13oTmDlqAtf" role="3bR37C">
+          <node concept="3bR9La" id="13oTmDlqAtg" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:1TaHNgiIbIQ" resolve="MPS.Core" />
+          </node>
+        </node>
+        <node concept="1BupzO" id="13oTmDlqAth" role="3bR31x">
+          <property role="3ZfqAx" value="models" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="13oTmDlqBZG" role="1HemKq">
+            <node concept="398BVA" id="13oTmDlqBZx" role="3LXTmr">
+              <ref role="398BVh" node="7uZw0yZ2_Lj" resolve="mpsutil" />
+              <node concept="2Ry0Ak" id="13oTmDlqBZy" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="13oTmDlqBZz" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mbeddr.mpsutil.collections.runtime" />
+                  <node concept="2Ry0Ak" id="13oTmDlqBZ$" role="2Ry0An">
+                    <property role="2Ry0Am" value="models" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="13oTmDlqBZH" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+        <node concept="3rtmxn" id="13oTmDlqAtu" role="3bR31x">
+          <node concept="3LXTmp" id="13oTmDlqAtv" role="3rtmxm">
+            <node concept="3qWCbU" id="13oTmDlqAtw" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+            <node concept="398BVA" id="13oTmDlqAtx" role="3LXTmr">
+              <ref role="398BVh" node="7uZw0yZ2_Lj" resolve="mpsutil" />
+              <node concept="2Ry0Ak" id="13oTmDlqAty" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="13oTmDlqAtz" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mbeddr.mpsutil.checkinHandler" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="13oTmDlqBZt" role="3bR37C">
+          <node concept="3bR9La" id="13oTmDlqBZu" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:1ia2VB5guYy" resolve="MPS.IDEA" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="13oTmDlqBZv" role="3bR37C">
+          <node concept="3bR9La" id="13oTmDlqBZw" role="1SiIV1">
+            <property role="3bR36h" value="true" />
+            <ref role="3bR37D" to="90a9:6fQhGuklQWU" resolve="de.q60.mps.collections.libs" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="4JmsWjEr2hh" role="3bR37C">
+          <node concept="3bR9La" id="4JmsWjEr2hi" role="1SiIV1">
+            <ref role="3bR37D" node="776vT$mQZbf" resolve="com.mbeddr.mpsutil.comparator" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="4JmsWjEr2hj" role="3bR37C">
+          <node concept="3bR9La" id="4JmsWjEr2hk" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:7Kfy9QB6KYb" resolve="jetbrains.mps.baseLanguage" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="4JmsWjEr2hl" role="3bR37C">
+          <node concept="3bR9La" id="4JmsWjEr2hm" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:7Kfy9QB6Lg8" resolve="jetbrains.mps.runtime" />
+          </node>
+        </node>
+      </node>
+      <node concept="1E1JtD" id="13oTmDlqC$D" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="com.mbeddr.mpsutil.collections" />
+        <property role="3LESm3" value="e89e1550-b8fe-4f0d-a7fd-487968b42405" />
+        <node concept="398BVA" id="13oTmDlqCL0" role="3LF7KH">
+          <ref role="398BVh" node="7uZw0yZ2_Lj" resolve="mpsutil" />
+          <node concept="2Ry0Ak" id="13oTmDlqD9E" role="iGT6I">
+            <property role="2Ry0Am" value="languages" />
+            <node concept="2Ry0Ak" id="13oTmDlqDyj" role="2Ry0An">
+              <property role="2Ry0Am" value="com.mbeddr.mpsutil.collections" />
+              <node concept="2Ry0Ak" id="13oTmDlqDUW" role="2Ry0An">
+                <property role="2Ry0Am" value="com.mbeddr.mpsutil.collections.mpl" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1BupzO" id="13oTmDlqESi" role="3bR31x">
+          <property role="3ZfqAx" value="models" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="13oTmDlqESj" role="1HemKq">
+            <node concept="398BVA" id="13oTmDlqES7" role="3LXTmr">
+              <ref role="398BVh" node="7uZw0yZ2_Lj" resolve="mpsutil" />
+              <node concept="2Ry0Ak" id="13oTmDlqES8" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="13oTmDlqES9" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mbeddr.mpsutil.collections" />
+                  <node concept="2Ry0Ak" id="13oTmDlqESa" role="2Ry0An">
+                    <property role="2Ry0Am" value="models" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="13oTmDlqESk" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+        <node concept="1E0d5M" id="13oTmDlqESl" role="1E1XAP">
+          <ref role="1E0d5P" node="13oTmDlqAt2" resolve="com.mbeddr.mpsutil.collections.runtime" />
+        </node>
+        <node concept="1yeLz9" id="13oTmDlqESm" role="1TViLv">
+          <property role="TrG5h" value="com.mbeddr.mpsutil.collections.generator" />
+          <property role="3LESm3" value="9226b771-fcee-4dfc-a461-81a859795d14" />
+          <node concept="1BupzO" id="13oTmDlqES$" role="3bR31x">
+            <property role="3ZfqAx" value="generator/templates" />
+            <property role="1Hdu6h" value="true" />
+            <property role="1HemKv" value="true" />
+            <node concept="3LXTmp" id="13oTmDlqES_" role="1HemKq">
+              <node concept="398BVA" id="13oTmDlqESn" role="3LXTmr">
+                <ref role="398BVh" node="7uZw0yZ2_Lj" resolve="mpsutil" />
+                <node concept="2Ry0Ak" id="13oTmDlqESo" role="iGT6I">
+                  <property role="2Ry0Am" value="languages" />
+                  <node concept="2Ry0Ak" id="13oTmDlqESp" role="2Ry0An">
+                    <property role="2Ry0Am" value="com.mbeddr.mpsutil.collections" />
+                    <node concept="2Ry0Ak" id="13oTmDlqESq" role="2Ry0An">
+                      <property role="2Ry0Am" value="generator" />
+                      <node concept="2Ry0Ak" id="13oTmDlqESr" role="2Ry0An">
+                        <property role="2Ry0Am" value="templates" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3qWCbU" id="13oTmDlqESA" role="3LXTna">
+                <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+              </node>
+            </node>
+          </node>
+          <node concept="1SiIV0" id="4JmsWjEr2hZ" role="3bR37C">
+            <node concept="3bR9La" id="4JmsWjEr2i0" role="1SiIV1">
+              <ref role="3bR37D" to="ffeo:1H905DlDUSw" resolve="MPS.OpenAPI" />
+            </node>
+          </node>
+          <node concept="1SiIV0" id="4JmsWjEr2i1" role="3bR37C">
+            <node concept="3bR9La" id="4JmsWjEr2i2" role="1SiIV1">
+              <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
+            </node>
+          </node>
+          <node concept="1SiIV0" id="4JmsWjEr2i3" role="3bR37C">
+            <node concept="3bR9La" id="4JmsWjEr2i4" role="1SiIV1">
+              <ref role="3bR37D" to="ffeo:7Kfy9QB6KYb" resolve="jetbrains.mps.baseLanguage" />
+            </node>
+          </node>
+        </node>
+        <node concept="3rtmxn" id="13oTmDlqF4U" role="3bR31x">
+          <node concept="3LXTmp" id="13oTmDlqF4V" role="3rtmxm">
+            <node concept="398BVA" id="13oTmDlqF4W" role="3LXTmr">
+              <ref role="398BVh" node="7uZw0yZ2_Lj" resolve="mpsutil" />
+              <node concept="2Ry0Ak" id="13oTmDlqF4X" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="13oTmDlqF4Y" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mbeddr.mpsutil.collections" />
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="13oTmDlqF50" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="4JmsWjEr2hy" role="3bR37C">
+          <node concept="3bR9La" id="4JmsWjEr2hz" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:1H905DlDUSw" resolve="MPS.OpenAPI" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="4JmsWjEr2h$" role="3bR37C">
+          <node concept="3bR9La" id="4JmsWjEr2h_" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="4JmsWjEr2hA" role="3bR37C">
+          <node concept="3bR9La" id="4JmsWjEr2hB" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:7Kfy9QB6KXW" resolve="jetbrains.mps.lang.core" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="4JmsWjEr2hC" role="3bR37C">
+          <node concept="3bR9La" id="4JmsWjEr2hD" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:7Kfy9QB6KYb" resolve="jetbrains.mps.baseLanguage" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="4JmsWjEr2hE" role="3bR37C">
+          <node concept="3bR9La" id="4JmsWjEr2hF" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:7Kfy9QB6L9O" resolve="jetbrains.mps.lang.smodel" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="4JmsWjEr2hG" role="3bR37C">
+          <node concept="3bR9La" id="4JmsWjEr2hH" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:1TaHNgiIbIQ" resolve="MPS.Core" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="4JmsWjEr2hI" role="3bR37C">
+          <node concept="3bR9La" id="4JmsWjEr2hJ" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:7Kfy9QB6L0h" resolve="jetbrains.mps.baseLanguage.collections" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="4JmsWjEr2hK" role="3bR37C">
+          <node concept="3bR9La" id="4JmsWjEr2hL" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:7Kfy9QB6LaO" resolve="jetbrains.mps.lang.structure" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="4JmsWjEr2hX" role="3bR37C">
+          <node concept="1Busua" id="4JmsWjEr2hY" role="1SiIV1">
+            <ref role="1Busuk" to="ffeo:7Kfy9QB6KYb" resolve="jetbrains.mps.baseLanguage" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="m$_wf" id="13oTmDlqFtC" role="3989C9">
+      <property role="m$_wk" value="com.mbeddr.mpsutil.collections" />
+      <node concept="3_J27D" id="13oTmDlqFtE" role="m$_yQ">
+        <node concept="3Mxwew" id="13oTmDlqFtF" role="3MwsjC">
+          <property role="3MwjfP" value="com.mbeddr.mpsutil.collections" />
+        </node>
+      </node>
+      <node concept="3_J27D" id="13oTmDlqFtG" role="m_cZH">
+        <node concept="3Mxwew" id="13oTmDlqFtH" role="3MwsjC">
+          <property role="3MwjfP" value="com.mbeddr.mpsutil.collection" />
+        </node>
+      </node>
+      <node concept="3_J27D" id="13oTmDlqFtI" role="m$_w8">
+        <node concept="3Mxwew" id="13oTmDlqFtJ" role="3MwsjC">
+          <property role="3MwjfP" value="mbeddr" />
+        </node>
+      </node>
+      <node concept="2iUeEo" id="13oTmDlqFtK" role="2iVFfd">
+        <property role="2iUeEt" value="mbeddr" />
+        <property role="2iUeEu" value="http://mbeddr.com" />
+      </node>
+      <node concept="m$f5U" id="13oTmDlqFtL" role="m$_yh">
+        <ref role="m$f5T" node="13oTmDlqAt1" resolve="com.mbeddr.mpsutil.collections" />
+      </node>
+      <node concept="3_J27D" id="13oTmDlqGrh" role="3s6cr7">
+        <node concept="3Mxwew" id="13oTmDlqGri" role="3MwsjC">
+          <property role="3MwjfP" value="extensions for the MPS collections language" />
+        </node>
+      </node>
+      <node concept="m$_yC" id="13oTmDlqH0c" role="m$_yJ">
+        <ref role="m$_y1" to="90a9:2OJNL7ElZsF" resolve="de.q60.mps.collections.libs" />
+      </node>
+      <node concept="m$_yC" id="4JmsWjEr2u_" role="m$_yJ">
+        <ref role="m$_y1" node="DnqfiuSO_Q" resolve="com.mbeddr.mpsutil.compare" />
       </node>
     </node>
     <node concept="m$_wf" id="2hNr1jFzOYG" role="3989C9">

--- a/code/languages/com.mbeddr.mpsutil/.mps/modules.xml
+++ b/code/languages/com.mbeddr.mpsutil/.mps/modules.xml
@@ -15,6 +15,7 @@
       <modulePath path="$PROJECT_DIR$/languages/com.mbeddr.mpsutil.ccmenu/com.mbeddr.mpsutil.ccmenu.mpl" folder="rest.ccmenu" />
       <modulePath path="$PROJECT_DIR$/languages/com.mbeddr.mpsutil.checkinHandler.demo/com.mbeddr.mpsutil.checkinHandler.demo.mpl" folder="" />
       <modulePath path="$PROJECT_DIR$/languages/com.mbeddr.mpsutil.checkinHandler/com.mbeddr.mpsutil.checkinHandler.mpl" folder="" />
+      <modulePath path="$PROJECT_DIR$/languages/com.mbeddr.mpsutil.collections/com.mbeddr.mpsutil.collections.mpl" folder="collections" />
       <modulePath path="$PROJECT_DIR$/languages/com.mbeddr.mpsutil.compare.pattern.baselang/com.mbeddr.mpsutil.compare.pattern.baselang.mpl" folder="staging.comparator" />
       <modulePath path="$PROJECT_DIR$/languages/com.mbeddr.mpsutil.compare.pattern.generator/com.mbeddr.mpsutil.compare.pattern.generator.mpl" folder="staging.comparator" />
       <modulePath path="$PROJECT_DIR$/languages/com.mbeddr.mpsutil.compare.pattern/com.mbeddr.mpsutil.compare.pattern.mpl" folder="staging.comparator" />
@@ -112,6 +113,7 @@
       <modulePath path="$PROJECT_DIR$/solutions/com.mbeddr.mpsutil.ccmenu.sandbox/com.mbeddr.mpsutil.ccmenu.sandbox.msd" folder="rest.ccmenu" />
       <modulePath path="$PROJECT_DIR$/solutions/com.mbeddr.mpsutil.checkinHandler.demo.plugin/com.mbeddr.mpsutil.checkinHandler.demo.plugin.msd" folder="checkinHandler" />
       <modulePath path="$PROJECT_DIR$/solutions/com.mbeddr.mpsutil.checkinHandler/com.mbeddr.mpsutil.checkinHandler.msd" folder="checkinHandler" />
+      <modulePath path="$PROJECT_DIR$/solutions/com.mbeddr.mpsutil.collections.runtime/com.mbeddr.mpsutil.collections.runtime.msd" folder="collections" />
       <modulePath path="$PROJECT_DIR$/solutions/com.mbeddr.mpsutil.common/com.mbeddr.mpsutil.common.msd" folder="staging.common" />
       <modulePath path="$PROJECT_DIR$/solutions/com.mbeddr.mpsutil.comparator.diff.demo.genplan/com.mbeddr.mpsutil.comparator.diff.demo.genplan.msd" folder="staging.comparator.demo" />
       <modulePath path="$PROJECT_DIR$/solutions/com.mbeddr.mpsutil.comparator.diff.demo.tests/com.mbeddr.mpsutil.comparator.diff.demo.tests.msd" folder="staging.comparator.demo" />
@@ -186,6 +188,7 @@
       <modulePath path="$PROJECT_DIR$/solutions/org.apache.batik/org.apache.batik.msd" folder="" />
       <modulePath path="$PROJECT_DIR$/solutions/org.mockito/org.mockito.msd" folder="stubs" />
       <modulePath path="$PROJECT_DIR$/solutions/org.xml/org.xml.msd" folder="" />
+      <modulePath path="$PROJECT_DIR$/solutions/test.com.mbeddr.mpsutil.collections.runtime/test.com.mbeddr.mpsutil.collections.runtime.msd" folder="collections" />
       <modulePath path="$PROJECT_DIR$/solutions/test.com.mbeddr.mpsutil.logicalChild/test.com.mbeddr.mpsutil.logicalChild.msd" folder="logicalChild" />
       <modulePath path="$PROJECT_DIR$/tests/com.mbeddr.mpsutil.compare.pattern.test/com.mbeddr.mpsutil.compare.pattern.test.msd" folder="staging.comparator" />
       <modulePath path="$PROJECT_DIR$/tests/com.mbeddr.mpsutil.javainterpreter.test/com.mbeddr.mpsutil.javainterpreter.test.mpl" folder="staging.javainterpreter" />

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.collections/com.mbeddr.mpsutil.collections.mpl
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.collections/com.mbeddr.mpsutil.collections.mpl
@@ -1,0 +1,160 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<language namespace="com.mbeddr.mpsutil.collections" uuid="e89e1550-b8fe-4f0d-a7fd-487968b42405" languageVersion="0" moduleVersion="0">
+  <models>
+    <modelRoot type="default" contentPath="${module}">
+      <sourceRoot location="models" />
+    </modelRoot>
+  </models>
+  <facets>
+    <facet compile="mps" classes="mps" ext="yes" type="java">
+      <classes generated="true" path="${module}/classes_gen" />
+    </facet>
+  </facets>
+  <accessoryModels />
+  <generators>
+    <generator alias="main" namespace="com.mbeddr.mpsutil.collections.generator" uuid="9226b771-fcee-4dfc-a461-81a859795d14">
+      <models>
+        <modelRoot type="default" contentPath="${module}/generator">
+          <sourceRoot location="templates" />
+        </modelRoot>
+      </models>
+      <facets>
+        <facet compile="mps" classes="mps" ext="no" type="java">
+          <classes generated="true" path="${module}/generator/classes_gen" />
+        </facet>
+      </facets>
+      <external-templates />
+      <dependencies>
+        <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
+        <dependency reexport="false">8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)</dependency>
+        <dependency reexport="false" scope="design">2bdcefec-ba49-4b32-ab50-ebc7a41d5090(jetbrains.mps.lang.smodel#1139186730696)</dependency>
+        <dependency reexport="false">f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)</dependency>
+      </dependencies>
+      <languageVersions>
+        <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
+        <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
+        <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
+        <language slang="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" version="2" />
+        <language slang="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" version="0" />
+        <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
+        <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
+        <language slang="l:b401a680-8325-4110-8fd3-84331ff25bef:jetbrains.mps.lang.generator" version="4" />
+        <language slang="l:d7706f63-9be2-479c-a3da-ae92af1e64d5:jetbrains.mps.lang.generator.generationContext" version="2" />
+        <language slang="l:289fcc83-6543-41e8-a5ca-768235715ce4:jetbrains.mps.lang.generator.generationParameters" version="0" />
+        <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
+        <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="5" />
+        <language slang="l:13744753-c81f-424a-9c1b-cf8943bf4e86:jetbrains.mps.lang.sharedConcepts" version="0" />
+        <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="19" />
+        <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
+        <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
+      </languageVersions>
+      <dependencyVersions>
+        <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
+        <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
+        <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
+        <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
+        <module reference="e89e1550-b8fe-4f0d-a7fd-487968b42405(com.mbeddr.mpsutil.collections)" version="0" />
+        <module reference="9226b771-fcee-4dfc-a461-81a859795d14(com.mbeddr.mpsutil.collections.generator)" version="0" />
+        <module reference="3f2dbc2e-ad41-470f-b5f1-2869513d2b58(com.mbeddr.mpsutil.collections.runtime)" version="0" />
+        <module reference="ecfb9949-7433-4db5-85de-0f84d172e4ce(de.q60.mps.collections.libs)" version="0" />
+        <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
+        <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
+        <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
+        <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
+        <module reference="2bdcefec-ba49-4b32-ab50-ebc7a41d5090(jetbrains.mps.lang.smodel#1139186730696)" version="0" />
+        <module reference="9ded098b-ad6a-4657-bfd9-48636cfe8bc3(jetbrains.mps.lang.traceable)" version="0" />
+      </dependencyVersions>
+      <mapping-priorities>
+        <mapping-priority-rule kind="strictly_together">
+          <greater-priority-mapping>
+            <generator generatorUID="9226b771-fcee-4dfc-a461-81a859795d14(com.mbeddr.mpsutil.collections.generator)" />
+            <external-mapping>
+              <mapping-node modelUID="r:fe83d388-8fd7-46fd-b1ae-3b9bf9de62b8(com.mbeddr.mpsutil.collections.generator.templates@generator)" nodeID="942304653331834795" />
+            </external-mapping>
+          </greater-priority-mapping>
+          <lesser-priority-mapping>
+            <generator generatorUID="2bdcefec-ba49-4b32-ab50-ebc7a41d5090(jetbrains.mps.lang.smodel#1139186730696)" />
+            <external-mapping>
+              <mapping-node modelUID="r:00000000-0000-4000-0000-011c89590303(jetbrains.mps.lang.smodel.generator.baseLanguage.template.main@generator)" nodeID="1139186732963" />
+            </external-mapping>
+          </lesser-priority-mapping>
+        </mapping-priority-rule>
+      </mapping-priorities>
+    </generator>
+  </generators>
+  <sourcePath />
+  <dependencies>
+    <dependency reexport="false">c72da2b9-7cce-4447-8389-f407dc1158b7(jetbrains.mps.lang.structure)</dependency>
+    <dependency reexport="false">f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)</dependency>
+    <dependency reexport="false">ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)</dependency>
+    <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
+    <dependency reexport="false">8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)</dependency>
+    <dependency reexport="false">6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)</dependency>
+    <dependency reexport="false">83888646-71ce-4f1c-9c53-c54016f6ad4f(jetbrains.mps.baseLanguage.collections)</dependency>
+    <dependency reexport="false">7866978e-a0f0-4cc7-81bc-4d213d9375e1(jetbrains.mps.lang.smodel)</dependency>
+  </dependencies>
+  <languageVersions>
+    <language slang="l:e89e1550-b8fe-4f0d-a7fd-487968b42405:com.mbeddr.mpsutil.collections" version="0" />
+    <language slang="l:9d69e719-78c8-4286-90db-fb19c107d049:com.mbeddr.mpsutil.grammarcells" version="2" />
+    <language slang="l:b4f35ed8-45af-4efa-abe4-00ac26956e69:com.mbeddr.mpsutil.grammarcells.runtimelang" version="0" />
+    <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
+    <language slang="l:443f4c36-fcf5-4eb6-9500-8d06ed259e3e:jetbrains.mps.baseLanguage.classifiers" version="0" />
+    <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
+    <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
+    <language slang="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" version="2" />
+    <language slang="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" version="0" />
+    <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
+    <language slang="l:aee9cad2-acd4-4608-aef2-0004f6a1cdbd:jetbrains.mps.lang.actions" version="4" />
+    <language slang="l:af65afd8-f0dd-4942-87d9-63a55f2a9db1:jetbrains.mps.lang.behavior" version="2" />
+    <language slang="l:3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1:jetbrains.mps.lang.constraints" version="6" />
+    <language slang="l:e51810c5-7308-4642-bcb6-469e61b5dd18:jetbrains.mps.lang.constraints.msg.specification" version="0" />
+    <language slang="l:47257bf3-78d3-470b-89d9-8c3261a61d15:jetbrains.mps.lang.constraints.rules" version="0" />
+    <language slang="l:5dae8159-ab99-46bb-a40d-0cee30ee7018:jetbrains.mps.lang.constraints.rules.kinds" version="0" />
+    <language slang="l:134c38d4-e3af-4d9e-b069-1c7df0a4005d:jetbrains.mps.lang.constraints.rules.skeleton" version="0" />
+    <language slang="l:3ad5badc-1d9c-461c-b7b1-fa2fcd0a0ae7:jetbrains.mps.lang.context" version="0" />
+    <language slang="l:ea3159bf-f48e-4720-bde2-86dba75f0d34:jetbrains.mps.lang.context.defs" version="0" />
+    <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
+    <language slang="l:f4ad079d-bc71-4ffb-9600-9328705cf998:jetbrains.mps.lang.descriptor" version="0" />
+    <language slang="l:18bc6592-03a6-4e29-a83a-7ff23bde13ba:jetbrains.mps.lang.editor" version="14" />
+    <language slang="l:ad93155d-79b2-4759-b10c-55123e763903:jetbrains.mps.lang.messages" version="0" />
+    <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
+    <language slang="l:d4615e3b-d671-4ba9-af01-2b78369b0ba7:jetbrains.mps.lang.pattern" version="2" />
+    <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="5" />
+    <language slang="l:982eb8df-2c96-4bd7-9963-11712ea622e5:jetbrains.mps.lang.resources" version="2" />
+    <language slang="l:b3551702-269c-4f05-ba61-58060cef4292:jetbrains.mps.lang.rulesAndMessages" version="0" />
+    <language slang="l:d8f591ec-4d86-4af2-9f92-a9e93c803ffa:jetbrains.mps.lang.scopes" version="0" />
+    <language slang="l:13744753-c81f-424a-9c1b-cf8943bf4e86:jetbrains.mps.lang.sharedConcepts" version="0" />
+    <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="19" />
+    <language slang="l:c72da2b9-7cce-4447-8389-f407dc1158b7:jetbrains.mps.lang.structure" version="9" />
+    <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
+    <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
+    <language slang="l:7a5dda62-9140-4668-ab76-d5ed1746f2b2:jetbrains.mps.lang.typesystem" version="5" />
+  </languageVersions>
+  <dependencyVersions>
+    <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
+    <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
+    <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
+    <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
+    <module reference="e89e1550-b8fe-4f0d-a7fd-487968b42405(com.mbeddr.mpsutil.collections)" version="0" />
+    <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
+    <module reference="fd392034-7849-419d-9071-12563d152375(jetbrains.mps.baseLanguage.closures)" version="0" />
+    <module reference="83888646-71ce-4f1c-9c53-c54016f6ad4f(jetbrains.mps.baseLanguage.collections)" version="0" />
+    <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
+    <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
+    <module reference="d936855b-48da-4812-a8a0-2bfddd633ac5(jetbrains.mps.lang.behavior.api)" version="0" />
+    <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
+    <module reference="a9e4c532-c5f5-4bb7-99ef-42abb73bbb70(jetbrains.mps.lang.descriptor.aspects)" version="0" />
+    <module reference="446c26eb-2b7b-4bf0-9b35-f83fa582753e(jetbrains.mps.lang.modelapi)" version="0" />
+    <module reference="d7eb0a2a-bd50-4576-beae-e4a89db35f20(jetbrains.mps.lang.scopes.runtime)" version="0" />
+    <module reference="7866978e-a0f0-4cc7-81bc-4d213d9375e1(jetbrains.mps.lang.smodel)" version="1" />
+    <module reference="c72da2b9-7cce-4447-8389-f407dc1158b7(jetbrains.mps.lang.structure)" version="0" />
+    <module reference="9ded098b-ad6a-4657-bfd9-48636cfe8bc3(jetbrains.mps.lang.traceable)" version="0" />
+  </dependencyVersions>
+  <runtime>
+    <dependency reexport="false">3f2dbc2e-ad41-470f-b5f1-2869513d2b58(com.mbeddr.mpsutil.collections.runtime)</dependency>
+  </runtime>
+  <extendedLanguages>
+    <extendedLanguage>f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)</extendedLanguage>
+  </extendedLanguages>
+</language>
+

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.collections/generator/templates/com.mbeddr.mpsutil.collections.generator.templates@generator.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.collections/generator/templates/com.mbeddr.mpsutil.collections.generator.templates@generator.mps
@@ -1,0 +1,209 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:fe83d388-8fd7-46fd-b1ae-3b9bf9de62b8(com.mbeddr.mpsutil.collections.generator.templates@generator)">
+  <persistence version="9" />
+  <languages>
+    <use id="b401a680-8325-4110-8fd3-84331ff25bef" name="jetbrains.mps.lang.generator" version="4" />
+    <devkit ref="a2eb3a43-fcc2-4200-80dc-c60110c4862d(jetbrains.mps.devkit.templates)" />
+  </languages>
+  <imports>
+    <import index="i2rk" ref="r:baa9d6ac-6b79-40af-928c-6bdcbfd7265f(com.mbeddr.mpsutil.collections.structure)" />
+    <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
+    <import index="mhbf" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.model(MPS.OpenAPI/)" />
+    <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" />
+    <import index="co" ref="r:240d60dc-7568-46d8-a080-a0889db7fd44(com.mbeddr.mpsutil.collections.runtime)" />
+  </imports>
+  <registry>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
+        <child id="1145553007750" name="creator" index="2ShVmc" />
+      </concept>
+      <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
+        <child id="1137022507850" name="body" index="2VODD2" />
+      </concept>
+      <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ng" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
+      </concept>
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
+      </concept>
+      <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk" />
+      <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
+        <reference id="1107535924139" name="classifier" index="3uigEE" />
+        <child id="1109201940907" name="parameter" index="11_B2D" />
+      </concept>
+    </language>
+    <language id="b401a680-8325-4110-8fd3-84331ff25bef" name="jetbrains.mps.lang.generator">
+      <concept id="1114706874351" name="jetbrains.mps.lang.generator.structure.CopySrcNodeMacro" flags="ln" index="29HgVG">
+        <child id="1168024447342" name="sourceNodeQuery" index="3NFExx" />
+      </concept>
+      <concept id="1095416546421" name="jetbrains.mps.lang.generator.structure.MappingConfiguration" flags="ig" index="bUwia">
+        <child id="1167328349397" name="reductionMappingRule" index="3acgRq" />
+      </concept>
+      <concept id="1177093525992" name="jetbrains.mps.lang.generator.structure.InlineTemplate_RuleConsequence" flags="lg" index="gft3U">
+        <child id="1177093586806" name="templateNode" index="gfFT$" />
+      </concept>
+      <concept id="1167168920554" name="jetbrains.mps.lang.generator.structure.BaseMappingRule_Condition" flags="in" index="30G5F_" />
+      <concept id="1167169188348" name="jetbrains.mps.lang.generator.structure.TemplateFunctionParameter_sourceNode" flags="nn" index="30H73N" />
+      <concept id="1167169308231" name="jetbrains.mps.lang.generator.structure.BaseMappingRule" flags="ng" index="30H$t8">
+        <reference id="1167169349424" name="applicableConcept" index="30HIoZ" />
+        <child id="1167169362365" name="conditionFunction" index="30HLyM" />
+      </concept>
+      <concept id="1167327847730" name="jetbrains.mps.lang.generator.structure.Reduction_MappingRule" flags="lg" index="3aamgX">
+        <child id="1169672767469" name="ruleConsequence" index="1lVwrX" />
+      </concept>
+      <concept id="1167945743726" name="jetbrains.mps.lang.generator.structure.IfMacro_Condition" flags="in" index="3IZrLx" />
+      <concept id="1168024337012" name="jetbrains.mps.lang.generator.structure.SourceSubstituteMacro_SourceNodeQuery" flags="in" index="3NFfHV" />
+      <concept id="1118773211870" name="jetbrains.mps.lang.generator.structure.IfMacro" flags="ln" index="1W57fq">
+        <child id="1194989344771" name="alternativeConsequence" index="UU_$l" />
+        <child id="1167945861827" name="conditionFunction" index="3IZSJc" />
+      </concept>
+    </language>
+    <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
+        <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
+      </concept>
+      <concept id="2396822768958367367" name="jetbrains.mps.lang.smodel.structure.AbstractTypeCastExpression" flags="nn" index="$5XWr">
+        <child id="6733348108486823193" name="leftExpression" index="1m5AlR" />
+        <child id="3906496115198199033" name="conceptArgument" index="3oSUPX" />
+      </concept>
+      <concept id="1139621453865" name="jetbrains.mps.lang.smodel.structure.Node_IsInstanceOfOperation" flags="nn" index="1mIQ4w">
+        <child id="1177027386292" name="conceptArgument" index="cj9EA" />
+      </concept>
+      <concept id="1172008320231" name="jetbrains.mps.lang.smodel.structure.Node_IsNotNullOperation" flags="nn" index="3x8VRR" />
+      <concept id="1140137987495" name="jetbrains.mps.lang.smodel.structure.SNodeTypeCastExpression" flags="nn" index="1PxgMI">
+        <property id="1238684351431" name="asCast" index="1BlNFB" />
+      </concept>
+      <concept id="1138056143562" name="jetbrains.mps.lang.smodel.structure.SLinkAccess" flags="nn" index="3TrEf2">
+        <reference id="1138056516764" name="link" index="3Tt5mk" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="bUwia" id="OjJhrO2EuF">
+    <property role="TrG5h" value="main" />
+    <node concept="3aamgX" id="h0CysJp" role="3acgRq">
+      <ref role="30HIoZ" to="i2rk:5wNjLS4fqEi" resolve="SNodeSetType" />
+      <node concept="gft3U" id="h8hxs_p" role="1lVwrX">
+        <node concept="3uibUv" id="h8hxuxe" role="gfFT$">
+          <ref role="3uigEE" to="33ny:~Set" resolve="Set" />
+          <node concept="3uibUv" id="h8hxw4o" role="11_B2D">
+            <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3aamgX" id="h0CyBP8" role="3acgRq">
+      <ref role="30HIoZ" to="tpee:gEShNN5" resolve="GenericNewExpression" />
+      <node concept="30G5F_" id="h0CyCFm" role="30HLyM">
+        <node concept="3clFbS" id="h0CyCFn" role="2VODD2">
+          <node concept="3clFbF" id="hbzt5Wo" role="3cqZAp">
+            <node concept="2OqwBi" id="hxx$NBK" role="3clFbG">
+              <node concept="2OqwBi" id="hxx$Nga" role="2Oq$k0">
+                <node concept="30H73N" id="h0CyDXF" role="2Oq$k0" />
+                <node concept="3TrEf2" id="h4IuMGW" role="2OqNvi">
+                  <ref role="3Tt5mk" to="tpee:gEShVi6" resolve="creator" />
+                </node>
+              </node>
+              <node concept="1mIQ4w" id="h0CyGzx" role="2OqNvi">
+                <node concept="chp4Y" id="h8hlVn6" role="cj9EA">
+                  <ref role="cht4Q" to="i2rk:4JmsWjDRcxX" resolve="SNodeSetCreator" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="gft3U" id="h8hy5wQ" role="1lVwrX">
+        <node concept="2ShNRf" id="hIfNzdj" role="gfFT$">
+          <node concept="1pGfFk" id="4JmsWjDRjYF" role="2ShVmc">
+            <property role="373rjd" value="true" />
+            <ref role="37wK5l" to="co:2UDGRNXxxvO" resolve="NodeHashSet" />
+            <node concept="10Nm6u" id="4JmsWjDZ6im" role="37wK5m">
+              <node concept="29HgVG" id="4JmsWjDZ6ji" role="lGtFl">
+                <node concept="3NFfHV" id="4JmsWjDZ6kh" role="3NFExx">
+                  <node concept="3clFbS" id="4JmsWjDZ6ki" role="2VODD2">
+                    <node concept="3clFbF" id="4JmsWjDZ6kk" role="3cqZAp">
+                      <node concept="2OqwBi" id="4JmsWjDRlAS" role="3clFbG">
+                        <node concept="1PxgMI" id="4JmsWjDRlh0" role="2Oq$k0">
+                          <property role="1BlNFB" value="true" />
+                          <node concept="chp4Y" id="4JmsWjDRlrk" role="3oSUPX">
+                            <ref role="cht4Q" to="i2rk:4JmsWjDRcxX" resolve="SNodeSetCreator" />
+                          </node>
+                          <node concept="2OqwBi" id="4JmsWjDRkgQ" role="1m5AlR">
+                            <node concept="30H73N" id="4JmsWjDRkgU" role="2Oq$k0" />
+                            <node concept="3TrEf2" id="4JmsWjDRk_p" role="2OqNvi">
+                              <ref role="3Tt5mk" to="tpee:gEShVi6" resolve="creator" />
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3TrEf2" id="4JmsWjDRlRp" role="2OqNvi">
+                          <ref role="3Tt5mk" to="i2rk:4JmsWjDRhF4" resolve="setCreator" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1W57fq" id="4JmsWjDZ6pi" role="lGtFl">
+            <node concept="3IZrLx" id="4JmsWjDZ6pj" role="3IZSJc">
+              <node concept="3clFbS" id="4JmsWjDZ6pk" role="2VODD2">
+                <node concept="3clFbF" id="4JmsWjDZ6vJ" role="3cqZAp">
+                  <node concept="2OqwBi" id="4JmsWjDZ71r" role="3clFbG">
+                    <node concept="2OqwBi" id="4JmsWjDZ6vL" role="2Oq$k0">
+                      <node concept="1PxgMI" id="4JmsWjDZ6vM" role="2Oq$k0">
+                        <property role="1BlNFB" value="true" />
+                        <node concept="chp4Y" id="4JmsWjDZ6vN" role="3oSUPX">
+                          <ref role="cht4Q" to="i2rk:4JmsWjDRcxX" resolve="SNodeSetCreator" />
+                        </node>
+                        <node concept="2OqwBi" id="4JmsWjDZ6vO" role="1m5AlR">
+                          <node concept="30H73N" id="4JmsWjDZ6vP" role="2Oq$k0" />
+                          <node concept="3TrEf2" id="4JmsWjDZ6vQ" role="2OqNvi">
+                            <ref role="3Tt5mk" to="tpee:gEShVi6" resolve="creator" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3TrEf2" id="4JmsWjDZ6vR" role="2OqNvi">
+                        <ref role="3Tt5mk" to="i2rk:4JmsWjDRhF4" resolve="setCreator" />
+                      </node>
+                    </node>
+                    <node concept="3x8VRR" id="4JmsWjDZ7sv" role="2OqNvi" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="gft3U" id="4JmsWjDZ7_9" role="UU_$l">
+              <node concept="2ShNRf" id="4JmsWjDZ7Cg" role="gfFT$">
+                <node concept="1pGfFk" id="4JmsWjDZ86u" role="2ShVmc">
+                  <property role="373rjd" value="true" />
+                  <ref role="37wK5l" to="co:2UDGRNXx5Xp" resolve="NodeHashSet" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.collections/models/com.mbeddr.mpsutil.collections.behavior.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.collections/models/com.mbeddr.mpsutil.collections.behavior.mps
@@ -1,0 +1,532 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:64817ef9-6800-49cd-a257-49b6c9f53acc(com.mbeddr.mpsutil.collections.behavior)">
+  <persistence version="9" />
+  <languages>
+    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
+    <use id="af65afd8-f0dd-4942-87d9-63a55f2a9db1" name="jetbrains.mps.lang.behavior" version="2" />
+    <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
+  </languages>
+  <imports>
+    <import index="tpek" ref="r:00000000-0000-4000-0000-011c895902c0(jetbrains.mps.baseLanguage.behavior)" />
+    <import index="tpcu" ref="r:00000000-0000-4000-0000-011c89590282(jetbrains.mps.lang.core.behavior)" />
+    <import index="tpce" ref="r:00000000-0000-4000-0000-011c89590292(jetbrains.mps.lang.structure.structure)" />
+    <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
+    <import index="tp2q" ref="r:00000000-0000-4000-0000-011c8959032e(jetbrains.mps.baseLanguage.collections.structure)" />
+    <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" />
+    <import index="mhbf" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.model(MPS.OpenAPI/)" />
+    <import index="18ew" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.util(MPS.Core/)" />
+    <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" />
+    <import index="i2rk" ref="r:baa9d6ac-6b79-40af-928c-6bdcbfd7265f(com.mbeddr.mpsutil.collections.structure)" implicit="true" />
+    <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="af65afd8-f0dd-4942-87d9-63a55f2a9db1" name="jetbrains.mps.lang.behavior">
+      <concept id="1225194240794" name="jetbrains.mps.lang.behavior.structure.ConceptBehavior" flags="ng" index="13h7C7">
+        <reference id="1225194240799" name="concept" index="13h7C2" />
+        <child id="1225194240805" name="method" index="13h7CS" />
+        <child id="1225194240801" name="constructor" index="13h7CW" />
+      </concept>
+      <concept id="1225194413805" name="jetbrains.mps.lang.behavior.structure.ConceptConstructorDeclaration" flags="in" index="13hLZK" />
+      <concept id="1225194472830" name="jetbrains.mps.lang.behavior.structure.ConceptMethodDeclaration" flags="ng" index="13i0hz">
+        <property id="1225194472832" name="isVirtual" index="13i0it" />
+        <property id="1225194472834" name="isAbstract" index="13i0iv" />
+        <reference id="1225194472831" name="overriddenMethod" index="13i0hy" />
+      </concept>
+      <concept id="1225194691553" name="jetbrains.mps.lang.behavior.structure.ThisNodeExpression" flags="nn" index="13iPFW" />
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1080223426719" name="jetbrains.mps.baseLanguage.structure.OrExpression" flags="nn" index="22lmx$" />
+      <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
+        <child id="1145553007750" name="creator" index="2ShVmc" />
+      </concept>
+      <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
+        <child id="1137022507850" name="body" index="2VODD2" />
+      </concept>
+      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
+        <property id="1070475926801" name="value" index="Xl_RC" />
+      </concept>
+      <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
+        <reference id="1144433194310" name="classConcept" index="1Pybhc" />
+      </concept>
+      <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
+      <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
+      <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
+        <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
+        <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
+      </concept>
+      <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
+      <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
+      <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
+        <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
+      <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
+        <child id="1068580123133" name="returnType" index="3clF45" />
+        <child id="1068580123134" name="parameter" index="3clF46" />
+        <child id="1068580123135" name="body" index="3clF47" />
+      </concept>
+      <concept id="1068580123152" name="jetbrains.mps.baseLanguage.structure.EqualsExpression" flags="nn" index="3clFbC" />
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
+        <child id="1068580123160" name="condition" index="3clFbw" />
+        <child id="1068580123161" name="ifTrue" index="3clFbx" />
+      </concept>
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT">
+        <property id="1068580123138" name="value" index="3clFbU" />
+      </concept>
+      <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
+      <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
+        <child id="1068581517676" name="expression" index="3cqZAk" />
+      </concept>
+      <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
+        <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
+      </concept>
+      <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
+      <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
+      </concept>
+      <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
+        <reference id="1107535924139" name="classifier" index="3uigEE" />
+        <child id="1109201940907" name="parameter" index="11_B2D" />
+      </concept>
+      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
+        <child id="1081773367579" name="rightExpression" index="3uHU7w" />
+        <child id="1081773367580" name="leftExpression" index="3uHU7B" />
+      </concept>
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
+        <child id="1178549979242" name="visibility" index="1B3o_S" />
+      </concept>
+      <concept id="1163668896201" name="jetbrains.mps.baseLanguage.structure.TernaryOperatorExpression" flags="nn" index="3K4zz7">
+        <child id="1163668914799" name="condition" index="3K4Cdx" />
+        <child id="1163668922816" name="ifTrue" index="3K4E3e" />
+        <child id="1163668934364" name="ifFalse" index="3K4GZi" />
+      </concept>
+      <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
+      <concept id="1146644641414" name="jetbrains.mps.baseLanguage.structure.ProtectedVisibility" flags="nn" index="3Tmbuc" />
+      <concept id="1116615150612" name="jetbrains.mps.baseLanguage.structure.ClassifierClassExpression" flags="nn" index="3VsKOn">
+        <reference id="1116615189566" name="classifier" index="3VsUkX" />
+      </concept>
+    </language>
+    <language id="3a13115c-633c-4c5c-bbcc-75c4219e9555" name="jetbrains.mps.lang.quotation">
+      <concept id="1196350785113" name="jetbrains.mps.lang.quotation.structure.Quotation" flags="nn" index="2c44tf">
+        <child id="1196350785114" name="quotedNode" index="2c44tc" />
+      </concept>
+    </language>
+    <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1140725362528" name="jetbrains.mps.lang.smodel.structure.Link_SetTargetOperation" flags="nn" index="2oxUTD">
+        <child id="1140725362529" name="linkTarget" index="2oxUTC" />
+      </concept>
+      <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
+      <concept id="2644386474300074836" name="jetbrains.mps.lang.smodel.structure.ConceptIdRefExpression" flags="nn" index="35c_gC">
+        <reference id="2644386474300074837" name="conceptDeclaration" index="35c_gD" />
+      </concept>
+      <concept id="6677504323281689838" name="jetbrains.mps.lang.smodel.structure.SConceptType" flags="in" index="3bZ5Sz" />
+      <concept id="1171999116870" name="jetbrains.mps.lang.smodel.structure.Node_IsNullOperation" flags="nn" index="3w_OXm" />
+      <concept id="1172008320231" name="jetbrains.mps.lang.smodel.structure.Node_IsNotNullOperation" flags="nn" index="3x8VRR" />
+      <concept id="1180636770613" name="jetbrains.mps.lang.smodel.structure.SNodeCreator" flags="nn" index="3zrR0B">
+        <child id="1180636770616" name="createdType" index="3zrR0E" />
+      </concept>
+      <concept id="1144146199828" name="jetbrains.mps.lang.smodel.structure.Node_CopyOperation" flags="nn" index="1$rogu" />
+      <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
+        <reference id="1138405853777" name="concept" index="ehGHo" />
+      </concept>
+      <concept id="1138056022639" name="jetbrains.mps.lang.smodel.structure.SPropertyAccess" flags="nn" index="3TrcHB">
+        <reference id="1138056395725" name="property" index="3TsBF5" />
+      </concept>
+      <concept id="1138056143562" name="jetbrains.mps.lang.smodel.structure.SLinkAccess" flags="nn" index="3TrEf2">
+        <reference id="1138056516764" name="link" index="3Tt5mk" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+    <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
+      <concept id="540871147943773365" name="jetbrains.mps.baseLanguage.collections.structure.SingleArgumentSequenceOperation" flags="nn" index="25WWJ4">
+        <child id="540871147943773366" name="argument" index="25WWJ7" />
+      </concept>
+      <concept id="1151688443754" name="jetbrains.mps.baseLanguage.collections.structure.ListType" flags="in" index="_YKpA">
+        <child id="1151688676805" name="elementType" index="_ZDj9" />
+      </concept>
+      <concept id="1237721394592" name="jetbrains.mps.baseLanguage.collections.structure.AbstractContainerCreator" flags="nn" index="HWqM0">
+        <child id="1237721435808" name="initValue" index="HW$Y0" />
+        <child id="1237721435807" name="elementType" index="HW$YZ" />
+      </concept>
+      <concept id="1160600644654" name="jetbrains.mps.baseLanguage.collections.structure.ListCreatorWithInit" flags="nn" index="Tc6Ow" />
+      <concept id="1160666733551" name="jetbrains.mps.baseLanguage.collections.structure.AddAllElementsOperation" flags="nn" index="X8dFx" />
+      <concept id="1197683403723" name="jetbrains.mps.baseLanguage.collections.structure.MapType" flags="in" index="3rvAFt">
+        <child id="1197683466920" name="keyType" index="3rvQeY" />
+        <child id="1197683475734" name="valueType" index="3rvSg0" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="13h7C7" id="5wNjLS4frY$">
+    <ref role="13h7C2" to="i2rk:5wNjLS4fqEi" resolve="SNodeSetType" />
+    <node concept="13i0hz" id="hEwIkrC" role="13h7CS">
+      <property role="TrG5h" value="getPresentation" />
+      <ref role="13i0hy" to="tpcu:hEwIMiw" resolve="getPresentation" />
+      <node concept="3clFbS" id="hEwIkrD" role="3clF47">
+        <node concept="3cpWs8" id="hEwIkrE" role="3cqZAp">
+          <node concept="3cpWsn" id="hEwIkrF" role="3cpWs9">
+            <property role="TrG5h" value="conceptDeclaration" />
+            <node concept="3Tqbb2" id="hEwIkrG" role="1tU5fm">
+              <ref role="ehGHo" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
+            </node>
+            <node concept="2OqwBi" id="hEwIkrH" role="33vP2m">
+              <node concept="13iPFW" id="hEwIkrI" role="2Oq$k0" />
+              <node concept="3TrEf2" id="hEwIkrJ" role="2OqNvi">
+                <ref role="3Tt5mk" to="i2rk:gEI9Wgx" resolve="elementConcept" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="hEwIkrK" role="3cqZAp">
+          <node concept="3K4zz7" id="hEwIkrL" role="3cqZAk">
+            <node concept="3clFbC" id="hEwIkrM" role="3K4Cdx">
+              <node concept="10Nm6u" id="hEwIkrN" role="3uHU7w" />
+              <node concept="37vLTw" id="3GM_nagT_Lk" role="3uHU7B">
+                <ref role="3cqZAo" node="hEwIkrF" resolve="conceptDeclaration" />
+              </node>
+            </node>
+            <node concept="Xl_RD" id="hEwIkrP" role="3K4E3e">
+              <property role="Xl_RC" value="nset&lt; &gt;" />
+            </node>
+            <node concept="3cpWs3" id="hEwIkrR" role="3K4GZi">
+              <node concept="Xl_RD" id="hEwIkrS" role="3uHU7w">
+                <property role="Xl_RC" value="&gt;" />
+              </node>
+              <node concept="3cpWs3" id="hEwIkrQ" role="3uHU7B">
+                <node concept="Xl_RD" id="hEwIkrW" role="3uHU7B">
+                  <property role="Xl_RC" value="nset&lt;" />
+                </node>
+                <node concept="2OqwBi" id="hEwIkrT" role="3uHU7w">
+                  <node concept="37vLTw" id="3GM_nagTAJX" role="2Oq$k0">
+                    <ref role="3cqZAo" node="hEwIkrF" resolve="conceptDeclaration" />
+                  </node>
+                  <node concept="3TrcHB" id="hEwIkrV" role="2OqNvi">
+                    <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="4druX3W0A1a" role="3clF45" />
+      <node concept="3Tm1VV" id="hJrm0Ga" role="1B3o_S" />
+    </node>
+    <node concept="13i0hz" id="hEwIkrY" role="13h7CS">
+      <property role="TrG5h" value="getVariableSuffixes" />
+      <ref role="13i0hy" to="tpek:hEwIzNo" resolve="getVariableSuffixes" />
+      <node concept="3clFbS" id="hEwIkrZ" role="3clF47">
+        <node concept="3cpWs8" id="hEwIks0" role="3cqZAp">
+          <node concept="3cpWsn" id="hEwIks1" role="3cpWs9">
+            <property role="TrG5h" value="variableSuffixes" />
+            <node concept="_YKpA" id="hEwIks2" role="1tU5fm">
+              <node concept="17QB3L" id="4druX3W0A1x" role="_ZDj9" />
+            </node>
+            <node concept="2ShNRf" id="hEwIks4" role="33vP2m">
+              <node concept="Tc6Ow" id="hEwIks5" role="2ShVmc">
+                <node concept="17QB3L" id="4druX3W0A0V" role="HW$YZ" />
+                <node concept="Xl_RD" id="hEwIks7" role="HW$Y0">
+                  <property role="Xl_RC" value="nodes" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="hEwIks8" role="3cqZAp">
+          <node concept="3clFbS" id="hEwIks9" role="3clFbx">
+            <node concept="3cpWs8" id="hEwIksa" role="3cqZAp">
+              <node concept="3cpWsn" id="hEwIksb" role="3cpWs9">
+                <property role="TrG5h" value="name" />
+                <node concept="17QB3L" id="4druX3W0A0Z" role="1tU5fm" />
+                <node concept="2YIFZM" id="hEwIksd" role="33vP2m">
+                  <ref role="37wK5l" to="18ew:~NameUtil.pluralize(java.lang.String)" resolve="pluralize" />
+                  <ref role="1Pybhc" to="18ew:~NameUtil" resolve="NameUtil" />
+                  <node concept="2YIFZM" id="hEwIkse" role="37wK5m">
+                    <ref role="37wK5l" to="18ew:~NameUtil.decapitalize(java.lang.String)" resolve="decapitalize" />
+                    <ref role="1Pybhc" to="18ew:~NameUtil" resolve="NameUtil" />
+                    <node concept="2OqwBi" id="hEwIksf" role="37wK5m">
+                      <node concept="2OqwBi" id="hEwIksg" role="2Oq$k0">
+                        <node concept="13iPFW" id="hEwIksh" role="2Oq$k0" />
+                        <node concept="3TrEf2" id="hEwIksi" role="2OqNvi">
+                          <ref role="3Tt5mk" to="i2rk:gEI9Wgx" resolve="elementConcept" />
+                        </node>
+                      </node>
+                      <node concept="3TrcHB" id="hEwIksj" role="2OqNvi">
+                        <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="hEwIksk" role="3cqZAp">
+              <node concept="2OqwBi" id="hEwIksl" role="3clFbG">
+                <node concept="37vLTw" id="3GM_nagTAp4" role="2Oq$k0">
+                  <ref role="3cqZAo" node="hEwIks1" resolve="variableSuffixes" />
+                </node>
+                <node concept="X8dFx" id="hEwIksn" role="2OqNvi">
+                  <node concept="2YIFZM" id="hEwIkso" role="25WWJ7">
+                    <ref role="37wK5l" to="18ew:~NameUtil.splitByCamels(java.lang.String)" resolve="splitByCamels" />
+                    <ref role="1Pybhc" to="18ew:~NameUtil" resolve="NameUtil" />
+                    <node concept="37vLTw" id="3GM_nagTxj5" role="37wK5m">
+                      <ref role="3cqZAo" node="hEwIksb" resolve="name" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="hEwIksq" role="3clFbw">
+            <node concept="2OqwBi" id="hEwIksr" role="2Oq$k0">
+              <node concept="13iPFW" id="hEwIkss" role="2Oq$k0" />
+              <node concept="3TrEf2" id="hEwIkst" role="2OqNvi">
+                <ref role="3Tt5mk" to="i2rk:gEI9Wgx" resolve="elementConcept" />
+              </node>
+            </node>
+            <node concept="3x8VRR" id="hEwIksu" role="2OqNvi" />
+          </node>
+        </node>
+        <node concept="3clFbF" id="hEwIksv" role="3cqZAp">
+          <node concept="37vLTw" id="3GM_nagTzaR" role="3clFbG">
+            <ref role="3cqZAo" node="hEwIks1" resolve="variableSuffixes" />
+          </node>
+        </node>
+      </node>
+      <node concept="_YKpA" id="hEwIksx" role="3clF45">
+        <node concept="17QB3L" id="4druX3W0A0M" role="_ZDj9" />
+      </node>
+      <node concept="3Tm1VV" id="hJrm0Fn" role="1B3o_S" />
+    </node>
+    <node concept="13i0hz" id="1gn9ujF3cpX" role="13h7CS">
+      <property role="TrG5h" value="hasPluralVariableSuffixes" />
+      <ref role="13i0hy" to="tpek:1gn9ujF3bz3" resolve="hasPluralVariableSuffixes" />
+      <node concept="3clFbS" id="1gn9ujF3cq0" role="3clF47">
+        <node concept="3clFbF" id="1gn9ujF3cq6" role="3cqZAp">
+          <node concept="3clFbT" id="1gn9ujF3cq7" role="3clFbG">
+            <property role="3clFbU" value="true" />
+          </node>
+        </node>
+      </node>
+      <node concept="10P_77" id="1gn9ujF3cq4" role="3clF45" />
+      <node concept="3Tmbuc" id="1gn9ujF3cq5" role="1B3o_S" />
+    </node>
+    <node concept="13i0hz" id="hEwIksz" role="13h7CS">
+      <property role="TrG5h" value="getAbstractCreator" />
+      <ref role="13i0hy" to="tpek:hEwIzNW" resolve="getAbstractCreator" />
+      <node concept="3clFbS" id="hEwIks$" role="3clF47">
+        <node concept="3cpWs8" id="hEwIks_" role="3cqZAp">
+          <node concept="3cpWsn" id="hEwIksA" role="3cpWs9">
+            <property role="TrG5h" value="creator" />
+            <node concept="3Tqbb2" id="hEwIksB" role="1tU5fm">
+              <ref role="ehGHo" to="i2rk:4JmsWjDRcxX" resolve="SNodeSetCreator" />
+            </node>
+            <node concept="2ShNRf" id="hEwIksC" role="33vP2m">
+              <node concept="3zrR0B" id="hEwIksD" role="2ShVmc">
+                <node concept="3Tqbb2" id="hEwIksE" role="3zrR0E">
+                  <ref role="ehGHo" to="i2rk:4JmsWjDRcxX" resolve="SNodeSetCreator" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="hEwIksF" role="3cqZAp">
+          <node concept="2OqwBi" id="hEwIksG" role="3clFbG">
+            <node concept="2OqwBi" id="hEwIksH" role="2Oq$k0">
+              <node concept="37vLTw" id="3GM_nagTwxv" role="2Oq$k0">
+                <ref role="3cqZAo" node="hEwIksA" resolve="creator" />
+              </node>
+              <node concept="3TrEf2" id="hEwIksJ" role="2OqNvi">
+                <ref role="3Tt5mk" to="i2rk:4JmsWjDRcBP" resolve="createdType" />
+              </node>
+            </node>
+            <node concept="2oxUTD" id="hEwIksK" role="2OqNvi">
+              <node concept="2OqwBi" id="hEwIksL" role="2oxUTC">
+                <node concept="13iPFW" id="hEwIksM" role="2Oq$k0" />
+                <node concept="1$rogu" id="hEwIksN" role="2OqNvi" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="hEwIksO" role="3cqZAp">
+          <node concept="37vLTw" id="3GM_nagTyWc" role="3clFbG">
+            <ref role="3cqZAo" node="hEwIksA" resolve="creator" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tqbb2" id="hEwIksQ" role="3clF45">
+        <ref role="ehGHo" to="tpee:gEShaYr" resolve="AbstractCreator" />
+      </node>
+      <node concept="3Tm1VV" id="hJrm0rA" role="1B3o_S" />
+    </node>
+    <node concept="13i0hz" id="hEwIksR" role="13h7CS">
+      <property role="TrG5h" value="getClassExpression" />
+      <ref role="13i0hy" to="tpek:hEwIzOd" resolve="getClassExpression" />
+      <node concept="3clFbS" id="hEwIksS" role="3clF47">
+        <node concept="3clFbF" id="hEwIksT" role="3cqZAp">
+          <node concept="2c44tf" id="hEwIksU" role="3clFbG">
+            <node concept="3VsKOn" id="hEwIksV" role="2c44tc">
+              <ref role="3VsUkX" to="33ny:~Set" resolve="Set" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tqbb2" id="hEwIksW" role="3clF45">
+        <ref role="ehGHo" to="tpee:fz3vP1J" resolve="Expression" />
+      </node>
+      <node concept="3Tm1VV" id="hJrm0v2" role="1B3o_S" />
+    </node>
+    <node concept="13i0hz" id="32KZwowYg6a" role="13h7CS">
+      <property role="TrG5h" value="hasMissingParameters" />
+      <ref role="13i0hy" to="tpek:32KZwowVoMu" resolve="hasMissingParameters" />
+      <node concept="3clFbS" id="32KZwowYg6d" role="3clF47">
+        <node concept="3clFbF" id="32KZwowYg6i" role="3cqZAp">
+          <node concept="2OqwBi" id="32KZwowYg6p" role="3clFbG">
+            <node concept="2OqwBi" id="32KZwowYg6k" role="2Oq$k0">
+              <node concept="13iPFW" id="32KZwowYg6j" role="2Oq$k0" />
+              <node concept="3TrEf2" id="32KZwowYg6o" role="2OqNvi">
+                <ref role="3Tt5mk" to="i2rk:gEI9Wgx" resolve="elementConcept" />
+              </node>
+            </node>
+            <node concept="3w_OXm" id="32KZwowYg6t" role="2OqNvi" />
+          </node>
+        </node>
+      </node>
+      <node concept="10P_77" id="32KZwowYg6g" role="3clF45" />
+      <node concept="3Tm1VV" id="32KZwowYg6h" role="1B3o_S" />
+    </node>
+    <node concept="13i0hz" id="5uUZ$FUUb6V" role="13h7CS">
+      <property role="13i0iv" value="false" />
+      <property role="TrG5h" value="canBeCoerced" />
+      <property role="13i0it" value="false" />
+      <ref role="13i0hy" to="tpek:476YRQvP9l3" resolve="canBeCoerced" />
+      <node concept="3Tm1VV" id="5uUZ$FUUb6W" role="1B3o_S" />
+      <node concept="3clFbS" id="5uUZ$FUUb6X" role="3clF47">
+        <node concept="3clFbJ" id="5wNjLS4fEdK" role="3cqZAp">
+          <node concept="3clFbS" id="5wNjLS4fEdL" role="3clFbx">
+            <node concept="3cpWs6" id="5wNjLS4fEdM" role="3cqZAp">
+              <node concept="3clFbT" id="5wNjLS4fEdN" role="3cqZAk">
+                <property role="3clFbU" value="false" />
+              </node>
+            </node>
+          </node>
+          <node concept="22lmx$" id="xCjMjVCrns" role="3clFbw">
+            <node concept="22lmx$" id="5wNjLS4fEdO" role="3uHU7B">
+              <node concept="22lmx$" id="5wNjLS4fEdP" role="3uHU7B">
+                <node concept="2OqwBi" id="5wNjLS4fEdQ" role="3uHU7B">
+                  <node concept="liA8E" id="5wNjLS4fEdR" role="2OqNvi">
+                    <ref role="37wK5l" to="wyt6:~Object.equals(java.lang.Object)" resolve="equals" />
+                    <node concept="37vLTw" id="5xzMQBRytSA" role="37wK5m">
+                      <ref role="3cqZAo" node="5xzMQBRytSi" resolve="c" />
+                    </node>
+                  </node>
+                  <node concept="35c_gC" id="5xzMQBRytS_" role="2Oq$k0">
+                    <ref role="35c_gD" to="tp2q:2Uq2TE90jvD" resolve="LinkedListType" />
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="5wNjLS4fEdS" role="3uHU7w">
+                  <node concept="liA8E" id="5wNjLS4fEdT" role="2OqNvi">
+                    <ref role="37wK5l" to="wyt6:~Object.equals(java.lang.Object)" resolve="equals" />
+                    <node concept="37vLTw" id="5xzMQBRytSC" role="37wK5m">
+                      <ref role="3cqZAo" node="5xzMQBRytSi" resolve="c" />
+                    </node>
+                  </node>
+                  <node concept="35c_gC" id="5xzMQBRytSB" role="2Oq$k0">
+                    <ref role="35c_gD" to="tp2q:2UpUqInRBsh" resolve="DequeType" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2OqwBi" id="5wNjLS4fEdU" role="3uHU7w">
+                <node concept="liA8E" id="5wNjLS4fEdV" role="2OqNvi">
+                  <ref role="37wK5l" to="wyt6:~Object.equals(java.lang.Object)" resolve="equals" />
+                  <node concept="37vLTw" id="5xzMQBRytSE" role="37wK5m">
+                    <ref role="3cqZAo" node="5xzMQBRytSi" resolve="c" />
+                  </node>
+                </node>
+                <node concept="35c_gC" id="5xzMQBRytSD" role="2Oq$k0">
+                  <ref role="35c_gD" to="tp2q:5T$hED6V_VG" resolve="StackType" />
+                </node>
+              </node>
+            </node>
+            <node concept="2OqwBi" id="xCjMjVCrnv" role="3uHU7w">
+              <node concept="liA8E" id="xCjMjVCrnx" role="2OqNvi">
+                <ref role="37wK5l" to="wyt6:~Object.equals(java.lang.Object)" resolve="equals" />
+                <node concept="37vLTw" id="5xzMQBRytSG" role="37wK5m">
+                  <ref role="3cqZAo" node="5xzMQBRytSi" resolve="c" />
+                </node>
+              </node>
+              <node concept="35c_gC" id="5xzMQBRytSF" role="2Oq$k0">
+                <ref role="35c_gD" to="tp2q:gK_YKtE" resolve="ListType" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="xCjMjVCrnb" role="3cqZAp">
+          <node concept="3clFbT" id="xCjMjVCrnd" role="3cqZAk">
+            <property role="3clFbU" value="true" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="5xzMQBRytSi" role="3clF46">
+        <property role="TrG5h" value="c" />
+        <node concept="3bZ5Sz" id="5xzMQBRytSj" role="1tU5fm" />
+      </node>
+      <node concept="10P_77" id="5xzMQBRytSk" role="3clF45" />
+    </node>
+    <node concept="13i0hz" id="2eR5sdQzBt5" role="13h7CS">
+      <property role="13i0iv" value="false" />
+      <property role="TrG5h" value="collectGenericSubstitutions" />
+      <property role="13i0it" value="false" />
+      <ref role="13i0hy" to="tpek:3zZky3wF74h" resolve="collectGenericSubstitutions" />
+      <node concept="3Tm1VV" id="2eR5sdQzBt6" role="1B3o_S" />
+      <node concept="3clFbS" id="2eR5sdQzBt7" role="3clF47">
+        <node concept="3clFbF" id="2eR5sdQzBtl" role="3cqZAp">
+          <node concept="2OqwBi" id="2eR5sdQzBtN" role="3clFbG">
+            <node concept="2c44tf" id="2eR5sdQzBtm" role="2Oq$k0">
+              <node concept="3uibUv" id="2eR5sdQzBtp" role="2c44tc">
+                <ref role="3uigEE" to="33ny:~Set" resolve="Set" />
+                <node concept="3uibUv" id="2eR5sdQzBtu" role="11_B2D">
+                  <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
+                </node>
+              </node>
+            </node>
+            <node concept="2qgKlT" id="2eR5sdQzBtS" role="2OqNvi">
+              <ref role="37wK5l" to="tpek:3zZky3wF74h" resolve="collectGenericSubstitutions" />
+              <node concept="37vLTw" id="2eR5sdQzBtT" role="37wK5m">
+                <ref role="3cqZAo" node="2eR5sdQzBt8" resolve="substitutions" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="2eR5sdQzBt8" role="3clF46">
+        <property role="TrG5h" value="substitutions" />
+        <node concept="3rvAFt" id="2eR5sdQzBt9" role="1tU5fm">
+          <node concept="3Tqbb2" id="2eR5sdQzBta" role="3rvQeY" />
+          <node concept="3Tqbb2" id="2eR5sdQzBtb" role="3rvSg0" />
+        </node>
+      </node>
+      <node concept="3cqZAl" id="2eR5sdQzBtc" role="3clF45" />
+    </node>
+    <node concept="13hLZK" id="5wNjLS4frY_" role="13h7CW">
+      <node concept="3clFbS" id="5wNjLS4frYA" role="2VODD2" />
+    </node>
+  </node>
+</model>
+

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.collections/models/com.mbeddr.mpsutil.collections.constraints.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.collections/models/com.mbeddr.mpsutil.collections.constraints.mps
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:b44263d8-ad21-4fbf-b1ed-856ec6359da0(com.mbeddr.mpsutil.collections.constraints)">
+  <persistence version="9" />
+  <languages>
+    <use id="5dae8159-ab99-46bb-a40d-0cee30ee7018" name="jetbrains.mps.lang.constraints.rules.kinds" version="0" />
+    <use id="ea3159bf-f48e-4720-bde2-86dba75f0d34" name="jetbrains.mps.lang.context.defs" version="0" />
+    <use id="e51810c5-7308-4642-bcb6-469e61b5dd18" name="jetbrains.mps.lang.constraints.msg.specification" version="0" />
+    <use id="134c38d4-e3af-4d9e-b069-1c7df0a4005d" name="jetbrains.mps.lang.constraints.rules.skeleton" version="0" />
+    <use id="b3551702-269c-4f05-ba61-58060cef4292" name="jetbrains.mps.lang.rulesAndMessages" version="0" />
+    <use id="3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1" name="jetbrains.mps.lang.constraints" version="6" />
+    <use id="13744753-c81f-424a-9c1b-cf8943bf4e86" name="jetbrains.mps.lang.sharedConcepts" version="0" />
+    <use id="3ad5badc-1d9c-461c-b7b1-fa2fcd0a0ae7" name="jetbrains.mps.lang.context" version="0" />
+    <use id="ad93155d-79b2-4759-b10c-55123e763903" name="jetbrains.mps.lang.messages" version="0" />
+    <devkit ref="00000000-0000-4000-0000-5604ebd4f22c(jetbrains.mps.devkit.aspect.constraints)" />
+  </languages>
+  <imports />
+  <registry />
+</model>
+

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.collections/models/com.mbeddr.mpsutil.collections.editor.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.collections/models/com.mbeddr.mpsutil.collections.editor.mps
@@ -145,8 +145,12 @@
         <node concept="3EZMnI" id="4JmsWjDRhK2" role="_tjki">
           <node concept="2iRfu4" id="4JmsWjDRhK3" role="2iSdaV" />
           <node concept="3F0ifn" id="4JmsWjDRhIC" role="3EZMnx">
-            <property role="3F0ifm" value="by" />
-            <ref role="1k5W1q" to="tpen:hgVS8CF" resolve="KeyWord" />
+            <property role="3F0ifm" value="(" />
+            <ref role="1k5W1q" to="tpen:hY9fg1G" resolve="LeftParenAfterName" />
+          </node>
+          <node concept="3F0ifn" id="5YWahjSLxMn" role="3EZMnx">
+            <property role="3F0ifm" value="copy:" />
+            <ref role="1k5W1q" to="tpen:hshU_KJ" resolve="Annotation" />
           </node>
           <node concept="3F1sOY" id="4JmsWjDRhKL" role="3EZMnx">
             <property role="39s7Ar" value="true" />
@@ -163,6 +167,10 @@
             </node>
           </node>
         </node>
+      </node>
+      <node concept="3F0ifn" id="5YWahjSLxMq" role="3EZMnx">
+        <property role="3F0ifm" value=")" />
+        <ref role="1k5W1q" to="tpen:hFCSUmN" resolve="RightParen" />
       </node>
     </node>
   </node>

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.collections/models/com.mbeddr.mpsutil.collections.editor.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.collections/models/com.mbeddr.mpsutil.collections.editor.mps
@@ -1,0 +1,170 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:310f1b3d-c384-4c7a-9fb9-b1c0d8b8d542(com.mbeddr.mpsutil.collections.editor)">
+  <persistence version="9" />
+  <languages>
+    <use id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor" version="14" />
+    <use id="9d69e719-78c8-4286-90db-fb19c107d049" name="com.mbeddr.mpsutil.grammarcells" version="2" />
+    <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
+  </languages>
+  <imports>
+    <import index="tpen" ref="r:00000000-0000-4000-0000-011c895902c3(jetbrains.mps.baseLanguage.editor)" />
+    <import index="i2rk" ref="r:baa9d6ac-6b79-40af-928c-6bdcbfd7265f(com.mbeddr.mpsutil.collections.structure)" implicit="true" />
+    <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor">
+      <concept id="1071666914219" name="jetbrains.mps.lang.editor.structure.ConceptEditorDeclaration" flags="ig" index="24kQdi" />
+      <concept id="1106270549637" name="jetbrains.mps.lang.editor.structure.CellLayout_Horizontal" flags="nn" index="2iRfu4" />
+      <concept id="1237303669825" name="jetbrains.mps.lang.editor.structure.CellLayout_Indent" flags="nn" index="l2Vlx" />
+      <concept id="1080736578640" name="jetbrains.mps.lang.editor.structure.BaseEditorComponent" flags="ig" index="2wURMF">
+        <child id="1080736633877" name="cellModel" index="2wV5jI" />
+      </concept>
+      <concept id="1078938745671" name="jetbrains.mps.lang.editor.structure.EditorComponentDeclaration" flags="ig" index="PKFIW" />
+      <concept id="1186403694788" name="jetbrains.mps.lang.editor.structure.ColorStyleClassItem" flags="ln" index="VaVBg">
+        <property id="1186403713874" name="color" index="Vb096" />
+      </concept>
+      <concept id="1186404549998" name="jetbrains.mps.lang.editor.structure.ForegroundColorStyleClassItem" flags="ln" index="VechU" />
+      <concept id="1088013125922" name="jetbrains.mps.lang.editor.structure.CellModel_RefCell" flags="sg" stub="730538219795941030" index="1iCGBv">
+        <child id="1088186146602" name="editorComponent" index="1sWHZn" />
+      </concept>
+      <concept id="1381004262292414836" name="jetbrains.mps.lang.editor.structure.ICellStyle" flags="ng" index="1k5N5V">
+        <reference id="1381004262292426837" name="parentStyleClass" index="1k5W1q" />
+      </concept>
+      <concept id="1088185857835" name="jetbrains.mps.lang.editor.structure.InlineEditorComponent" flags="ig" index="1sVBvm" />
+      <concept id="1215007762405" name="jetbrains.mps.lang.editor.structure.FloatStyleClassItem" flags="ln" index="3$6MrZ">
+        <property id="1215007802031" name="value" index="3$6WeP" />
+      </concept>
+      <concept id="1215007897487" name="jetbrains.mps.lang.editor.structure.PaddingRightStyleClassItem" flags="ln" index="3$7jql" />
+      <concept id="1139848536355" name="jetbrains.mps.lang.editor.structure.CellModel_WithRole" flags="ng" index="1$h60E">
+        <property id="1214560368769" name="emptyNoTargetText" index="39s7Ar" />
+        <property id="1139852716018" name="noTargetText" index="1$x2rV" />
+        <property id="1140017977771" name="readOnly" index="1Intyy" />
+        <reference id="1140103550593" name="relationDeclaration" index="1NtTu8" />
+      </concept>
+      <concept id="1073389446423" name="jetbrains.mps.lang.editor.structure.CellModel_Collection" flags="sn" stub="3013115976261988961" index="3EZMnI">
+        <child id="1106270802874" name="cellLayout" index="2iSdaV" />
+        <child id="1073389446424" name="childCellModel" index="3EZMnx" />
+      </concept>
+      <concept id="1073389577006" name="jetbrains.mps.lang.editor.structure.CellModel_Constant" flags="sn" stub="3610246225209162225" index="3F0ifn">
+        <property id="1073389577007" name="text" index="3F0ifm" />
+      </concept>
+      <concept id="1073389658414" name="jetbrains.mps.lang.editor.structure.CellModel_Property" flags="sg" stub="730538219796134133" index="3F0A7n" />
+      <concept id="1219418625346" name="jetbrains.mps.lang.editor.structure.IStyleContainer" flags="ng" index="3F0Thp">
+        <child id="1219418656006" name="styleItem" index="3F10Kt" />
+      </concept>
+      <concept id="1073389882823" name="jetbrains.mps.lang.editor.structure.CellModel_RefNode" flags="sg" stub="730538219795960754" index="3F1sOY" />
+      <concept id="1166049232041" name="jetbrains.mps.lang.editor.structure.AbstractComponent" flags="ng" index="1XWOmA">
+        <reference id="1166049300910" name="conceptDeclaration" index="1XX52x" />
+      </concept>
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
+        <child id="1137022507850" name="body" index="2VODD2" />
+      </concept>
+      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
+        <property id="1070475926801" name="value" index="Xl_RC" />
+      </concept>
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+    </language>
+    <language id="9d69e719-78c8-4286-90db-fb19c107d049" name="com.mbeddr.mpsutil.grammarcells">
+      <concept id="9041925471455857605" name="com.mbeddr.mpsutil.grammarcells.structure.Cell_DescriptionText" flags="ig" index="uPpia" />
+      <concept id="5083944728298846680" name="com.mbeddr.mpsutil.grammarcells.structure.OptionalCell" flags="ng" index="_tjkj">
+        <child id="5083944728298846681" name="option" index="_tjki" />
+      </concept>
+      <concept id="848437706375087728" name="com.mbeddr.mpsutil.grammarcells.structure.ICanHaveDescriptionText" flags="ng" index="1djCvD">
+        <child id="848437706375087729" name="descriptionText" index="1djCvC" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="24kQdi" id="5wNjLS4fqEl">
+    <ref role="1XX52x" to="i2rk:5wNjLS4fqEi" resolve="SNodeSetType" />
+    <node concept="3EZMnI" id="gEIaltJ" role="2wV5jI">
+      <node concept="3F0ifn" id="gEIaltK" role="3EZMnx">
+        <property role="3F0ifm" value="nset" />
+        <ref role="1k5W1q" to="tpen:hgVS8CF" resolve="KeyWord" />
+        <node concept="3$7jql" id="hFHA57K" role="3F10Kt">
+          <property role="3$6WeP" value="0.0" />
+        </node>
+      </node>
+      <node concept="3F0ifn" id="gEIaltL" role="3EZMnx">
+        <property role="3F0ifm" value="&lt;" />
+        <ref role="1k5W1q" to="tpen:hY9fg1G" resolve="LeftParenAfterName" />
+      </node>
+      <node concept="1iCGBv" id="gEIasb5" role="3EZMnx">
+        <property role="39s7Ar" value="true" />
+        <ref role="1NtTu8" to="i2rk:gEI9Wgx" resolve="elementConcept" />
+        <node concept="1sVBvm" id="gEIasb6" role="1sWHZn">
+          <node concept="3F0A7n" id="gEIat7U" role="2wV5jI">
+            <property role="1Intyy" value="true" />
+            <property role="1$x2rV" value="&lt;no name&gt;" />
+            <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
+            <node concept="VechU" id="hEZR8mY" role="3F10Kt">
+              <property role="Vb096" value="g1_qVrt" />
+            </node>
+            <node concept="3$7jql" id="hFH_rY2" role="3F10Kt">
+              <property role="3$6WeP" value="0.0" />
+            </node>
+          </node>
+        </node>
+        <node concept="3$7jql" id="hJwgsgQ" role="3F10Kt">
+          <property role="3$6WeP" value="0.0" />
+        </node>
+      </node>
+      <node concept="3F0ifn" id="gEIaltR" role="3EZMnx">
+        <property role="3F0ifm" value="&gt;" />
+        <ref role="1k5W1q" to="tpen:hFCSUmN" resolve="RightParen" />
+      </node>
+      <node concept="l2Vlx" id="i0NEeNA" role="2iSdaV" />
+    </node>
+  </node>
+  <node concept="PKFIW" id="7Oamrh2d1a_">
+    <property role="TrG5h" value="DummyForGrammarCells" />
+    <ref role="1XX52x" to="tpck:gw2VY9q" resolve="BaseConcept" />
+    <node concept="3F0ifn" id="7Oamrh2d1aA" role="2wV5jI">
+      <property role="3F0ifm" value="Workaround to fix contributions to BaseConcept generated by grammarCells." />
+    </node>
+  </node>
+  <node concept="24kQdi" id="4JmsWjDRcEg">
+    <ref role="1XX52x" to="i2rk:4JmsWjDRcxX" resolve="SNodeSetCreator" />
+    <node concept="3EZMnI" id="4JmsWjDRhE0" role="2wV5jI">
+      <node concept="2iRfu4" id="4JmsWjDRhE1" role="2iSdaV" />
+      <node concept="3F1sOY" id="4JmsWjDRcEY" role="3EZMnx">
+        <ref role="1NtTu8" to="i2rk:4JmsWjDRcBP" resolve="createdType" />
+      </node>
+      <node concept="_tjkj" id="4JmsWjDRhIe" role="3EZMnx">
+        <node concept="3EZMnI" id="4JmsWjDRhK2" role="_tjki">
+          <node concept="2iRfu4" id="4JmsWjDRhK3" role="2iSdaV" />
+          <node concept="3F0ifn" id="4JmsWjDRhIC" role="3EZMnx">
+            <property role="3F0ifm" value="by" />
+            <ref role="1k5W1q" to="tpen:hgVS8CF" resolve="KeyWord" />
+          </node>
+          <node concept="3F1sOY" id="4JmsWjDRhKL" role="3EZMnx">
+            <property role="39s7Ar" value="true" />
+            <property role="1$x2rV" value="new hashset" />
+            <ref role="1NtTu8" to="i2rk:4JmsWjDRhF4" resolve="setCreator" />
+          </node>
+        </node>
+        <node concept="uPpia" id="4JmsWjE3HsV" role="1djCvC">
+          <node concept="3clFbS" id="4JmsWjE3HsW" role="2VODD2">
+            <node concept="3clFbF" id="4JmsWjE3HOn" role="3cqZAp">
+              <node concept="Xl_RD" id="4JmsWjE3HOm" role="3clFbG">
+                <property role="Xl_RC" value="by using the following set" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.collections/models/com.mbeddr.mpsutil.collections.structure.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.collections/models/com.mbeddr.mpsutil.collections.structure.mps
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:baa9d6ac-6b79-40af-928c-6bdcbfd7265f(com.mbeddr.mpsutil.collections.structure)">
+  <persistence version="9" />
+  <languages>
+    <devkit ref="78434eb8-b0e5-444b-850d-e7c4ad2da9ab(jetbrains.mps.devkit.aspect.structure)" />
+  </languages>
+  <imports>
+    <import index="tpce" ref="r:00000000-0000-4000-0000-011c89590292(jetbrains.mps.lang.structure.structure)" />
+    <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" />
+  </imports>
+  <registry>
+    <language id="c72da2b9-7cce-4447-8389-f407dc1158b7" name="jetbrains.mps.lang.structure">
+      <concept id="1169125787135" name="jetbrains.mps.lang.structure.structure.AbstractConceptDeclaration" flags="ig" index="PkWjJ">
+        <property id="6714410169261853888" name="conceptId" index="EcuMT" />
+        <property id="4628067390765907488" name="conceptShortDescription" index="R4oN_" />
+        <property id="5092175715804935370" name="conceptAlias" index="34LRSv" />
+        <child id="1071489727083" name="linkDeclaration" index="1TKVEi" />
+      </concept>
+      <concept id="1169127622168" name="jetbrains.mps.lang.structure.structure.InterfaceConceptReference" flags="ig" index="PrWs8">
+        <reference id="1169127628841" name="intfc" index="PrY4T" />
+      </concept>
+      <concept id="1071489090640" name="jetbrains.mps.lang.structure.structure.ConceptDeclaration" flags="ig" index="1TIwiD">
+        <reference id="1071489389519" name="extends" index="1TJDcQ" />
+        <child id="1169129564478" name="implements" index="PzmwI" />
+      </concept>
+      <concept id="1071489288298" name="jetbrains.mps.lang.structure.structure.LinkDeclaration" flags="ig" index="1TJgyj">
+        <property id="1071599776563" name="role" index="20kJfa" />
+        <property id="1071599893252" name="sourceCardinality" index="20lbJX" />
+        <property id="1071599937831" name="metaClass" index="20lmBu" />
+        <property id="241647608299431140" name="linkId" index="IQ2ns" />
+        <reference id="1071599976176" name="target" index="20lvS9" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="1TIwiD" id="5wNjLS4fqEi">
+    <property role="EcuMT" value="6355510489488665234" />
+    <property role="TrG5h" value="SNodeSetType" />
+    <property role="34LRSv" value="nset&lt;&gt;" />
+    <property role="R4oN_" value="set of nodes" />
+    <ref role="1TJDcQ" to="tpee:fz3vP1H" resolve="Type" />
+    <node concept="1TJgyj" id="gEI9Wgx" role="1TKVEi">
+      <property role="20kJfa" value="elementConcept" />
+      <property role="IQ2ns" value="1145383142433" />
+      <ref role="20lvS9" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
+    </node>
+    <node concept="PrWs8" id="5wNjLS4fqEj" role="PzmwI">
+      <ref role="PrY4T" to="tpee:3zZky3wF74d" resolve="IGenericType" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="4JmsWjDRcxX">
+    <property role="EcuMT" value="5464682487435020413" />
+    <property role="TrG5h" value="SNodeSetCreator" />
+    <property role="34LRSv" value="nset" />
+    <property role="R4oN_" value="set of (s)nodes" />
+    <ref role="1TJDcQ" to="tpee:gEShaYr" resolve="AbstractCreator" />
+    <node concept="1TJgyj" id="4JmsWjDRcBP" role="1TKVEi">
+      <property role="IQ2ns" value="5464682487435020789" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="createdType" />
+      <property role="20lbJX" value="fLJekj4/_1" />
+      <ref role="20lvS9" node="5wNjLS4fqEi" resolve="SNodeSetType" />
+    </node>
+    <node concept="1TJgyj" id="4JmsWjDRhF4" role="1TKVEi">
+      <property role="IQ2ns" value="5464682487435041476" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="setCreator" />
+      <ref role="20lvS9" to="tpee:fz3vP1J" resolve="Expression" />
+    </node>
+  </node>
+</model>
+

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.collections/models/com.mbeddr.mpsutil.collections.typesystem.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.collections/models/com.mbeddr.mpsutil.collections.typesystem.mps
@@ -1,0 +1,688 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:98449c2c-1cb6-4e11-8e93-d22a8497c2fe(com.mbeddr.mpsutil.collections.typesystem)">
+  <persistence version="9" />
+  <languages>
+    <use id="7a5dda62-9140-4668-ab76-d5ed1746f2b2" name="jetbrains.mps.lang.typesystem" version="5" />
+    <use id="e89e1550-b8fe-4f0d-a7fd-487968b42405" name="com.mbeddr.mpsutil.collections" version="0" />
+    <devkit ref="00000000-0000-4000-0000-1de82b3a4936(jetbrains.mps.devkit.aspect.typesystem)" />
+  </languages>
+  <imports>
+    <import index="i2rk" ref="r:baa9d6ac-6b79-40af-928c-6bdcbfd7265f(com.mbeddr.mpsutil.collections.structure)" />
+    <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
+    <import index="mhbf" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.model(MPS.OpenAPI/)" />
+    <import index="tp25" ref="r:00000000-0000-4000-0000-011c89590301(jetbrains.mps.lang.smodel.structure)" />
+    <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
+    <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" implicit="true" />
+    <import index="tpce" ref="r:00000000-0000-4000-0000-011c89590292(jetbrains.mps.lang.structure.structure)" implicit="true" />
+    <import index="tpcn" ref="r:00000000-0000-4000-0000-011c8959028b(jetbrains.mps.lang.structure.behavior)" implicit="true" />
+    <import index="tp2q" ref="r:00000000-0000-4000-0000-011c8959032e(jetbrains.mps.baseLanguage.collections.structure)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1082485599095" name="jetbrains.mps.baseLanguage.structure.BlockStatement" flags="nn" index="9aQIb">
+        <child id="1082485599096" name="statements" index="9aQI4" />
+      </concept>
+      <concept id="1154032098014" name="jetbrains.mps.baseLanguage.structure.AbstractLoopStatement" flags="nn" index="2LF5Ji">
+        <child id="1154032183016" name="body" index="2LFqv$" />
+      </concept>
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
+        <child id="1145553007750" name="creator" index="2ShVmc" />
+      </concept>
+      <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
+      <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
+        <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1068431790189" name="jetbrains.mps.baseLanguage.structure.Type" flags="in" index="33vP2l" />
+      <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
+        <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
+      </concept>
+      <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
+        <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
+        <child id="1082485599094" name="ifFalseStatement" index="9aQIa" />
+        <child id="1068580123160" name="condition" index="3clFbw" />
+        <child id="1068580123161" name="ifTrue" index="3clFbx" />
+      </concept>
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
+        <child id="1068581517676" name="expression" index="3cqZAk" />
+      </concept>
+      <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
+        <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
+      </concept>
+      <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
+      <concept id="1081516740877" name="jetbrains.mps.baseLanguage.structure.NotExpression" flags="nn" index="3fqX7Q">
+        <child id="1081516765348" name="expression" index="3fr31v" />
+      </concept>
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+      </concept>
+      <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
+        <reference id="1107535924139" name="classifier" index="3uigEE" />
+        <child id="1109201940907" name="parameter" index="11_B2D" />
+      </concept>
+      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
+        <child id="1081773367579" name="rightExpression" index="3uHU7w" />
+        <child id="1081773367580" name="leftExpression" index="3uHU7B" />
+      </concept>
+      <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
+    </language>
+    <language id="d4615e3b-d671-4ba9-af01-2b78369b0ba7" name="jetbrains.mps.lang.pattern">
+      <concept id="1136720037777" name="jetbrains.mps.lang.pattern.structure.PatternExpression" flags="in" index="2DMOqp">
+        <child id="9046399079000773837" name="pattern" index="HM535" />
+      </concept>
+      <concept id="1136720037779" name="jetbrains.mps.lang.pattern.structure.PatternVariableDeclaration" flags="ng" index="2DMOqr">
+        <property id="1136720037780" name="varName" index="2DMOqs" />
+      </concept>
+      <concept id="1137418540378" name="jetbrains.mps.lang.pattern.structure.LinkPatternVariableDeclaration" flags="ng" index="3jrphi">
+        <property id="1137418571428" name="varName" index="3jrwYG" />
+      </concept>
+    </language>
+    <language id="e89e1550-b8fe-4f0d-a7fd-487968b42405" name="com.mbeddr.mpsutil.collections">
+      <concept id="6355510489488665234" name="com.mbeddr.mpsutil.collections.structure.SNodeSetType" flags="ig" index="1s3Imc">
+        <reference id="1145383142433" name="elementConcept" index="2I9WkF" />
+      </concept>
+    </language>
+    <language id="3a13115c-633c-4c5c-bbcc-75c4219e9555" name="jetbrains.mps.lang.quotation">
+      <concept id="1196350785110" name="jetbrains.mps.lang.quotation.structure.AbstractAntiquotation" flags="ng" index="2c44t0">
+        <child id="1196350785111" name="expression" index="2c44t1" />
+      </concept>
+      <concept id="1196350785117" name="jetbrains.mps.lang.quotation.structure.ReferenceAntiquotation" flags="ng" index="2c44tb" />
+      <concept id="1196350785112" name="jetbrains.mps.lang.quotation.structure.Antiquotation" flags="ng" index="2c44te" />
+      <concept id="1196350785113" name="jetbrains.mps.lang.quotation.structure.Quotation" flags="nn" index="2c44tf">
+        <child id="1196350785114" name="quotedNode" index="2c44tc" />
+      </concept>
+    </language>
+    <language id="7a5dda62-9140-4668-ab76-d5ed1746f2b2" name="jetbrains.mps.lang.typesystem">
+      <concept id="1174989242422" name="jetbrains.mps.lang.typesystem.structure.PatternVariableReference" flags="nn" index="2iOg4B">
+        <reference id="1174989274720" name="patternVarDecl" index="2iOnXL" />
+      </concept>
+      <concept id="1174989777619" name="jetbrains.mps.lang.typesystem.structure.LinkPatternVariableReference" flags="nn" index="2iQiJ2">
+        <reference id="1174989841903" name="patternVarDecl" index="2iQyjY" />
+      </concept>
+      <concept id="1185788614172" name="jetbrains.mps.lang.typesystem.structure.NormalTypeClause" flags="ng" index="mw_s8">
+        <child id="1185788644032" name="normalType" index="mwGJk" />
+      </concept>
+      <concept id="1175147569072" name="jetbrains.mps.lang.typesystem.structure.AbstractSubtypingRule" flags="ig" index="2sgdUx">
+        <child id="1175147624276" name="body" index="2sgrp5" />
+      </concept>
+      <concept id="1175147670730" name="jetbrains.mps.lang.typesystem.structure.SubtypingRule" flags="ig" index="2sgARr" />
+      <concept id="1212056081426" name="jetbrains.mps.lang.typesystem.structure.AbstractInequationStatement" flags="ng" index="Ob1k8">
+        <property id="7739208407757103786" name="orientation" index="2osLew" />
+        <property id="7739208407757103785" name="strong" index="2osLez" />
+      </concept>
+      <concept id="1201607707634" name="jetbrains.mps.lang.typesystem.structure.InequationReplacementRule" flags="ig" index="35pCF_">
+        <child id="1201607798918" name="supertypeNode" index="35pZ6h" />
+      </concept>
+      <concept id="1195213580585" name="jetbrains.mps.lang.typesystem.structure.AbstractCheckingRule" flags="ig" index="18hYwZ">
+        <child id="1195213635060" name="body" index="18ibNy" />
+      </concept>
+      <concept id="1174642788531" name="jetbrains.mps.lang.typesystem.structure.ConceptReference" flags="ig" index="1YaCAy">
+        <reference id="1174642800329" name="concept" index="1YaFvo" />
+      </concept>
+      <concept id="1174642900584" name="jetbrains.mps.lang.typesystem.structure.PatternCondition" flags="ig" index="1Yb3XT">
+        <child id="1174642936809" name="pattern" index="1YbcFS" />
+      </concept>
+      <concept id="1174643105530" name="jetbrains.mps.lang.typesystem.structure.InferenceRule" flags="ig" index="1YbPZF" />
+      <concept id="1174648085619" name="jetbrains.mps.lang.typesystem.structure.AbstractRule" flags="ng" index="1YuPPy">
+        <child id="1174648101952" name="applicableNode" index="1YuTPh" />
+      </concept>
+      <concept id="1174650418652" name="jetbrains.mps.lang.typesystem.structure.ApplicableNodeReference" flags="nn" index="1YBJjd">
+        <reference id="1174650432090" name="applicableNode" index="1YBMHb" />
+      </concept>
+      <concept id="1174657487114" name="jetbrains.mps.lang.typesystem.structure.TypeOfExpression" flags="nn" index="1Z2H0r">
+        <child id="1174657509053" name="term" index="1Z2MuG" />
+      </concept>
+      <concept id="1174658326157" name="jetbrains.mps.lang.typesystem.structure.CreateEquationStatement" flags="nn" index="1Z5TYs" />
+      <concept id="1174660718586" name="jetbrains.mps.lang.typesystem.structure.AbstractEquationStatement" flags="nn" index="1Zf1VF">
+        <child id="1174660783413" name="leftExpression" index="1ZfhK$" />
+        <child id="1174660783414" name="rightExpression" index="1ZfhKB" />
+      </concept>
+      <concept id="1174663118805" name="jetbrains.mps.lang.typesystem.structure.CreateLessThanInequationStatement" flags="nn" index="1ZobV4" />
+      <concept id="1174665551739" name="jetbrains.mps.lang.typesystem.structure.TypeVarDeclaration" flags="ng" index="1ZxtTE" />
+      <concept id="1174666260556" name="jetbrains.mps.lang.typesystem.structure.TypeVarReference" flags="nn" index="1Z$b5t">
+        <reference id="1174666276259" name="typeVarDeclaration" index="1Z$eMM" />
+      </concept>
+    </language>
+    <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
+        <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
+      </concept>
+      <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
+      <concept id="1145383075378" name="jetbrains.mps.lang.smodel.structure.SNodeListType" flags="in" index="2I9FWS" />
+      <concept id="1139621453865" name="jetbrains.mps.lang.smodel.structure.Node_IsInstanceOfOperation" flags="nn" index="1mIQ4w">
+        <child id="1177027386292" name="conceptArgument" index="cj9EA" />
+      </concept>
+      <concept id="1172008320231" name="jetbrains.mps.lang.smodel.structure.Node_IsNotNullOperation" flags="nn" index="3x8VRR" />
+      <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
+        <reference id="1138405853777" name="concept" index="ehGHo" />
+      </concept>
+      <concept id="1138056143562" name="jetbrains.mps.lang.smodel.structure.SLinkAccess" flags="nn" index="3TrEf2">
+        <reference id="1138056516764" name="link" index="3Tt5mk" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
+      <concept id="3364660638048049745" name="jetbrains.mps.lang.core.structure.LinkAttribute" flags="ng" index="A9Btn">
+        <property id="1757699476691236116" name="role_DebugInfo" index="2qtEX8" />
+        <property id="1341860900488019036" name="linkId" index="P3scX" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+    <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
+      <concept id="540871147943773365" name="jetbrains.mps.baseLanguage.collections.structure.SingleArgumentSequenceOperation" flags="nn" index="25WWJ4">
+        <child id="540871147943773366" name="argument" index="25WWJ7" />
+      </concept>
+      <concept id="1226511727824" name="jetbrains.mps.baseLanguage.collections.structure.SetType" flags="in" index="2hMVRd">
+        <child id="1226511765987" name="elementType" index="2hN53Y" />
+      </concept>
+      <concept id="1151688443754" name="jetbrains.mps.baseLanguage.collections.structure.ListType" flags="in" index="_YKpA">
+        <child id="1151688676805" name="elementType" index="_ZDj9" />
+      </concept>
+      <concept id="1151689724996" name="jetbrains.mps.baseLanguage.collections.structure.SequenceType" flags="in" index="A3Dl8">
+        <child id="1151689745422" name="elementType" index="A3Ik2" />
+      </concept>
+      <concept id="1153943597977" name="jetbrains.mps.baseLanguage.collections.structure.ForEachStatement" flags="nn" index="2Gpval">
+        <child id="1153944400369" name="variable" index="2Gsz3X" />
+        <child id="1153944424730" name="inputSequence" index="2GsD0m" />
+      </concept>
+      <concept id="1153944193378" name="jetbrains.mps.baseLanguage.collections.structure.ForEachVariable" flags="nr" index="2GrKxI" />
+      <concept id="1153944233411" name="jetbrains.mps.baseLanguage.collections.structure.ForEachVariableReference" flags="nn" index="2GrUjf">
+        <reference id="1153944258490" name="variable" index="2Gs0qQ" />
+      </concept>
+      <concept id="1237721394592" name="jetbrains.mps.baseLanguage.collections.structure.AbstractContainerCreator" flags="nn" index="HWqM0">
+        <child id="1237721435807" name="elementType" index="HW$YZ" />
+      </concept>
+      <concept id="1160600644654" name="jetbrains.mps.baseLanguage.collections.structure.ListCreatorWithInit" flags="nn" index="Tc6Ow" />
+      <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="nn" index="TSZUe" />
+    </language>
+  </registry>
+  <node concept="35pCF_" id="16dBgEFdgZE">
+    <property role="TrG5h" value="nset_subtypeOf_set_of_nodes" />
+    <node concept="1Yb3XT" id="16dBgEFdgZN" role="35pZ6h">
+      <property role="TrG5h" value="setOfAny" />
+      <node concept="2DMOqp" id="16dBgEFdgZO" role="1YbcFS">
+        <node concept="2c44tf" id="7oTZmjkCr87" role="HM535">
+          <node concept="2hMVRd" id="5wNjLS4jP6g" role="2c44tc">
+            <node concept="33vP2l" id="5wNjLS4jP6i" role="2hN53Y">
+              <node concept="2DMOqr" id="5wNjLS4jP6j" role="lGtFl">
+                <property role="2DMOqs" value="ELEMENT" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3clFbS" id="16dBgEFdgZG" role="2sgrp5">
+      <node concept="3clFbJ" id="5NvVtQ6r6T9" role="3cqZAp">
+        <node concept="3clFbS" id="5NvVtQ6r6Tb" role="3clFbx">
+          <node concept="1ZobV4" id="6DFN5BsWHZY" role="3cqZAp">
+            <node concept="mw_s8" id="6DFN5BsWHZZ" role="1ZfhK$">
+              <node concept="2c44tf" id="6DFN5BsWI00" role="mwGJk">
+                <node concept="3Tqbb2" id="6DFN5BsWI01" role="2c44tc">
+                  <ref role="ehGHo" to="tpck:gw2VY9q" resolve="BaseConcept" />
+                  <node concept="2c44tb" id="6DFN5BsWI02" role="lGtFl">
+                    <property role="2qtEX8" value="concept" />
+                    <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/1138055754698/1138405853777" />
+                    <node concept="2iQiJ2" id="6DFN5BsWI03" role="2c44t1">
+                      <ref role="2iQyjY" node="7Oamrh2dPKP" resolve="#CONCEPT" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="mw_s8" id="6DFN5BsWI04" role="1ZfhKB">
+              <node concept="2iOg4B" id="6DFN5BsWI05" role="mwGJk">
+                <ref role="2iOnXL" node="5wNjLS4jP6j" resolve="#ELEMENT" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3fqX7Q" id="5NvVtQ6r6Tw" role="3clFbw">
+          <node concept="2OqwBi" id="5NvVtQ6r7ip" role="3fr31v">
+            <node concept="2iOg4B" id="5NvVtQ6r6U3" role="2Oq$k0">
+              <ref role="2iOnXL" node="5wNjLS4jP6j" resolve="#ELEMENT" />
+            </node>
+            <node concept="1mIQ4w" id="5NvVtQ6r7DX" role="2OqNvi">
+              <node concept="chp4Y" id="5NvVtQ6r7Fv" role="cj9EA">
+                <ref role="cht4Q" to="tpee:h3qTviz" resolve="WildCardType" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1Yb3XT" id="7Oamrh2d6hW" role="1YuTPh">
+      <property role="TrG5h" value="nset" />
+      <node concept="2DMOqp" id="7Oamrh2d6hY" role="1YbcFS">
+        <node concept="2c44tf" id="7Oamrh2d6i0" role="HM535">
+          <node concept="1s3Imc" id="7Oamrh2dPHp" role="2c44tc">
+            <ref role="2I9WkF" to="tpck:gw2VY9q" resolve="BaseConcept" />
+            <node concept="3jrphi" id="7Oamrh2dPKP" role="lGtFl">
+              <property role="2qtEX8" value="elementConcept" />
+              <property role="P3scX" value="e89e1550-b8fe-4f0d-a7fd-487968b42405/6355510489488665234/1145383142433" />
+              <property role="3jrwYG" value="CONCEPT" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="35pCF_" id="7$oyN7_KHfj">
+    <property role="TrG5h" value="nset_subtypeOf_sequence_of_nodes" />
+    <node concept="1Yb3XT" id="7$oyN7_KIi5" role="35pZ6h">
+      <property role="TrG5h" value="seq" />
+      <node concept="2DMOqp" id="7$oyN7_KIiz" role="1YbcFS">
+        <node concept="2c44tf" id="7oTZmjkCr7X" role="HM535">
+          <node concept="A3Dl8" id="7$oyN7_KIj5" role="2c44tc">
+            <node concept="33vP2l" id="7$oyN7_KIj7" role="A3Ik2">
+              <node concept="2DMOqr" id="7$oyN7_KIj8" role="lGtFl">
+                <property role="2DMOqs" value="ELEMENT" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3clFbS" id="7$oyN7_KHfl" role="2sgrp5">
+      <node concept="3clFbJ" id="5NvVtQ6r9T2" role="3cqZAp">
+        <node concept="3clFbS" id="5NvVtQ6r9T4" role="3clFbx">
+          <node concept="1ZobV4" id="7$oyN7_KMYh" role="3cqZAp">
+            <node concept="mw_s8" id="7$oyN7_KMYi" role="1ZfhK$">
+              <node concept="2c44tf" id="7$oyN7_KMYj" role="mwGJk">
+                <node concept="3Tqbb2" id="7$oyN7_KMYk" role="2c44tc">
+                  <ref role="ehGHo" to="tpck:gw2VY9q" resolve="BaseConcept" />
+                  <node concept="2c44tb" id="7$oyN7_KMYl" role="lGtFl">
+                    <property role="2qtEX8" value="concept" />
+                    <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/1138055754698/1138405853777" />
+                    <node concept="2iQiJ2" id="7$oyN7_KMYm" role="2c44t1">
+                      <ref role="2iQyjY" node="7Oamrh2dPu7" resolve="#CONCEPT" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="mw_s8" id="7$oyN7_KMYn" role="1ZfhKB">
+              <node concept="2iOg4B" id="7$oyN7_KMYo" role="mwGJk">
+                <ref role="2iOnXL" node="7$oyN7_KIj8" resolve="#ELEMENT" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3fqX7Q" id="5NvVtQ6r9Tp" role="3clFbw">
+          <node concept="2OqwBi" id="5NvVtQ6r9VY" role="3fr31v">
+            <node concept="2iOg4B" id="5NvVtQ6r9TD" role="2Oq$k0">
+              <ref role="2iOnXL" node="7$oyN7_KIj8" resolve="#ELEMENT" />
+            </node>
+            <node concept="1mIQ4w" id="5NvVtQ6rajy" role="2OqNvi">
+              <node concept="chp4Y" id="5NvVtQ6ral4" role="cj9EA">
+                <ref role="cht4Q" to="tpee:h3qTviz" resolve="WildCardType" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1Yb3XT" id="7Oamrh2dPr4" role="1YuTPh">
+      <property role="TrG5h" value="nset" />
+      <node concept="2DMOqp" id="7Oamrh2dPr6" role="1YbcFS">
+        <node concept="2c44tf" id="7Oamrh2dPr8" role="HM535">
+          <node concept="1s3Imc" id="7Oamrh2dPsj" role="2c44tc">
+            <ref role="2I9WkF" to="tpck:gw2VY9q" resolve="BaseConcept" />
+            <node concept="3jrphi" id="7Oamrh2dPu7" role="lGtFl">
+              <property role="2qtEX8" value="elementConcept" />
+              <property role="P3scX" value="e89e1550-b8fe-4f0d-a7fd-487968b42405/6355510489488665234/1145383142433" />
+              <property role="3jrwYG" value="CONCEPT" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="2sgARr" id="h9nq4$C">
+    <property role="TrG5h" value="supertypesOf_SNodeSetType" />
+    <node concept="3clFbS" id="h9nq4$D" role="2sgrp5">
+      <node concept="3cpWs8" id="haij1ZH" role="3cqZAp">
+        <node concept="3cpWsn" id="haij1ZI" role="3cpWs9">
+          <property role="TrG5h" value="supertypes" />
+          <node concept="2I9FWS" id="16dBgEFdjJr" role="1tU5fm" />
+          <node concept="2ShNRf" id="haij5Wv" role="33vP2m">
+            <node concept="Tc6Ow" id="haij6n8" role="2ShVmc">
+              <node concept="3Tqbb2" id="haij7Ho" role="HW$YZ" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3cpWs8" id="hanF00U" role="3cqZAp">
+        <node concept="3cpWsn" id="hanF00V" role="3cpWs9">
+          <property role="TrG5h" value="elementConcept" />
+          <node concept="3Tqbb2" id="2raaoKmZ87U" role="1tU5fm">
+            <ref role="ehGHo" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
+          </node>
+          <node concept="2OqwBi" id="hx2Fv3P" role="33vP2m">
+            <node concept="1YBJjd" id="hanEX1c" role="2Oq$k0">
+              <ref role="1YBMHb" node="h9nq4$H" resolve="nset" />
+            </node>
+            <node concept="3TrEf2" id="hanEZnV" role="2OqNvi">
+              <ref role="3Tt5mk" to="i2rk:gEI9Wgx" resolve="elementConcept" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbJ" id="hanF3$o" role="3cqZAp">
+        <node concept="3clFbS" id="hanF3$p" role="3clFbx">
+          <node concept="3cpWs8" id="hanF9ov" role="3cqZAp">
+            <node concept="3cpWsn" id="hanF9ow" role="3cpWs9">
+              <property role="TrG5h" value="superConcepts" />
+              <node concept="_YKpA" id="hanF9ox" role="1tU5fm">
+                <node concept="3Tqbb2" id="2raaoKmZ8nf" role="_ZDj9">
+                  <ref role="ehGHo" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
+                </node>
+              </node>
+              <node concept="2OqwBi" id="hx2Fvdo" role="33vP2m">
+                <node concept="37vLTw" id="3GM_nagTyD9" role="2Oq$k0">
+                  <ref role="3cqZAo" node="hanF00V" resolve="elementConcept" />
+                </node>
+                <node concept="2qgKlT" id="2raaoKmZ7Wt" role="2OqNvi">
+                  <ref role="37wK5l" to="tpcn:hMuxyK2" resolve="getImmediateSuperconcepts" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2Gpval" id="hanFe0T" role="3cqZAp">
+            <node concept="2GrKxI" id="hanFe0U" role="2Gsz3X">
+              <property role="TrG5h" value="superConcept" />
+            </node>
+            <node concept="37vLTw" id="3GM_nagTBUE" role="2GsD0m">
+              <ref role="3cqZAo" node="hanF9ow" resolve="superConcepts" />
+            </node>
+            <node concept="3clFbS" id="hanFe0W" role="2LFqv$">
+              <node concept="3clFbF" id="5wNjLS4jSxQ" role="3cqZAp">
+                <node concept="2OqwBi" id="5wNjLS4jSxR" role="3clFbG">
+                  <node concept="37vLTw" id="5wNjLS4jSxS" role="2Oq$k0">
+                    <ref role="3cqZAo" node="haij1ZI" resolve="supertypes" />
+                  </node>
+                  <node concept="TSZUe" id="5wNjLS4jSxT" role="2OqNvi">
+                    <node concept="2c44tf" id="5wNjLS4jSxU" role="25WWJ7">
+                      <node concept="1s3Imc" id="7Oamrh2dQz1" role="2c44tc">
+                        <ref role="2I9WkF" to="tpck:gw2VY9q" resolve="BaseConcept" />
+                        <node concept="2c44tb" id="7Oamrh2dQEN" role="lGtFl">
+                          <property role="2qtEX8" value="elementConcept" />
+                          <property role="P3scX" value="e89e1550-b8fe-4f0d-a7fd-487968b42405/6355510489488665234/1145383142433" />
+                          <node concept="2GrUjf" id="7Oamrh2dQKQ" role="2c44t1">
+                            <ref role="2Gs0qQ" node="hanFe0U" resolve="superConcept" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="5wNjLS4jU6J" role="3cqZAp">
+            <node concept="2OqwBi" id="5wNjLS4jVB$" role="3clFbG">
+              <node concept="37vLTw" id="5wNjLS4jU6H" role="2Oq$k0">
+                <ref role="3cqZAo" node="haij1ZI" resolve="supertypes" />
+              </node>
+              <node concept="TSZUe" id="5wNjLS4jWUA" role="2OqNvi">
+                <node concept="2c44tf" id="5wNjLS4jX1I" role="25WWJ7">
+                  <node concept="1s3Imc" id="7Oamrh2dQWG" role="2c44tc" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3y3z36" id="hanF4Bi" role="3clFbw">
+          <node concept="10Nm6u" id="hanF54_" role="3uHU7w" />
+          <node concept="37vLTw" id="3GM_nagTAfo" role="3uHU7B">
+            <ref role="3cqZAo" node="hanF00V" resolve="elementConcept" />
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbF" id="5wNjLS4jY8D" role="3cqZAp">
+        <node concept="2OqwBi" id="5wNjLS4jZDI" role="3clFbG">
+          <node concept="37vLTw" id="5wNjLS4jY8B" role="2Oq$k0">
+            <ref role="3cqZAo" node="haij1ZI" resolve="supertypes" />
+          </node>
+          <node concept="TSZUe" id="5wNjLS4k15f" role="2OqNvi">
+            <node concept="2c44tf" id="5wNjLS4k1cA" role="25WWJ7">
+              <node concept="2hMVRd" id="5wNjLS4k1jR" role="2c44tc">
+                <node concept="3Tqbb2" id="5wNjLS4k1ub" role="2hN53Y">
+                  <ref role="ehGHo" to="tpck:gw2VY9q" resolve="BaseConcept" />
+                  <node concept="2c44tb" id="5wNjLS4k1Ir" role="lGtFl">
+                    <property role="2qtEX8" value="concept" />
+                    <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/1138055754698/1138405853777" />
+                    <node concept="37vLTw" id="5wNjLS4k1IB" role="2c44t1">
+                      <ref role="3cqZAo" node="hanF00V" resolve="elementConcept" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbF" id="5wNjLS4k20j" role="3cqZAp">
+        <node concept="2OqwBi" id="5wNjLS4k3xg" role="3clFbG">
+          <node concept="37vLTw" id="5wNjLS4k20h" role="2Oq$k0">
+            <ref role="3cqZAo" node="haij1ZI" resolve="supertypes" />
+          </node>
+          <node concept="TSZUe" id="5wNjLS4k4Xo" role="2OqNvi">
+            <node concept="2c44tf" id="5wNjLS4k54o" role="25WWJ7">
+              <node concept="3uibUv" id="5wNjLS4k5bL" role="2c44tc">
+                <ref role="3uigEE" to="33ny:~Set" resolve="Set" />
+                <node concept="3uibUv" id="5wNjLS4k5_c" role="11_B2D">
+                  <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3cpWs6" id="h9nq4$E" role="3cqZAp">
+        <node concept="37vLTw" id="3GM_nagTvnK" role="3cqZAk">
+          <ref role="3cqZAo" node="haij1ZI" resolve="supertypes" />
+        </node>
+      </node>
+    </node>
+    <node concept="1YaCAy" id="h9nq4$H" role="1YuTPh">
+      <property role="TrG5h" value="nset" />
+      <ref role="1YaFvo" to="i2rk:5wNjLS4fqEi" resolve="SNodeSetType" />
+    </node>
+  </node>
+  <node concept="1YbPZF" id="4JmsWjDRcKG">
+    <property role="TrG5h" value="typeof_SNodeSetCreator" />
+    <node concept="3clFbS" id="4JmsWjDRcKH" role="18ibNy">
+      <node concept="1Z5TYs" id="4JmsWjDRcZ0" role="3cqZAp">
+        <node concept="mw_s8" id="4JmsWjDRcZw" role="1ZfhKB">
+          <node concept="2OqwBi" id="4JmsWjDRd6K" role="mwGJk">
+            <node concept="1YBJjd" id="4JmsWjDRcZu" role="2Oq$k0">
+              <ref role="1YBMHb" node="4JmsWjDRcKJ" resolve="creator" />
+            </node>
+            <node concept="3TrEf2" id="4JmsWjDRdhL" role="2OqNvi">
+              <ref role="3Tt5mk" to="i2rk:4JmsWjDRcBP" resolve="createdType" />
+            </node>
+          </node>
+        </node>
+        <node concept="mw_s8" id="4JmsWjDRcZ3" role="1ZfhK$">
+          <node concept="1Z2H0r" id="4JmsWjDRcMf" role="mwGJk">
+            <node concept="1YBJjd" id="4JmsWjDRcOs" role="1Z2MuG">
+              <ref role="1YBMHb" node="4JmsWjDRcKJ" resolve="creator" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbJ" id="4JmsWjE3qfN" role="3cqZAp">
+        <node concept="3clFbS" id="4JmsWjE3qfP" role="3clFbx">
+          <node concept="1ZobV4" id="4JmsWjDRiZU" role="3cqZAp">
+            <node concept="mw_s8" id="4JmsWjDRiZX" role="1ZfhK$">
+              <node concept="1Z2H0r" id="4JmsWjDRhR$" role="mwGJk">
+                <node concept="2OqwBi" id="4JmsWjDRi33" role="1Z2MuG">
+                  <node concept="1YBJjd" id="4JmsWjDRhTN" role="2Oq$k0">
+                    <ref role="1YBMHb" node="4JmsWjDRcKJ" resolve="creator" />
+                  </node>
+                  <node concept="3TrEf2" id="4JmsWjDRif4" role="2OqNvi">
+                    <ref role="3Tt5mk" to="i2rk:4JmsWjDRhF4" resolve="setCreator" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="mw_s8" id="4JmsWjDRj4N" role="1ZfhKB">
+              <node concept="2c44tf" id="4JmsWjDRj4J" role="mwGJk">
+                <node concept="2hMVRd" id="4JmsWjDRj69" role="2c44tc">
+                  <node concept="3Tqbb2" id="4JmsWjDRj76" role="2hN53Y">
+                    <ref role="ehGHo" to="tpck:gw2VY9q" resolve="BaseConcept" />
+                    <node concept="2c44tb" id="4JmsWjE1s5S" role="lGtFl">
+                      <property role="2qtEX8" value="concept" />
+                      <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/1138055754698/1138405853777" />
+                      <node concept="2OqwBi" id="4JmsWjE1LvU" role="2c44t1">
+                        <node concept="2OqwBi" id="4JmsWjE1usB" role="2Oq$k0">
+                          <node concept="1YBJjd" id="4JmsWjE1uhB" role="2Oq$k0">
+                            <ref role="1YBMHb" node="4JmsWjDRcKJ" resolve="creator" />
+                          </node>
+                          <node concept="3TrEf2" id="4JmsWjE1uGo" role="2OqNvi">
+                            <ref role="3Tt5mk" to="i2rk:4JmsWjDRcBP" resolve="createdType" />
+                          </node>
+                        </node>
+                        <node concept="3TrEf2" id="4JmsWjE1LSv" role="2OqNvi">
+                          <ref role="3Tt5mk" to="i2rk:gEI9Wgx" resolve="elementConcept" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2OqwBi" id="4JmsWjE3qVU" role="3clFbw">
+          <node concept="2OqwBi" id="4JmsWjE3qfY" role="2Oq$k0">
+            <node concept="2OqwBi" id="4JmsWjE3qfZ" role="2Oq$k0">
+              <node concept="1YBJjd" id="4JmsWjE3qg0" role="2Oq$k0">
+                <ref role="1YBMHb" node="4JmsWjDRcKJ" resolve="creator" />
+              </node>
+              <node concept="3TrEf2" id="4JmsWjE3qg1" role="2OqNvi">
+                <ref role="3Tt5mk" to="i2rk:4JmsWjDRcBP" resolve="createdType" />
+              </node>
+            </node>
+            <node concept="3TrEf2" id="4JmsWjE3qg2" role="2OqNvi">
+              <ref role="3Tt5mk" to="i2rk:gEI9Wgx" resolve="elementConcept" />
+            </node>
+          </node>
+          <node concept="3x8VRR" id="4JmsWjE3ruS" role="2OqNvi" />
+        </node>
+        <node concept="9aQIb" id="4JmsWjE3rCK" role="9aQIa">
+          <node concept="3clFbS" id="4JmsWjE3rCL" role="9aQI4">
+            <node concept="1ZxtTE" id="4JmsWjE3uJS" role="3cqZAp">
+              <property role="TrG5h" value="T" />
+            </node>
+            <node concept="1ZobV4" id="4JmsWjE3uK2" role="3cqZAp">
+              <node concept="mw_s8" id="4JmsWjE3uK7" role="1ZfhK$">
+                <node concept="1Z$b5t" id="4JmsWjE3uK5" role="mwGJk">
+                  <ref role="1Z$eMM" node="4JmsWjE3uJS" resolve="T" />
+                </node>
+              </node>
+              <node concept="mw_s8" id="4JmsWjE3uKi" role="1ZfhKB">
+                <node concept="2c44tf" id="4JmsWjE3uKe" role="mwGJk">
+                  <node concept="3Tqbb2" id="4JmsWjE3uLi" role="2c44tc" />
+                </node>
+              </node>
+            </node>
+            <node concept="1ZobV4" id="4JmsWjE3rCM" role="3cqZAp">
+              <node concept="mw_s8" id="4JmsWjE3rCN" role="1ZfhK$">
+                <node concept="1Z2H0r" id="4JmsWjE3rCO" role="mwGJk">
+                  <node concept="2OqwBi" id="4JmsWjE3rCP" role="1Z2MuG">
+                    <node concept="1YBJjd" id="4JmsWjE3rCQ" role="2Oq$k0">
+                      <ref role="1YBMHb" node="4JmsWjDRcKJ" resolve="creator" />
+                    </node>
+                    <node concept="3TrEf2" id="4JmsWjE3rCR" role="2OqNvi">
+                      <ref role="3Tt5mk" to="i2rk:4JmsWjDRhF4" resolve="setCreator" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="mw_s8" id="4JmsWjE3rCS" role="1ZfhKB">
+                <node concept="2c44tf" id="4JmsWjE3rCT" role="mwGJk">
+                  <node concept="2hMVRd" id="4JmsWjE3rCU" role="2c44tc">
+                    <node concept="3Tqbb2" id="4JmsWjE3uLY" role="2hN53Y">
+                      <node concept="2c44te" id="4JmsWjE3uMu" role="lGtFl">
+                        <node concept="1Z$b5t" id="4JmsWjE3uMA" role="2c44t1">
+                          <ref role="1Z$eMM" node="4JmsWjE3uJS" resolve="T" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1YaCAy" id="4JmsWjDRcKJ" role="1YuTPh">
+      <property role="TrG5h" value="creator" />
+      <ref role="1YaFvo" to="i2rk:4JmsWjDRcxX" resolve="SNodeSetCreator" />
+    </node>
+  </node>
+  <node concept="35pCF_" id="2z6Ep1mP264">
+    <property role="TrG5h" value="listSubtypeOfNodeList" />
+    <node concept="1YaCAy" id="2z6Ep1mP269" role="35pZ6h">
+      <property role="TrG5h" value="nsetType" />
+      <ref role="1YaFvo" to="i2rk:5wNjLS4fqEi" resolve="SNodeSetType" />
+    </node>
+    <node concept="3clFbS" id="2z6Ep1mP266" role="2sgrp5">
+      <node concept="1ZobV4" id="2z6Ep1mP26m" role="3cqZAp">
+        <property role="2osLew" value="6HBcgFN52aA/1" />
+        <property role="2osLez" value="6HBcgFN52aA/1" />
+        <node concept="mw_s8" id="2z6Ep1mP26p" role="1ZfhK$">
+          <node concept="2OqwBi" id="2z6Ep1mP26h" role="mwGJk">
+            <node concept="1YBJjd" id="2z6Ep1mP26g" role="2Oq$k0">
+              <ref role="1YBMHb" node="2z6Ep1mP268" resolve="setType" />
+            </node>
+            <node concept="3TrEf2" id="2z6Ep1mP26l" role="2OqNvi">
+              <ref role="3Tt5mk" to="tp2q:hQhN57z" resolve="elementType" />
+            </node>
+          </node>
+        </node>
+        <node concept="mw_s8" id="2z6Ep1mP26x" role="1ZfhKB">
+          <node concept="2c44tf" id="2z6Ep1mP26y" role="mwGJk">
+            <node concept="3Tqbb2" id="2z6Ep1mP26$" role="2c44tc">
+              <node concept="2c44tb" id="2z6Ep1mP26_" role="lGtFl">
+                <property role="2qtEX8" value="concept" />
+                <property role="P3scX" value="7866978e-a0f0-4cc7-81bc-4d213d9375e1/1138055754698/1138405853777" />
+                <node concept="2OqwBi" id="2z6Ep1mP26C" role="2c44t1">
+                  <node concept="1YBJjd" id="2z6Ep1mP26B" role="2Oq$k0">
+                    <ref role="1YBMHb" node="2z6Ep1mP269" resolve="nsetType" />
+                  </node>
+                  <node concept="3TrEf2" id="2z6Ep1mP26G" role="2OqNvi">
+                    <ref role="3Tt5mk" to="i2rk:gEI9Wgx" resolve="elementConcept" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1YaCAy" id="2z6Ep1mP268" role="1YuTPh">
+      <property role="TrG5h" value="setType" />
+      <ref role="1YaFvo" to="tp2q:hQhMVNg" resolve="SetType" />
+    </node>
+  </node>
+</model>
+

--- a/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.collections.runtime/com.mbeddr.mpsutil.collections.runtime.msd
+++ b/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.collections.runtime/com.mbeddr.mpsutil.collections.runtime.msd
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<solution name="com.mbeddr.mpsutil.collections.runtime" uuid="3f2dbc2e-ad41-470f-b5f1-2869513d2b58" moduleVersion="0" compileInMPS="true">
+  <models>
+    <modelRoot type="default" contentPath="${module}">
+      <sourceRoot location="models" />
+    </modelRoot>
+  </models>
+  <facets>
+    <facet compile="mps" classes="mps" ext="no" type="java">
+      <classes generated="true" path="${module}/classes_gen" />
+    </facet>
+  </facets>
+  <sourcePath />
+  <dependencies>
+    <dependency reexport="false">8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)</dependency>
+    <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
+    <dependency reexport="false">498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)</dependency>
+    <dependency reexport="true">ecfb9949-7433-4db5-85de-0f84d172e4ce(de.q60.mps.collections.libs)</dependency>
+    <dependency reexport="false">6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)</dependency>
+    <dependency reexport="false">c6420b75-4569-420d-aaf7-9bc590ad7b2a(com.mbeddr.mpsutil.comparator)</dependency>
+    <dependency reexport="false">9a4afe51-f114-4595-b5df-048ce3c596be(jetbrains.mps.runtime)</dependency>
+    <dependency reexport="false">f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)</dependency>
+  </dependencies>
+  <languageVersions>
+    <language slang="l:e89e1550-b8fe-4f0d-a7fd-487968b42405:com.mbeddr.mpsutil.collections" version="0" />
+    <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
+    <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
+    <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
+    <language slang="l:acfc188d-d5d6-4598-b370-6f4a983f05b2:jetbrains.mps.baseLanguage.methodReferences" version="0" />
+    <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
+    <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
+    <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="19" />
+    <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
+  </languageVersions>
+  <dependencyVersions>
+    <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
+    <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
+    <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
+    <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
+    <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
+    <module reference="3f2dbc2e-ad41-470f-b5f1-2869513d2b58(com.mbeddr.mpsutil.collections.runtime)" version="0" />
+    <module reference="c6420b75-4569-420d-aaf7-9bc590ad7b2a(com.mbeddr.mpsutil.comparator)" version="0" />
+    <module reference="ecfb9949-7433-4db5-85de-0f84d172e4ce(de.q60.mps.collections.libs)" version="0" />
+    <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
+    <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
+    <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
+    <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
+    <module reference="9ded098b-ad6a-4657-bfd9-48636cfe8bc3(jetbrains.mps.lang.traceable)" version="0" />
+    <module reference="9a4afe51-f114-4595-b5df-048ce3c596be(jetbrains.mps.runtime)" version="0" />
+  </dependencyVersions>
+</solution>
+

--- a/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.collections.runtime/models/com.mbeddr.mpsutil.collections.runtime.mps
+++ b/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.collections.runtime/models/com.mbeddr.mpsutil.collections.runtime.mps
@@ -1413,7 +1413,7 @@
     <node concept="3clFbW" id="2UDGRNXxxvO" role="jymVt">
       <node concept="3cqZAl" id="2UDGRNXxxvP" role="3clF45" />
       <node concept="37vLTG" id="2UDGRNXxxvQ" role="3clF46">
-        <property role="TrG5h" value="set" />
+        <property role="TrG5h" value="copy" />
         <node concept="3uibUv" id="2UDGRNXxxvR" role="1tU5fm">
           <ref role="3uigEE" to="33ny:~Set" resolve="Set" />
         </node>
@@ -1422,7 +1422,7 @@
         <node concept="XkiVB" id="2UDGRNXx_PA" role="3cqZAp">
           <ref role="37wK5l" node="5wNjLS4qFj3" resolve="EquivalenceHashSet" />
           <node concept="37vLTw" id="2UDGRNXxFBw" role="37wK5m">
-            <ref role="3cqZAo" node="2UDGRNXxxvQ" resolve="set" />
+            <ref role="3cqZAo" node="2UDGRNXxxvQ" resolve="copy" />
           </node>
           <node concept="2ShNRf" id="2UDGRNXxFFV" role="37wK5m">
             <node concept="HV5vD" id="2UDGRNXxFFW" role="2ShVmc">

--- a/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.collections.runtime/models/com.mbeddr.mpsutil.collections.runtime.mps
+++ b/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.collections.runtime/models/com.mbeddr.mpsutil.collections.runtime.mps
@@ -1,0 +1,1440 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:240d60dc-7568-46d8-a080-a0889db7fd44(com.mbeddr.mpsutil.collections.runtime)">
+  <persistence version="9" />
+  <languages>
+    <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="12" />
+    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
+    <use id="acfc188d-d5d6-4598-b370-6f4a983f05b2" name="jetbrains.mps.baseLanguage.methodReferences" version="0" />
+    <use id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections" version="1" />
+    <use id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures" version="0" />
+    <use id="e89e1550-b8fe-4f0d-a7fd-487968b42405" name="com.mbeddr.mpsutil.collections" version="0" />
+  </languages>
+  <imports>
+    <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" />
+    <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
+    <import index="e8no" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.util.containers(MPS.IDEA/)" />
+    <import index="gyfg" ref="ecfb9949-7433-4db5-85de-0f84d172e4ce/java:com.google.common.base(de.q60.mps.collections.libs/)" />
+    <import index="mhbf" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.model(MPS.OpenAPI/)" />
+    <import index="w1kc" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel(MPS.Core/)" />
+    <import index="mqum" ref="r:ec874b45-e888-42e6-995a-a298cefdff55(com.mbeddr.mpsutil.comparator.code)" />
+    <import index="lui2" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.module(MPS.OpenAPI/)" />
+    <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" />
+    <import index="i8bi" ref="r:c3548bac-30eb-4a2a-937c-0111d5697309(jetbrains.mps.lang.smodel.generator.smodelAdapter)" />
+    <import index="1ctc" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util.stream(JDK/)" />
+    <import index="guwi" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.io(JDK/)" />
+    <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" />
+  </imports>
+  <registry>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
+        <child id="1068498886297" name="rValue" index="37vLTx" />
+        <child id="1068498886295" name="lValue" index="37vLTJ" />
+      </concept>
+      <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="nn" index="2tJIrI" />
+      <concept id="1188207840427" name="jetbrains.mps.baseLanguage.structure.AnnotationInstance" flags="nn" index="2AHcQZ">
+        <reference id="1188208074048" name="annotation" index="2AI5Lk" />
+      </concept>
+      <concept id="1188208481402" name="jetbrains.mps.baseLanguage.structure.HasAnnotation" flags="ng" index="2AJDlI">
+        <child id="1188208488637" name="annotation" index="2AJF6D" />
+      </concept>
+      <concept id="2820489544401957797" name="jetbrains.mps.baseLanguage.structure.DefaultClassCreator" flags="nn" index="HV5vD">
+        <reference id="2820489544401957798" name="classifier" index="HV5vE" />
+      </concept>
+      <concept id="1154032098014" name="jetbrains.mps.baseLanguage.structure.AbstractLoopStatement" flags="nn" index="2LF5Ji">
+        <child id="1154032183016" name="body" index="2LFqv$" />
+      </concept>
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1197029447546" name="jetbrains.mps.baseLanguage.structure.FieldReferenceOperation" flags="nn" index="2OwXpG">
+        <reference id="1197029500499" name="fieldDeclaration" index="2Oxat5" />
+      </concept>
+      <concept id="5763944538902644732" name="jetbrains.mps.baseLanguage.structure.StaticMethodCallOperation" flags="ng" index="2PDubS" />
+      <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
+        <child id="1145553007750" name="creator" index="2ShVmc" />
+      </concept>
+      <concept id="1070462154015" name="jetbrains.mps.baseLanguage.structure.StaticFieldDeclaration" flags="ig" index="Wx3nA" />
+      <concept id="1070475354124" name="jetbrains.mps.baseLanguage.structure.ThisExpression" flags="nn" index="Xjq3P" />
+      <concept id="1070475587102" name="jetbrains.mps.baseLanguage.structure.SuperConstructorInvocation" flags="nn" index="XkiVB" />
+      <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
+        <reference id="1144433194310" name="classConcept" index="1Pybhc" />
+      </concept>
+      <concept id="1070533707846" name="jetbrains.mps.baseLanguage.structure.StaticFieldReference" flags="nn" index="10M0yZ">
+        <reference id="1144433057691" name="classifier" index="1PxDUh" />
+      </concept>
+      <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
+      <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
+      <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
+      <concept id="1070534760951" name="jetbrains.mps.baseLanguage.structure.ArrayType" flags="in" index="10Q1$e">
+        <child id="1070534760952" name="componentType" index="10Q1$1" />
+      </concept>
+      <concept id="1070534934090" name="jetbrains.mps.baseLanguage.structure.CastExpression" flags="nn" index="10QFUN">
+        <child id="1070534934091" name="type" index="10QFUM" />
+        <child id="1070534934092" name="expression" index="10QFUP" />
+      </concept>
+      <concept id="1068390468200" name="jetbrains.mps.baseLanguage.structure.FieldDeclaration" flags="ig" index="312cEg" />
+      <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu">
+        <property id="1221565133444" name="isFinal" index="1EXbeo" />
+        <child id="1095933932569" name="implementedInterface" index="EKbjA" />
+        <child id="1165602531693" name="superclass" index="1zkMxy" />
+      </concept>
+      <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
+        <property id="1176718929932" name="isFinal" index="3TUv4t" />
+        <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ng" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
+      </concept>
+      <concept id="1109279763828" name="jetbrains.mps.baseLanguage.structure.TypeVariableDeclaration" flags="ng" index="16euLQ" />
+      <concept id="1109279851642" name="jetbrains.mps.baseLanguage.structure.GenericDeclaration" flags="ng" index="16eOlS">
+        <child id="1109279881614" name="typeVariableDeclaration" index="16eVyc" />
+      </concept>
+      <concept id="1109283449304" name="jetbrains.mps.baseLanguage.structure.TypeVariableReference" flags="in" index="16syzq">
+        <reference id="1109283546497" name="typeVariableDeclaration" index="16sUi3" />
+      </concept>
+      <concept id="1092119917967" name="jetbrains.mps.baseLanguage.structure.MulExpression" flags="nn" index="17qRlL" />
+      <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
+        <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
+      </concept>
+      <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
+      <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
+      <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
+        <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
+      <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
+        <child id="1068580123133" name="returnType" index="3clF45" />
+        <child id="1068580123134" name="parameter" index="3clF46" />
+        <child id="1068580123135" name="body" index="3clF47" />
+      </concept>
+      <concept id="1068580123165" name="jetbrains.mps.baseLanguage.structure.InstanceMethodDeclaration" flags="ig" index="3clFb_" />
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
+      <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
+        <child id="1068580123160" name="condition" index="3clFbw" />
+        <child id="1068580123161" name="ifTrue" index="3clFbx" />
+      </concept>
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT">
+        <property id="1068580123138" name="value" index="3clFbU" />
+      </concept>
+      <concept id="1068580123140" name="jetbrains.mps.baseLanguage.structure.ConstructorDeclaration" flags="ig" index="3clFbW" />
+      <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
+        <property id="1068580320021" name="value" index="3cmrfH" />
+      </concept>
+      <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
+      <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
+        <child id="1068581517676" name="expression" index="3cqZAk" />
+      </concept>
+      <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
+        <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
+      </concept>
+      <concept id="1068581242867" name="jetbrains.mps.baseLanguage.structure.LongType" flags="in" index="3cpWsb" />
+      <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
+      <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
+      <concept id="1079359253375" name="jetbrains.mps.baseLanguage.structure.ParenthesizedExpression" flags="nn" index="1eOMI4">
+        <child id="1079359253376" name="expression" index="1eOMHV" />
+      </concept>
+      <concept id="1081516740877" name="jetbrains.mps.baseLanguage.structure.NotExpression" flags="nn" index="3fqX7Q">
+        <child id="1081516765348" name="expression" index="3fr31v" />
+      </concept>
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
+        <child id="4972241301747169160" name="typeArgument" index="3PaCim" />
+      </concept>
+      <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
+        <property id="521412098689998745" name="nonStatic" index="2bfB8j" />
+        <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
+      </concept>
+      <concept id="1171903607971" name="jetbrains.mps.baseLanguage.structure.WildCardType" flags="in" index="3qTvmN" />
+      <concept id="1171903916106" name="jetbrains.mps.baseLanguage.structure.UpperBoundType" flags="in" index="3qUE_q">
+        <child id="1171903916107" name="bound" index="3qUE_r" />
+      </concept>
+      <concept id="7812454656619025412" name="jetbrains.mps.baseLanguage.structure.LocalMethodCall" flags="nn" index="1rXfSq" />
+      <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
+        <reference id="1107535924139" name="classifier" index="3uigEE" />
+        <child id="1109201940907" name="parameter" index="11_B2D" />
+      </concept>
+      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
+        <child id="1081773367579" name="rightExpression" index="3uHU7w" />
+        <child id="1081773367580" name="leftExpression" index="3uHU7B" />
+      </concept>
+      <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
+        <child id="1178549979242" name="visibility" index="1B3o_S" />
+      </concept>
+      <concept id="1144226303539" name="jetbrains.mps.baseLanguage.structure.ForeachStatement" flags="nn" index="1DcWWT">
+        <child id="1144226360166" name="iterable" index="1DdaDG" />
+      </concept>
+      <concept id="1144230876926" name="jetbrains.mps.baseLanguage.structure.AbstractForStatement" flags="nn" index="1DupvO">
+        <child id="1144230900587" name="variable" index="1Duv9x" />
+      </concept>
+      <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
+      <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
+      <concept id="1146644641414" name="jetbrains.mps.baseLanguage.structure.ProtectedVisibility" flags="nn" index="3Tmbuc" />
+      <concept id="1178893518978" name="jetbrains.mps.baseLanguage.structure.ThisConstructorInvocation" flags="nn" index="1VxSAg" />
+    </language>
+    <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
+      <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
+        <child id="1199569906740" name="parameter" index="1bW2Oz" />
+        <child id="1199569916463" name="body" index="1bW5cS" />
+      </concept>
+    </language>
+    <language id="acfc188d-d5d6-4598-b370-6f4a983f05b2" name="jetbrains.mps.baseLanguage.methodReferences">
+      <concept id="7915009415671748557" name="jetbrains.mps.baseLanguage.methodReferences.structure.MethodReferenceTypeTargetExpression" flags="ng" index="2FaPjH">
+        <child id="7915009415671751864" name="type" index="2FaQuo" />
+      </concept>
+      <concept id="237887375562511215" name="jetbrains.mps.baseLanguage.methodReferences.structure.MethodReference" flags="ng" index="37Ijox" />
+      <concept id="3507059745126391419" name="jetbrains.mps.baseLanguage.methodReferences.structure.IMethodReference" flags="ng" index="3UZKCU">
+        <reference id="237887375562511297" name="method" index="37Ijqf" />
+        <child id="962278442658307079" name="target" index="wWaWy" />
+      </concept>
+    </language>
+    <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2" />
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+    <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
+      <concept id="1226516258405" name="jetbrains.mps.baseLanguage.collections.structure.HashSetCreator" flags="nn" index="2i4dXS" />
+    </language>
+  </registry>
+  <node concept="312cEu" id="5wNjLS4lSKq">
+    <property role="TrG5h" value="EquivalenceHashSet" />
+    <node concept="312cEg" id="5wNjLS4qFiS" role="jymVt">
+      <property role="TrG5h" value="internalSet" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3uibUv" id="5wNjLS4qFiU" role="1tU5fm">
+        <ref role="3uigEE" to="33ny:~Set" resolve="Set" />
+        <node concept="3uibUv" id="5wNjLS4qFiV" role="11_B2D">
+          <ref role="3uigEE" to="gyfg:~Equivalence$Wrapper" resolve="Equivalence.Wrapper" />
+          <node concept="16syzq" id="5wNjLS4qOsm" role="11_B2D">
+            <ref role="16sUi3" node="5wNjLS4lSL2" resolve="T" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm6S6" id="5wNjLS4qFiX" role="1B3o_S" />
+    </node>
+    <node concept="312cEg" id="5wNjLS4qFiY" role="jymVt">
+      <property role="TrG5h" value="equivalence" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3uibUv" id="5wNjLS4qFj0" role="1tU5fm">
+        <ref role="3uigEE" to="gyfg:~Equivalence" resolve="Equivalence" />
+        <node concept="16syzq" id="5wNjLS4rl4m" role="11_B2D">
+          <ref role="16sUi3" node="5wNjLS4lSL2" resolve="T" />
+        </node>
+      </node>
+      <node concept="3Tm6S6" id="5wNjLS4qFj2" role="1B3o_S" />
+    </node>
+    <node concept="2tJIrI" id="5wNjLS4qPTv" role="jymVt" />
+    <node concept="3clFbW" id="6WJM9CJzpYH" role="jymVt">
+      <node concept="3cqZAl" id="6WJM9CJzpYI" role="3clF45" />
+      <node concept="3clFbS" id="6WJM9CJzpYK" role="3clF47">
+        <node concept="1VxSAg" id="6WJM9CJzwSg" role="3cqZAp">
+          <ref role="37wK5l" node="6WJM9CJyjjM" resolve="EquivalenceHashSet" />
+          <node concept="10QFUN" id="6WJM9CJ$Xnx" role="37wK5m">
+            <node concept="10M0yZ" id="6WJM9CJ$Gzb" role="10QFUP">
+              <ref role="3cqZAo" node="6WJM9CJzRQZ" resolve="INSTANCE" />
+              <ref role="1PxDUh" node="6WJM9CJzRQV" resolve="EqualsEquivalence" />
+            </node>
+            <node concept="3uibUv" id="6WJM9CJ$Xny" role="10QFUM">
+              <ref role="3uigEE" to="gyfg:~Equivalence" resolve="Equivalence" />
+              <node concept="16syzq" id="6WJM9CJ$Xnz" role="11_B2D">
+                <ref role="16sUi3" node="5wNjLS4lSL2" resolve="T" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="6WJM9CJzkcj" role="1B3o_S" />
+    </node>
+    <node concept="2tJIrI" id="6WJM9CJzepj" role="jymVt" />
+    <node concept="3clFbW" id="6WJM9CJyjjM" role="jymVt">
+      <node concept="3cqZAl" id="6WJM9CJyjjN" role="3clF45" />
+      <node concept="37vLTG" id="6WJM9CJySND" role="3clF46">
+        <property role="TrG5h" value="equivalence" />
+        <node concept="3uibUv" id="6WJM9CJySNE" role="1tU5fm">
+          <ref role="3uigEE" to="gyfg:~Equivalence" resolve="Equivalence" />
+          <node concept="16syzq" id="6WJM9CJySNF" role="11_B2D">
+            <ref role="16sUi3" node="5wNjLS4lSL2" resolve="T" />
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbS" id="6WJM9CJyjjT" role="3clF47">
+        <node concept="1VxSAg" id="6WJM9CJyGVC" role="3cqZAp">
+          <ref role="37wK5l" node="5wNjLS4qFj3" resolve="EquivalenceHashSet" />
+          <node concept="2ShNRf" id="6WJM9CJz9bV" role="37wK5m">
+            <node concept="2i4dXS" id="6WJM9CJzc4A" role="2ShVmc" />
+          </node>
+          <node concept="37vLTw" id="6WJM9CJyJ$w" role="37wK5m">
+            <ref role="3cqZAo" node="6WJM9CJySND" resolve="equivalence" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="6WJM9CJyjk6" role="1B3o_S" />
+    </node>
+    <node concept="2tJIrI" id="6WJM9CJydyo" role="jymVt" />
+    <node concept="3clFbW" id="5wNjLS4qFj3" role="jymVt">
+      <node concept="3cqZAl" id="5wNjLS4qFj4" role="3clF45" />
+      <node concept="37vLTG" id="68F0Oxke5Qh" role="3clF46">
+        <property role="TrG5h" value="set" />
+        <node concept="3uibUv" id="68F0Oxke8AG" role="1tU5fm">
+          <ref role="3uigEE" to="33ny:~Set" resolve="Set" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="5wNjLS4qFj5" role="3clF46">
+        <property role="TrG5h" value="equivalence" />
+        <node concept="3uibUv" id="5wNjLS4qFj6" role="1tU5fm">
+          <ref role="3uigEE" to="gyfg:~Equivalence" resolve="Equivalence" />
+          <node concept="16syzq" id="5wNjLS4roQ2" role="11_B2D">
+            <ref role="16sUi3" node="5wNjLS4lSL2" resolve="T" />
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbS" id="5wNjLS4qFj8" role="3clF47">
+        <node concept="3clFbF" id="5wNjLS4qFj9" role="3cqZAp">
+          <node concept="37vLTI" id="5wNjLS4qFja" role="3clFbG">
+            <node concept="2OqwBi" id="5wNjLS4qFjb" role="37vLTJ">
+              <node concept="Xjq3P" id="5wNjLS4qFjc" role="2Oq$k0" />
+              <node concept="2OwXpG" id="5wNjLS4qFjd" role="2OqNvi">
+                <ref role="2Oxat5" node="5wNjLS4qFiS" resolve="internalSet" />
+              </node>
+            </node>
+            <node concept="37vLTw" id="68F0Oxkex_b" role="37vLTx">
+              <ref role="3cqZAo" node="68F0Oxke5Qh" resolve="set" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="5wNjLS4qFjf" role="3cqZAp">
+          <node concept="37vLTI" id="5wNjLS4qFjg" role="3clFbG">
+            <node concept="2OqwBi" id="5wNjLS4qFjh" role="37vLTJ">
+              <node concept="Xjq3P" id="5wNjLS4qFji" role="2Oq$k0" />
+              <node concept="2OwXpG" id="5wNjLS4qFjj" role="2OqNvi">
+                <ref role="2Oxat5" node="5wNjLS4qFiY" resolve="equivalence" />
+              </node>
+            </node>
+            <node concept="37vLTw" id="5wNjLS4qFjk" role="37vLTx">
+              <ref role="3cqZAo" node="5wNjLS4qFj5" resolve="equivalence" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="5wNjLS4qFjl" role="1B3o_S" />
+    </node>
+    <node concept="2tJIrI" id="5wNjLS4rs5t" role="jymVt" />
+    <node concept="3clFb_" id="5wNjLS4qFjm" role="jymVt">
+      <property role="TrG5h" value="wrap" />
+      <node concept="37vLTG" id="5wNjLS4qFjn" role="3clF46">
+        <property role="TrG5h" value="element" />
+        <node concept="16syzq" id="5wNjLS4rCez" role="1tU5fm">
+          <ref role="16sUi3" node="5wNjLS4lSL2" resolve="T" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="5wNjLS4qFjp" role="3clF47">
+        <node concept="3cpWs6" id="5wNjLS4qFjq" role="3cqZAp">
+          <node concept="2OqwBi" id="5wNjLS4rahh" role="3cqZAk">
+            <node concept="37vLTw" id="5wNjLS4qMqG" role="2Oq$k0">
+              <ref role="3cqZAo" node="5wNjLS4qFiY" resolve="equivalence" />
+            </node>
+            <node concept="liA8E" id="5wNjLS4rahi" role="2OqNvi">
+              <ref role="37wK5l" to="gyfg:~Equivalence.wrap(java.lang.Object)" resolve="wrap" />
+              <node concept="37vLTw" id="5wNjLS4rahj" role="37wK5m">
+                <ref role="3cqZAo" node="5wNjLS4qFjn" resolve="element" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm6S6" id="5wNjLS4qFjt" role="1B3o_S" />
+      <node concept="3uibUv" id="5wNjLS4qFju" role="3clF45">
+        <ref role="3uigEE" to="gyfg:~Equivalence$Wrapper" resolve="Equivalence.Wrapper" />
+        <node concept="16syzq" id="5wNjLS4rwwR" role="11_B2D">
+          <ref role="16sUi3" node="5wNjLS4lSL2" resolve="T" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="5wNjLS4rzN6" role="jymVt" />
+    <node concept="3clFb_" id="5wNjLS4qFjw" role="jymVt">
+      <property role="TrG5h" value="add" />
+      <node concept="2AHcQZ" id="5wNjLS4qFjx" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+      <node concept="37vLTG" id="5wNjLS4qFjy" role="3clF46">
+        <property role="TrG5h" value="element" />
+        <node concept="16syzq" id="5wNjLS4rFup" role="1tU5fm">
+          <ref role="16sUi3" node="5wNjLS4lSL2" resolve="T" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="5wNjLS4qFj$" role="3clF47">
+        <node concept="3cpWs6" id="5wNjLS4qFj_" role="3cqZAp">
+          <node concept="2OqwBi" id="5wNjLS4r9gi" role="3cqZAk">
+            <node concept="37vLTw" id="5wNjLS4qMQ1" role="2Oq$k0">
+              <ref role="3cqZAo" node="5wNjLS4qFiS" resolve="internalSet" />
+            </node>
+            <node concept="liA8E" id="5wNjLS4r9gj" role="2OqNvi">
+              <ref role="37wK5l" to="33ny:~Set.add(java.lang.Object)" resolve="add" />
+              <node concept="1rXfSq" id="5wNjLS4r9gk" role="37wK5m">
+                <ref role="37wK5l" node="5wNjLS4qFjm" resolve="wrap" />
+                <node concept="37vLTw" id="5wNjLS4r9gl" role="37wK5m">
+                  <ref role="3cqZAo" node="5wNjLS4qFjy" resolve="element" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="5wNjLS4qFjD" role="1B3o_S" />
+      <node concept="10P_77" id="5wNjLS4qFjE" role="3clF45" />
+    </node>
+    <node concept="2tJIrI" id="5wNjLS4rIi$" role="jymVt" />
+    <node concept="3clFb_" id="5wNjLS4qFjF" role="jymVt">
+      <property role="TrG5h" value="addAll" />
+      <node concept="2AHcQZ" id="5wNjLS4qFjG" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+      <node concept="37vLTG" id="5wNjLS4qFjH" role="3clF46">
+        <property role="TrG5h" value="elements" />
+        <node concept="3uibUv" id="5wNjLS4qFjI" role="1tU5fm">
+          <ref role="3uigEE" to="33ny:~Collection" resolve="Collection" />
+          <node concept="3qUE_q" id="5wNjLS4qFjK" role="11_B2D">
+            <node concept="16syzq" id="5wNjLS4rMQq" role="3qUE_r">
+              <ref role="16sUi3" node="5wNjLS4lSL2" resolve="T" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbS" id="5wNjLS4qFjL" role="3clF47">
+        <node concept="3cpWs8" id="5wNjLS4qFjN" role="3cqZAp">
+          <node concept="3cpWsn" id="5wNjLS4qFjM" role="3cpWs9">
+            <property role="TrG5h" value="modified" />
+            <node concept="10P_77" id="5wNjLS4qFjO" role="1tU5fm" />
+            <node concept="3clFbT" id="5wNjLS4qFjP" role="33vP2m" />
+          </node>
+        </node>
+        <node concept="1DcWWT" id="5wNjLS4qFjQ" role="3cqZAp">
+          <node concept="37vLTw" id="5wNjLS4qFk5" role="1DdaDG">
+            <ref role="3cqZAo" node="5wNjLS4qFjH" resolve="elements" />
+          </node>
+          <node concept="3cpWsn" id="5wNjLS4qFk2" role="1Duv9x">
+            <property role="TrG5h" value="element" />
+            <node concept="16syzq" id="5wNjLS4rQfZ" role="1tU5fm">
+              <ref role="16sUi3" node="5wNjLS4lSL2" resolve="T" />
+            </node>
+          </node>
+          <node concept="3clFbS" id="5wNjLS4qFjS" role="2LFqv$">
+            <node concept="3clFbJ" id="5wNjLS4qFjT" role="3cqZAp">
+              <node concept="1rXfSq" id="5wNjLS4qFjU" role="3clFbw">
+                <ref role="37wK5l" node="5wNjLS4qFjw" resolve="add" />
+                <node concept="37vLTw" id="5wNjLS4qFjV" role="37wK5m">
+                  <ref role="3cqZAo" node="5wNjLS4qFk2" resolve="element" />
+                </node>
+              </node>
+              <node concept="3clFbS" id="5wNjLS4qFjX" role="3clFbx">
+                <node concept="3clFbF" id="5wNjLS4qFjY" role="3cqZAp">
+                  <node concept="37vLTI" id="5wNjLS4qFjZ" role="3clFbG">
+                    <node concept="37vLTw" id="5wNjLS4qFk0" role="37vLTJ">
+                      <ref role="3cqZAo" node="5wNjLS4qFjM" resolve="modified" />
+                    </node>
+                    <node concept="3clFbT" id="5wNjLS4qFk1" role="37vLTx">
+                      <property role="3clFbU" value="true" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="5wNjLS4qFk6" role="3cqZAp">
+          <node concept="37vLTw" id="5wNjLS4qFk7" role="3cqZAk">
+            <ref role="3cqZAo" node="5wNjLS4qFjM" resolve="modified" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="5wNjLS4qFk8" role="1B3o_S" />
+      <node concept="10P_77" id="5wNjLS4qFk9" role="3clF45" />
+    </node>
+    <node concept="2tJIrI" id="5wNjLS4rTC0" role="jymVt" />
+    <node concept="3clFb_" id="5wNjLS4qFka" role="jymVt">
+      <property role="TrG5h" value="size" />
+      <node concept="2AHcQZ" id="5wNjLS4qFkb" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+      <node concept="3clFbS" id="5wNjLS4qFkc" role="3clF47">
+        <node concept="3clFbF" id="3jVUTQDsIM1" role="3cqZAp">
+          <node concept="2OqwBi" id="5wNjLS4rck3" role="3clFbG">
+            <node concept="37vLTw" id="5wNjLS4qMGS" role="2Oq$k0">
+              <ref role="3cqZAo" node="5wNjLS4qFiS" resolve="internalSet" />
+            </node>
+            <node concept="liA8E" id="5wNjLS4rck4" role="2OqNvi">
+              <ref role="37wK5l" to="33ny:~Set.size()" resolve="size" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="5wNjLS4qFkf" role="1B3o_S" />
+      <node concept="10Oyi0" id="5wNjLS4qFkg" role="3clF45" />
+    </node>
+    <node concept="2tJIrI" id="5wNjLS4rYci" role="jymVt" />
+    <node concept="3clFb_" id="5wNjLS4qFkh" role="jymVt">
+      <property role="TrG5h" value="isEmpty" />
+      <node concept="2AHcQZ" id="5wNjLS4qFki" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+      <node concept="3clFbS" id="5wNjLS4qFkj" role="3clF47">
+        <node concept="3clFbF" id="3jVUTQDsDZk" role="3cqZAp">
+          <node concept="2OqwBi" id="5wNjLS4rfq1" role="3clFbG">
+            <node concept="37vLTw" id="5wNjLS4qMma" role="2Oq$k0">
+              <ref role="3cqZAo" node="5wNjLS4qFiS" resolve="internalSet" />
+            </node>
+            <node concept="liA8E" id="5wNjLS4rfq2" role="2OqNvi">
+              <ref role="37wK5l" to="33ny:~Set.isEmpty()" resolve="isEmpty" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="5wNjLS4qFkm" role="1B3o_S" />
+      <node concept="10P_77" id="5wNjLS4qFkn" role="3clF45" />
+    </node>
+    <node concept="2tJIrI" id="5wNjLS4s2K$" role="jymVt" />
+    <node concept="3clFb_" id="5wNjLS4qFko" role="jymVt">
+      <property role="TrG5h" value="contains" />
+      <node concept="2AHcQZ" id="5wNjLS4qFkp" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+      <node concept="37vLTG" id="5wNjLS4qFkq" role="3clF46">
+        <property role="TrG5h" value="o" />
+        <node concept="3uibUv" id="5wNjLS4qFkr" role="1tU5fm">
+          <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="5wNjLS4qFks" role="3clF47">
+        <node concept="3clFbF" id="3jVUTQDs_5C" role="3cqZAp">
+          <node concept="2OqwBi" id="5wNjLS4rgrJ" role="3clFbG">
+            <node concept="37vLTw" id="5wNjLS4qN3F" role="2Oq$k0">
+              <ref role="3cqZAo" node="5wNjLS4qFiS" resolve="internalSet" />
+            </node>
+            <node concept="liA8E" id="5wNjLS4rgrK" role="2OqNvi">
+              <ref role="37wK5l" to="33ny:~Set.contains(java.lang.Object)" resolve="contains" />
+              <node concept="1rXfSq" id="3jVUTQDq5wl" role="37wK5m">
+                <ref role="37wK5l" node="5wNjLS4qFjm" resolve="wrap" />
+                <node concept="1eOMI4" id="3jVUTQDqs1Q" role="37wK5m">
+                  <node concept="10QFUN" id="3jVUTQDqs1N" role="1eOMHV">
+                    <node concept="16syzq" id="3jVUTQDqw33" role="10QFUM">
+                      <ref role="16sUi3" node="5wNjLS4lSL2" resolve="T" />
+                    </node>
+                    <node concept="37vLTw" id="3jVUTQDq$6n" role="10QFUP">
+                      <ref role="3cqZAo" node="5wNjLS4qFkq" resolve="o" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="5wNjLS4qFkw" role="1B3o_S" />
+      <node concept="10P_77" id="5wNjLS4qFkx" role="3clF45" />
+    </node>
+    <node concept="2tJIrI" id="5wNjLS4s7kQ" role="jymVt" />
+    <node concept="3clFb_" id="5wNjLS4qFky" role="jymVt">
+      <property role="TrG5h" value="iterator" />
+      <node concept="2AHcQZ" id="5wNjLS4qFkz" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+      <node concept="3clFbS" id="5wNjLS4qFk$" role="3clF47">
+        <node concept="3clFbF" id="5wNjLS4tatO" role="3cqZAp">
+          <node concept="2YIFZM" id="5wNjLS4tl6h" role="3clFbG">
+            <ref role="37wK5l" to="e8no:~ContainerUtil.filterIterator(java.util.Iterator,com.intellij.openapi.util.Condition)" resolve="filterIterator" />
+            <ref role="1Pybhc" to="e8no:~ContainerUtil" resolve="ContainerUtil" />
+            <node concept="2YIFZM" id="5wNjLS4trVX" role="37wK5m">
+              <ref role="37wK5l" to="e8no:~ContainerUtil.mapIterator(java.util.Iterator,com.intellij.util.Function)" resolve="mapIterator" />
+              <ref role="1Pybhc" to="e8no:~ContainerUtil" resolve="ContainerUtil" />
+              <node concept="2OqwBi" id="5wNjLS4twqt" role="37wK5m">
+                <node concept="37vLTw" id="5wNjLS4tvl3" role="2Oq$k0">
+                  <ref role="3cqZAo" node="5wNjLS4qFiS" resolve="internalSet" />
+                </node>
+                <node concept="liA8E" id="5wNjLS4t$eF" role="2OqNvi">
+                  <ref role="37wK5l" to="33ny:~Set.iterator()" resolve="iterator" />
+                </node>
+              </node>
+              <node concept="37Ijox" id="5wNjLS4tJIj" role="37wK5m">
+                <ref role="37Ijqf" to="gyfg:~Equivalence$Wrapper.get()" resolve="get" />
+                <node concept="2FaPjH" id="5wNjLS4tJIl" role="wWaWy">
+                  <node concept="3uibUv" id="5wNjLS4tJIm" role="2FaQuo">
+                    <ref role="3uigEE" to="gyfg:~Equivalence$Wrapper" resolve="Equivalence.Wrapper" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="37Ijox" id="5wNjLS4u0Fv" role="37wK5m">
+              <ref role="37Ijqf" to="33ny:~Objects.nonNull(java.lang.Object)" resolve="nonNull" />
+              <node concept="2FaPjH" id="5wNjLS4u0Fx" role="wWaWy">
+                <node concept="3uibUv" id="5wNjLS4u0Fy" role="2FaQuo">
+                  <ref role="3uigEE" to="33ny:~Objects" resolve="Objects" />
+                </node>
+              </node>
+            </node>
+            <node concept="16syzq" id="5wNjLS4uAt0" role="3PaCim">
+              <ref role="16sUi3" node="5wNjLS4lSL2" resolve="T" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="5wNjLS4qFkB" role="1B3o_S" />
+      <node concept="3uibUv" id="5wNjLS4qFkC" role="3clF45">
+        <ref role="3uigEE" to="33ny:~Iterator" resolve="Iterator" />
+        <node concept="16syzq" id="5wNjLS4thxI" role="11_B2D">
+          <ref role="16sUi3" node="5wNjLS4lSL2" resolve="T" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="5wNjLS4sbT8" role="jymVt" />
+    <node concept="3clFb_" id="5wNjLS4qFkF" role="jymVt">
+      <property role="TrG5h" value="toArray" />
+      <node concept="2AHcQZ" id="5wNjLS4qFkG" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+      <node concept="3clFbS" id="5wNjLS4qFkH" role="3clF47">
+        <node concept="3clFbF" id="3jVUTQDsvDJ" role="3cqZAp">
+          <node concept="2OqwBi" id="3jVUTQDsvDL" role="3clFbG">
+            <node concept="2OqwBi" id="3jVUTQDsvDM" role="2Oq$k0">
+              <node concept="2OqwBi" id="3jVUTQDsvDN" role="2Oq$k0">
+                <node concept="37vLTw" id="3jVUTQDsvDO" role="2Oq$k0">
+                  <ref role="3cqZAo" node="5wNjLS4qFiS" resolve="internalSet" />
+                </node>
+                <node concept="liA8E" id="3jVUTQDsvDP" role="2OqNvi">
+                  <ref role="37wK5l" to="33ny:~Collection.stream()" resolve="stream" />
+                </node>
+              </node>
+              <node concept="liA8E" id="3jVUTQDsvDQ" role="2OqNvi">
+                <ref role="37wK5l" to="1ctc:~Stream.map(java.util.function.Function)" resolve="map" />
+                <node concept="1bVj0M" id="3jVUTQDsvDR" role="37wK5m">
+                  <node concept="3clFbS" id="3jVUTQDsvDS" role="1bW5cS">
+                    <node concept="3clFbF" id="3jVUTQDsvDT" role="3cqZAp">
+                      <node concept="2OqwBi" id="3jVUTQDsvDU" role="3clFbG">
+                        <node concept="37vLTw" id="3jVUTQDsvDV" role="2Oq$k0">
+                          <ref role="3cqZAo" node="3jVUTQDsvDX" resolve="e" />
+                        </node>
+                        <node concept="liA8E" id="3jVUTQDsvDW" role="2OqNvi">
+                          <ref role="37wK5l" to="gyfg:~Equivalence$Wrapper.get()" resolve="get" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="37vLTG" id="3jVUTQDsvDX" role="1bW2Oz">
+                    <property role="TrG5h" value="e" />
+                    <node concept="3uibUv" id="3jVUTQDsvDY" role="1tU5fm">
+                      <ref role="3uigEE" to="gyfg:~Equivalence$Wrapper" resolve="Equivalence.Wrapper" />
+                      <node concept="16syzq" id="3jVUTQDsvDZ" role="11_B2D">
+                        <ref role="16sUi3" node="5wNjLS4lSL2" resolve="T" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="liA8E" id="3jVUTQDsvE0" role="2OqNvi">
+              <ref role="37wK5l" to="1ctc:~Stream.toArray()" resolve="toArray" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="5wNjLS4qFkK" role="1B3o_S" />
+      <node concept="10Q1$e" id="5wNjLS4qFkM" role="3clF45">
+        <node concept="3uibUv" id="5wNjLS4qFkL" role="10Q1$1">
+          <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="5wNjLS4sjS9" role="jymVt" />
+    <node concept="3clFb_" id="5wNjLS4qFkN" role="jymVt">
+      <property role="TrG5h" value="toArray" />
+      <node concept="2AHcQZ" id="5wNjLS4qFkO" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+      <node concept="16euLQ" id="5wNjLS4qFkP" role="16eVyc">
+        <property role="TrG5h" value="T" />
+      </node>
+      <node concept="37vLTG" id="5wNjLS4qFkQ" role="3clF46">
+        <property role="TrG5h" value="a" />
+        <node concept="10Q1$e" id="5wNjLS4qFkS" role="1tU5fm">
+          <node concept="16syzq" id="5wNjLS4qFkR" role="10Q1$1">
+            <ref role="16sUi3" node="5wNjLS4qFkP" resolve="T" />
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbS" id="5wNjLS4qFkT" role="3clF47">
+        <node concept="3clFbF" id="3jVUTQDqSwU" role="3cqZAp">
+          <node concept="2OqwBi" id="3jVUTQDuxrD" role="3clFbG">
+            <node concept="2OqwBi" id="3jVUTQDvaY$" role="2Oq$k0">
+              <node concept="2OqwBi" id="3jVUTQDrgbb" role="2Oq$k0">
+                <node concept="2OqwBi" id="3jVUTQDqUht" role="2Oq$k0">
+                  <node concept="37vLTw" id="3jVUTQDqSwS" role="2Oq$k0">
+                    <ref role="3cqZAo" node="5wNjLS4qFiS" resolve="internalSet" />
+                  </node>
+                  <node concept="liA8E" id="3jVUTQDrdkb" role="2OqNvi">
+                    <ref role="37wK5l" to="33ny:~Collection.stream()" resolve="stream" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="3jVUTQDtAz4" role="2OqNvi">
+                  <ref role="37wK5l" to="1ctc:~Stream.map(java.util.function.Function)" resolve="map" />
+                  <node concept="1bVj0M" id="3jVUTQDtF16" role="37wK5m">
+                    <node concept="3clFbS" id="3jVUTQDtF17" role="1bW5cS">
+                      <node concept="3clFbF" id="3jVUTQDudnw" role="3cqZAp">
+                        <node concept="10QFUN" id="3jVUTQDvU_y" role="3clFbG">
+                          <node concept="16syzq" id="3jVUTQDvZ1l" role="10QFUM">
+                            <ref role="16sUi3" node="5wNjLS4qFkP" resolve="T" />
+                          </node>
+                          <node concept="2OqwBi" id="3jVUTQDuenY" role="10QFUP">
+                            <node concept="37vLTw" id="3jVUTQDudnv" role="2Oq$k0">
+                              <ref role="3cqZAo" node="3jVUTQDtLrw" resolve="a" />
+                            </node>
+                            <node concept="liA8E" id="3jVUTQDuiCC" role="2OqNvi">
+                              <ref role="37wK5l" to="gyfg:~Equivalence$Wrapper.get()" resolve="get" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="37vLTG" id="3jVUTQDtLrw" role="1bW2Oz">
+                      <property role="TrG5h" value="a" />
+                      <node concept="3uibUv" id="3jVUTQDtLrv" role="1tU5fm">
+                        <ref role="3uigEE" to="gyfg:~Equivalence$Wrapper" resolve="Equivalence.Wrapper" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="liA8E" id="3jVUTQDvdh_" role="2OqNvi">
+                <ref role="37wK5l" to="1ctc:~Stream.collect(java.util.stream.Collector)" resolve="collect" />
+                <node concept="2YIFZM" id="3jVUTQDvncw" role="37wK5m">
+                  <ref role="37wK5l" to="1ctc:~Collectors.toList()" resolve="toList" />
+                  <ref role="1Pybhc" to="1ctc:~Collectors" resolve="Collectors" />
+                </node>
+              </node>
+            </node>
+            <node concept="liA8E" id="3jVUTQDuAL9" role="2OqNvi">
+              <ref role="37wK5l" to="33ny:~List.toArray(java.lang.Object[])" resolve="toArray" />
+              <node concept="37vLTw" id="3jVUTQDuFLh" role="37wK5m">
+                <ref role="3cqZAo" node="5wNjLS4qFkQ" resolve="a" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="5wNjLS4qFkX" role="1B3o_S" />
+      <node concept="10Q1$e" id="5wNjLS4qFkZ" role="3clF45">
+        <node concept="16syzq" id="5wNjLS4qFkY" role="10Q1$1">
+          <ref role="16sUi3" node="5wNjLS4qFkP" resolve="T" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="5wNjLS4swWD" role="jymVt" />
+    <node concept="3clFb_" id="5wNjLS4qFl0" role="jymVt">
+      <property role="TrG5h" value="remove" />
+      <node concept="2AHcQZ" id="5wNjLS4qFl1" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+      <node concept="37vLTG" id="5wNjLS4qFl2" role="3clF46">
+        <property role="TrG5h" value="o" />
+        <node concept="3uibUv" id="5wNjLS4qFl3" role="1tU5fm">
+          <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="5wNjLS4qFl4" role="3clF47">
+        <node concept="3clFbF" id="3jVUTQDsihi" role="3cqZAp">
+          <node concept="2OqwBi" id="5wNjLS4reoY" role="3clFbG">
+            <node concept="37vLTw" id="5wNjLS4qMU_" role="2Oq$k0">
+              <ref role="3cqZAo" node="5wNjLS4qFiS" resolve="internalSet" />
+            </node>
+            <node concept="liA8E" id="5wNjLS4reoZ" role="2OqNvi">
+              <ref role="37wK5l" to="33ny:~Set.remove(java.lang.Object)" resolve="remove" />
+              <node concept="1rXfSq" id="3jVUTQDdKZv" role="37wK5m">
+                <ref role="37wK5l" node="5wNjLS4qFjm" resolve="wrap" />
+                <node concept="1eOMI4" id="3jVUTQDenk2" role="37wK5m">
+                  <node concept="10QFUN" id="3jVUTQDenjZ" role="1eOMHV">
+                    <node concept="16syzq" id="3jVUTQDer53" role="10QFUM">
+                      <ref role="16sUi3" node="5wNjLS4lSL2" resolve="T" />
+                    </node>
+                    <node concept="37vLTw" id="3jVUTQDdP2z" role="10QFUP">
+                      <ref role="3cqZAo" node="5wNjLS4qFl2" resolve="o" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="5wNjLS4qFl8" role="1B3o_S" />
+      <node concept="10P_77" id="5wNjLS4qFl9" role="3clF45" />
+    </node>
+    <node concept="2tJIrI" id="5wNjLS4s_k_" role="jymVt" />
+    <node concept="3clFb_" id="5wNjLS4qFla" role="jymVt">
+      <property role="TrG5h" value="containsAll" />
+      <node concept="2AHcQZ" id="5wNjLS4qFlb" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+      <node concept="37vLTG" id="5wNjLS4qFlc" role="3clF46">
+        <property role="TrG5h" value="c" />
+        <node concept="3uibUv" id="5wNjLS4qFld" role="1tU5fm">
+          <ref role="3uigEE" to="33ny:~Collection" resolve="Collection" />
+          <node concept="3qTvmN" id="5wNjLS4qFle" role="11_B2D" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="5wNjLS4qFlf" role="3clF47">
+        <node concept="3clFbF" id="3jVUTQDsmNs" role="3cqZAp">
+          <node concept="2OqwBi" id="5wNjLS4r86Y" role="3clFbG">
+            <node concept="37vLTw" id="5wNjLS4qMZ8" role="2Oq$k0">
+              <ref role="3cqZAo" node="5wNjLS4qFiS" resolve="internalSet" />
+            </node>
+            <node concept="liA8E" id="5wNjLS4r86Z" role="2OqNvi">
+              <ref role="37wK5l" to="33ny:~Set.containsAll(java.util.Collection)" resolve="containsAll" />
+              <node concept="37vLTw" id="5wNjLS4r870" role="37wK5m">
+                <ref role="3cqZAo" node="5wNjLS4qFlc" resolve="c" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="5wNjLS4qFlj" role="1B3o_S" />
+      <node concept="10P_77" id="5wNjLS4qFlk" role="3clF45" />
+    </node>
+    <node concept="2tJIrI" id="5wNjLS4sDGx" role="jymVt" />
+    <node concept="3clFb_" id="5wNjLS4qFll" role="jymVt">
+      <property role="TrG5h" value="removeAll" />
+      <node concept="2AHcQZ" id="5wNjLS4qFlm" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+      <node concept="37vLTG" id="5wNjLS4qFln" role="3clF46">
+        <property role="TrG5h" value="c" />
+        <node concept="3uibUv" id="5wNjLS4qFlo" role="1tU5fm">
+          <ref role="3uigEE" to="33ny:~Collection" resolve="Collection" />
+          <node concept="3qTvmN" id="5wNjLS4qFlp" role="11_B2D" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="5wNjLS4qFlq" role="3clF47">
+        <node concept="3cpWs6" id="5wNjLS4qFlr" role="3cqZAp">
+          <node concept="2OqwBi" id="5wNjLS4rbii" role="3cqZAk">
+            <node concept="37vLTw" id="5wNjLS4qMzM" role="2Oq$k0">
+              <ref role="3cqZAo" node="5wNjLS4qFiS" resolve="internalSet" />
+            </node>
+            <node concept="liA8E" id="5wNjLS4rbij" role="2OqNvi">
+              <ref role="37wK5l" to="33ny:~Set.removeAll(java.util.Collection)" resolve="removeAll" />
+              <node concept="37vLTw" id="5wNjLS4rbik" role="37wK5m">
+                <ref role="3cqZAo" node="5wNjLS4qFln" resolve="c" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="5wNjLS4qFlu" role="1B3o_S" />
+      <node concept="10P_77" id="5wNjLS4qFlv" role="3clF45" />
+    </node>
+    <node concept="2tJIrI" id="5wNjLS4sEcv" role="jymVt" />
+    <node concept="3clFb_" id="5wNjLS4qFlw" role="jymVt">
+      <property role="TrG5h" value="retainAll" />
+      <node concept="2AHcQZ" id="5wNjLS4qFlx" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+      <node concept="37vLTG" id="5wNjLS4qFly" role="3clF46">
+        <property role="TrG5h" value="c" />
+        <node concept="3uibUv" id="5wNjLS4qFlz" role="1tU5fm">
+          <ref role="3uigEE" to="33ny:~Collection" resolve="Collection" />
+          <node concept="3qTvmN" id="5wNjLS4qFl$" role="11_B2D" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="5wNjLS4qFl_" role="3clF47">
+        <node concept="3clFbF" id="3jVUTQDsreB" role="3cqZAp">
+          <node concept="2OqwBi" id="5wNjLS4rj1h" role="3clFbG">
+            <node concept="37vLTw" id="5wNjLS4qMCl" role="2Oq$k0">
+              <ref role="3cqZAo" node="5wNjLS4qFiS" resolve="internalSet" />
+            </node>
+            <node concept="liA8E" id="5wNjLS4rj1i" role="2OqNvi">
+              <ref role="37wK5l" to="33ny:~Set.retainAll(java.util.Collection)" resolve="retainAll" />
+              <node concept="37vLTw" id="5wNjLS4rj1j" role="37wK5m">
+                <ref role="3cqZAo" node="5wNjLS4qFly" resolve="c" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="5wNjLS4qFlD" role="1B3o_S" />
+      <node concept="10P_77" id="5wNjLS4qFlE" role="3clF45" />
+    </node>
+    <node concept="2tJIrI" id="5wNjLS4sI$r" role="jymVt" />
+    <node concept="3clFb_" id="5wNjLS4qFlF" role="jymVt">
+      <property role="TrG5h" value="clear" />
+      <node concept="2AHcQZ" id="5wNjLS4qFlG" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+      <node concept="3clFbS" id="5wNjLS4qFlH" role="3clF47">
+        <node concept="3clFbF" id="5wNjLS4qFlI" role="3cqZAp">
+          <node concept="2OqwBi" id="5wNjLS4r6RB" role="3clFbG">
+            <node concept="37vLTw" id="5wNjLS4qMaQ" role="2Oq$k0">
+              <ref role="3cqZAo" node="5wNjLS4qFiS" resolve="internalSet" />
+            </node>
+            <node concept="liA8E" id="5wNjLS4r6RC" role="2OqNvi">
+              <ref role="37wK5l" to="33ny:~Set.clear()" resolve="clear" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="5wNjLS4qFlK" role="1B3o_S" />
+      <node concept="3cqZAl" id="5wNjLS4qFlL" role="3clF45" />
+    </node>
+    <node concept="3Tm1VV" id="5wNjLS4lSKr" role="1B3o_S" />
+    <node concept="16euLQ" id="5wNjLS4lSL2" role="16eVyc">
+      <property role="TrG5h" value="T" />
+    </node>
+    <node concept="3uibUv" id="5wNjLS4lSLu" role="1zkMxy">
+      <ref role="3uigEE" to="33ny:~AbstractSet" resolve="AbstractSet" />
+      <node concept="16syzq" id="5wNjLS4lSRE" role="11_B2D">
+        <ref role="16sUi3" node="5wNjLS4lSL2" resolve="T" />
+      </node>
+    </node>
+  </node>
+  <node concept="312cEu" id="68F0OxjVEW9">
+    <property role="TrG5h" value="NodeEquivalence" />
+    <property role="2bfB8j" value="true" />
+    <node concept="2tJIrI" id="13oTmDl$GDR" role="jymVt" />
+    <node concept="3Tm1VV" id="68F0OxjVEWa" role="1B3o_S" />
+    <node concept="3uibUv" id="68F0OxjVEWb" role="1zkMxy">
+      <ref role="3uigEE" to="gyfg:~Equivalence" resolve="Equivalence" />
+      <node concept="3Tqbb2" id="68F0OxkeOjy" role="11_B2D" />
+    </node>
+    <node concept="3clFb_" id="68F0OxjVEWd" role="jymVt">
+      <property role="TrG5h" value="doEquivalent" />
+      <node concept="2AHcQZ" id="68F0OxjVEWe" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+      <node concept="37vLTG" id="68F0OxjVEWf" role="3clF46">
+        <property role="TrG5h" value="a" />
+        <node concept="3Tqbb2" id="68F0OxkeOy4" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="68F0OxjVEWh" role="3clF46">
+        <property role="TrG5h" value="b" />
+        <node concept="3Tqbb2" id="68F0OxkeOCm" role="1tU5fm" />
+      </node>
+      <node concept="3clFbS" id="68F0OxjVEWj" role="3clF47">
+        <node concept="3clFbF" id="13oTmDlvuIT" role="3cqZAp">
+          <node concept="2OqwBi" id="13oTmDlvze6" role="3clFbG">
+            <node concept="2OqwBi" id="13oTmDlvy9z" role="2Oq$k0">
+              <node concept="2ShNRf" id="13oTmDlvuIP" role="2Oq$k0">
+                <node concept="HV5vD" id="13oTmDlvxXc" role="2ShVmc">
+                  <property role="373rjd" value="true" />
+                  <ref role="HV5vE" to="mqum:3n2rqT9UxKL" resolve="MPSNodeComparator" />
+                </node>
+              </node>
+              <node concept="2PDubS" id="13oTmDlvyvn" role="2OqNvi">
+                <ref role="37wK5l" to="mqum:6fymoI4Ry1f" resolve="compare" />
+                <node concept="37vLTw" id="13oTmDlvyFG" role="37wK5m">
+                  <ref role="3cqZAo" node="68F0OxjVEWf" resolve="a" />
+                </node>
+                <node concept="37vLTw" id="13oTmDlvz1w" role="37wK5m">
+                  <ref role="3cqZAo" node="68F0OxjVEWh" resolve="b" />
+                </node>
+              </node>
+            </node>
+            <node concept="liA8E" id="13oTmDlvzt7" role="2OqNvi">
+              <ref role="37wK5l" to="mqum:DYlgnAAwiA" resolve="areEquals" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tmbuc" id="68F0OxjVEXa" role="1B3o_S" />
+      <node concept="10P_77" id="68F0OxjVEXb" role="3clF45" />
+    </node>
+    <node concept="2tJIrI" id="13oTmDl_Jle" role="jymVt" />
+    <node concept="3clFb_" id="68F0OxjVEXc" role="jymVt">
+      <property role="TrG5h" value="doHash" />
+      <node concept="2AHcQZ" id="68F0OxjVEXd" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+      <node concept="37vLTG" id="68F0OxjVEXe" role="3clF46">
+        <property role="TrG5h" value="node" />
+        <node concept="3Tqbb2" id="68F0OxkeOlZ" role="1tU5fm" />
+      </node>
+      <node concept="3clFbS" id="68F0OxjVEXg" role="3clF47">
+        <node concept="3clFbF" id="6uHwNxldOue" role="3cqZAp">
+          <node concept="1rXfSq" id="6uHwNxldOud" role="3clFbG">
+            <ref role="37wK5l" node="6uHwNxldFAD" resolve="doHash" />
+            <node concept="37vLTw" id="6uHwNxldPfh" role="37wK5m">
+              <ref role="3cqZAo" node="68F0OxjVEXe" resolve="node" />
+            </node>
+            <node concept="3clFbT" id="6uHwNxldQiq" role="37wK5m" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tmbuc" id="68F0OxjVEXT" role="1B3o_S" />
+      <node concept="10Oyi0" id="68F0OxjVEXU" role="3clF45" />
+    </node>
+    <node concept="2tJIrI" id="6uHwNxldFeI" role="jymVt" />
+    <node concept="3clFb_" id="6uHwNxldFAD" role="jymVt">
+      <property role="TrG5h" value="doHash" />
+      <node concept="3clFbS" id="6uHwNxldFAG" role="3clF47">
+        <node concept="3cpWs8" id="6uHwNxldEPY" role="3cqZAp">
+          <node concept="3cpWsn" id="6uHwNxldEPX" role="3cpWs9">
+            <property role="TrG5h" value="snode" />
+            <node concept="3uibUv" id="6uHwNxldEPZ" role="1tU5fm">
+              <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
+            </node>
+            <node concept="37vLTw" id="6uHwNxldEQ0" role="33vP2m">
+              <ref role="3cqZAo" node="6uHwNxldFXO" resolve="node" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="6uHwNxldEQ2" role="3cqZAp">
+          <node concept="3cpWsn" id="6uHwNxldEQ1" role="3cpWs9">
+            <property role="TrG5h" value="hash" />
+            <node concept="10Oyi0" id="6uHwNxldEQ3" role="1tU5fm" />
+            <node concept="2OqwBi" id="6uHwNxldLMA" role="33vP2m">
+              <node concept="2OqwBi" id="6uHwNxldKdU" role="2Oq$k0">
+                <node concept="37vLTw" id="6uHwNxldINV" role="2Oq$k0">
+                  <ref role="3cqZAo" node="6uHwNxldEPX" resolve="snode" />
+                </node>
+                <node concept="liA8E" id="6uHwNxldKdV" role="2OqNvi">
+                  <ref role="37wK5l" to="mhbf:~SNode.getConcept()" resolve="getConcept" />
+                </node>
+              </node>
+              <node concept="liA8E" id="6uHwNxldLMB" role="2OqNvi">
+                <ref role="37wK5l" to="wyt6:~Object.hashCode()" resolve="hashCode" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1DcWWT" id="6uHwNxldEQ6" role="3cqZAp">
+          <node concept="2OqwBi" id="6uHwNxldJZI" role="1DdaDG">
+            <node concept="37vLTw" id="6uHwNxldIOy" role="2Oq$k0">
+              <ref role="3cqZAo" node="6uHwNxldEPX" resolve="snode" />
+            </node>
+            <node concept="liA8E" id="6uHwNxldJZJ" role="2OqNvi">
+              <ref role="37wK5l" to="mhbf:~SNode.getProperties()" resolve="getProperties" />
+            </node>
+          </node>
+          <node concept="3cpWsn" id="6uHwNxldEQj" role="1Duv9x">
+            <property role="TrG5h" value="property" />
+            <node concept="3uibUv" id="6uHwNxldEQl" role="1tU5fm">
+              <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
+            </node>
+          </node>
+          <node concept="3clFbS" id="6uHwNxldEQ8" role="2LFqv$">
+            <node concept="3clFbF" id="4JmsWjEv_F_" role="3cqZAp">
+              <node concept="37vLTI" id="4JmsWjEvASb" role="3clFbG">
+                <node concept="3cpWs3" id="4JmsWjEvCRF" role="37vLTx">
+                  <node concept="2OqwBi" id="4JmsWjEvELA" role="3uHU7w">
+                    <node concept="37vLTw" id="4JmsWjEvDQV" role="2Oq$k0">
+                      <ref role="3cqZAo" node="6uHwNxldEQj" resolve="property" />
+                    </node>
+                    <node concept="liA8E" id="4JmsWjEvFjY" role="2OqNvi">
+                      <ref role="37wK5l" to="wyt6:~Object.hashCode()" resolve="hashCode" />
+                    </node>
+                  </node>
+                  <node concept="17qRlL" id="4JmsWjEvCal" role="3uHU7B">
+                    <node concept="3cmrfG" id="4JmsWjEvBil" role="3uHU7B">
+                      <property role="3cmrfH" value="31" />
+                    </node>
+                    <node concept="37vLTw" id="4JmsWjEvCE6" role="3uHU7w">
+                      <ref role="3cqZAo" node="6uHwNxldEQ1" resolve="hash" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="37vLTw" id="4JmsWjEv_Fz" role="37vLTJ">
+                  <ref role="3cqZAo" node="6uHwNxldEQ1" resolve="hash" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="6uHwNxldEQ9" role="3cqZAp">
+              <node concept="37vLTI" id="6uHwNxldEQa" role="3clFbG">
+                <node concept="37vLTw" id="6uHwNxldEQb" role="37vLTJ">
+                  <ref role="3cqZAo" node="6uHwNxldEQ1" resolve="hash" />
+                </node>
+                <node concept="3cpWs3" id="6uHwNxldEQc" role="37vLTx">
+                  <node concept="17qRlL" id="6uHwNxldEQd" role="3uHU7B">
+                    <node concept="3cmrfG" id="6uHwNxldEQe" role="3uHU7B">
+                      <property role="3cmrfH" value="31" />
+                    </node>
+                    <node concept="37vLTw" id="6uHwNxldEQf" role="3uHU7w">
+                      <ref role="3cqZAo" node="6uHwNxldEQ1" resolve="hash" />
+                    </node>
+                  </node>
+                  <node concept="2OqwBi" id="6uHwNxldMe1" role="3uHU7w">
+                    <node concept="2OqwBi" id="6uHwNxldJU9" role="2Oq$k0">
+                      <node concept="37vLTw" id="6uHwNxldIMG" role="2Oq$k0">
+                        <ref role="3cqZAo" node="6uHwNxldEPX" resolve="snode" />
+                      </node>
+                      <node concept="liA8E" id="6uHwNxldJUa" role="2OqNvi">
+                        <ref role="37wK5l" to="mhbf:~SNode.getProperty(org.jetbrains.mps.openapi.language.SProperty)" resolve="getProperty" />
+                        <node concept="37vLTw" id="6uHwNxldJUb" role="37wK5m">
+                          <ref role="3cqZAo" node="6uHwNxldEQj" resolve="property" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="liA8E" id="6uHwNxldMe2" role="2OqNvi">
+                      <ref role="37wK5l" to="wyt6:~String.hashCode()" resolve="hashCode" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1DcWWT" id="6uHwNxldEQn" role="3cqZAp">
+          <node concept="2OqwBi" id="6uHwNxldKli" role="1DdaDG">
+            <node concept="37vLTw" id="6uHwNxldILu" role="2Oq$k0">
+              <ref role="3cqZAo" node="6uHwNxldEPX" resolve="snode" />
+            </node>
+            <node concept="liA8E" id="6uHwNxldKlj" role="2OqNvi">
+              <ref role="37wK5l" to="mhbf:~SNode.getChildren()" resolve="getChildren" />
+            </node>
+          </node>
+          <node concept="3cpWsn" id="6uHwNxldEQz" role="1Duv9x">
+            <property role="TrG5h" value="child" />
+            <node concept="3uibUv" id="6uHwNxldEQ_" role="1tU5fm">
+              <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
+            </node>
+          </node>
+          <node concept="3clFbS" id="6uHwNxldEQp" role="2LFqv$">
+            <node concept="3clFbF" id="4JmsWjEvG7w" role="3cqZAp">
+              <node concept="37vLTI" id="4JmsWjEvHtw" role="3clFbG">
+                <node concept="3cpWs3" id="4JmsWjEvKaa" role="37vLTx">
+                  <node concept="2OqwBi" id="4JmsWjEvNmx" role="3uHU7w">
+                    <node concept="2OqwBi" id="4JmsWjEvM45" role="2Oq$k0">
+                      <node concept="37vLTw" id="4JmsWjEvLjs" role="2Oq$k0">
+                        <ref role="3cqZAo" node="6uHwNxldEQz" resolve="child" />
+                      </node>
+                      <node concept="liA8E" id="4JmsWjEvMwE" role="2OqNvi">
+                        <ref role="37wK5l" to="mhbf:~SNode.getContainmentLink()" resolve="getContainmentLink" />
+                      </node>
+                    </node>
+                    <node concept="liA8E" id="4JmsWjEvOkK" role="2OqNvi">
+                      <ref role="37wK5l" to="wyt6:~Object.hashCode()" resolve="hashCode" />
+                    </node>
+                  </node>
+                  <node concept="17qRlL" id="4JmsWjEvI_q" role="3uHU7B">
+                    <node concept="3cmrfG" id="4JmsWjEvHPX" role="3uHU7B">
+                      <property role="3cmrfH" value="31" />
+                    </node>
+                    <node concept="37vLTw" id="4JmsWjEvIXk" role="3uHU7w">
+                      <ref role="3cqZAo" node="6uHwNxldEQ1" resolve="hash" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="37vLTw" id="4JmsWjEvG7u" role="37vLTJ">
+                  <ref role="3cqZAo" node="6uHwNxldEQ1" resolve="hash" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="6uHwNxldEQq" role="3cqZAp">
+              <node concept="37vLTI" id="6uHwNxldEQr" role="3clFbG">
+                <node concept="37vLTw" id="6uHwNxldEQs" role="37vLTJ">
+                  <ref role="3cqZAo" node="6uHwNxldEQ1" resolve="hash" />
+                </node>
+                <node concept="3cpWs3" id="6uHwNxldEQt" role="37vLTx">
+                  <node concept="17qRlL" id="6uHwNxldEQu" role="3uHU7B">
+                    <node concept="3cmrfG" id="6uHwNxldEQv" role="3uHU7B">
+                      <property role="3cmrfH" value="31" />
+                    </node>
+                    <node concept="37vLTw" id="6uHwNxldEQw" role="3uHU7w">
+                      <ref role="3cqZAo" node="6uHwNxldEQ1" resolve="hash" />
+                    </node>
+                  </node>
+                  <node concept="1rXfSq" id="6uHwNxldEQx" role="3uHU7w">
+                    <ref role="37wK5l" node="6uHwNxldFAD" resolve="doHash" />
+                    <node concept="37vLTw" id="6uHwNxldEQy" role="37wK5m">
+                      <ref role="3cqZAo" node="6uHwNxldEQz" resolve="child" />
+                    </node>
+                    <node concept="3clFbT" id="6uHwNxleb1Q" role="37wK5m">
+                      <property role="3clFbU" value="true" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="6uHwNxldSEo" role="3cqZAp" />
+        <node concept="3clFbJ" id="6uHwNxldTd$" role="3cqZAp">
+          <node concept="3clFbS" id="6uHwNxldTdA" role="3clFbx">
+            <node concept="1DcWWT" id="6uHwNxldEQB" role="3cqZAp">
+              <node concept="2OqwBi" id="6uHwNxldJO8" role="1DdaDG">
+                <node concept="37vLTw" id="6uHwNxldIKR" role="2Oq$k0">
+                  <ref role="3cqZAo" node="6uHwNxldEPX" resolve="snode" />
+                </node>
+                <node concept="liA8E" id="6uHwNxldJO9" role="2OqNvi">
+                  <ref role="37wK5l" to="mhbf:~SNode.getReferences()" resolve="getReferences" />
+                </node>
+              </node>
+              <node concept="3cpWsn" id="6uHwNxldEQT" role="1Duv9x">
+                <property role="TrG5h" value="reference" />
+                <node concept="3uibUv" id="6uHwNxldEQV" role="1tU5fm">
+                  <ref role="3uigEE" to="mhbf:~SReference" resolve="SReference" />
+                </node>
+              </node>
+              <node concept="3clFbS" id="6uHwNxldEQD" role="2LFqv$">
+                <node concept="3clFbF" id="4JmsWjEvPo0" role="3cqZAp">
+                  <node concept="37vLTI" id="4JmsWjEvQJ1" role="3clFbG">
+                    <node concept="3cpWs3" id="4JmsWjEvSn0" role="37vLTx">
+                      <node concept="2OqwBi" id="4JmsWjEvUFP" role="3uHU7w">
+                        <node concept="2OqwBi" id="4JmsWjEvT$g" role="2Oq$k0">
+                          <node concept="37vLTw" id="4JmsWjEvSJZ" role="2Oq$k0">
+                            <ref role="3cqZAo" node="6uHwNxldEQT" resolve="reference" />
+                          </node>
+                          <node concept="liA8E" id="4JmsWjEvU9R" role="2OqNvi">
+                            <ref role="37wK5l" to="mhbf:~SReference.getLink()" resolve="getLink" />
+                          </node>
+                        </node>
+                        <node concept="liA8E" id="4JmsWjEvVvv" role="2OqNvi">
+                          <ref role="37wK5l" to="wyt6:~Object.hashCode()" resolve="hashCode" />
+                        </node>
+                      </node>
+                      <node concept="17qRlL" id="4JmsWjEvRAv" role="3uHU7B">
+                        <node concept="3cmrfG" id="4JmsWjEvQXG" role="3uHU7B">
+                          <property role="3cmrfH" value="31" />
+                        </node>
+                        <node concept="37vLTw" id="4JmsWjEvS7U" role="3uHU7w">
+                          <ref role="3cqZAo" node="6uHwNxldEQ1" resolve="hash" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="37vLTw" id="4JmsWjEvPnY" role="37vLTJ">
+                      <ref role="3cqZAo" node="6uHwNxldEQ1" resolve="hash" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbJ" id="6uHwNxldEQE" role="3cqZAp">
+                  <node concept="3y3z36" id="6uHwNxldEQF" role="3clFbw">
+                    <node concept="2OqwBi" id="6uHwNxldKv1" role="3uHU7B">
+                      <node concept="37vLTw" id="6uHwNxldINk" role="2Oq$k0">
+                        <ref role="3cqZAo" node="6uHwNxldEQT" resolve="reference" />
+                      </node>
+                      <node concept="liA8E" id="6uHwNxldKv2" role="2OqNvi">
+                        <ref role="37wK5l" to="mhbf:~SReference.getTargetNode()" resolve="getTargetNode" />
+                      </node>
+                    </node>
+                    <node concept="10Nm6u" id="6uHwNxldEQH" role="3uHU7w" />
+                  </node>
+                  <node concept="3clFbS" id="6uHwNxldEQJ" role="3clFbx">
+                    <node concept="3clFbF" id="6uHwNxldEQK" role="3cqZAp">
+                      <node concept="37vLTI" id="6uHwNxldEQL" role="3clFbG">
+                        <node concept="37vLTw" id="6uHwNxldEQM" role="37vLTJ">
+                          <ref role="3cqZAo" node="6uHwNxldEQ1" resolve="hash" />
+                        </node>
+                        <node concept="3cpWs3" id="6uHwNxldEQN" role="37vLTx">
+                          <node concept="17qRlL" id="6uHwNxldEQO" role="3uHU7B">
+                            <node concept="3cmrfG" id="6uHwNxldEQP" role="3uHU7B">
+                              <property role="3cmrfH" value="31" />
+                            </node>
+                            <node concept="37vLTw" id="6uHwNxldEQQ" role="3uHU7w">
+                              <ref role="3cqZAo" node="6uHwNxldEQ1" resolve="hash" />
+                            </node>
+                          </node>
+                          <node concept="1rXfSq" id="6uHwNxldEQR" role="3uHU7w">
+                            <ref role="37wK5l" node="6uHwNxldFAD" resolve="doHash" />
+                            <node concept="2OqwBi" id="6uHwNxldK6J" role="37wK5m">
+                              <node concept="37vLTw" id="6uHwNxldIM5" role="2Oq$k0">
+                                <ref role="3cqZAo" node="6uHwNxldEQT" resolve="reference" />
+                              </node>
+                              <node concept="liA8E" id="6uHwNxldK6K" role="2OqNvi">
+                                <ref role="37wK5l" to="mhbf:~SReference.getTargetNode()" resolve="getTargetNode" />
+                              </node>
+                            </node>
+                            <node concept="3clFbT" id="6uHwNxldRQ7" role="37wK5m">
+                              <property role="3clFbU" value="true" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3fqX7Q" id="6uHwNxldTIJ" role="3clFbw">
+            <node concept="37vLTw" id="6uHwNxldUL2" role="3fr31v">
+              <ref role="3cqZAo" node="6uHwNxldGzQ" resolve="ignoreReferences" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="6uHwNxldEQX" role="3cqZAp">
+          <node concept="37vLTw" id="6uHwNxldEQY" role="3cqZAk">
+            <ref role="3cqZAo" node="6uHwNxldEQ1" resolve="hash" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tmbuc" id="6uHwNxldFfS" role="1B3o_S" />
+      <node concept="10Oyi0" id="6uHwNxldFgr" role="3clF45" />
+      <node concept="37vLTG" id="6uHwNxldFXO" role="3clF46">
+        <property role="TrG5h" value="node" />
+        <node concept="3Tqbb2" id="6uHwNxldFXN" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="6uHwNxldGzQ" role="3clF46">
+        <property role="TrG5h" value="ignoreReferences" />
+        <node concept="10P_77" id="6uHwNxldG$K" role="1tU5fm" />
+      </node>
+    </node>
+  </node>
+  <node concept="312cEu" id="6WJM9CJzRQV">
+    <property role="TrG5h" value="EqualsEquivalence" />
+    <property role="1EXbeo" value="true" />
+    <property role="2bfB8j" value="true" />
+    <node concept="3uibUv" id="6WJM9CJzRQW" role="1zkMxy">
+      <ref role="3uigEE" to="gyfg:~Equivalence" resolve="Equivalence" />
+      <node concept="16syzq" id="6WJM9CJ$eik" role="11_B2D">
+        <ref role="16sUi3" node="6WJM9CJ$t6r" resolve="T" />
+      </node>
+    </node>
+    <node concept="3uibUv" id="6WJM9CJ$3P$" role="EKbjA">
+      <ref role="3uigEE" to="guwi:~Serializable" resolve="Serializable" />
+    </node>
+    <node concept="Wx3nA" id="6WJM9CJzRQZ" role="jymVt">
+      <property role="TrG5h" value="INSTANCE" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3uibUv" id="6WJM9CJzRR0" role="1tU5fm">
+        <ref role="3uigEE" node="6WJM9CJzRQV" resolve="EqualsEquivalence" />
+      </node>
+      <node concept="2ShNRf" id="6WJM9CJzW7r" role="33vP2m">
+        <node concept="HV5vD" id="6WJM9CJzW7t" role="2ShVmc">
+          <property role="373rjd" value="true" />
+          <ref role="HV5vE" node="6WJM9CJzRQV" resolve="EqualsEquivalence" />
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="6WJM9CJ$96I" role="1B3o_S" />
+    </node>
+    <node concept="3clFb_" id="6WJM9CJzRR6" role="jymVt">
+      <property role="TrG5h" value="doEquivalent" />
+      <node concept="2AHcQZ" id="6WJM9CJzRR7" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+      <node concept="37vLTG" id="6WJM9CJzRR8" role="3clF46">
+        <property role="TrG5h" value="a" />
+        <node concept="16syzq" id="6WJM9CJ$MG2" role="1tU5fm">
+          <ref role="16sUi3" node="6WJM9CJ$t6r" resolve="T" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="6WJM9CJzRRa" role="3clF46">
+        <property role="TrG5h" value="b" />
+        <node concept="16syzq" id="6WJM9CJ$MPT" role="1tU5fm">
+          <ref role="16sUi3" node="6WJM9CJ$t6r" resolve="T" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="6WJM9CJzRRc" role="3clF47">
+        <node concept="3cpWs6" id="6WJM9CJzRRd" role="3cqZAp">
+          <node concept="2OqwBi" id="6WJM9CJzYCS" role="3cqZAk">
+            <node concept="37vLTw" id="6WJM9CJzWa5" role="2Oq$k0">
+              <ref role="3cqZAo" node="6WJM9CJzRR8" resolve="a" />
+            </node>
+            <node concept="liA8E" id="6WJM9CJzYCT" role="2OqNvi">
+              <ref role="37wK5l" to="wyt6:~Object.equals(java.lang.Object)" resolve="equals" />
+              <node concept="37vLTw" id="6WJM9CJzYCU" role="37wK5m">
+                <ref role="3cqZAo" node="6WJM9CJzRRa" resolve="b" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tmbuc" id="6WJM9CJzRRg" role="1B3o_S" />
+      <node concept="10P_77" id="6WJM9CJzRRh" role="3clF45" />
+    </node>
+    <node concept="3clFb_" id="6WJM9CJzRRi" role="jymVt">
+      <property role="TrG5h" value="doHash" />
+      <node concept="2AHcQZ" id="6WJM9CJzRRj" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+      <node concept="37vLTG" id="6WJM9CJzRRk" role="3clF46">
+        <property role="TrG5h" value="o" />
+        <node concept="3uibUv" id="6WJM9CJzRRl" role="1tU5fm">
+          <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="6WJM9CJzRRm" role="3clF47">
+        <node concept="3cpWs6" id="6WJM9CJzRRn" role="3cqZAp">
+          <node concept="2OqwBi" id="6WJM9CJzY$X" role="3cqZAk">
+            <node concept="37vLTw" id="6WJM9CJzW7p" role="2Oq$k0">
+              <ref role="3cqZAo" node="6WJM9CJzRRk" resolve="o" />
+            </node>
+            <node concept="liA8E" id="6WJM9CJzY$Y" role="2OqNvi">
+              <ref role="37wK5l" to="wyt6:~Object.hashCode()" resolve="hashCode" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tmbuc" id="6WJM9CJzRRp" role="1B3o_S" />
+      <node concept="10Oyi0" id="6WJM9CJzRRq" role="3clF45" />
+    </node>
+    <node concept="2tJIrI" id="6WJM9CJ$sU0" role="jymVt" />
+    <node concept="Wx3nA" id="6WJM9CJzRR2" role="jymVt">
+      <property role="TrG5h" value="serialVersionUID" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3cpWsb" id="6WJM9CJzRR3" role="1tU5fm" />
+      <node concept="3cmrfG" id="6WJM9CJzRR4" role="33vP2m">
+        <property role="3cmrfH" value="1" />
+      </node>
+      <node concept="3Tm6S6" id="6WJM9CJzRR5" role="1B3o_S" />
+    </node>
+    <node concept="3Tm1VV" id="6WJM9CJ$6Dy" role="1B3o_S" />
+    <node concept="16euLQ" id="6WJM9CJ$t6r" role="16eVyc">
+      <property role="TrG5h" value="T" />
+    </node>
+  </node>
+  <node concept="312cEu" id="2UDGRNXwY3K">
+    <property role="TrG5h" value="NodeHashSet" />
+    <node concept="3Tm1VV" id="2UDGRNXwY3L" role="1B3o_S" />
+    <node concept="3uibUv" id="2UDGRNXwYar" role="1zkMxy">
+      <ref role="3uigEE" node="5wNjLS4lSKq" resolve="EquivalenceHashSet" />
+      <node concept="3Tqbb2" id="2UDGRNXx5xC" role="11_B2D" />
+    </node>
+    <node concept="3clFbW" id="2UDGRNXx5Xp" role="jymVt">
+      <node concept="3cqZAl" id="2UDGRNXx5Xq" role="3clF45" />
+      <node concept="3Tm1VV" id="2UDGRNXx5Xx" role="1B3o_S" />
+      <node concept="3clFbS" id="2UDGRNXx5Xy" role="3clF47">
+        <node concept="XkiVB" id="2UDGRNXx5Xz" role="3cqZAp">
+          <ref role="37wK5l" node="6WJM9CJyjjM" resolve="EquivalenceHashSet" />
+          <node concept="2ShNRf" id="68F0OxkeEQ2" role="37wK5m">
+            <node concept="HV5vD" id="13oTmDl_hOS" role="2ShVmc">
+              <property role="373rjd" value="true" />
+              <ref role="HV5vE" node="68F0OxjVEW9" resolve="NodeEquivalence" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="2UDGRNXxug3" role="jymVt" />
+    <node concept="3clFbW" id="2UDGRNXxxvO" role="jymVt">
+      <node concept="3cqZAl" id="2UDGRNXxxvP" role="3clF45" />
+      <node concept="37vLTG" id="2UDGRNXxxvQ" role="3clF46">
+        <property role="TrG5h" value="set" />
+        <node concept="3uibUv" id="2UDGRNXxxvR" role="1tU5fm">
+          <ref role="3uigEE" to="33ny:~Set" resolve="Set" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="2UDGRNXxxvV" role="3clF47">
+        <node concept="XkiVB" id="2UDGRNXx_PA" role="3cqZAp">
+          <ref role="37wK5l" node="5wNjLS4qFj3" resolve="EquivalenceHashSet" />
+          <node concept="37vLTw" id="2UDGRNXxFBw" role="37wK5m">
+            <ref role="3cqZAo" node="2UDGRNXxxvQ" resolve="set" />
+          </node>
+          <node concept="2ShNRf" id="2UDGRNXxFFV" role="37wK5m">
+            <node concept="HV5vD" id="2UDGRNXxFFW" role="2ShVmc">
+              <property role="373rjd" value="true" />
+              <ref role="HV5vE" node="68F0OxjVEW9" resolve="NodeEquivalence" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="2UDGRNXxxw8" role="1B3o_S" />
+    </node>
+    <node concept="2tJIrI" id="2UDGRNXxxvu" role="jymVt" />
+  </node>
+</model>
+

--- a/code/languages/com.mbeddr.mpsutil/solutions/test.com.mbeddr.mpsutil.collections.runtime/models/test.com.mbeddr.mpsutil.collections.runtime.mps
+++ b/code/languages/com.mbeddr.mpsutil/solutions/test.com.mbeddr.mpsutil.collections.runtime/models/test.com.mbeddr.mpsutil.collections.runtime.mps
@@ -1,0 +1,3968 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:6fb7db1c-1859-474b-8d33-1e840624caa8(test.com.mbeddr.mpsutil.collections.runtime)">
+  <persistence version="9" />
+  <languages>
+    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
+    <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="6" />
+    <use id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections" version="1" />
+    <use id="446c26eb-2b7b-4bf0-9b35-f83fa582753e" name="jetbrains.mps.lang.modelapi" version="0" />
+    <use id="3a13115c-633c-4c5c-bbcc-75c4219e9555" name="jetbrains.mps.lang.quotation" version="5" />
+    <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="12" />
+    <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="1" />
+    <use id="e89e1550-b8fe-4f0d-a7fd-487968b42405" name="com.mbeddr.mpsutil.collections" version="0" />
+  </languages>
+  <imports>
+    <import index="lui2" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.module(MPS.OpenAPI/)" />
+    <import index="gyfg" ref="ecfb9949-7433-4db5-85de-0f84d172e4ce/java:com.google.common.base(de.q60.mps.collections.libs/)" />
+    <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" />
+    <import index="mhbf" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.model(MPS.OpenAPI/)" />
+    <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" />
+    <import index="co" ref="r:240d60dc-7568-46d8-a080-a0889db7fd44(com.mbeddr.mpsutil.collections.runtime)" />
+    <import index="w1kc" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel(MPS.Core/)" />
+    <import index="tp5g" ref="r:00000000-0000-4000-0000-011c89590388(jetbrains.mps.lang.test.structure)" />
+    <import index="tpeh" ref="r:00000000-0000-4000-0000-011c895902c5(jetbrains.mps.baseLanguage.typesystem)" />
+    <import index="tp2v" ref="r:00000000-0000-4000-0000-011c8959032b(jetbrains.mps.baseLanguage.collections.typesystem)" />
+    <import index="wwkp" ref="r:98449c2c-1cb6-4e11-8e93-d22a8497c2fe(com.mbeddr.mpsutil.collections.typesystem)" />
+    <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
+      <concept id="1215603922101" name="jetbrains.mps.lang.test.structure.NodeOperationsContainer" flags="ng" index="7CXmI">
+        <child id="1215604436604" name="nodeOperations" index="7EUXB" />
+      </concept>
+      <concept id="1215607067978" name="jetbrains.mps.lang.test.structure.CheckNodeForErrorMessagesOperation" flags="ng" index="7OXhh">
+        <property id="3743352646565420194" name="includeSelf" index="GvXf4" />
+      </concept>
+      <concept id="7691029917083872157" name="jetbrains.mps.lang.test.structure.IRuleReference" flags="ng" index="2u4UPC">
+        <reference id="8333855927540250453" name="declaration" index="39XzEq" />
+      </concept>
+      <concept id="428590876651279930" name="jetbrains.mps.lang.test.structure.NodeTypeSystemErrorCheckOperation" flags="ng" index="2DdRWr">
+        <child id="4649457259824818099" name="equationRef" index="MJxsd" />
+      </concept>
+      <concept id="4649457259824807647" name="jetbrains.mps.lang.test.structure.TypesystemEquationReference" flags="ng" index="MGsTx" />
+      <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
+        <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
+      </concept>
+      <concept id="1225469856668" name="jetbrains.mps.lang.test.structure.ModelExpression" flags="nn" index="1jGwE1" />
+      <concept id="1216913645126" name="jetbrains.mps.lang.test.structure.NodesTestCase" flags="lg" index="1lH9Xt">
+        <property id="2616911529524314943" name="accessMode" index="3DII0k" />
+        <child id="1216993439383" name="methods" index="1qtyYc" />
+        <child id="1217501822150" name="nodesToCheck" index="1SKRRt" />
+        <child id="1217501895093" name="testMethods" index="1SL9yI" />
+      </concept>
+      <concept id="1216989428737" name="jetbrains.mps.lang.test.structure.TestNode" flags="ng" index="1qefOq">
+        <child id="1216989461394" name="nodeToCheck" index="1qenE9" />
+      </concept>
+      <concept id="1225978065297" name="jetbrains.mps.lang.test.structure.SimpleNodeTest" flags="ng" index="1LZb2c" />
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1082485599095" name="jetbrains.mps.baseLanguage.structure.BlockStatement" flags="nn" index="9aQIb">
+        <child id="1082485599096" name="statements" index="9aQI4" />
+      </concept>
+      <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="1239714755177" name="jetbrains.mps.baseLanguage.structure.AbstractUnaryNumberOperation" flags="nn" index="2$Kvd9">
+        <child id="1239714902950" name="expression" index="2$L3a6" />
+      </concept>
+      <concept id="2820489544401957797" name="jetbrains.mps.baseLanguage.structure.DefaultClassCreator" flags="nn" index="HV5vD">
+        <reference id="2820489544401957798" name="classifier" index="HV5vE" />
+      </concept>
+      <concept id="1154032098014" name="jetbrains.mps.baseLanguage.structure.AbstractLoopStatement" flags="nn" index="2LF5Ji">
+        <child id="1154032183016" name="body" index="2LFqv$" />
+      </concept>
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
+        <child id="1145553007750" name="creator" index="2ShVmc" />
+      </concept>
+      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
+        <property id="1070475926801" name="value" index="Xl_RC" />
+      </concept>
+      <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
+      <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
+      <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
+        <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ng" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
+      </concept>
+      <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
+        <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
+      </concept>
+      <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
+      <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
+      <concept id="1225271283259" name="jetbrains.mps.baseLanguage.structure.NPEEqualsExpression" flags="nn" index="17R0WA" />
+      <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
+        <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
+      <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
+        <child id="1068580123133" name="returnType" index="3clF45" />
+        <child id="1068580123134" name="parameter" index="3clF46" />
+        <child id="1068580123135" name="body" index="3clF47" />
+      </concept>
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
+        <property id="1068580320021" name="value" index="3cmrfH" />
+      </concept>
+      <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
+        <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
+      </concept>
+      <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
+      <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
+      <concept id="1081506773034" name="jetbrains.mps.baseLanguage.structure.LessThanExpression" flags="nn" index="3eOVzh" />
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
+      </concept>
+      <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk" />
+      <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
+        <reference id="1107535924139" name="classifier" index="3uigEE" />
+      </concept>
+      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
+        <child id="1081773367579" name="rightExpression" index="3uHU7w" />
+        <child id="1081773367580" name="leftExpression" index="3uHU7B" />
+      </concept>
+      <concept id="1214918800624" name="jetbrains.mps.baseLanguage.structure.PostfixIncrementExpression" flags="nn" index="3uNrnE" />
+      <concept id="1144230876926" name="jetbrains.mps.baseLanguage.structure.AbstractForStatement" flags="nn" index="1DupvO">
+        <child id="1144230900587" name="variable" index="1Duv9x" />
+      </concept>
+      <concept id="1144231330558" name="jetbrains.mps.baseLanguage.structure.ForStatement" flags="nn" index="1Dw8fO">
+        <child id="1144231399730" name="condition" index="1Dwp0S" />
+        <child id="1144231408325" name="iteration" index="1Dwrff" />
+      </concept>
+      <concept id="1208890769693" name="jetbrains.mps.baseLanguage.structure.ArrayLengthOperation" flags="nn" index="1Rwk04" />
+      <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="nn" index="3SKdUt">
+        <child id="8356039341262087992" name="line" index="1aUNEU" />
+      </concept>
+    </language>
+    <language id="e89e1550-b8fe-4f0d-a7fd-487968b42405" name="com.mbeddr.mpsutil.collections">
+      <concept id="5464682487435020413" name="com.mbeddr.mpsutil.collections.structure.SNodeSetCreator" flags="ng" index="2y2FIT">
+        <child id="5464682487435020789" name="createdType" index="2y2FCL" />
+        <child id="5464682487435041476" name="setCreator" index="2y2Q$0" />
+      </concept>
+      <concept id="6355510489488665234" name="com.mbeddr.mpsutil.collections.structure.SNodeSetType" flags="ig" index="1s3Imc">
+        <reference id="1145383142433" name="elementConcept" index="2I9WkF" />
+      </concept>
+    </language>
+    <language id="443f4c36-fcf5-4eb6-9500-8d06ed259e3e" name="jetbrains.mps.baseLanguage.classifiers">
+      <concept id="1205752633985" name="jetbrains.mps.baseLanguage.classifiers.structure.ThisClassifierExpression" flags="nn" index="2WthIp" />
+      <concept id="1205756064662" name="jetbrains.mps.baseLanguage.classifiers.structure.IMemberOperation" flags="ng" index="2WEnae">
+        <reference id="1205756909548" name="member" index="2WH_rO" />
+      </concept>
+      <concept id="1205769003971" name="jetbrains.mps.baseLanguage.classifiers.structure.DefaultClassifierMethodDeclaration" flags="ng" index="2XrIbr" />
+      <concept id="1205769149993" name="jetbrains.mps.baseLanguage.classifiers.structure.DefaultClassifierMethodCallOperation" flags="nn" index="2XshWL">
+        <child id="1205770614681" name="actualArgument" index="2XxRq1" />
+      </concept>
+    </language>
+    <language id="3a13115c-633c-4c5c-bbcc-75c4219e9555" name="jetbrains.mps.lang.quotation">
+      <concept id="5455284157993911077" name="jetbrains.mps.lang.quotation.structure.NodeBuilderInitProperty" flags="ng" index="2pJxcG">
+        <reference id="5455284157993911078" name="property" index="2pJxcJ" />
+        <child id="1595412875168045201" name="initValue" index="28ntcv" />
+      </concept>
+      <concept id="5455284157993863837" name="jetbrains.mps.lang.quotation.structure.NodeBuilder" flags="nn" index="2pJPEk">
+        <child id="5455284157993863838" name="quotedNode" index="2pJPEn" />
+      </concept>
+      <concept id="5455284157993863840" name="jetbrains.mps.lang.quotation.structure.NodeBuilderNode" flags="nn" index="2pJPED">
+        <reference id="5455284157993910961" name="concept" index="2pJxaS" />
+        <child id="5455284157993911099" name="values" index="2pJxcM" />
+      </concept>
+      <concept id="6985522012210254362" name="jetbrains.mps.lang.quotation.structure.NodeBuilderPropertyExpression" flags="nn" index="WxPPo">
+        <child id="6985522012210254363" name="expression" index="WxPPp" />
+      </concept>
+    </language>
+    <language id="446c26eb-2b7b-4bf0-9b35-f83fa582753e" name="jetbrains.mps.lang.modelapi">
+      <concept id="4733039728785194814" name="jetbrains.mps.lang.modelapi.structure.NamedNodeReference" flags="ng" index="ZC_QK">
+        <reference id="7256306938026143658" name="target" index="2aWVGs" />
+      </concept>
+    </language>
+    <language id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest">
+      <concept id="7080278351417106679" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertIsNotNull" flags="nn" index="2Hmddi">
+        <child id="7080278351417106681" name="expression" index="2Hmdds" />
+      </concept>
+      <concept id="8427750732757990717" name="jetbrains.mps.baseLanguage.unitTest.structure.BinaryAssert" flags="nn" index="3tpDYu">
+        <child id="8427750732757990725" name="actual" index="3tpDZA" />
+        <child id="8427750732757990724" name="expected" index="3tpDZB" />
+      </concept>
+      <concept id="1171978097730" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertEquals" flags="nn" index="3vlDli" />
+      <concept id="1171981022339" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertTrue" flags="nn" index="3vwNmj">
+        <child id="1171981057159" name="condition" index="3vwVQn" />
+      </concept>
+      <concept id="1171983834376" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertFalse" flags="nn" index="3vFxKo">
+        <child id="1171983854940" name="condition" index="3vFALc" />
+      </concept>
+      <concept id="1172073500303" name="jetbrains.mps.baseLanguage.unitTest.structure.Message" flags="ng" index="3_1$Yv" />
+      <concept id="1172075514136" name="jetbrains.mps.baseLanguage.unitTest.structure.MessageHolder" flags="ng" index="3_9gw8">
+        <child id="1172075534298" name="message" index="3_9lra" />
+      </concept>
+    </language>
+    <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="7400021826774799413" name="jetbrains.mps.lang.smodel.structure.NodePointerExpression" flags="ng" index="2tJFMh">
+        <child id="7400021826774799510" name="ref" index="2tJFKM" />
+      </concept>
+      <concept id="4065387505485742749" name="jetbrains.mps.lang.smodel.structure.AbstractPointerResolveOperation" flags="ng" index="2yCiFS">
+        <child id="3648723375513868575" name="repositoryArg" index="Vysub" />
+      </concept>
+      <concept id="1145383075378" name="jetbrains.mps.lang.smodel.structure.SNodeListType" flags="in" index="2I9FWS">
+        <reference id="1145383142433" name="elementConcept" index="2I9WkG" />
+      </concept>
+      <concept id="1145567426890" name="jetbrains.mps.lang.smodel.structure.SNodeListCreator" flags="nn" index="2T8Vx0">
+        <child id="1145567471833" name="createdType" index="2T96Bj" />
+      </concept>
+      <concept id="3648723375513868532" name="jetbrains.mps.lang.smodel.structure.NodePointer_ResolveOperation" flags="ng" index="Vyspw" />
+      <concept id="1144146199828" name="jetbrains.mps.lang.smodel.structure.Node_CopyOperation" flags="nn" index="1$rogu" />
+      <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
+        <reference id="1138405853777" name="concept" index="ehGHo" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+    <language id="c7fb639f-be78-4307-89b0-b5959c3fa8c8" name="jetbrains.mps.lang.text">
+      <concept id="155656958578482948" name="jetbrains.mps.lang.text.structure.Word" flags="nn" index="3oM_SD">
+        <property id="155656958578482949" name="value" index="3oM_SC" />
+      </concept>
+      <concept id="2535923850359271782" name="jetbrains.mps.lang.text.structure.Line" flags="nn" index="1PaTwC">
+        <child id="2535923850359271783" name="elements" index="1PaTwD" />
+      </concept>
+    </language>
+    <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
+      <concept id="540871147943773365" name="jetbrains.mps.baseLanguage.collections.structure.SingleArgumentSequenceOperation" flags="nn" index="25WWJ4">
+        <child id="540871147943773366" name="argument" index="25WWJ7" />
+      </concept>
+      <concept id="1226511727824" name="jetbrains.mps.baseLanguage.collections.structure.SetType" flags="in" index="2hMVRd">
+        <child id="1226511765987" name="elementType" index="2hN53Y" />
+      </concept>
+      <concept id="1226516258405" name="jetbrains.mps.baseLanguage.collections.structure.HashSetCreator" flags="nn" index="2i4dXS" />
+      <concept id="1151688443754" name="jetbrains.mps.baseLanguage.collections.structure.ListType" flags="in" index="_YKpA">
+        <child id="1151688676805" name="elementType" index="_ZDj9" />
+      </concept>
+      <concept id="1237721394592" name="jetbrains.mps.baseLanguage.collections.structure.AbstractContainerCreator" flags="nn" index="HWqM0">
+        <child id="1237721435807" name="elementType" index="HW$YZ" />
+      </concept>
+      <concept id="1160600644654" name="jetbrains.mps.baseLanguage.collections.structure.ListCreatorWithInit" flags="nn" index="Tc6Ow" />
+      <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="nn" index="TSZUe" />
+      <concept id="1171391069720" name="jetbrains.mps.baseLanguage.collections.structure.GetIndexOfOperation" flags="nn" index="2WmjW8" />
+      <concept id="1240217271293" name="jetbrains.mps.baseLanguage.collections.structure.LinkedHashSetCreator" flags="nn" index="32HrFt" />
+      <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="nn" index="34oBXx" />
+      <concept id="1167380149909" name="jetbrains.mps.baseLanguage.collections.structure.RemoveElementOperation" flags="nn" index="3dhRuq" />
+      <concept id="1173946412755" name="jetbrains.mps.baseLanguage.collections.structure.RemoveAllElementsOperation" flags="nn" index="1kEaZ2" />
+      <concept id="1165530316231" name="jetbrains.mps.baseLanguage.collections.structure.IsEmptyOperation" flags="nn" index="1v1jN8" />
+      <concept id="1172254888721" name="jetbrains.mps.baseLanguage.collections.structure.ContainsOperation" flags="nn" index="3JPx81" />
+      <concept id="1228228912534" name="jetbrains.mps.baseLanguage.collections.structure.DowncastExpression" flags="nn" index="3S9uib">
+        <child id="1228228959951" name="expression" index="3S9DZi" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="1lH9Xt" id="68F0Oxkg9_i">
+    <property role="3DII0k" value="2hh8MJdVwqX/command" />
+    <property role="TrG5h" value="NodeEquivalence" />
+    <node concept="1LZb2c" id="68F0Oxkg9_j" role="1SL9yI">
+      <property role="TrG5h" value="nullNodes" />
+      <node concept="3cqZAl" id="68F0Oxkg9_k" role="3clF45" />
+      <node concept="3clFbS" id="68F0Oxkg9_l" role="3clF47">
+        <node concept="3cpWs8" id="68F0Oxkgi7o" role="3cqZAp">
+          <node concept="3cpWsn" id="68F0Oxkgi7p" role="3cpWs9">
+            <property role="TrG5h" value="equivalence" />
+            <node concept="3uibUv" id="68F0Oxkgi7k" role="1tU5fm">
+              <ref role="3uigEE" to="co:68F0OxjVEW9" resolve="NodeEquivalence" />
+            </node>
+            <node concept="2ShNRf" id="68F0Oxkgi7q" role="33vP2m">
+              <node concept="HV5vD" id="13oTmDl_euq" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="HV5vE" to="co:68F0OxjVEW9" resolve="NodeEquivalence" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="68F0OxkgjHU" role="3cqZAp">
+          <node concept="3cpWsn" id="68F0OxkgjHV" role="3cpWs9">
+            <property role="TrG5h" value="cl1" />
+            <node concept="3Tqbb2" id="68F0OxkgjHW" role="1tU5fm">
+              <ref role="ehGHo" to="tpee:fz12cDA" resolve="ClassConcept" />
+            </node>
+            <node concept="10Nm6u" id="4JmsWjEledZ" role="33vP2m" />
+          </node>
+        </node>
+        <node concept="3cpWs8" id="68F0Oxkgozy" role="3cqZAp">
+          <node concept="3cpWsn" id="68F0Oxkgozz" role="3cpWs9">
+            <property role="TrG5h" value="cl2" />
+            <node concept="3Tqbb2" id="68F0Oxkgoz$" role="1tU5fm">
+              <ref role="ehGHo" to="tpee:fz12cDA" resolve="ClassConcept" />
+            </node>
+            <node concept="10Nm6u" id="4JmsWjElepF" role="33vP2m" />
+          </node>
+        </node>
+        <node concept="3vwNmj" id="68F0Oxkgrxv" role="3cqZAp">
+          <node concept="2OqwBi" id="68F0OxkgrPB" role="3vwVQn">
+            <node concept="2OqwBi" id="68F0OxkgrAa" role="2Oq$k0">
+              <node concept="37vLTw" id="68F0OxkgrAb" role="2Oq$k0">
+                <ref role="3cqZAo" node="68F0Oxkgi7p" resolve="equivalence" />
+              </node>
+              <node concept="liA8E" id="68F0OxkgrAc" role="2OqNvi">
+                <ref role="37wK5l" to="gyfg:~Equivalence.wrap(java.lang.Object)" resolve="wrap" />
+                <node concept="37vLTw" id="68F0OxkgrAd" role="37wK5m">
+                  <ref role="3cqZAo" node="68F0OxkgjHV" resolve="cl1" />
+                </node>
+              </node>
+            </node>
+            <node concept="liA8E" id="68F0Oxkgsg0" role="2OqNvi">
+              <ref role="37wK5l" to="gyfg:~Equivalence$Wrapper.equals(java.lang.Object)" resolve="equals" />
+              <node concept="2OqwBi" id="68F0Oxkgsn$" role="37wK5m">
+                <node concept="37vLTw" id="68F0Oxkgsn_" role="2Oq$k0">
+                  <ref role="3cqZAo" node="68F0Oxkgi7p" resolve="equivalence" />
+                </node>
+                <node concept="liA8E" id="68F0OxkgsnA" role="2OqNvi">
+                  <ref role="37wK5l" to="gyfg:~Equivalence.wrap(java.lang.Object)" resolve="wrap" />
+                  <node concept="37vLTw" id="68F0OxkgsnB" role="37wK5m">
+                    <ref role="3cqZAo" node="68F0Oxkgozz" resolve="cl2" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="4JmsWjEldxq" role="1SL9yI">
+      <property role="TrG5h" value="sameStructure" />
+      <node concept="3cqZAl" id="4JmsWjEldxr" role="3clF45" />
+      <node concept="3clFbS" id="4JmsWjEldxs" role="3clF47">
+        <node concept="3cpWs8" id="4JmsWjEldxt" role="3cqZAp">
+          <node concept="3cpWsn" id="4JmsWjEldxu" role="3cpWs9">
+            <property role="TrG5h" value="equivalence" />
+            <node concept="3uibUv" id="4JmsWjEldxv" role="1tU5fm">
+              <ref role="3uigEE" to="co:68F0OxjVEW9" resolve="NodeEquivalence" />
+            </node>
+            <node concept="2ShNRf" id="4JmsWjEldxw" role="33vP2m">
+              <node concept="HV5vD" id="4JmsWjEldxx" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="HV5vE" to="co:68F0OxjVEW9" resolve="NodeEquivalence" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="4JmsWjEldxy" role="3cqZAp">
+          <node concept="3cpWsn" id="4JmsWjEldxz" role="3cpWs9">
+            <property role="TrG5h" value="cl1" />
+            <node concept="3Tqbb2" id="4JmsWjEldx$" role="1tU5fm">
+              <ref role="ehGHo" to="tpee:fz12cDA" resolve="ClassConcept" />
+            </node>
+            <node concept="2pJPEk" id="4JmsWjEldx_" role="33vP2m">
+              <node concept="2pJPED" id="4JmsWjEldxA" role="2pJPEn">
+                <ref role="2pJxaS" to="tpee:fz12cDA" resolve="ClassConcept" />
+                <node concept="2pJxcG" id="4JmsWjEldxB" role="2pJxcM">
+                  <ref role="2pJxcJ" to="tpck:h0TrG11" resolve="name" />
+                  <node concept="WxPPo" id="4JmsWjEldxC" role="28ntcv">
+                    <node concept="Xl_RD" id="4JmsWjEldxD" role="WxPPp">
+                      <property role="Xl_RC" value="Cls" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="4JmsWjEldxE" role="3cqZAp">
+          <node concept="3cpWsn" id="4JmsWjEldxF" role="3cpWs9">
+            <property role="TrG5h" value="cl2" />
+            <node concept="3Tqbb2" id="4JmsWjEldxG" role="1tU5fm">
+              <ref role="ehGHo" to="tpee:fz12cDA" resolve="ClassConcept" />
+            </node>
+            <node concept="2pJPEk" id="4JmsWjEldxH" role="33vP2m">
+              <node concept="2pJPED" id="4JmsWjEldxI" role="2pJPEn">
+                <ref role="2pJxaS" to="tpee:fz12cDA" resolve="ClassConcept" />
+                <node concept="2pJxcG" id="4JmsWjEldxJ" role="2pJxcM">
+                  <ref role="2pJxcJ" to="tpck:h0TrG11" resolve="name" />
+                  <node concept="WxPPo" id="4JmsWjEldxK" role="28ntcv">
+                    <node concept="Xl_RD" id="4JmsWjEldxL" role="WxPPp">
+                      <property role="Xl_RC" value="Cls" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3vwNmj" id="4JmsWjEldxM" role="3cqZAp">
+          <node concept="2OqwBi" id="4JmsWjEldxN" role="3vwVQn">
+            <node concept="2OqwBi" id="4JmsWjEldxO" role="2Oq$k0">
+              <node concept="37vLTw" id="4JmsWjEldxP" role="2Oq$k0">
+                <ref role="3cqZAo" node="4JmsWjEldxu" resolve="equivalence" />
+              </node>
+              <node concept="liA8E" id="4JmsWjEldxQ" role="2OqNvi">
+                <ref role="37wK5l" to="gyfg:~Equivalence.wrap(java.lang.Object)" resolve="wrap" />
+                <node concept="37vLTw" id="4JmsWjEldxR" role="37wK5m">
+                  <ref role="3cqZAo" node="4JmsWjEldxz" resolve="cl1" />
+                </node>
+              </node>
+            </node>
+            <node concept="liA8E" id="4JmsWjEldxS" role="2OqNvi">
+              <ref role="37wK5l" to="gyfg:~Equivalence$Wrapper.equals(java.lang.Object)" resolve="equals" />
+              <node concept="2OqwBi" id="4JmsWjEldxT" role="37wK5m">
+                <node concept="37vLTw" id="4JmsWjEldxU" role="2Oq$k0">
+                  <ref role="3cqZAo" node="4JmsWjEldxu" resolve="equivalence" />
+                </node>
+                <node concept="liA8E" id="4JmsWjEldxV" role="2OqNvi">
+                  <ref role="37wK5l" to="gyfg:~Equivalence.wrap(java.lang.Object)" resolve="wrap" />
+                  <node concept="37vLTw" id="4JmsWjEldxW" role="37wK5m">
+                    <ref role="3cqZAo" node="4JmsWjEldxF" resolve="cl2" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="68F0OxkguH0" role="1SL9yI">
+      <property role="TrG5h" value="sameStructure2" />
+      <node concept="3cqZAl" id="68F0OxkguH1" role="3clF45" />
+      <node concept="3clFbS" id="68F0OxkguH2" role="3clF47">
+        <node concept="3cpWs8" id="68F0OxkguH3" role="3cqZAp">
+          <node concept="3cpWsn" id="68F0OxkguH4" role="3cpWs9">
+            <property role="TrG5h" value="equivalence" />
+            <node concept="3uibUv" id="68F0OxkguH5" role="1tU5fm">
+              <ref role="3uigEE" to="co:68F0OxjVEW9" resolve="NodeEquivalence" />
+            </node>
+            <node concept="2ShNRf" id="68F0OxkguH6" role="33vP2m">
+              <node concept="HV5vD" id="13oTmDl_eES" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="HV5vE" to="co:68F0OxjVEW9" resolve="NodeEquivalence" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="68F0OxkgwBT" role="3cqZAp">
+          <node concept="3cpWsn" id="68F0OxkgwBU" role="3cpWs9">
+            <property role="TrG5h" value="cls" />
+            <node concept="3Tqbb2" id="68F0OxkgwBV" role="1tU5fm">
+              <ref role="ehGHo" to="tpee:fz12cDA" resolve="ClassConcept" />
+            </node>
+            <node concept="2OqwBi" id="68F0OxkgwBW" role="33vP2m">
+              <node concept="2tJFMh" id="68F0OxkgwBX" role="2Oq$k0">
+                <node concept="ZC_QK" id="68F0OxkgwBY" role="2tJFKM">
+                  <ref role="2aWVGs" to="co:5wNjLS4lSKq" resolve="EquivalenceHashSet" />
+                </node>
+              </node>
+              <node concept="Vyspw" id="68F0OxkgwBZ" role="2OqNvi">
+                <node concept="2OqwBi" id="68F0Oxkgz1q" role="Vysub">
+                  <node concept="1jGwE1" id="68F0OxkgyO1" role="2Oq$k0" />
+                  <node concept="liA8E" id="68F0Oxkgzdp" role="2OqNvi">
+                    <ref role="37wK5l" to="mhbf:~SModel.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3vwNmj" id="68F0OxkguHo" role="3cqZAp">
+          <node concept="2OqwBi" id="68F0OxkguHp" role="3vwVQn">
+            <node concept="2OqwBi" id="68F0OxkguHq" role="2Oq$k0">
+              <node concept="37vLTw" id="68F0OxkguHr" role="2Oq$k0">
+                <ref role="3cqZAo" node="68F0OxkguH4" resolve="equivalence" />
+              </node>
+              <node concept="liA8E" id="68F0OxkguHs" role="2OqNvi">
+                <ref role="37wK5l" to="gyfg:~Equivalence.wrap(java.lang.Object)" resolve="wrap" />
+                <node concept="37vLTw" id="68F0OxkguHt" role="37wK5m">
+                  <ref role="3cqZAo" node="68F0OxkgwBU" resolve="cls" />
+                </node>
+              </node>
+            </node>
+            <node concept="liA8E" id="68F0OxkguHu" role="2OqNvi">
+              <ref role="37wK5l" to="gyfg:~Equivalence$Wrapper.equals(java.lang.Object)" resolve="equals" />
+              <node concept="2OqwBi" id="68F0OxkguHv" role="37wK5m">
+                <node concept="37vLTw" id="68F0OxkguHw" role="2Oq$k0">
+                  <ref role="3cqZAo" node="68F0OxkguH4" resolve="equivalence" />
+                </node>
+                <node concept="liA8E" id="68F0OxkguHx" role="2OqNvi">
+                  <ref role="37wK5l" to="gyfg:~Equivalence.wrap(java.lang.Object)" resolve="wrap" />
+                  <node concept="2OqwBi" id="68F0OxkgxCw" role="37wK5m">
+                    <node concept="37vLTw" id="68F0OxkguHy" role="2Oq$k0">
+                      <ref role="3cqZAo" node="68F0OxkgwBU" resolve="cls" />
+                    </node>
+                    <node concept="1$rogu" id="68F0Oxkgyz0" role="2OqNvi" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="68F0Oxkgr15" role="1SL9yI">
+      <property role="TrG5h" value="differentStructure" />
+      <node concept="3cqZAl" id="68F0Oxkgr16" role="3clF45" />
+      <node concept="3clFbS" id="68F0Oxkgr17" role="3clF47">
+        <node concept="3cpWs8" id="68F0Oxkgr18" role="3cqZAp">
+          <node concept="3cpWsn" id="68F0Oxkgr19" role="3cpWs9">
+            <property role="TrG5h" value="equivalence" />
+            <node concept="3uibUv" id="68F0Oxkgr1a" role="1tU5fm">
+              <ref role="3uigEE" to="co:68F0OxjVEW9" resolve="NodeEquivalence" />
+            </node>
+            <node concept="2ShNRf" id="68F0Oxkgr1b" role="33vP2m">
+              <node concept="HV5vD" id="13oTmDl_eRA" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="HV5vE" to="co:68F0OxjVEW9" resolve="NodeEquivalence" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="68F0Oxkgr1d" role="3cqZAp">
+          <node concept="3cpWsn" id="68F0Oxkgr1e" role="3cpWs9">
+            <property role="TrG5h" value="cl1" />
+            <node concept="3Tqbb2" id="68F0Oxkgr1f" role="1tU5fm">
+              <ref role="ehGHo" to="tpee:fz12cDA" resolve="ClassConcept" />
+            </node>
+            <node concept="2pJPEk" id="68F0Oxkgr1g" role="33vP2m">
+              <node concept="2pJPED" id="68F0Oxkgr1h" role="2pJPEn">
+                <ref role="2pJxaS" to="tpee:fz12cDA" resolve="ClassConcept" />
+                <node concept="2pJxcG" id="68F0Oxkgr1i" role="2pJxcM">
+                  <ref role="2pJxcJ" to="tpck:h0TrG11" resolve="name" />
+                  <node concept="WxPPo" id="68F0Oxkgr1j" role="28ntcv">
+                    <node concept="Xl_RD" id="68F0Oxkgr1k" role="WxPPp">
+                      <property role="Xl_RC" value="Cls" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="68F0Oxkgr1l" role="3cqZAp">
+          <node concept="3cpWsn" id="68F0Oxkgr1m" role="3cpWs9">
+            <property role="TrG5h" value="cl2" />
+            <node concept="3Tqbb2" id="68F0Oxkgr1n" role="1tU5fm">
+              <ref role="ehGHo" to="tpee:fz12cDA" resolve="ClassConcept" />
+            </node>
+            <node concept="2pJPEk" id="68F0Oxkgr1o" role="33vP2m">
+              <node concept="2pJPED" id="68F0Oxkgr1p" role="2pJPEn">
+                <ref role="2pJxaS" to="tpee:fz12cDA" resolve="ClassConcept" />
+                <node concept="2pJxcG" id="68F0Oxkgr1q" role="2pJxcM">
+                  <ref role="2pJxcJ" to="tpck:h0TrG11" resolve="name" />
+                  <node concept="WxPPo" id="68F0Oxkgr1r" role="28ntcv">
+                    <node concept="Xl_RD" id="68F0Oxkgr1s" role="WxPPp">
+                      <property role="Xl_RC" value="Cls2" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3vFxKo" id="68F0Oxkgroa" role="3cqZAp">
+          <node concept="2OqwBi" id="68F0OxkgsG1" role="3vFALc">
+            <node concept="2OqwBi" id="68F0OxkgsG2" role="2Oq$k0">
+              <node concept="37vLTw" id="68F0OxkgsG3" role="2Oq$k0">
+                <ref role="3cqZAo" node="68F0Oxkgr19" resolve="equivalence" />
+              </node>
+              <node concept="liA8E" id="68F0OxkgsG4" role="2OqNvi">
+                <ref role="37wK5l" to="gyfg:~Equivalence.wrap(java.lang.Object)" resolve="wrap" />
+                <node concept="37vLTw" id="68F0OxkgsG5" role="37wK5m">
+                  <ref role="3cqZAo" node="68F0Oxkgr1e" resolve="cl1" />
+                </node>
+              </node>
+            </node>
+            <node concept="liA8E" id="68F0OxkgsG6" role="2OqNvi">
+              <ref role="37wK5l" to="gyfg:~Equivalence$Wrapper.equals(java.lang.Object)" resolve="equals" />
+              <node concept="2OqwBi" id="68F0OxkgsG7" role="37wK5m">
+                <node concept="37vLTw" id="68F0OxkgsG8" role="2Oq$k0">
+                  <ref role="3cqZAo" node="68F0Oxkgr19" resolve="equivalence" />
+                </node>
+                <node concept="liA8E" id="68F0OxkgsG9" role="2OqNvi">
+                  <ref role="37wK5l" to="gyfg:~Equivalence.wrap(java.lang.Object)" resolve="wrap" />
+                  <node concept="37vLTw" id="68F0OxkgsGa" role="37wK5m">
+                    <ref role="3cqZAo" node="68F0Oxkgr1m" resolve="cl2" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="1lH9Xt" id="68F0OxkdYXd">
+    <property role="3DII0k" value="2hh8MJdVwqX/command" />
+    <property role="TrG5h" value="EquivalenceHashSet" />
+    <node concept="2XrIbr" id="3jVUTQDfPQ9" role="1qtyYc">
+      <property role="TrG5h" value="addMultipleTimes" />
+      <node concept="3cqZAl" id="3jVUTQDfPX9" role="3clF45" />
+      <node concept="3clFbS" id="3jVUTQDfPQb" role="3clF47">
+        <node concept="1Dw8fO" id="3jVUTQDfQ1m" role="3cqZAp">
+          <node concept="3cpWsn" id="3jVUTQDfQ1n" role="1Duv9x">
+            <property role="TrG5h" value="i" />
+            <node concept="10Oyi0" id="3jVUTQDfQ1Z" role="1tU5fm" />
+            <node concept="3cmrfG" id="3jVUTQDfQ24" role="33vP2m">
+              <property role="3cmrfH" value="0" />
+            </node>
+          </node>
+          <node concept="3clFbS" id="3jVUTQDfQ1o" role="2LFqv$">
+            <node concept="3clFbF" id="3jVUTQDfRfZ" role="3cqZAp">
+              <node concept="2OqwBi" id="3jVUTQDfRxa" role="3clFbG">
+                <node concept="37vLTw" id="3jVUTQDfRfY" role="2Oq$k0">
+                  <ref role="3cqZAo" node="3jVUTQDfPYs" resolve="set" />
+                </node>
+                <node concept="TSZUe" id="3jVUTQDfRKS" role="2OqNvi">
+                  <node concept="37vLTw" id="3jVUTQDfS2P" role="25WWJ7">
+                    <ref role="3cqZAo" node="3jVUTQDfPZl" resolve="value" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3eOVzh" id="3jVUTQDfQR0" role="1Dwp0S">
+            <node concept="3cmrfG" id="3jVUTQDfQR3" role="3uHU7w">
+              <property role="3cmrfH" value="2" />
+            </node>
+            <node concept="37vLTw" id="3jVUTQDfQ25" role="3uHU7B">
+              <ref role="3cqZAo" node="3jVUTQDfQ1n" resolve="i" />
+            </node>
+          </node>
+          <node concept="3uNrnE" id="3jVUTQDfReZ" role="1Dwrff">
+            <node concept="37vLTw" id="3jVUTQDfRf1" role="2$L3a6">
+              <ref role="3cqZAo" node="3jVUTQDfQ1n" resolve="i" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="3jVUTQDfPYs" role="3clF46">
+        <property role="TrG5h" value="set" />
+        <node concept="2hMVRd" id="3jVUTQDfPYq" role="1tU5fm">
+          <node concept="17QB3L" id="4JmsWjEf2gM" role="2hN53Y" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="3jVUTQDfPZl" role="3clF46">
+        <property role="TrG5h" value="value" />
+        <node concept="17QB3L" id="4JmsWjEey6n" role="1tU5fm" />
+      </node>
+    </node>
+    <node concept="1LZb2c" id="68F0OxkdYXk" role="1SL9yI">
+      <property role="TrG5h" value="sameNodeAndDifferentNode" />
+      <node concept="3cqZAl" id="68F0OxkdYXl" role="3clF45" />
+      <node concept="3clFbS" id="68F0OxkdYXp" role="3clF47">
+        <node concept="3cpWs8" id="4JmsWjEd_Sa" role="3cqZAp">
+          <node concept="3cpWsn" id="4JmsWjEd_Sd" role="3cpWs9">
+            <property role="TrG5h" value="set" />
+            <node concept="2hMVRd" id="4JmsWjEd_S6" role="1tU5fm">
+              <node concept="17QB3L" id="4JmsWjEdADC" role="2hN53Y" />
+            </node>
+            <node concept="2ShNRf" id="4JmsWjEdAHi" role="33vP2m">
+              <node concept="1pGfFk" id="4JmsWjEdAR$" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="co:6WJM9CJzpYH" resolve="EquivalenceHashSet" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="4JmsWjEdB29" role="3cqZAp" />
+        <node concept="3vwNmj" id="68F0OxkeR_P" role="3cqZAp">
+          <node concept="2OqwBi" id="68F0OxkeS4i" role="3vwVQn">
+            <node concept="37vLTw" id="68F0OxkeR_W" role="2Oq$k0">
+              <ref role="3cqZAo" node="4JmsWjEd_Sd" resolve="set" />
+            </node>
+            <node concept="1v1jN8" id="68F0OxkeSbk" role="2OqNvi" />
+          </node>
+        </node>
+        <node concept="3clFbH" id="68F0Oxkf4hE" role="3cqZAp" />
+        <node concept="3clFbF" id="3jVUTQDg0Pb" role="3cqZAp">
+          <node concept="2OqwBi" id="3jVUTQDg0P5" role="3clFbG">
+            <node concept="2WthIp" id="3jVUTQDg0P8" role="2Oq$k0" />
+            <node concept="2XshWL" id="3jVUTQDg0Pa" role="2OqNvi">
+              <ref role="2WH_rO" node="3jVUTQDfPQ9" resolve="addMultipleTimes" />
+              <node concept="37vLTw" id="3jVUTQDg1eY" role="2XxRq1">
+                <ref role="3cqZAo" node="4JmsWjEd_Sd" resolve="set" />
+              </node>
+              <node concept="Xl_RD" id="4JmsWjEec$F" role="2XxRq1">
+                <property role="Xl_RC" value="hello" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3vlDli" id="68F0OxkeSn$" role="3cqZAp">
+          <node concept="3cmrfG" id="68F0OxkeSnL" role="3tpDZB">
+            <property role="3cmrfH" value="1" />
+          </node>
+          <node concept="2OqwBi" id="68F0OxkeSo5" role="3tpDZA">
+            <node concept="37vLTw" id="68F0OxkeSnR" role="2Oq$k0">
+              <ref role="3cqZAo" node="4JmsWjEd_Sd" resolve="set" />
+            </node>
+            <node concept="34oBXx" id="68F0OxkeSv7" role="2OqNvi" />
+          </node>
+          <node concept="3_1$Yv" id="68F0OxkfjnG" role="3_9lra" />
+        </node>
+        <node concept="3clFbH" id="68F0Oxkf68w" role="3cqZAp" />
+        <node concept="3clFbF" id="3jVUTQDg35q" role="3cqZAp">
+          <node concept="2OqwBi" id="3jVUTQDg3u7" role="3clFbG">
+            <node concept="2WthIp" id="3jVUTQDg35o" role="2Oq$k0" />
+            <node concept="2XshWL" id="3jVUTQDg3Bw" role="2OqNvi">
+              <ref role="2WH_rO" node="3jVUTQDfPQ9" resolve="addMultipleTimes" />
+              <node concept="37vLTw" id="3jVUTQDg3VV" role="2XxRq1">
+                <ref role="3cqZAo" node="4JmsWjEd_Sd" resolve="set" />
+              </node>
+              <node concept="Xl_RD" id="4JmsWjEf1lh" role="2XxRq1">
+                <property role="Xl_RC" value="world" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3vlDli" id="68F0OxkeTSK" role="3cqZAp">
+          <node concept="2OqwBi" id="68F0OxkeTSM" role="3tpDZA">
+            <node concept="37vLTw" id="68F0OxkeTSN" role="2Oq$k0">
+              <ref role="3cqZAo" node="4JmsWjEd_Sd" resolve="set" />
+            </node>
+            <node concept="34oBXx" id="68F0OxkeTSO" role="2OqNvi" />
+          </node>
+          <node concept="3cmrfG" id="68F0OxkeTWi" role="3tpDZB">
+            <property role="3cmrfH" value="2" />
+          </node>
+          <node concept="3_1$Yv" id="68F0OxkflNt" role="3_9lra" />
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="68F0Oxkf9KS" role="1SL9yI">
+      <property role="TrG5h" value="sameNodeCopyAndDifferentNode" />
+      <node concept="3cqZAl" id="68F0Oxkf9KT" role="3clF45" />
+      <node concept="3clFbS" id="68F0Oxkf9KU" role="3clF47">
+        <node concept="3cpWs8" id="4JmsWjEfWV7" role="3cqZAp">
+          <node concept="3cpWsn" id="4JmsWjEfWV8" role="3cpWs9">
+            <property role="TrG5h" value="set" />
+            <node concept="2hMVRd" id="4JmsWjEfWV9" role="1tU5fm">
+              <node concept="17QB3L" id="4JmsWjEfWVa" role="2hN53Y" />
+            </node>
+            <node concept="2ShNRf" id="4JmsWjEfWVb" role="33vP2m">
+              <node concept="1pGfFk" id="4JmsWjEfWVc" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="co:6WJM9CJzpYH" resolve="EquivalenceHashSet" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="68F0Oxkf9Lj" role="3cqZAp" />
+        <node concept="3vwNmj" id="68F0Oxkf9L_" role="3cqZAp">
+          <node concept="2OqwBi" id="68F0Oxkf9LA" role="3vwVQn">
+            <node concept="37vLTw" id="68F0Oxkf9LB" role="2Oq$k0">
+              <ref role="3cqZAo" node="4JmsWjEfWV8" resolve="set" />
+            </node>
+            <node concept="1v1jN8" id="68F0Oxkf9LC" role="2OqNvi" />
+          </node>
+        </node>
+        <node concept="3clFbH" id="68F0Oxkf9LD" role="3cqZAp" />
+        <node concept="3clFbF" id="3jVUTQDfSWL" role="3cqZAp">
+          <node concept="2OqwBi" id="3jVUTQDfSWF" role="3clFbG">
+            <node concept="2WthIp" id="3jVUTQDfSWI" role="2Oq$k0" />
+            <node concept="2XshWL" id="3jVUTQDfSWK" role="2OqNvi">
+              <ref role="2WH_rO" node="3jVUTQDfPQ9" resolve="addMultipleTimes" />
+              <node concept="37vLTw" id="3jVUTQDfSWN" role="2XxRq1">
+                <ref role="3cqZAo" node="4JmsWjEfWV8" resolve="set" />
+              </node>
+              <node concept="Xl_RD" id="4JmsWjEga9C" role="2XxRq1">
+                <property role="Xl_RC" value="hello" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3vlDli" id="68F0Oxkf9LJ" role="3cqZAp">
+          <node concept="3cmrfG" id="68F0Oxkf9LK" role="3tpDZB">
+            <property role="3cmrfH" value="1" />
+          </node>
+          <node concept="2OqwBi" id="68F0Oxkf9LL" role="3tpDZA">
+            <node concept="37vLTw" id="68F0Oxkf9LM" role="2Oq$k0">
+              <ref role="3cqZAo" node="4JmsWjEfWV8" resolve="set" />
+            </node>
+            <node concept="34oBXx" id="68F0Oxkf9LN" role="2OqNvi" />
+          </node>
+          <node concept="3_1$Yv" id="68F0OxkfoHc" role="3_9lra" />
+        </node>
+        <node concept="3clFbH" id="3jVUTQDfVmd" role="3cqZAp" />
+        <node concept="3clFbF" id="3jVUTQDfZ7a" role="3cqZAp">
+          <node concept="2OqwBi" id="3jVUTQDfZ7b" role="3clFbG">
+            <node concept="2WthIp" id="3jVUTQDfZ7c" role="2Oq$k0" />
+            <node concept="2XshWL" id="3jVUTQDfZ7d" role="2OqNvi">
+              <ref role="2WH_rO" node="3jVUTQDfPQ9" resolve="addMultipleTimes" />
+              <node concept="37vLTw" id="3jVUTQDfZ7e" role="2XxRq1">
+                <ref role="3cqZAo" node="4JmsWjEfWV8" resolve="set" />
+              </node>
+              <node concept="Xl_RD" id="4JmsWjEgbVE" role="2XxRq1">
+                <property role="Xl_RC" value="world" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3vlDli" id="68F0Oxkf9M5" role="3cqZAp">
+          <node concept="2OqwBi" id="68F0Oxkf9M6" role="3tpDZA">
+            <node concept="37vLTw" id="68F0Oxkf9M7" role="2Oq$k0">
+              <ref role="3cqZAo" node="4JmsWjEfWV8" resolve="set" />
+            </node>
+            <node concept="34oBXx" id="68F0Oxkf9M8" role="2OqNvi" />
+          </node>
+          <node concept="3cmrfG" id="68F0Oxkf9M9" role="3tpDZB">
+            <property role="3cmrfH" value="2" />
+          </node>
+          <node concept="3_1$Yv" id="68F0Oxkfsh6" role="3_9lra" />
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="6uHwNxleUTp" role="1SL9yI">
+      <property role="TrG5h" value="index" />
+      <node concept="3cqZAl" id="6uHwNxleUTq" role="3clF45" />
+      <node concept="3clFbS" id="6uHwNxleUTu" role="3clF47">
+        <node concept="3SKdUt" id="4JmsWjEhrS2" role="3cqZAp">
+          <node concept="1PaTwC" id="4JmsWjEhrS3" role="1aUNEU">
+            <node concept="3oM_SD" id="4JmsWjEhrS6" role="1PaTwD">
+              <property role="3oM_SC" value="linked" />
+            </node>
+            <node concept="3oM_SD" id="4JmsWjEhs6t" role="1PaTwD">
+              <property role="3oM_SC" value="hashset" />
+            </node>
+            <node concept="3oM_SD" id="4JmsWjEhs6u" role="1PaTwD">
+              <property role="3oM_SC" value="to" />
+            </node>
+            <node concept="3oM_SD" id="4JmsWjEhs6v" role="1PaTwD">
+              <property role="3oM_SC" value="keep" />
+            </node>
+            <node concept="3oM_SD" id="4JmsWjEhs6w" role="1PaTwD">
+              <property role="3oM_SC" value="the" />
+            </node>
+            <node concept="3oM_SD" id="4JmsWjEhs6x" role="1PaTwD">
+              <property role="3oM_SC" value="order" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="4JmsWjEfX8_" role="3cqZAp">
+          <node concept="3cpWsn" id="4JmsWjEfX8A" role="3cpWs9">
+            <property role="TrG5h" value="set" />
+            <node concept="2hMVRd" id="4JmsWjEfX8B" role="1tU5fm">
+              <node concept="17QB3L" id="4JmsWjEfX8C" role="2hN53Y" />
+            </node>
+            <node concept="2ShNRf" id="4JmsWjEhr9t" role="33vP2m">
+              <node concept="1pGfFk" id="4JmsWjEhr9u" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="co:5wNjLS4qFj3" resolve="EquivalenceHashSet" />
+                <node concept="2ShNRf" id="4JmsWjEhknO" role="37wK5m">
+                  <node concept="32HrFt" id="4JmsWjEhkH3" role="2ShVmc">
+                    <node concept="17QB3L" id="4JmsWjEhlOY" role="HW$YZ" />
+                  </node>
+                </node>
+                <node concept="2ShNRf" id="4JmsWjEhj3b" role="37wK5m">
+                  <node concept="HV5vD" id="4JmsWjEhju3" role="2ShVmc">
+                    <property role="373rjd" value="true" />
+                    <ref role="HV5vE" to="co:6WJM9CJzRQV" resolve="EqualsEquivalence" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="6uHwNxleVxx" role="3cqZAp" />
+        <node concept="3vwNmj" id="6uHwNxleVxy" role="3cqZAp">
+          <node concept="2OqwBi" id="6uHwNxleVxz" role="3vwVQn">
+            <node concept="37vLTw" id="6uHwNxleVx$" role="2Oq$k0">
+              <ref role="3cqZAo" node="4JmsWjEfX8A" resolve="set" />
+            </node>
+            <node concept="1v1jN8" id="6uHwNxleVx_" role="2OqNvi" />
+          </node>
+        </node>
+        <node concept="3clFbH" id="6uHwNxleVxA" role="3cqZAp" />
+        <node concept="3clFbF" id="3jVUTQDg5dv" role="3cqZAp">
+          <node concept="2OqwBi" id="3jVUTQDg5dp" role="3clFbG">
+            <node concept="2WthIp" id="3jVUTQDg5ds" role="2Oq$k0" />
+            <node concept="2XshWL" id="3jVUTQDg5du" role="2OqNvi">
+              <ref role="2WH_rO" node="3jVUTQDfPQ9" resolve="addMultipleTimes" />
+              <node concept="37vLTw" id="3jVUTQDg5B3" role="2XxRq1">
+                <ref role="3cqZAo" node="4JmsWjEfX8A" resolve="set" />
+              </node>
+              <node concept="Xl_RD" id="4JmsWjEghpd" role="2XxRq1">
+                <property role="Xl_RC" value="hello" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="3jVUTQDg62h" role="3cqZAp">
+          <node concept="2OqwBi" id="3jVUTQDg62i" role="3clFbG">
+            <node concept="2WthIp" id="3jVUTQDg62j" role="2Oq$k0" />
+            <node concept="2XshWL" id="3jVUTQDg62k" role="2OqNvi">
+              <ref role="2WH_rO" node="3jVUTQDfPQ9" resolve="addMultipleTimes" />
+              <node concept="37vLTw" id="3jVUTQDg62l" role="2XxRq1">
+                <ref role="3cqZAo" node="4JmsWjEfX8A" resolve="set" />
+              </node>
+              <node concept="Xl_RD" id="4JmsWjEgh$Q" role="2XxRq1">
+                <property role="Xl_RC" value="world" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="6uHwNxleXR9" role="3cqZAp" />
+        <node concept="3vlDli" id="6uHwNxlf44E" role="3cqZAp">
+          <node concept="3cmrfG" id="6uHwNxlf794" role="3tpDZB">
+            <property role="3cmrfH" value="0" />
+          </node>
+          <node concept="2OqwBi" id="6uHwNxlf5d4" role="3tpDZA">
+            <node concept="37vLTw" id="6uHwNxlf44K" role="2Oq$k0">
+              <ref role="3cqZAo" node="4JmsWjEfX8A" resolve="set" />
+            </node>
+            <node concept="2WmjW8" id="6uHwNxlf6gu" role="2OqNvi">
+              <node concept="Xl_RD" id="4JmsWjEgigV" role="25WWJ7">
+                <property role="Xl_RC" value="hello" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3vlDli" id="6uHwNxlf7L4" role="3cqZAp">
+          <node concept="2OqwBi" id="6uHwNxlf7L6" role="3tpDZA">
+            <node concept="37vLTw" id="6uHwNxlf7L7" role="2Oq$k0">
+              <ref role="3cqZAo" node="4JmsWjEfX8A" resolve="set" />
+            </node>
+            <node concept="2WmjW8" id="6uHwNxlf7L8" role="2OqNvi">
+              <node concept="Xl_RD" id="4JmsWjEgisE" role="25WWJ7">
+                <property role="Xl_RC" value="world" />
+              </node>
+            </node>
+          </node>
+          <node concept="3cmrfG" id="6uHwNxlf8gH" role="3tpDZB">
+            <property role="3cmrfH" value="1" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="6uHwNxlf9K_" role="1SL9yI">
+      <property role="TrG5h" value="remove" />
+      <node concept="3cqZAl" id="6uHwNxlf9KA" role="3clF45" />
+      <node concept="3clFbS" id="6uHwNxlf9KB" role="3clF47">
+        <node concept="3cpWs8" id="4JmsWjEfXkL" role="3cqZAp">
+          <node concept="3cpWsn" id="4JmsWjEfXkM" role="3cpWs9">
+            <property role="TrG5h" value="set" />
+            <node concept="2hMVRd" id="4JmsWjEfXkN" role="1tU5fm">
+              <node concept="17QB3L" id="4JmsWjEfXkO" role="2hN53Y" />
+            </node>
+            <node concept="2ShNRf" id="4JmsWjEfXkP" role="33vP2m">
+              <node concept="1pGfFk" id="4JmsWjEfXkQ" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="co:6WJM9CJzpYH" resolve="EquivalenceHashSet" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="6uHwNxlf9L0" role="3cqZAp" />
+        <node concept="3vlDli" id="6uHwNxlf$hA" role="3cqZAp">
+          <node concept="3cmrfG" id="6uHwNxlf$hB" role="3tpDZB">
+            <property role="3cmrfH" value="0" />
+          </node>
+          <node concept="2OqwBi" id="6uHwNxlf$hC" role="3tpDZA">
+            <node concept="37vLTw" id="6uHwNxlf$hD" role="2Oq$k0">
+              <ref role="3cqZAo" node="4JmsWjEfXkM" resolve="set" />
+            </node>
+            <node concept="34oBXx" id="6uHwNxlf$hE" role="2OqNvi" />
+          </node>
+        </node>
+        <node concept="3clFbH" id="6uHwNxlf9Lm" role="3cqZAp" />
+        <node concept="3clFbF" id="3jVUTQDgair" role="3cqZAp">
+          <node concept="2OqwBi" id="3jVUTQDgail" role="3clFbG">
+            <node concept="2WthIp" id="3jVUTQDgaio" role="2Oq$k0" />
+            <node concept="2XshWL" id="3jVUTQDgaiq" role="2OqNvi">
+              <ref role="2WH_rO" node="3jVUTQDfPQ9" resolve="addMultipleTimes" />
+              <node concept="37vLTw" id="3jVUTQDgHwq" role="2XxRq1">
+                <ref role="3cqZAo" node="4JmsWjEfXkM" resolve="set" />
+              </node>
+              <node concept="Xl_RD" id="4JmsWjEgmaO" role="2XxRq1">
+                <property role="Xl_RC" value="hello" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="3jVUTQDgdE3" role="3cqZAp">
+          <node concept="2OqwBi" id="3jVUTQDgdE4" role="3clFbG">
+            <node concept="2WthIp" id="3jVUTQDgdE5" role="2Oq$k0" />
+            <node concept="2XshWL" id="3jVUTQDgdE6" role="2OqNvi">
+              <ref role="2WH_rO" node="3jVUTQDfPQ9" resolve="addMultipleTimes" />
+              <node concept="37vLTw" id="3jVUTQDgIOH" role="2XxRq1">
+                <ref role="3cqZAo" node="4JmsWjEfXkM" resolve="set" />
+              </node>
+              <node concept="Xl_RD" id="4JmsWjEgnzR" role="2XxRq1">
+                <property role="Xl_RC" value="world" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="6uHwNxlf9Lx" role="3cqZAp" />
+        <node concept="3vlDli" id="6uHwNxlfcnz" role="3cqZAp">
+          <node concept="3cmrfG" id="6uHwNxlfcnD" role="3tpDZB">
+            <property role="3cmrfH" value="2" />
+          </node>
+          <node concept="2OqwBi" id="6uHwNxlfdzv" role="3tpDZA">
+            <node concept="37vLTw" id="6uHwNxlfcnE" role="2Oq$k0">
+              <ref role="3cqZAo" node="4JmsWjEfXkM" resolve="set" />
+            </node>
+            <node concept="34oBXx" id="6uHwNxlfeEB" role="2OqNvi" />
+          </node>
+        </node>
+        <node concept="3clFbH" id="6uHwNxlffbu" role="3cqZAp" />
+        <node concept="3clFbF" id="6uHwNxlffb_" role="3cqZAp">
+          <node concept="2OqwBi" id="6uHwNxlfgtk" role="3clFbG">
+            <node concept="37vLTw" id="6uHwNxlffbz" role="2Oq$k0">
+              <ref role="3cqZAo" node="4JmsWjEfXkM" resolve="set" />
+            </node>
+            <node concept="3dhRuq" id="6uHwNxlfhyc" role="2OqNvi">
+              <node concept="Xl_RD" id="4JmsWjEgoWX" role="25WWJ7">
+                <property role="Xl_RC" value="hello" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="6uHwNxlfiit" role="3cqZAp">
+          <node concept="2OqwBi" id="6uHwNxlfiiu" role="3clFbG">
+            <node concept="37vLTw" id="6uHwNxlfiiv" role="2Oq$k0">
+              <ref role="3cqZAo" node="4JmsWjEfXkM" resolve="set" />
+            </node>
+            <node concept="3dhRuq" id="6uHwNxlfiiw" role="2OqNvi">
+              <node concept="Xl_RD" id="4JmsWjEgpEM" role="25WWJ7">
+                <property role="Xl_RC" value="world" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="6uHwNxlfmP6" role="3cqZAp" />
+        <node concept="3vlDli" id="6uHwNxlfCkR" role="3cqZAp">
+          <node concept="3cmrfG" id="6uHwNxlfCkS" role="3tpDZB">
+            <property role="3cmrfH" value="0" />
+          </node>
+          <node concept="2OqwBi" id="6uHwNxlfCkT" role="3tpDZA">
+            <node concept="37vLTw" id="6uHwNxlfCkU" role="2Oq$k0">
+              <ref role="3cqZAo" node="4JmsWjEfXkM" resolve="set" />
+            </node>
+            <node concept="34oBXx" id="6uHwNxlfCkV" role="2OqNvi" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="3jVUTQDeYnn" role="1SL9yI">
+      <property role="TrG5h" value="removeAll" />
+      <node concept="3cqZAl" id="3jVUTQDeYno" role="3clF45" />
+      <node concept="3clFbS" id="3jVUTQDeYnp" role="3clF47">
+        <node concept="3cpWs8" id="4JmsWjEfXze" role="3cqZAp">
+          <node concept="3cpWsn" id="4JmsWjEfXzf" role="3cpWs9">
+            <property role="TrG5h" value="set" />
+            <node concept="2hMVRd" id="4JmsWjEfXzg" role="1tU5fm">
+              <node concept="17QB3L" id="4JmsWjEfXzh" role="2hN53Y" />
+            </node>
+            <node concept="2ShNRf" id="4JmsWjEfXzi" role="33vP2m">
+              <node concept="1pGfFk" id="4JmsWjEfXzj" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="co:6WJM9CJzpYH" resolve="EquivalenceHashSet" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="3jVUTQDeYnM" role="3cqZAp" />
+        <node concept="3vlDli" id="3jVUTQDeYo4" role="3cqZAp">
+          <node concept="3cmrfG" id="3jVUTQDeYo5" role="3tpDZB">
+            <property role="3cmrfH" value="0" />
+          </node>
+          <node concept="2OqwBi" id="3jVUTQDeYo6" role="3tpDZA">
+            <node concept="37vLTw" id="3jVUTQDeYo7" role="2Oq$k0">
+              <ref role="3cqZAo" node="4JmsWjEfXzf" resolve="set" />
+            </node>
+            <node concept="34oBXx" id="3jVUTQDeYo8" role="2OqNvi" />
+          </node>
+        </node>
+        <node concept="3clFbH" id="3jVUTQDeYo9" role="3cqZAp" />
+        <node concept="3clFbF" id="3jVUTQDgkBW" role="3cqZAp">
+          <node concept="2OqwBi" id="3jVUTQDgkBQ" role="3clFbG">
+            <node concept="2WthIp" id="3jVUTQDgkBT" role="2Oq$k0" />
+            <node concept="2XshWL" id="3jVUTQDgkBV" role="2OqNvi">
+              <ref role="2WH_rO" node="3jVUTQDfPQ9" resolve="addMultipleTimes" />
+              <node concept="37vLTw" id="3jVUTQDgBFW" role="2XxRq1">
+                <ref role="3cqZAo" node="4JmsWjEfXzf" resolve="set" />
+              </node>
+              <node concept="Xl_RD" id="4JmsWjEgu7Z" role="2XxRq1">
+                <property role="Xl_RC" value="hello" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="3jVUTQDglR7" role="3cqZAp">
+          <node concept="2OqwBi" id="3jVUTQDglR8" role="3clFbG">
+            <node concept="2WthIp" id="3jVUTQDglR9" role="2Oq$k0" />
+            <node concept="2XshWL" id="3jVUTQDglRa" role="2OqNvi">
+              <ref role="2WH_rO" node="3jVUTQDfPQ9" resolve="addMultipleTimes" />
+              <node concept="37vLTw" id="3jVUTQDgC1M" role="2XxRq1">
+                <ref role="3cqZAo" node="4JmsWjEfXzf" resolve="set" />
+              </node>
+              <node concept="Xl_RD" id="4JmsWjEgweD" role="2XxRq1">
+                <property role="Xl_RC" value="world" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="3jVUTQDeYok" role="3cqZAp" />
+        <node concept="3vlDli" id="3jVUTQDeYol" role="3cqZAp">
+          <node concept="3cmrfG" id="3jVUTQDeYom" role="3tpDZB">
+            <property role="3cmrfH" value="2" />
+          </node>
+          <node concept="2OqwBi" id="3jVUTQDeYon" role="3tpDZA">
+            <node concept="37vLTw" id="3jVUTQDeYoo" role="2Oq$k0">
+              <ref role="3cqZAo" node="4JmsWjEfXzf" resolve="set" />
+            </node>
+            <node concept="34oBXx" id="3jVUTQDeYop" role="2OqNvi" />
+          </node>
+        </node>
+        <node concept="3clFbH" id="3jVUTQDeYoq" role="3cqZAp" />
+        <node concept="3cpWs8" id="3jVUTQDfcBI" role="3cqZAp">
+          <node concept="3cpWsn" id="3jVUTQDfcBL" role="3cpWs9">
+            <property role="TrG5h" value="list" />
+            <node concept="2ShNRf" id="3jVUTQDfhZ0" role="33vP2m">
+              <node concept="Tc6Ow" id="4JmsWjEgBH8" role="2ShVmc">
+                <node concept="17QB3L" id="4JmsWjEgDQo" role="HW$YZ" />
+              </node>
+            </node>
+            <node concept="_YKpA" id="4JmsWjEg$di" role="1tU5fm">
+              <node concept="17QB3L" id="4JmsWjEg_nV" role="_ZDj9" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="3jVUTQDfjAZ" role="3cqZAp">
+          <node concept="2OqwBi" id="3jVUTQDflCl" role="3clFbG">
+            <node concept="37vLTw" id="3jVUTQDfjAX" role="2Oq$k0">
+              <ref role="3cqZAo" node="3jVUTQDfcBL" resolve="list" />
+            </node>
+            <node concept="TSZUe" id="3jVUTQDfnE2" role="2OqNvi">
+              <node concept="Xl_RD" id="4JmsWjEgwHr" role="25WWJ7">
+                <property role="Xl_RC" value="hello" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="3jVUTQDfpJP" role="3cqZAp">
+          <node concept="2OqwBi" id="3jVUTQDfpJQ" role="3clFbG">
+            <node concept="37vLTw" id="3jVUTQDfpJR" role="2Oq$k0">
+              <ref role="3cqZAo" node="3jVUTQDfcBL" resolve="list" />
+            </node>
+            <node concept="TSZUe" id="3jVUTQDfpJS" role="2OqNvi">
+              <node concept="Xl_RD" id="4JmsWjEgxwp" role="25WWJ7">
+                <property role="Xl_RC" value="world" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="3jVUTQDfaCy" role="3cqZAp" />
+        <node concept="3clFbF" id="3jVUTQDeYor" role="3cqZAp">
+          <node concept="2OqwBi" id="3jVUTQDeYos" role="3clFbG">
+            <node concept="37vLTw" id="3jVUTQDeYot" role="2Oq$k0">
+              <ref role="3cqZAo" node="4JmsWjEfXzf" resolve="set" />
+            </node>
+            <node concept="1kEaZ2" id="3jVUTQDf0W5" role="2OqNvi">
+              <node concept="37vLTw" id="3jVUTQDfwcm" role="25WWJ7">
+                <ref role="3cqZAo" node="3jVUTQDfcBL" resolve="list" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="3jVUTQDeYo_" role="3cqZAp" />
+        <node concept="3vlDli" id="3jVUTQDeYoA" role="3cqZAp">
+          <node concept="3cmrfG" id="3jVUTQDeYoB" role="3tpDZB">
+            <property role="3cmrfH" value="0" />
+          </node>
+          <node concept="2OqwBi" id="3jVUTQDeYoC" role="3tpDZA">
+            <node concept="37vLTw" id="3jVUTQDeYoD" role="2Oq$k0">
+              <ref role="3cqZAo" node="4JmsWjEfXzf" resolve="set" />
+            </node>
+            <node concept="34oBXx" id="3jVUTQDeYoE" role="2OqNvi" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="3jVUTQDfDOn" role="1SL9yI">
+      <property role="TrG5h" value="contains" />
+      <node concept="3cqZAl" id="3jVUTQDfDOo" role="3clF45" />
+      <node concept="3clFbS" id="3jVUTQDfDOp" role="3clF47">
+        <node concept="3cpWs8" id="4JmsWjEfY1T" role="3cqZAp">
+          <node concept="3cpWsn" id="4JmsWjEfY1U" role="3cpWs9">
+            <property role="TrG5h" value="set" />
+            <node concept="2hMVRd" id="4JmsWjEfY1V" role="1tU5fm">
+              <node concept="17QB3L" id="4JmsWjEfY1W" role="2hN53Y" />
+            </node>
+            <node concept="2ShNRf" id="4JmsWjEfY1X" role="33vP2m">
+              <node concept="1pGfFk" id="4JmsWjEfY1Y" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="co:6WJM9CJzpYH" resolve="EquivalenceHashSet" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="3jVUTQDfDP3" role="3cqZAp" />
+        <node concept="3vlDli" id="3jVUTQDfDP4" role="3cqZAp">
+          <node concept="3cmrfG" id="3jVUTQDfDP5" role="3tpDZB">
+            <property role="3cmrfH" value="0" />
+          </node>
+          <node concept="2OqwBi" id="3jVUTQDfDP6" role="3tpDZA">
+            <node concept="37vLTw" id="3jVUTQDfDP7" role="2Oq$k0">
+              <ref role="3cqZAo" node="4JmsWjEfY1U" resolve="set" />
+            </node>
+            <node concept="34oBXx" id="3jVUTQDfDP8" role="2OqNvi" />
+          </node>
+        </node>
+        <node concept="3clFbH" id="3jVUTQDfDP9" role="3cqZAp" />
+        <node concept="3clFbF" id="3jVUTQDgp1D" role="3cqZAp">
+          <node concept="2OqwBi" id="3jVUTQDgp1z" role="3clFbG">
+            <node concept="2WthIp" id="3jVUTQDgp1A" role="2Oq$k0" />
+            <node concept="2XshWL" id="3jVUTQDgp1C" role="2OqNvi">
+              <ref role="2WH_rO" node="3jVUTQDfPQ9" resolve="addMultipleTimes" />
+              <node concept="37vLTw" id="3jVUTQDgzRn" role="2XxRq1">
+                <ref role="3cqZAo" node="4JmsWjEfY1U" resolve="set" />
+              </node>
+              <node concept="Xl_RD" id="4JmsWjEgJzQ" role="2XxRq1">
+                <property role="Xl_RC" value="hello" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="3jVUTQDgpGc" role="3cqZAp">
+          <node concept="2OqwBi" id="3jVUTQDgpGd" role="3clFbG">
+            <node concept="2WthIp" id="3jVUTQDgpGe" role="2Oq$k0" />
+            <node concept="2XshWL" id="3jVUTQDgpGf" role="2OqNvi">
+              <ref role="2WH_rO" node="3jVUTQDfPQ9" resolve="addMultipleTimes" />
+              <node concept="37vLTw" id="3jVUTQDg$2C" role="2XxRq1">
+                <ref role="3cqZAo" node="4JmsWjEfY1U" resolve="set" />
+              </node>
+              <node concept="Xl_RD" id="4JmsWjEgJJL" role="2XxRq1">
+                <property role="Xl_RC" value="world" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="3jVUTQDfDPk" role="3cqZAp" />
+        <node concept="3vwNmj" id="3jVUTQDfGMe" role="3cqZAp">
+          <node concept="2OqwBi" id="3jVUTQDfHPB" role="3vwVQn">
+            <node concept="37vLTw" id="3jVUTQDfGMi" role="2Oq$k0">
+              <ref role="3cqZAo" node="4JmsWjEfY1U" resolve="set" />
+            </node>
+            <node concept="3JPx81" id="3jVUTQDfIFA" role="2OqNvi">
+              <node concept="Xl_RD" id="4JmsWjEgJVJ" role="25WWJ7">
+                <property role="Xl_RC" value="hello" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3vwNmj" id="3jVUTQDfIP7" role="3cqZAp">
+          <node concept="2OqwBi" id="3jVUTQDfIP8" role="3vwVQn">
+            <node concept="37vLTw" id="3jVUTQDfIP9" role="2Oq$k0">
+              <ref role="3cqZAo" node="4JmsWjEfY1U" resolve="set" />
+            </node>
+            <node concept="3JPx81" id="3jVUTQDfIPa" role="2OqNvi">
+              <node concept="Xl_RD" id="4JmsWjEgK7K" role="25WWJ7">
+                <property role="Xl_RC" value="world" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="3jVUTQDgMHD" role="1SL9yI">
+      <property role="TrG5h" value="retainAll" />
+      <node concept="3cqZAl" id="3jVUTQDgMHE" role="3clF45" />
+      <node concept="3clFbS" id="3jVUTQDgMHF" role="3clF47">
+        <node concept="3cpWs8" id="4JmsWjEfYeU" role="3cqZAp">
+          <node concept="3cpWsn" id="4JmsWjEfYeV" role="3cpWs9">
+            <property role="TrG5h" value="set" />
+            <node concept="2hMVRd" id="4JmsWjEfYeW" role="1tU5fm">
+              <node concept="17QB3L" id="4JmsWjEfYeX" role="2hN53Y" />
+            </node>
+            <node concept="2ShNRf" id="4JmsWjEfYeY" role="33vP2m">
+              <node concept="1pGfFk" id="4JmsWjEfYeZ" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="co:6WJM9CJzpYH" resolve="EquivalenceHashSet" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="4JmsWjEfYqq" role="3cqZAp">
+          <node concept="3cpWsn" id="4JmsWjEfYqr" role="3cpWs9">
+            <property role="TrG5h" value="set2" />
+            <node concept="2hMVRd" id="4JmsWjEfYqs" role="1tU5fm">
+              <node concept="17QB3L" id="4JmsWjEfYqt" role="2hN53Y" />
+            </node>
+            <node concept="2ShNRf" id="4JmsWjEfYqu" role="33vP2m">
+              <node concept="1pGfFk" id="4JmsWjEfYqv" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="co:6WJM9CJzpYH" resolve="EquivalenceHashSet" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="3jVUTQDgMI4" role="3cqZAp" />
+        <node concept="3vlDli" id="3jVUTQDgMIm" role="3cqZAp">
+          <node concept="3cmrfG" id="3jVUTQDgMIn" role="3tpDZB">
+            <property role="3cmrfH" value="0" />
+          </node>
+          <node concept="2OqwBi" id="3jVUTQDgMIo" role="3tpDZA">
+            <node concept="37vLTw" id="3jVUTQDgMIp" role="2Oq$k0">
+              <ref role="3cqZAo" node="4JmsWjEfYeV" resolve="set" />
+            </node>
+            <node concept="34oBXx" id="3jVUTQDgMIq" role="2OqNvi" />
+          </node>
+        </node>
+        <node concept="3clFbH" id="3jVUTQDgMIr" role="3cqZAp" />
+        <node concept="3clFbF" id="3jVUTQDgMIs" role="3cqZAp">
+          <node concept="2OqwBi" id="3jVUTQDgMIt" role="3clFbG">
+            <node concept="2WthIp" id="3jVUTQDgMIu" role="2Oq$k0" />
+            <node concept="2XshWL" id="3jVUTQDgMIv" role="2OqNvi">
+              <ref role="2WH_rO" node="3jVUTQDfPQ9" resolve="addMultipleTimes" />
+              <node concept="37vLTw" id="3jVUTQDgMIw" role="2XxRq1">
+                <ref role="3cqZAo" node="4JmsWjEfYeV" resolve="set" />
+              </node>
+              <node concept="Xl_RD" id="4JmsWjEgKvR" role="2XxRq1">
+                <property role="Xl_RC" value="hello" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="3jVUTQDgMIy" role="3cqZAp">
+          <node concept="2OqwBi" id="3jVUTQDgMIz" role="3clFbG">
+            <node concept="2WthIp" id="3jVUTQDgMI$" role="2Oq$k0" />
+            <node concept="2XshWL" id="3jVUTQDgMI_" role="2OqNvi">
+              <ref role="2WH_rO" node="3jVUTQDfPQ9" resolve="addMultipleTimes" />
+              <node concept="37vLTw" id="3jVUTQDgMIA" role="2XxRq1">
+                <ref role="3cqZAo" node="4JmsWjEfYeV" resolve="set" />
+              </node>
+              <node concept="Xl_RD" id="4JmsWjEgM6$" role="2XxRq1">
+                <property role="Xl_RC" value="world" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="3jVUTQDgTmS" role="3cqZAp" />
+        <node concept="3vwNmj" id="3jVUTQDgMID" role="3cqZAp">
+          <node concept="2OqwBi" id="3jVUTQDgR4B" role="3vwVQn">
+            <node concept="3S9uib" id="3jVUTQDgQul" role="2Oq$k0">
+              <node concept="37vLTw" id="3jVUTQDgMIF" role="3S9DZi">
+                <ref role="3cqZAo" node="4JmsWjEfYeV" resolve="set" />
+              </node>
+            </node>
+            <node concept="liA8E" id="3jVUTQDgSYh" role="2OqNvi">
+              <ref role="37wK5l" to="33ny:~Set.retainAll(java.util.Collection)" resolve="retainAll" />
+              <node concept="37vLTw" id="3jVUTQDgVpn" role="37wK5m">
+                <ref role="3cqZAo" node="4JmsWjEfYqr" resolve="set2" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="3jVUTQDgMIN" role="3cqZAp" />
+      </node>
+    </node>
+    <node concept="1LZb2c" id="3jVUTQDhc43" role="1SL9yI">
+      <property role="TrG5h" value="toArray" />
+      <node concept="3cqZAl" id="3jVUTQDhc44" role="3clF45" />
+      <node concept="3clFbS" id="3jVUTQDhc45" role="3clF47">
+        <node concept="3cpWs8" id="4JmsWjEfZpU" role="3cqZAp">
+          <node concept="3cpWsn" id="4JmsWjEfZpV" role="3cpWs9">
+            <property role="TrG5h" value="set" />
+            <node concept="2hMVRd" id="4JmsWjEfZpW" role="1tU5fm">
+              <node concept="17QB3L" id="4JmsWjEfZpX" role="2hN53Y" />
+            </node>
+            <node concept="2ShNRf" id="4JmsWjEfZpY" role="33vP2m">
+              <node concept="1pGfFk" id="4JmsWjEfZpZ" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="co:6WJM9CJzpYH" resolve="EquivalenceHashSet" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="3jVUTQDhc4J" role="3cqZAp" />
+        <node concept="3vlDli" id="3jVUTQDhc51" role="3cqZAp">
+          <node concept="3cmrfG" id="3jVUTQDhc52" role="3tpDZB">
+            <property role="3cmrfH" value="0" />
+          </node>
+          <node concept="2OqwBi" id="3jVUTQDhc53" role="3tpDZA">
+            <node concept="37vLTw" id="3jVUTQDhc54" role="2Oq$k0">
+              <ref role="3cqZAo" node="4JmsWjEfZpV" resolve="set" />
+            </node>
+            <node concept="34oBXx" id="3jVUTQDhc55" role="2OqNvi" />
+          </node>
+        </node>
+        <node concept="3clFbH" id="3jVUTQDhc56" role="3cqZAp" />
+        <node concept="3clFbF" id="3jVUTQDhc57" role="3cqZAp">
+          <node concept="2OqwBi" id="3jVUTQDhc58" role="3clFbG">
+            <node concept="2WthIp" id="3jVUTQDhc59" role="2Oq$k0" />
+            <node concept="2XshWL" id="3jVUTQDhc5a" role="2OqNvi">
+              <ref role="2WH_rO" node="3jVUTQDfPQ9" resolve="addMultipleTimes" />
+              <node concept="37vLTw" id="3jVUTQDhc5b" role="2XxRq1">
+                <ref role="3cqZAo" node="4JmsWjEfZpV" resolve="set" />
+              </node>
+              <node concept="Xl_RD" id="4JmsWjEgPd1" role="2XxRq1">
+                <property role="Xl_RC" value="hello" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="3jVUTQDhc5d" role="3cqZAp">
+          <node concept="2OqwBi" id="3jVUTQDhc5e" role="3clFbG">
+            <node concept="2WthIp" id="3jVUTQDhc5f" role="2Oq$k0" />
+            <node concept="2XshWL" id="3jVUTQDhc5g" role="2OqNvi">
+              <ref role="2WH_rO" node="3jVUTQDfPQ9" resolve="addMultipleTimes" />
+              <node concept="37vLTw" id="3jVUTQDhc5h" role="2XxRq1">
+                <ref role="3cqZAo" node="4JmsWjEfZpV" resolve="set" />
+              </node>
+              <node concept="Xl_RD" id="4JmsWjEgQk_" role="2XxRq1">
+                <property role="Xl_RC" value="world" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="3jVUTQDhc5w" role="3cqZAp" />
+        <node concept="3vlDli" id="3jVUTQDpj3x" role="3cqZAp">
+          <node concept="3cmrfG" id="3jVUTQDpj3B" role="3tpDZB">
+            <property role="3cmrfH" value="2" />
+          </node>
+          <node concept="2OqwBi" id="3jVUTQDpjk8" role="3tpDZA">
+            <node concept="2OqwBi" id="3jVUTQDhc5y" role="2Oq$k0">
+              <node concept="3S9uib" id="3jVUTQDhc5z" role="2Oq$k0">
+                <node concept="37vLTw" id="3jVUTQDhc5$" role="3S9DZi">
+                  <ref role="3cqZAo" node="4JmsWjEfZpV" resolve="set" />
+                </node>
+              </node>
+              <node concept="liA8E" id="3jVUTQDhc5_" role="2OqNvi">
+                <ref role="37wK5l" to="33ny:~Set.toArray()" resolve="toArray" />
+              </node>
+            </node>
+            <node concept="1Rwk04" id="3jVUTQDpjKL" role="2OqNvi" />
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="2XOHcx" id="5yvl18N8PtL">
+    <property role="2XOHcw" value="${mbeddr.github.core.home}/code/languages/com.mbeddr.mpsutil" />
+  </node>
+  <node concept="1lH9Xt" id="13oTmDlxaxG">
+    <property role="3DII0k" value="2hh8MJdVwqX/command" />
+    <property role="TrG5h" value="HashCode" />
+    <node concept="1LZb2c" id="13oTmDlxaxH" role="1SL9yI">
+      <property role="TrG5h" value="nullHash" />
+      <node concept="3cqZAl" id="13oTmDlxaxI" role="3clF45" />
+      <node concept="3clFbS" id="13oTmDlxaxJ" role="3clF47">
+        <node concept="3cpWs8" id="13oTmDlxaxK" role="3cqZAp">
+          <node concept="3cpWsn" id="13oTmDlxaxL" role="3cpWs9">
+            <property role="TrG5h" value="equivalence" />
+            <node concept="3uibUv" id="13oTmDlxaxM" role="1tU5fm">
+              <ref role="3uigEE" to="co:68F0OxjVEW9" resolve="NodeEquivalence" />
+            </node>
+            <node concept="2ShNRf" id="13oTmDlxaxN" role="33vP2m">
+              <node concept="HV5vD" id="13oTmDl_dEi" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="HV5vE" to="co:68F0OxjVEW9" resolve="NodeEquivalence" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3vlDli" id="13oTmDlxcTW" role="3cqZAp">
+          <node concept="3cmrfG" id="4JmsWjEl399" role="3tpDZB">
+            <property role="3cmrfH" value="0" />
+          </node>
+          <node concept="2OqwBi" id="13oTmDlxcZm" role="3tpDZA">
+            <node concept="37vLTw" id="13oTmDlxcZn" role="2Oq$k0">
+              <ref role="3cqZAo" node="13oTmDlxaxL" resolve="equivalence" />
+            </node>
+            <node concept="liA8E" id="13oTmDlxcZo" role="2OqNvi">
+              <ref role="37wK5l" to="gyfg:~Equivalence.hash(java.lang.Object)" resolve="hash" />
+              <node concept="10Nm6u" id="4JmsWjEl2$3" role="37wK5m" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="4JmsWjEl1Yq" role="1SL9yI">
+      <property role="TrG5h" value="sameStructure" />
+      <node concept="3cqZAl" id="4JmsWjEl1Yr" role="3clF45" />
+      <node concept="3clFbS" id="4JmsWjEl1Ys" role="3clF47">
+        <node concept="3cpWs8" id="4JmsWjEl1Yt" role="3cqZAp">
+          <node concept="3cpWsn" id="4JmsWjEl1Yu" role="3cpWs9">
+            <property role="TrG5h" value="equivalence" />
+            <node concept="3uibUv" id="4JmsWjEl1Yv" role="1tU5fm">
+              <ref role="3uigEE" to="co:68F0OxjVEW9" resolve="NodeEquivalence" />
+            </node>
+            <node concept="2ShNRf" id="4JmsWjEl1Yw" role="33vP2m">
+              <node concept="HV5vD" id="4JmsWjEl1Yx" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="HV5vE" to="co:68F0OxjVEW9" resolve="NodeEquivalence" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="4JmsWjEl1Yy" role="3cqZAp">
+          <node concept="3cpWsn" id="4JmsWjEl1Yz" role="3cpWs9">
+            <property role="TrG5h" value="cl1" />
+            <node concept="3Tqbb2" id="4JmsWjEl1Y$" role="1tU5fm">
+              <ref role="ehGHo" to="tpee:fz12cDA" resolve="ClassConcept" />
+            </node>
+            <node concept="2pJPEk" id="4JmsWjEl1Y_" role="33vP2m">
+              <node concept="2pJPED" id="4JmsWjEl1YA" role="2pJPEn">
+                <ref role="2pJxaS" to="tpee:fz12cDA" resolve="ClassConcept" />
+                <node concept="2pJxcG" id="4JmsWjEl1YB" role="2pJxcM">
+                  <ref role="2pJxcJ" to="tpck:h0TrG11" resolve="name" />
+                  <node concept="WxPPo" id="4JmsWjEl1YC" role="28ntcv">
+                    <node concept="Xl_RD" id="4JmsWjEl1YD" role="WxPPp">
+                      <property role="Xl_RC" value="Cls" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="4JmsWjEl1YE" role="3cqZAp">
+          <node concept="3cpWsn" id="4JmsWjEl1YF" role="3cpWs9">
+            <property role="TrG5h" value="cl2" />
+            <node concept="3Tqbb2" id="4JmsWjEl1YG" role="1tU5fm">
+              <ref role="ehGHo" to="tpee:fz12cDA" resolve="ClassConcept" />
+            </node>
+            <node concept="2pJPEk" id="4JmsWjEl1YH" role="33vP2m">
+              <node concept="2pJPED" id="4JmsWjEl1YI" role="2pJPEn">
+                <ref role="2pJxaS" to="tpee:fz12cDA" resolve="ClassConcept" />
+                <node concept="2pJxcG" id="4JmsWjEl1YJ" role="2pJxcM">
+                  <ref role="2pJxcJ" to="tpck:h0TrG11" resolve="name" />
+                  <node concept="WxPPo" id="4JmsWjEl1YK" role="28ntcv">
+                    <node concept="Xl_RD" id="4JmsWjEl1YL" role="WxPPp">
+                      <property role="Xl_RC" value="Cls" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3vlDli" id="4JmsWjEl1YM" role="3cqZAp">
+          <node concept="2OqwBi" id="4JmsWjEl1YN" role="3tpDZB">
+            <node concept="37vLTw" id="4JmsWjEl1YO" role="2Oq$k0">
+              <ref role="3cqZAo" node="4JmsWjEl1Yu" resolve="equivalence" />
+            </node>
+            <node concept="liA8E" id="4JmsWjEl1YP" role="2OqNvi">
+              <ref role="37wK5l" to="gyfg:~Equivalence.hash(java.lang.Object)" resolve="hash" />
+              <node concept="37vLTw" id="4JmsWjEl1YQ" role="37wK5m">
+                <ref role="3cqZAo" node="4JmsWjEl1Yz" resolve="cl1" />
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="4JmsWjEl1YR" role="3tpDZA">
+            <node concept="37vLTw" id="4JmsWjEl1YS" role="2Oq$k0">
+              <ref role="3cqZAo" node="4JmsWjEl1Yu" resolve="equivalence" />
+            </node>
+            <node concept="liA8E" id="4JmsWjEl1YT" role="2OqNvi">
+              <ref role="37wK5l" to="gyfg:~Equivalence.hash(java.lang.Object)" resolve="hash" />
+              <node concept="37vLTw" id="4JmsWjEl1YU" role="37wK5m">
+                <ref role="3cqZAo" node="4JmsWjEl1YF" resolve="cl2" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="13oTmDlxayg" role="1SL9yI">
+      <property role="TrG5h" value="sameStructure2" />
+      <node concept="3cqZAl" id="13oTmDlxayh" role="3clF45" />
+      <node concept="3clFbS" id="13oTmDlxayi" role="3clF47">
+        <node concept="3cpWs8" id="13oTmDlxayj" role="3cqZAp">
+          <node concept="3cpWsn" id="13oTmDlxayk" role="3cpWs9">
+            <property role="TrG5h" value="equivalence" />
+            <node concept="3uibUv" id="13oTmDlxayl" role="1tU5fm">
+              <ref role="3uigEE" to="co:68F0OxjVEW9" resolve="NodeEquivalence" />
+            </node>
+            <node concept="2ShNRf" id="13oTmDlxaym" role="33vP2m">
+              <node concept="HV5vD" id="13oTmDl_d$N" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="HV5vE" to="co:68F0OxjVEW9" resolve="NodeEquivalence" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="13oTmDlxayo" role="3cqZAp">
+          <node concept="3cpWsn" id="13oTmDlxayp" role="3cpWs9">
+            <property role="TrG5h" value="cls" />
+            <node concept="3Tqbb2" id="13oTmDlxayq" role="1tU5fm">
+              <ref role="ehGHo" to="tpee:fz12cDA" resolve="ClassConcept" />
+            </node>
+            <node concept="2OqwBi" id="13oTmDlxayr" role="33vP2m">
+              <node concept="2tJFMh" id="13oTmDlxays" role="2Oq$k0">
+                <node concept="ZC_QK" id="13oTmDlxayt" role="2tJFKM">
+                  <ref role="2aWVGs" to="co:5wNjLS4lSKq" resolve="EquivalenceHashSet" />
+                </node>
+              </node>
+              <node concept="Vyspw" id="13oTmDlxayu" role="2OqNvi">
+                <node concept="2OqwBi" id="13oTmDlxayv" role="Vysub">
+                  <node concept="1jGwE1" id="13oTmDlxayw" role="2Oq$k0" />
+                  <node concept="liA8E" id="13oTmDlxayx" role="2OqNvi">
+                    <ref role="37wK5l" to="mhbf:~SModel.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3vlDli" id="13oTmDlxepo" role="3cqZAp">
+          <node concept="2OqwBi" id="13oTmDlxexs" role="3tpDZB">
+            <node concept="37vLTw" id="13oTmDlxext" role="2Oq$k0">
+              <ref role="3cqZAo" node="13oTmDlxayk" resolve="equivalence" />
+            </node>
+            <node concept="liA8E" id="13oTmDlxexu" role="2OqNvi">
+              <ref role="37wK5l" to="gyfg:~Equivalence.hash(java.lang.Object)" resolve="hash" />
+              <node concept="37vLTw" id="13oTmDlxexv" role="37wK5m">
+                <ref role="3cqZAo" node="13oTmDlxayp" resolve="cls" />
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="13oTmDlxeEM" role="3tpDZA">
+            <node concept="37vLTw" id="13oTmDlxeEN" role="2Oq$k0">
+              <ref role="3cqZAo" node="13oTmDlxayk" resolve="equivalence" />
+            </node>
+            <node concept="liA8E" id="13oTmDlxeEO" role="2OqNvi">
+              <ref role="37wK5l" to="gyfg:~Equivalence.hash(java.lang.Object)" resolve="hash" />
+              <node concept="2OqwBi" id="13oTmDl$bSU" role="37wK5m">
+                <node concept="37vLTw" id="13oTmDl$bvT" role="2Oq$k0">
+                  <ref role="3cqZAo" node="13oTmDlxayp" resolve="cls" />
+                </node>
+                <node concept="1$rogu" id="13oTmDl$cM6" role="2OqNvi" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="6uHwNxleLUE" role="1SL9yI">
+      <property role="TrG5h" value="sameStructure3" />
+      <node concept="3cqZAl" id="6uHwNxleLUF" role="3clF45" />
+      <node concept="3clFbS" id="6uHwNxleLUG" role="3clF47">
+        <node concept="3cpWs8" id="6uHwNxleLUH" role="3cqZAp">
+          <node concept="3cpWsn" id="6uHwNxleLUI" role="3cpWs9">
+            <property role="TrG5h" value="equivalence" />
+            <node concept="3uibUv" id="6uHwNxleLUJ" role="1tU5fm">
+              <ref role="3uigEE" to="co:68F0OxjVEW9" resolve="NodeEquivalence" />
+            </node>
+            <node concept="2ShNRf" id="6uHwNxleLUK" role="33vP2m">
+              <node concept="HV5vD" id="6uHwNxleLUL" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="HV5vE" to="co:68F0OxjVEW9" resolve="NodeEquivalence" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="6uHwNxleLUM" role="3cqZAp">
+          <node concept="3cpWsn" id="6uHwNxleLUN" role="3cpWs9">
+            <property role="TrG5h" value="cls" />
+            <node concept="3Tqbb2" id="6uHwNxleLUO" role="1tU5fm">
+              <ref role="ehGHo" to="tp5g:hHlH9T6" resolve="NodesTestCase" />
+            </node>
+            <node concept="2OqwBi" id="6uHwNxleLUP" role="33vP2m">
+              <node concept="2tJFMh" id="6uHwNxleLUQ" role="2Oq$k0">
+                <node concept="ZC_QK" id="6uHwNxleLUR" role="2tJFKM">
+                  <ref role="2aWVGs" node="13oTmDlxaxG" resolve="HashCode" />
+                </node>
+              </node>
+              <node concept="Vyspw" id="6uHwNxleLUS" role="2OqNvi">
+                <node concept="2OqwBi" id="6uHwNxleLUT" role="Vysub">
+                  <node concept="1jGwE1" id="6uHwNxleLUU" role="2Oq$k0" />
+                  <node concept="liA8E" id="6uHwNxleLUV" role="2OqNvi">
+                    <ref role="37wK5l" to="mhbf:~SModel.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3vlDli" id="6uHwNxleLUW" role="3cqZAp">
+          <node concept="2OqwBi" id="6uHwNxleLUX" role="3tpDZB">
+            <node concept="37vLTw" id="6uHwNxleLUY" role="2Oq$k0">
+              <ref role="3cqZAo" node="6uHwNxleLUI" resolve="equivalence" />
+            </node>
+            <node concept="liA8E" id="6uHwNxleLUZ" role="2OqNvi">
+              <ref role="37wK5l" to="gyfg:~Equivalence.hash(java.lang.Object)" resolve="hash" />
+              <node concept="37vLTw" id="6uHwNxleLV0" role="37wK5m">
+                <ref role="3cqZAo" node="6uHwNxleLUN" resolve="cls" />
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="6uHwNxleLV1" role="3tpDZA">
+            <node concept="37vLTw" id="6uHwNxleLV2" role="2Oq$k0">
+              <ref role="3cqZAo" node="6uHwNxleLUI" resolve="equivalence" />
+            </node>
+            <node concept="liA8E" id="6uHwNxleLV3" role="2OqNvi">
+              <ref role="37wK5l" to="gyfg:~Equivalence.hash(java.lang.Object)" resolve="hash" />
+              <node concept="2OqwBi" id="6uHwNxleLV4" role="37wK5m">
+                <node concept="37vLTw" id="6uHwNxleLV5" role="2Oq$k0">
+                  <ref role="3cqZAo" node="6uHwNxleLUN" resolve="cls" />
+                </node>
+                <node concept="1$rogu" id="6uHwNxleLV6" role="2OqNvi" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="13oTmDlxayJ" role="1SL9yI">
+      <property role="TrG5h" value="differentStructure" />
+      <node concept="3cqZAl" id="13oTmDlxayK" role="3clF45" />
+      <node concept="3clFbS" id="13oTmDlxayL" role="3clF47">
+        <node concept="3cpWs8" id="13oTmDlxayM" role="3cqZAp">
+          <node concept="3cpWsn" id="13oTmDlxayN" role="3cpWs9">
+            <property role="TrG5h" value="equivalence" />
+            <node concept="3uibUv" id="13oTmDlxayO" role="1tU5fm">
+              <ref role="3uigEE" to="co:68F0OxjVEW9" resolve="NodeEquivalence" />
+            </node>
+            <node concept="2ShNRf" id="13oTmDlxayP" role="33vP2m">
+              <node concept="HV5vD" id="13oTmDl_dM9" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="HV5vE" to="co:68F0OxjVEW9" resolve="NodeEquivalence" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="13oTmDlxayR" role="3cqZAp">
+          <node concept="3cpWsn" id="13oTmDlxayS" role="3cpWs9">
+            <property role="TrG5h" value="cl1" />
+            <node concept="3Tqbb2" id="13oTmDlxayT" role="1tU5fm">
+              <ref role="ehGHo" to="tpee:fz12cDA" resolve="ClassConcept" />
+            </node>
+            <node concept="2pJPEk" id="13oTmDlxayU" role="33vP2m">
+              <node concept="2pJPED" id="13oTmDlxayV" role="2pJPEn">
+                <ref role="2pJxaS" to="tpee:fz12cDA" resolve="ClassConcept" />
+                <node concept="2pJxcG" id="13oTmDlxayW" role="2pJxcM">
+                  <ref role="2pJxcJ" to="tpck:h0TrG11" resolve="name" />
+                  <node concept="WxPPo" id="13oTmDlxayX" role="28ntcv">
+                    <node concept="Xl_RD" id="13oTmDlxayY" role="WxPPp">
+                      <property role="Xl_RC" value="Cls" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="13oTmDlxayZ" role="3cqZAp">
+          <node concept="3cpWsn" id="13oTmDlxaz0" role="3cpWs9">
+            <property role="TrG5h" value="cl2" />
+            <node concept="3Tqbb2" id="13oTmDlxaz1" role="1tU5fm">
+              <ref role="ehGHo" to="tpee:fz12cDA" resolve="ClassConcept" />
+            </node>
+            <node concept="2pJPEk" id="13oTmDlxaz2" role="33vP2m">
+              <node concept="2pJPED" id="13oTmDlxaz3" role="2pJPEn">
+                <ref role="2pJxaS" to="tpee:fz12cDA" resolve="ClassConcept" />
+                <node concept="2pJxcG" id="13oTmDlxaz4" role="2pJxcM">
+                  <ref role="2pJxcJ" to="tpck:h0TrG11" resolve="name" />
+                  <node concept="WxPPo" id="13oTmDlxaz5" role="28ntcv">
+                    <node concept="Xl_RD" id="13oTmDlxaz6" role="WxPPp">
+                      <property role="Xl_RC" value="Cls2" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3vFxKo" id="13oTmDlxgHv" role="3cqZAp">
+          <node concept="17R0WA" id="13oTmDlxj3a" role="3vFALc">
+            <node concept="2OqwBi" id="13oTmDlxgOC" role="3uHU7B">
+              <node concept="37vLTw" id="13oTmDlxgOD" role="2Oq$k0">
+                <ref role="3cqZAo" node="13oTmDlxayN" resolve="equivalence" />
+              </node>
+              <node concept="liA8E" id="13oTmDlxgOE" role="2OqNvi">
+                <ref role="37wK5l" to="gyfg:~Equivalence.hash(java.lang.Object)" resolve="hash" />
+                <node concept="37vLTw" id="13oTmDlxgOF" role="37wK5m">
+                  <ref role="3cqZAo" node="13oTmDlxayS" resolve="cl1" />
+                </node>
+              </node>
+            </node>
+            <node concept="2OqwBi" id="13oTmDlxj6u" role="3uHU7w">
+              <node concept="37vLTw" id="13oTmDlxj6v" role="2Oq$k0">
+                <ref role="3cqZAo" node="13oTmDlxayN" resolve="equivalence" />
+              </node>
+              <node concept="liA8E" id="13oTmDlxj6w" role="2OqNvi">
+                <ref role="37wK5l" to="gyfg:~Equivalence.hash(java.lang.Object)" resolve="hash" />
+                <node concept="37vLTw" id="13oTmDlxj6x" role="37wK5m">
+                  <ref role="3cqZAo" node="13oTmDlxaz0" resolve="cl2" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="1lH9Xt" id="4JmsWjE0V8_">
+    <property role="3DII0k" value="2hh8MJdVwqX/command" />
+    <property role="TrG5h" value="NSet" />
+    <node concept="1LZb2c" id="4JmsWjE0V8A" role="1SL9yI">
+      <property role="TrG5h" value="sameStructure" />
+      <node concept="3cqZAl" id="4JmsWjE0V8B" role="3clF45" />
+      <node concept="3clFbS" id="4JmsWjE0V8C" role="3clF47">
+        <node concept="3cpWs8" id="4JmsWjE0V8D" role="3cqZAp">
+          <node concept="3cpWsn" id="4JmsWjE0V8E" role="3cpWs9">
+            <property role="TrG5h" value="equivalence" />
+            <node concept="3uibUv" id="4JmsWjE0V8F" role="1tU5fm">
+              <ref role="3uigEE" to="co:68F0OxjVEW9" resolve="NodeEquivalence" />
+            </node>
+            <node concept="2ShNRf" id="4JmsWjE0V8G" role="33vP2m">
+              <node concept="HV5vD" id="4JmsWjE0V8H" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="HV5vE" to="co:68F0OxjVEW9" resolve="NodeEquivalence" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="4JmsWjE0V8I" role="3cqZAp">
+          <node concept="3cpWsn" id="4JmsWjE0V8J" role="3cpWs9">
+            <property role="TrG5h" value="cl1" />
+            <node concept="3Tqbb2" id="4JmsWjE0V8K" role="1tU5fm">
+              <ref role="ehGHo" to="tpee:fz12cDA" resolve="ClassConcept" />
+            </node>
+            <node concept="2pJPEk" id="4JmsWjE0V8L" role="33vP2m">
+              <node concept="2pJPED" id="4JmsWjE0V8M" role="2pJPEn">
+                <ref role="2pJxaS" to="tpee:fz12cDA" resolve="ClassConcept" />
+                <node concept="2pJxcG" id="4JmsWjE0V8N" role="2pJxcM">
+                  <ref role="2pJxcJ" to="tpck:h0TrG11" resolve="name" />
+                  <node concept="WxPPo" id="4JmsWjE0V8O" role="28ntcv">
+                    <node concept="Xl_RD" id="4JmsWjE0V8P" role="WxPPp">
+                      <property role="Xl_RC" value="Cls" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="4JmsWjE0V8Q" role="3cqZAp">
+          <node concept="3cpWsn" id="4JmsWjE0V8R" role="3cpWs9">
+            <property role="TrG5h" value="cl2" />
+            <node concept="3Tqbb2" id="4JmsWjE0V8S" role="1tU5fm">
+              <ref role="ehGHo" to="tpee:fz12cDA" resolve="ClassConcept" />
+            </node>
+            <node concept="2pJPEk" id="4JmsWjE0V8T" role="33vP2m">
+              <node concept="2pJPED" id="4JmsWjE0V8U" role="2pJPEn">
+                <ref role="2pJxaS" to="tpee:fz12cDA" resolve="ClassConcept" />
+                <node concept="2pJxcG" id="4JmsWjE0V8V" role="2pJxcM">
+                  <ref role="2pJxcJ" to="tpck:h0TrG11" resolve="name" />
+                  <node concept="WxPPo" id="4JmsWjE0V8W" role="28ntcv">
+                    <node concept="Xl_RD" id="4JmsWjE0V8X" role="WxPPp">
+                      <property role="Xl_RC" value="Cls" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3vwNmj" id="4JmsWjE0V8Y" role="3cqZAp">
+          <node concept="2OqwBi" id="4JmsWjE0V8Z" role="3vwVQn">
+            <node concept="2OqwBi" id="4JmsWjE0V90" role="2Oq$k0">
+              <node concept="37vLTw" id="4JmsWjE0V91" role="2Oq$k0">
+                <ref role="3cqZAo" node="4JmsWjE0V8E" resolve="equivalence" />
+              </node>
+              <node concept="liA8E" id="4JmsWjE0V92" role="2OqNvi">
+                <ref role="37wK5l" to="gyfg:~Equivalence.wrap(java.lang.Object)" resolve="wrap" />
+                <node concept="37vLTw" id="4JmsWjE0V93" role="37wK5m">
+                  <ref role="3cqZAo" node="4JmsWjE0V8J" resolve="cl1" />
+                </node>
+              </node>
+            </node>
+            <node concept="liA8E" id="4JmsWjE0V94" role="2OqNvi">
+              <ref role="37wK5l" to="gyfg:~Equivalence$Wrapper.equals(java.lang.Object)" resolve="equals" />
+              <node concept="2OqwBi" id="4JmsWjE0V95" role="37wK5m">
+                <node concept="37vLTw" id="4JmsWjE0V96" role="2Oq$k0">
+                  <ref role="3cqZAo" node="4JmsWjE0V8E" resolve="equivalence" />
+                </node>
+                <node concept="liA8E" id="4JmsWjE0V97" role="2OqNvi">
+                  <ref role="37wK5l" to="gyfg:~Equivalence.wrap(java.lang.Object)" resolve="wrap" />
+                  <node concept="37vLTw" id="4JmsWjE0V98" role="37wK5m">
+                    <ref role="3cqZAo" node="4JmsWjE0V8R" resolve="cl2" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="4JmsWjE0V99" role="1SL9yI">
+      <property role="TrG5h" value="sameStructure2" />
+      <node concept="3cqZAl" id="4JmsWjE0V9a" role="3clF45" />
+      <node concept="3clFbS" id="4JmsWjE0V9b" role="3clF47">
+        <node concept="3cpWs8" id="4JmsWjE0V9c" role="3cqZAp">
+          <node concept="3cpWsn" id="4JmsWjE0V9d" role="3cpWs9">
+            <property role="TrG5h" value="equivalence" />
+            <node concept="3uibUv" id="4JmsWjE0V9e" role="1tU5fm">
+              <ref role="3uigEE" to="co:68F0OxjVEW9" resolve="NodeEquivalence" />
+            </node>
+            <node concept="2ShNRf" id="4JmsWjE0V9f" role="33vP2m">
+              <node concept="HV5vD" id="4JmsWjE0V9g" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="HV5vE" to="co:68F0OxjVEW9" resolve="NodeEquivalence" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="4JmsWjE0V9h" role="3cqZAp">
+          <node concept="3cpWsn" id="4JmsWjE0V9i" role="3cpWs9">
+            <property role="TrG5h" value="cls" />
+            <node concept="3Tqbb2" id="4JmsWjE0V9j" role="1tU5fm">
+              <ref role="ehGHo" to="tpee:fz12cDA" resolve="ClassConcept" />
+            </node>
+            <node concept="2OqwBi" id="4JmsWjE0V9k" role="33vP2m">
+              <node concept="2tJFMh" id="4JmsWjE0V9l" role="2Oq$k0">
+                <node concept="ZC_QK" id="4JmsWjE0V9m" role="2tJFKM">
+                  <ref role="2aWVGs" to="co:5wNjLS4lSKq" resolve="EquivalenceHashSet" />
+                </node>
+              </node>
+              <node concept="Vyspw" id="4JmsWjE0V9n" role="2OqNvi">
+                <node concept="2OqwBi" id="4JmsWjE0V9o" role="Vysub">
+                  <node concept="1jGwE1" id="4JmsWjE0V9p" role="2Oq$k0" />
+                  <node concept="liA8E" id="4JmsWjE0V9q" role="2OqNvi">
+                    <ref role="37wK5l" to="mhbf:~SModel.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3vwNmj" id="4JmsWjE0V9r" role="3cqZAp">
+          <node concept="2OqwBi" id="4JmsWjE0V9s" role="3vwVQn">
+            <node concept="2OqwBi" id="4JmsWjE0V9t" role="2Oq$k0">
+              <node concept="37vLTw" id="4JmsWjE0V9u" role="2Oq$k0">
+                <ref role="3cqZAo" node="4JmsWjE0V9d" resolve="equivalence" />
+              </node>
+              <node concept="liA8E" id="4JmsWjE0V9v" role="2OqNvi">
+                <ref role="37wK5l" to="gyfg:~Equivalence.wrap(java.lang.Object)" resolve="wrap" />
+                <node concept="37vLTw" id="4JmsWjE0V9w" role="37wK5m">
+                  <ref role="3cqZAo" node="4JmsWjE0V9i" resolve="cls" />
+                </node>
+              </node>
+            </node>
+            <node concept="liA8E" id="4JmsWjE0V9x" role="2OqNvi">
+              <ref role="37wK5l" to="gyfg:~Equivalence$Wrapper.equals(java.lang.Object)" resolve="equals" />
+              <node concept="2OqwBi" id="4JmsWjE0V9y" role="37wK5m">
+                <node concept="37vLTw" id="4JmsWjE0V9z" role="2Oq$k0">
+                  <ref role="3cqZAo" node="4JmsWjE0V9d" resolve="equivalence" />
+                </node>
+                <node concept="liA8E" id="4JmsWjE0V9$" role="2OqNvi">
+                  <ref role="37wK5l" to="gyfg:~Equivalence.wrap(java.lang.Object)" resolve="wrap" />
+                  <node concept="2OqwBi" id="4JmsWjE0V9_" role="37wK5m">
+                    <node concept="37vLTw" id="4JmsWjE0V9A" role="2Oq$k0">
+                      <ref role="3cqZAo" node="4JmsWjE0V9i" resolve="cls" />
+                    </node>
+                    <node concept="1$rogu" id="4JmsWjE0V9B" role="2OqNvi" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="4JmsWjE0V9C" role="1SL9yI">
+      <property role="TrG5h" value="differentStructure" />
+      <node concept="3cqZAl" id="4JmsWjE0V9D" role="3clF45" />
+      <node concept="3clFbS" id="4JmsWjE0V9E" role="3clF47">
+        <node concept="3cpWs8" id="4JmsWjE0V9F" role="3cqZAp">
+          <node concept="3cpWsn" id="4JmsWjE0V9G" role="3cpWs9">
+            <property role="TrG5h" value="equivalence" />
+            <node concept="3uibUv" id="4JmsWjE0V9H" role="1tU5fm">
+              <ref role="3uigEE" to="co:68F0OxjVEW9" resolve="NodeEquivalence" />
+            </node>
+            <node concept="2ShNRf" id="4JmsWjE0V9I" role="33vP2m">
+              <node concept="HV5vD" id="4JmsWjE0V9J" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="HV5vE" to="co:68F0OxjVEW9" resolve="NodeEquivalence" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="4JmsWjE0V9K" role="3cqZAp">
+          <node concept="3cpWsn" id="4JmsWjE0V9L" role="3cpWs9">
+            <property role="TrG5h" value="cl1" />
+            <node concept="3Tqbb2" id="4JmsWjE0V9M" role="1tU5fm">
+              <ref role="ehGHo" to="tpee:fz12cDA" resolve="ClassConcept" />
+            </node>
+            <node concept="2pJPEk" id="4JmsWjE0V9N" role="33vP2m">
+              <node concept="2pJPED" id="4JmsWjE0V9O" role="2pJPEn">
+                <ref role="2pJxaS" to="tpee:fz12cDA" resolve="ClassConcept" />
+                <node concept="2pJxcG" id="4JmsWjE0V9P" role="2pJxcM">
+                  <ref role="2pJxcJ" to="tpck:h0TrG11" resolve="name" />
+                  <node concept="WxPPo" id="4JmsWjE0V9Q" role="28ntcv">
+                    <node concept="Xl_RD" id="4JmsWjE0V9R" role="WxPPp">
+                      <property role="Xl_RC" value="Cls" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="4JmsWjE0V9S" role="3cqZAp">
+          <node concept="3cpWsn" id="4JmsWjE0V9T" role="3cpWs9">
+            <property role="TrG5h" value="cl2" />
+            <node concept="3Tqbb2" id="4JmsWjE0V9U" role="1tU5fm">
+              <ref role="ehGHo" to="tpee:fz12cDA" resolve="ClassConcept" />
+            </node>
+            <node concept="2pJPEk" id="4JmsWjE0V9V" role="33vP2m">
+              <node concept="2pJPED" id="4JmsWjE0V9W" role="2pJPEn">
+                <ref role="2pJxaS" to="tpee:fz12cDA" resolve="ClassConcept" />
+                <node concept="2pJxcG" id="4JmsWjE0V9X" role="2pJxcM">
+                  <ref role="2pJxcJ" to="tpck:h0TrG11" resolve="name" />
+                  <node concept="WxPPo" id="4JmsWjE0V9Y" role="28ntcv">
+                    <node concept="Xl_RD" id="4JmsWjE0V9Z" role="WxPPp">
+                      <property role="Xl_RC" value="Cls2" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3vFxKo" id="4JmsWjE0Va0" role="3cqZAp">
+          <node concept="2OqwBi" id="4JmsWjE0Va1" role="3vFALc">
+            <node concept="2OqwBi" id="4JmsWjE0Va2" role="2Oq$k0">
+              <node concept="37vLTw" id="4JmsWjE0Va3" role="2Oq$k0">
+                <ref role="3cqZAo" node="4JmsWjE0V9G" resolve="equivalence" />
+              </node>
+              <node concept="liA8E" id="4JmsWjE0Va4" role="2OqNvi">
+                <ref role="37wK5l" to="gyfg:~Equivalence.wrap(java.lang.Object)" resolve="wrap" />
+                <node concept="37vLTw" id="4JmsWjE0Va5" role="37wK5m">
+                  <ref role="3cqZAo" node="4JmsWjE0V9L" resolve="cl1" />
+                </node>
+              </node>
+            </node>
+            <node concept="liA8E" id="4JmsWjE0Va6" role="2OqNvi">
+              <ref role="37wK5l" to="gyfg:~Equivalence$Wrapper.equals(java.lang.Object)" resolve="equals" />
+              <node concept="2OqwBi" id="4JmsWjE0Va7" role="37wK5m">
+                <node concept="37vLTw" id="4JmsWjE0Va8" role="2Oq$k0">
+                  <ref role="3cqZAo" node="4JmsWjE0V9G" resolve="equivalence" />
+                </node>
+                <node concept="liA8E" id="4JmsWjE0Va9" role="2OqNvi">
+                  <ref role="37wK5l" to="gyfg:~Equivalence.wrap(java.lang.Object)" resolve="wrap" />
+                  <node concept="37vLTw" id="4JmsWjE0Vaa" role="37wK5m">
+                    <ref role="3cqZAo" node="4JmsWjE0V9T" resolve="cl2" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="4JmsWjE0Xnp" role="1SKRRt">
+      <node concept="9aQIb" id="4JmsWjE0Xnn" role="1qenE9">
+        <node concept="3clFbS" id="4JmsWjE0Xno" role="9aQI4">
+          <node concept="3cpWs8" id="4JmsWjE0X_R" role="3cqZAp">
+            <node concept="3cpWsn" id="4JmsWjE0Wtq" role="3cpWs9">
+              <property role="TrG5h" value="a1" />
+              <node concept="2ShNRf" id="4JmsWjE0Wy9" role="33vP2m">
+                <node concept="2y2FIT" id="4JmsWjE0WEs" role="2ShVmc">
+                  <node concept="1s3Imc" id="4JmsWjE0WEu" role="2y2FCL" />
+                </node>
+              </node>
+              <node concept="1s3Imc" id="4JmsWjE0Wxb" role="1tU5fm" />
+            </node>
+          </node>
+          <node concept="3cpWs8" id="4JmsWjE0Y1V" role="3cqZAp">
+            <node concept="3cpWsn" id="4JmsWjE0Y1Y" role="3cpWs9">
+              <property role="TrG5h" value="a2" />
+              <node concept="2ShNRf" id="4JmsWjE0Y1Z" role="33vP2m">
+                <node concept="2y2FIT" id="4JmsWjE0Y20" role="2ShVmc">
+                  <node concept="1s3Imc" id="4JmsWjE0Y21" role="2y2FCL" />
+                  <node concept="2ShNRf" id="4JmsWjE29Va" role="2y2Q$0">
+                    <node concept="32HrFt" id="4JmsWjE2ajl" role="2ShVmc" />
+                  </node>
+                </node>
+              </node>
+              <node concept="1s3Imc" id="4JmsWjE0Y22" role="1tU5fm" />
+            </node>
+          </node>
+          <node concept="3cpWs8" id="4JmsWjE1hyq" role="3cqZAp">
+            <node concept="3cpWsn" id="4JmsWjE1hyr" role="3cpWs9">
+              <property role="TrG5h" value="a3" />
+              <node concept="2ShNRf" id="4JmsWjE1hys" role="33vP2m">
+                <node concept="2y2FIT" id="4JmsWjE1hyt" role="2ShVmc">
+                  <node concept="1s3Imc" id="4JmsWjE1hyu" role="2y2FCL" />
+                  <node concept="2ShNRf" id="4JmsWjE1h_d" role="2y2Q$0">
+                    <node concept="32HrFt" id="4JmsWjE1hMl" role="2ShVmc">
+                      <node concept="3Tqbb2" id="4JmsWjE1jE9" role="HW$YZ" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="1s3Imc" id="4JmsWjE1hyv" role="1tU5fm" />
+            </node>
+          </node>
+          <node concept="3cpWs8" id="4JmsWjE1hNp" role="3cqZAp">
+            <node concept="3cpWsn" id="4JmsWjE1hNq" role="3cpWs9">
+              <property role="TrG5h" value="a4" />
+              <node concept="2ShNRf" id="4JmsWjE1hNr" role="33vP2m">
+                <node concept="2y2FIT" id="4JmsWjE1hNs" role="2ShVmc">
+                  <node concept="1s3Imc" id="4JmsWjE1hNt" role="2y2FCL" />
+                  <node concept="2ShNRf" id="4JmsWjE1hNu" role="2y2Q$0">
+                    <node concept="32HrFt" id="4JmsWjE1hNv" role="2ShVmc">
+                      <node concept="3Tqbb2" id="4JmsWjE1inh" role="HW$YZ">
+                        <ref role="ehGHo" to="tpee:fz12cDA" resolve="ClassConcept" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="1s3Imc" id="4JmsWjE1hNw" role="1tU5fm" />
+            </node>
+          </node>
+          <node concept="3cpWs8" id="4JmsWjE0XAR" role="3cqZAp">
+            <node concept="3cpWsn" id="4JmsWjE0XAU" role="3cpWs9">
+              <property role="TrG5h" value="b1" />
+              <node concept="2ShNRf" id="4JmsWjE0XAV" role="33vP2m">
+                <node concept="2y2FIT" id="4JmsWjE0XAW" role="2ShVmc">
+                  <node concept="1s3Imc" id="4JmsWjE0XAX" role="2y2FCL">
+                    <ref role="2I9WkF" to="tpee:fz12cDA" resolve="ClassConcept" />
+                  </node>
+                </node>
+              </node>
+              <node concept="1s3Imc" id="4JmsWjE0XAY" role="1tU5fm">
+                <ref role="2I9WkF" to="tpee:fz12cDA" resolve="ClassConcept" />
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs8" id="4JmsWjE1qkb" role="3cqZAp">
+            <node concept="3cpWsn" id="4JmsWjE1qkc" role="3cpWs9">
+              <property role="TrG5h" value="b2" />
+              <node concept="2ShNRf" id="4JmsWjE1qkd" role="33vP2m">
+                <node concept="2y2FIT" id="4JmsWjE1qke" role="2ShVmc">
+                  <node concept="1s3Imc" id="4JmsWjE1qkf" role="2y2FCL">
+                    <ref role="2I9WkF" to="tpee:fz12cDA" resolve="ClassConcept" />
+                  </node>
+                  <node concept="2ShNRf" id="4JmsWjE1qkg" role="2y2Q$0">
+                    <node concept="32HrFt" id="4JmsWjE1qkh" role="2ShVmc">
+                      <node concept="3Tqbb2" id="4JmsWjE1qki" role="HW$YZ">
+                        <ref role="ehGHo" to="tpee:fz12cDA" resolve="ClassConcept" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="1s3Imc" id="4JmsWjE1qkj" role="1tU5fm">
+                <ref role="2I9WkF" to="tpee:fz12cDA" resolve="ClassConcept" />
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs8" id="4JmsWjE0ZPH" role="3cqZAp">
+            <node concept="3cpWsn" id="4JmsWjE0ZPI" role="3cpWs9">
+              <property role="TrG5h" value="c1" />
+              <node concept="2ShNRf" id="4JmsWjE0ZPJ" role="33vP2m">
+                <node concept="2y2FIT" id="4JmsWjE0ZPK" role="2ShVmc">
+                  <node concept="1s3Imc" id="4JmsWjE0ZPL" role="2y2FCL">
+                    <ref role="2I9WkF" to="tpee:fz12cDA" resolve="ClassConcept" />
+                  </node>
+                </node>
+              </node>
+              <node concept="1s3Imc" id="4JmsWjE0ZPM" role="1tU5fm" />
+            </node>
+          </node>
+          <node concept="3cpWs8" id="4JmsWjE1YjF" role="3cqZAp">
+            <node concept="3cpWsn" id="4JmsWjE1YjG" role="3cpWs9">
+              <property role="TrG5h" value="c2" />
+              <node concept="2ShNRf" id="4JmsWjE1YjH" role="33vP2m">
+                <node concept="2y2FIT" id="4JmsWjE1YjI" role="2ShVmc">
+                  <node concept="1s3Imc" id="4JmsWjE1YjJ" role="2y2FCL">
+                    <ref role="2I9WkF" to="tpee:fz12cDA" resolve="ClassConcept" />
+                  </node>
+                  <node concept="2ShNRf" id="4JmsWjE1YjK" role="2y2Q$0">
+                    <node concept="32HrFt" id="4JmsWjE1YjL" role="2ShVmc">
+                      <node concept="3Tqbb2" id="4JmsWjE1YjM" role="HW$YZ">
+                        <ref role="ehGHo" to="tpee:fz12cDA" resolve="ClassConcept" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="1s3Imc" id="4JmsWjE1YjN" role="1tU5fm" />
+            </node>
+          </node>
+          <node concept="3cpWs8" id="4JmsWjE8Hmf" role="3cqZAp">
+            <node concept="3cpWsn" id="4JmsWjE8Hmi" role="3cpWs9">
+              <property role="TrG5h" value="d1" />
+              <node concept="1s3Imc" id="4JmsWjE8Hmd" role="1tU5fm" />
+              <node concept="2ShNRf" id="4JmsWjE8HmC" role="33vP2m">
+                <node concept="2i4dXS" id="4JmsWjE8Hvi" role="2ShVmc">
+                  <node concept="3Tqbb2" id="4JmsWjE8IQb" role="HW$YZ" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs8" id="4JmsWjElRk5" role="3cqZAp">
+            <node concept="3cpWsn" id="4JmsWjElRk6" role="3cpWs9">
+              <property role="TrG5h" value="d2" />
+              <node concept="1s3Imc" id="4JmsWjElRk7" role="1tU5fm">
+                <ref role="2I9WkF" to="tpee:fz12cDA" resolve="ClassConcept" />
+              </node>
+              <node concept="2ShNRf" id="4JmsWjElRk8" role="33vP2m">
+                <node concept="2i4dXS" id="4JmsWjElRk9" role="2ShVmc">
+                  <node concept="3Tqbb2" id="4JmsWjElRka" role="HW$YZ">
+                    <ref role="ehGHo" to="tpee:fz12cDA" resolve="ClassConcept" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs8" id="4JmsWjElSAG" role="3cqZAp">
+            <node concept="3cpWsn" id="4JmsWjElSAH" role="3cpWs9">
+              <property role="TrG5h" value="d3" />
+              <node concept="1s3Imc" id="4JmsWjElSAI" role="1tU5fm" />
+              <node concept="2ShNRf" id="4JmsWjElSAJ" role="33vP2m">
+                <node concept="2i4dXS" id="4JmsWjElSAK" role="2ShVmc">
+                  <node concept="3Tqbb2" id="4JmsWjElSAL" role="HW$YZ">
+                    <ref role="ehGHo" to="tpee:fz12cDA" resolve="ClassConcept" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs8" id="4JmsWjE8Nux" role="3cqZAp">
+            <node concept="3cpWsn" id="4JmsWjE8Nuy" role="3cpWs9">
+              <property role="TrG5h" value="f1" />
+              <node concept="2hMVRd" id="4JmsWjE8NQu" role="1tU5fm">
+                <node concept="3Tqbb2" id="4JmsWjE8OuH" role="2hN53Y" />
+              </node>
+              <node concept="2ShNRf" id="4JmsWjE8Owk" role="33vP2m">
+                <node concept="2y2FIT" id="4JmsWjE8OD6" role="2ShVmc">
+                  <node concept="1s3Imc" id="4JmsWjE8OD8" role="2y2FCL" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs8" id="4JmsWjE8PtY" role="3cqZAp">
+            <node concept="3cpWsn" id="4JmsWjE8PtZ" role="3cpWs9">
+              <property role="TrG5h" value="f2" />
+              <node concept="2hMVRd" id="4JmsWjE8Pu0" role="1tU5fm">
+                <node concept="3Tqbb2" id="4JmsWjE8Pu1" role="2hN53Y">
+                  <ref role="ehGHo" to="tpee:fz12cDA" resolve="ClassConcept" />
+                </node>
+              </node>
+              <node concept="2ShNRf" id="4JmsWjE8Pu2" role="33vP2m">
+                <node concept="2y2FIT" id="4JmsWjE8Pu3" role="2ShVmc">
+                  <node concept="1s3Imc" id="4JmsWjE8Pu4" role="2y2FCL">
+                    <ref role="2I9WkF" to="tpee:fz12cDA" resolve="ClassConcept" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="7CXmI" id="4JmsWjE0X$Y" role="lGtFl">
+          <node concept="7OXhh" id="4JmsWjE0X_w" role="7EUXB">
+            <property role="GvXf4" value="true" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="4JmsWjE0XOu" role="1SKRRt">
+      <node concept="9aQIb" id="4JmsWjE0Y1o" role="1qenE9">
+        <node concept="3clFbS" id="4JmsWjE0Y1p" role="9aQI4">
+          <node concept="3cpWs8" id="4JmsWjE2e2v" role="3cqZAp">
+            <node concept="3cpWsn" id="4JmsWjE2e2w" role="3cpWs9">
+              <property role="TrG5h" value="b0" />
+              <node concept="2ShNRf" id="4JmsWjE2e2x" role="33vP2m">
+                <node concept="2y2FIT" id="4JmsWjE2e2y" role="2ShVmc">
+                  <node concept="1s3Imc" id="4JmsWjE2e2z" role="2y2FCL">
+                    <ref role="2I9WkF" to="tpee:fz12cDA" resolve="ClassConcept" />
+                  </node>
+                  <node concept="2ShNRf" id="4JmsWjE2e2$" role="2y2Q$0">
+                    <node concept="32HrFt" id="4JmsWjE2e2_" role="2ShVmc" />
+                    <node concept="7CXmI" id="4JmsWjE2e2A" role="lGtFl">
+                      <node concept="2DdRWr" id="4JmsWjE2e2B" role="7EUXB">
+                        <node concept="MGsTx" id="4JmsWjE2e2C" role="MJxsd">
+                          <ref role="39XzEq" to="tp2v:i4dA2T_" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="1s3Imc" id="4JmsWjE2e2D" role="1tU5fm" />
+            </node>
+          </node>
+          <node concept="3cpWs8" id="4JmsWjE1pvB" role="3cqZAp">
+            <node concept="3cpWsn" id="4JmsWjE1pvC" role="3cpWs9">
+              <property role="TrG5h" value="b1" />
+              <node concept="2ShNRf" id="4JmsWjE1pvD" role="33vP2m">
+                <node concept="2y2FIT" id="4JmsWjE1pvE" role="2ShVmc">
+                  <node concept="1s3Imc" id="4JmsWjE1pvF" role="2y2FCL">
+                    <ref role="2I9WkF" to="tpee:fz12cDA" resolve="ClassConcept" />
+                  </node>
+                  <node concept="2ShNRf" id="4JmsWjE1pyK" role="2y2Q$0">
+                    <node concept="32HrFt" id="4JmsWjE1pKd" role="2ShVmc">
+                      <node concept="3Tqbb2" id="4JmsWjE1qiX" role="HW$YZ" />
+                    </node>
+                    <node concept="7CXmI" id="4JmsWjE3xYy" role="lGtFl">
+                      <node concept="2DdRWr" id="4JmsWjE3zhF" role="7EUXB">
+                        <node concept="MGsTx" id="4JmsWjE3zhG" role="MJxsd">
+                          <ref role="39XzEq" to="tp2v:i4dA2T_" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="1s3Imc" id="4JmsWjE1pvG" role="1tU5fm">
+                <ref role="2I9WkF" to="tpee:fz12cDA" resolve="ClassConcept" />
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs8" id="4JmsWjE2e2E" role="3cqZAp">
+            <node concept="3cpWsn" id="4JmsWjE2e2F" role="3cpWs9">
+              <property role="TrG5h" value="c0" />
+              <node concept="2ShNRf" id="4JmsWjE2e2G" role="33vP2m">
+                <node concept="2y2FIT" id="4JmsWjE2e2H" role="2ShVmc">
+                  <node concept="1s3Imc" id="4JmsWjE2e2I" role="2y2FCL">
+                    <ref role="2I9WkF" to="tpee:fz12cDA" resolve="ClassConcept" />
+                  </node>
+                  <node concept="2ShNRf" id="4JmsWjE2e2J" role="2y2Q$0">
+                    <node concept="32HrFt" id="4JmsWjE2e2K" role="2ShVmc" />
+                    <node concept="7CXmI" id="4JmsWjE2e2L" role="lGtFl">
+                      <node concept="2DdRWr" id="4JmsWjE2e2M" role="7EUXB">
+                        <node concept="MGsTx" id="4JmsWjE2e2N" role="MJxsd">
+                          <ref role="39XzEq" to="tp2v:i4dA2T_" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="1s3Imc" id="4JmsWjE2e2O" role="1tU5fm" />
+            </node>
+          </node>
+          <node concept="3cpWs8" id="4JmsWjE1R$P" role="3cqZAp">
+            <node concept="3cpWsn" id="4JmsWjE1R$Q" role="3cpWs9">
+              <property role="TrG5h" value="c1" />
+              <node concept="2ShNRf" id="4JmsWjE1R$R" role="33vP2m">
+                <node concept="2y2FIT" id="4JmsWjE1R$S" role="2ShVmc">
+                  <node concept="1s3Imc" id="4JmsWjE1R$T" role="2y2FCL">
+                    <ref role="2I9WkF" to="tpee:fz12cDA" resolve="ClassConcept" />
+                  </node>
+                  <node concept="2ShNRf" id="4JmsWjE1T6U" role="2y2Q$0">
+                    <node concept="32HrFt" id="4JmsWjE1Ucm" role="2ShVmc">
+                      <node concept="3Tqbb2" id="4JmsWjE1Wtt" role="HW$YZ" />
+                    </node>
+                    <node concept="7CXmI" id="4JmsWjE3zjI" role="lGtFl">
+                      <node concept="2DdRWr" id="4JmsWjE3$BA" role="7EUXB">
+                        <node concept="MGsTx" id="4JmsWjE3$BB" role="MJxsd">
+                          <ref role="39XzEq" to="tp2v:i4dA2T_" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="1s3Imc" id="4JmsWjE1R$U" role="1tU5fm" />
+            </node>
+          </node>
+          <node concept="3cpWs8" id="4JmsWjE2k9s" role="3cqZAp">
+            <node concept="3cpWsn" id="4JmsWjE2k9t" role="3cpWs9">
+              <property role="TrG5h" value="d0" />
+              <node concept="2ShNRf" id="4JmsWjE2k9u" role="33vP2m">
+                <node concept="2y2FIT" id="4JmsWjE2k9v" role="2ShVmc">
+                  <node concept="1s3Imc" id="4JmsWjE2k9w" role="2y2FCL" />
+                  <node concept="2ShNRf" id="4JmsWjE2k9x" role="2y2Q$0">
+                    <node concept="32HrFt" id="4JmsWjE2k9y" role="2ShVmc" />
+                  </node>
+                </node>
+              </node>
+              <node concept="1s3Imc" id="4JmsWjE2k9A" role="1tU5fm">
+                <ref role="2I9WkF" to="tpee:fz12cDA" resolve="ClassConcept" />
+              </node>
+              <node concept="7CXmI" id="4JmsWjE48m_" role="lGtFl">
+                <node concept="2DdRWr" id="4JmsWjE49NU" role="7EUXB">
+                  <node concept="MGsTx" id="4JmsWjE49NV" role="MJxsd">
+                    <ref role="39XzEq" to="tpeh:uLhuAXWPEq" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs8" id="4JmsWjE2m$o" role="3cqZAp">
+            <node concept="3cpWsn" id="4JmsWjE2m$p" role="3cpWs9">
+              <property role="TrG5h" value="e0" />
+              <node concept="2ShNRf" id="4JmsWjE2m$q" role="33vP2m">
+                <node concept="2y2FIT" id="4JmsWjE2m$r" role="2ShVmc">
+                  <node concept="1s3Imc" id="4JmsWjE2m$s" role="2y2FCL">
+                    <ref role="2I9WkF" to="tpee:fz12cDA" resolve="ClassConcept" />
+                  </node>
+                  <node concept="2ShNRf" id="4JmsWjE2m$t" role="2y2Q$0">
+                    <node concept="32HrFt" id="4JmsWjE2m$u" role="2ShVmc" />
+                    <node concept="7CXmI" id="4JmsWjE2m$v" role="lGtFl">
+                      <node concept="2DdRWr" id="4JmsWjE2m$w" role="7EUXB">
+                        <node concept="MGsTx" id="4JmsWjE2m$x" role="MJxsd">
+                          <ref role="39XzEq" to="tp2v:i4dA2T_" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="1s3Imc" id="4JmsWjE2m$y" role="1tU5fm">
+                <ref role="2I9WkF" to="tpee:fz12cDA" resolve="ClassConcept" />
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs8" id="4JmsWjE2n7X" role="3cqZAp">
+            <node concept="3cpWsn" id="4JmsWjE2n7Y" role="3cpWs9">
+              <property role="TrG5h" value="f0" />
+              <node concept="2ShNRf" id="4JmsWjE2n7Z" role="33vP2m">
+                <node concept="2y2FIT" id="4JmsWjE2n80" role="2ShVmc">
+                  <node concept="1s3Imc" id="4JmsWjE2n81" role="2y2FCL">
+                    <ref role="2I9WkF" to="tpee:fz12cDA" resolve="ClassConcept" />
+                  </node>
+                  <node concept="2ShNRf" id="4JmsWjE2n82" role="2y2Q$0">
+                    <node concept="32HrFt" id="4JmsWjE2n83" role="2ShVmc">
+                      <node concept="3Tqbb2" id="4JmsWjE2pfm" role="HW$YZ">
+                        <ref role="ehGHo" to="tpee:2FJPm3OfY71" resolve="AbstractCatchClause" />
+                      </node>
+                    </node>
+                    <node concept="7CXmI" id="4JmsWjE3$C8" role="lGtFl">
+                      <node concept="2DdRWr" id="4JmsWjE3_Vh" role="7EUXB">
+                        <node concept="MGsTx" id="4JmsWjE3_Vi" role="MJxsd">
+                          <ref role="39XzEq" to="tp2v:i4dA2T_" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="1s3Imc" id="4JmsWjE2n87" role="1tU5fm">
+                <ref role="2I9WkF" to="tpee:fz12cDA" resolve="ClassConcept" />
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs8" id="4JmsWjE91mI" role="3cqZAp">
+            <node concept="3cpWsn" id="4JmsWjE91mJ" role="3cpWs9">
+              <property role="TrG5h" value="g0" />
+              <node concept="2hMVRd" id="4JmsWjE91mK" role="1tU5fm">
+                <node concept="3Tqbb2" id="4JmsWjE91mL" role="2hN53Y">
+                  <ref role="ehGHo" to="tpee:fz12cDA" resolve="ClassConcept" />
+                </node>
+              </node>
+              <node concept="2ShNRf" id="4JmsWjE91mM" role="33vP2m">
+                <node concept="2y2FIT" id="4JmsWjE91mN" role="2ShVmc">
+                  <node concept="1s3Imc" id="4JmsWjE91mO" role="2y2FCL">
+                    <ref role="2I9WkF" to="tpee:2FJPm3OfY71" resolve="AbstractCatchClause" />
+                  </node>
+                </node>
+              </node>
+              <node concept="7CXmI" id="4JmsWjE91Ye" role="lGtFl">
+                <node concept="2DdRWr" id="4JmsWjE93Dj" role="7EUXB">
+                  <node concept="MGsTx" id="4JmsWjE93Dk" role="MJxsd">
+                    <ref role="39XzEq" to="wwkp:6DFN5BsWHZY" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs8" id="4JmsWjE94lx" role="3cqZAp">
+            <node concept="3cpWsn" id="4JmsWjE94ly" role="3cpWs9">
+              <property role="TrG5h" value="h0" />
+              <node concept="2hMVRd" id="4JmsWjE94lz" role="1tU5fm">
+                <node concept="3Tqbb2" id="4JmsWjE94l$" role="2hN53Y">
+                  <ref role="ehGHo" to="tpee:2FJPm3OfY71" resolve="AbstractCatchClause" />
+                </node>
+              </node>
+              <node concept="2ShNRf" id="4JmsWjE94l_" role="33vP2m">
+                <node concept="2y2FIT" id="4JmsWjE94lA" role="2ShVmc">
+                  <node concept="1s3Imc" id="4JmsWjE94lB" role="2y2FCL">
+                    <ref role="2I9WkF" to="tpee:fz12cDA" resolve="ClassConcept" />
+                  </node>
+                </node>
+              </node>
+              <node concept="7CXmI" id="4JmsWjE94lC" role="lGtFl">
+                <node concept="2DdRWr" id="4JmsWjE97et" role="7EUXB">
+                  <node concept="MGsTx" id="4JmsWjE97eu" role="MJxsd">
+                    <ref role="39XzEq" to="wwkp:6DFN5BsWHZY" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs8" id="4JmsWjElVF7" role="3cqZAp">
+            <node concept="3cpWsn" id="4JmsWjElVF8" role="3cpWs9">
+              <property role="TrG5h" value="i0" />
+              <node concept="1s3Imc" id="4JmsWjElVF9" role="1tU5fm">
+                <ref role="2I9WkF" to="tpee:fz12cDA" resolve="ClassConcept" />
+              </node>
+              <node concept="2ShNRf" id="4JmsWjElVFa" role="33vP2m">
+                <node concept="2i4dXS" id="4JmsWjElVFb" role="2ShVmc">
+                  <node concept="3Tqbb2" id="4JmsWjElVFc" role="HW$YZ" />
+                </node>
+              </node>
+              <node concept="7CXmI" id="4JmsWjElWZA" role="lGtFl">
+                <node concept="2DdRWr" id="4JmsWjElYG9" role="7EUXB">
+                  <node concept="MGsTx" id="4JmsWjElYGa" role="MJxsd">
+                    <ref role="39XzEq" to="wwkp:2z6Ep1mP26m" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="1lH9Xt" id="4JmsWjEaqOg">
+    <property role="3DII0k" value="2hh8MJdVwqX/command" />
+    <property role="TrG5h" value="NSetOperations" />
+    <node concept="2XrIbr" id="4JmsWjEaqOh" role="1qtyYc">
+      <property role="TrG5h" value="addMultipleTimes" />
+      <node concept="3cqZAl" id="4JmsWjEaqOi" role="3clF45" />
+      <node concept="3clFbS" id="4JmsWjEaqOj" role="3clF47">
+        <node concept="1Dw8fO" id="4JmsWjEaqOk" role="3cqZAp">
+          <node concept="3cpWsn" id="4JmsWjEaqOl" role="1Duv9x">
+            <property role="TrG5h" value="i" />
+            <node concept="10Oyi0" id="4JmsWjEaqOm" role="1tU5fm" />
+            <node concept="3cmrfG" id="4JmsWjEaqOn" role="33vP2m">
+              <property role="3cmrfH" value="0" />
+            </node>
+          </node>
+          <node concept="3clFbS" id="4JmsWjEaqOo" role="2LFqv$">
+            <node concept="3clFbF" id="4JmsWjEaqOp" role="3cqZAp">
+              <node concept="2OqwBi" id="4JmsWjEaqOq" role="3clFbG">
+                <node concept="37vLTw" id="4JmsWjEaqOr" role="2Oq$k0">
+                  <ref role="3cqZAo" node="4JmsWjEaqOz" resolve="set" />
+                </node>
+                <node concept="TSZUe" id="4JmsWjEaqOs" role="2OqNvi">
+                  <node concept="37vLTw" id="4JmsWjEaqOt" role="25WWJ7">
+                    <ref role="3cqZAo" node="4JmsWjEaqOA" resolve="node" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3eOVzh" id="4JmsWjEaqOu" role="1Dwp0S">
+            <node concept="3cmrfG" id="4JmsWjEaqOv" role="3uHU7w">
+              <property role="3cmrfH" value="2" />
+            </node>
+            <node concept="37vLTw" id="4JmsWjEaqOw" role="3uHU7B">
+              <ref role="3cqZAo" node="4JmsWjEaqOl" resolve="i" />
+            </node>
+          </node>
+          <node concept="3uNrnE" id="4JmsWjEaqOx" role="1Dwrff">
+            <node concept="37vLTw" id="4JmsWjEaqOy" role="2$L3a6">
+              <ref role="3cqZAo" node="4JmsWjEaqOl" resolve="i" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="4JmsWjEaqOz" role="3clF46">
+        <property role="TrG5h" value="set" />
+        <node concept="2hMVRd" id="4JmsWjEaqO$" role="1tU5fm">
+          <node concept="3Tqbb2" id="4JmsWjEaqO_" role="2hN53Y" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="4JmsWjEaqOA" role="3clF46">
+        <property role="TrG5h" value="node" />
+        <node concept="3Tqbb2" id="4JmsWjEaqOB" role="1tU5fm" />
+      </node>
+    </node>
+    <node concept="1LZb2c" id="4JmsWjEaqOC" role="1SL9yI">
+      <property role="TrG5h" value="sameNodeAndDifferentNode" />
+      <node concept="3cqZAl" id="4JmsWjEaqOD" role="3clF45" />
+      <node concept="3clFbS" id="4JmsWjEaqOE" role="3clF47">
+        <node concept="3cpWs8" id="4JmsWjEaqOF" role="3cqZAp">
+          <node concept="3cpWsn" id="4JmsWjEaqOG" role="3cpWs9">
+            <property role="TrG5h" value="repository" />
+            <node concept="3uibUv" id="4JmsWjEaqOH" role="1tU5fm">
+              <ref role="3uigEE" to="lui2:~SRepository" resolve="SRepository" />
+            </node>
+            <node concept="2OqwBi" id="4JmsWjEaqOI" role="33vP2m">
+              <node concept="1jGwE1" id="4JmsWjEaqOJ" role="2Oq$k0" />
+              <node concept="liA8E" id="4JmsWjEaqOK" role="2OqNvi">
+                <ref role="37wK5l" to="mhbf:~SModel.getRepository()" resolve="getRepository" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="4JmsWjEaqOL" role="3cqZAp" />
+        <node concept="3cpWs8" id="4JmsWjEaqOM" role="3cqZAp">
+          <node concept="3cpWsn" id="4JmsWjEaqON" role="3cpWs9">
+            <property role="TrG5h" value="set" />
+            <node concept="1s3Imc" id="4JmsWjEaqOO" role="1tU5fm">
+              <ref role="2I9WkF" to="tpee:fz12cDA" resolve="ClassConcept" />
+            </node>
+            <node concept="2ShNRf" id="4JmsWjEaqOP" role="33vP2m">
+              <node concept="2y2FIT" id="4JmsWjEaqOQ" role="2ShVmc">
+                <node concept="1s3Imc" id="4JmsWjEaqOR" role="2y2FCL">
+                  <ref role="2I9WkF" to="tpee:fz12cDA" resolve="ClassConcept" />
+                </node>
+                <node concept="2ShNRf" id="4JmsWjEaqOS" role="2y2Q$0">
+                  <node concept="32HrFt" id="4JmsWjEaqOT" role="2ShVmc">
+                    <node concept="3Tqbb2" id="4JmsWjEaqOU" role="HW$YZ">
+                      <ref role="ehGHo" to="tpee:fz12cDA" resolve="ClassConcept" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="4JmsWjEaqOV" role="3cqZAp" />
+        <node concept="3cpWs8" id="4JmsWjEaqOW" role="3cqZAp">
+          <node concept="3cpWsn" id="4JmsWjEaqOX" role="3cpWs9">
+            <property role="TrG5h" value="cls" />
+            <node concept="3Tqbb2" id="4JmsWjEaqOY" role="1tU5fm">
+              <ref role="ehGHo" to="tpee:fz12cDA" resolve="ClassConcept" />
+            </node>
+            <node concept="2OqwBi" id="4JmsWjEaqOZ" role="33vP2m">
+              <node concept="2tJFMh" id="4JmsWjEaqP0" role="2Oq$k0">
+                <node concept="ZC_QK" id="4JmsWjEaqP1" role="2tJFKM">
+                  <ref role="2aWVGs" to="co:5wNjLS4lSKq" resolve="EquivalenceHashSet" />
+                </node>
+              </node>
+              <node concept="Vyspw" id="4JmsWjEaqP2" role="2OqNvi">
+                <node concept="37vLTw" id="4JmsWjEaqP3" role="Vysub">
+                  <ref role="3cqZAo" node="4JmsWjEaqOG" resolve="repository" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="4JmsWjEaqP4" role="3cqZAp">
+          <node concept="3cpWsn" id="4JmsWjEaqP5" role="3cpWs9">
+            <property role="TrG5h" value="other" />
+            <node concept="3Tqbb2" id="4JmsWjEaqP6" role="1tU5fm">
+              <ref role="ehGHo" to="tpee:g7pOWCK" resolve="Classifier" />
+            </node>
+            <node concept="2OqwBi" id="4JmsWjEaqP7" role="33vP2m">
+              <node concept="2tJFMh" id="4JmsWjEaqP8" role="2Oq$k0">
+                <node concept="ZC_QK" id="4JmsWjEaqP9" role="2tJFKM">
+                  <ref role="2aWVGs" to="co:68F0OxjVEW9" resolve="NodeEquivalence" />
+                </node>
+              </node>
+              <node concept="Vyspw" id="4JmsWjEaqPa" role="2OqNvi">
+                <node concept="37vLTw" id="4JmsWjEaqPb" role="Vysub">
+                  <ref role="3cqZAo" node="4JmsWjEaqOG" resolve="repository" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="4JmsWjEaqPc" role="3cqZAp" />
+        <node concept="2Hmddi" id="4JmsWjEaqPd" role="3cqZAp">
+          <node concept="37vLTw" id="4JmsWjEaqPe" role="2Hmdds">
+            <ref role="3cqZAo" node="4JmsWjEaqOX" resolve="cls" />
+          </node>
+        </node>
+        <node concept="2Hmddi" id="4JmsWjEaqPf" role="3cqZAp">
+          <node concept="37vLTw" id="4JmsWjEaqPg" role="2Hmdds">
+            <ref role="3cqZAo" node="4JmsWjEaqP5" resolve="other" />
+          </node>
+        </node>
+        <node concept="3clFbH" id="4JmsWjEaqPh" role="3cqZAp" />
+        <node concept="3vwNmj" id="4JmsWjEaqPi" role="3cqZAp">
+          <node concept="2OqwBi" id="4JmsWjEaqPj" role="3vwVQn">
+            <node concept="37vLTw" id="4JmsWjEaqPk" role="2Oq$k0">
+              <ref role="3cqZAo" node="4JmsWjEaqON" resolve="set" />
+            </node>
+            <node concept="1v1jN8" id="4JmsWjEaqPl" role="2OqNvi" />
+          </node>
+        </node>
+        <node concept="3clFbH" id="4JmsWjEaqPm" role="3cqZAp" />
+        <node concept="3clFbF" id="4JmsWjEaqPn" role="3cqZAp">
+          <node concept="2OqwBi" id="4JmsWjEaqPo" role="3clFbG">
+            <node concept="2WthIp" id="4JmsWjEaqPp" role="2Oq$k0" />
+            <node concept="2XshWL" id="4JmsWjEaqPq" role="2OqNvi">
+              <ref role="2WH_rO" node="4JmsWjEaqOh" resolve="addMultipleTimes" />
+              <node concept="37vLTw" id="4JmsWjEaqPr" role="2XxRq1">
+                <ref role="3cqZAo" node="4JmsWjEaqON" resolve="set" />
+              </node>
+              <node concept="37vLTw" id="4JmsWjEaqPs" role="2XxRq1">
+                <ref role="3cqZAo" node="4JmsWjEaqOX" resolve="cls" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3vlDli" id="4JmsWjEaqPt" role="3cqZAp">
+          <node concept="3cmrfG" id="4JmsWjEaqPu" role="3tpDZB">
+            <property role="3cmrfH" value="1" />
+          </node>
+          <node concept="2OqwBi" id="4JmsWjEaqPv" role="3tpDZA">
+            <node concept="37vLTw" id="4JmsWjEaqPw" role="2Oq$k0">
+              <ref role="3cqZAo" node="4JmsWjEaqON" resolve="set" />
+            </node>
+            <node concept="34oBXx" id="4JmsWjEaqPx" role="2OqNvi" />
+          </node>
+          <node concept="3_1$Yv" id="4JmsWjEaqPy" role="3_9lra" />
+        </node>
+        <node concept="3clFbH" id="4JmsWjEaqPz" role="3cqZAp" />
+        <node concept="3clFbF" id="4JmsWjEaqP$" role="3cqZAp">
+          <node concept="2OqwBi" id="4JmsWjEaqP_" role="3clFbG">
+            <node concept="2WthIp" id="4JmsWjEaqPA" role="2Oq$k0" />
+            <node concept="2XshWL" id="4JmsWjEaqPB" role="2OqNvi">
+              <ref role="2WH_rO" node="4JmsWjEaqOh" resolve="addMultipleTimes" />
+              <node concept="37vLTw" id="4JmsWjEaqPC" role="2XxRq1">
+                <ref role="3cqZAo" node="4JmsWjEaqON" resolve="set" />
+              </node>
+              <node concept="37vLTw" id="4JmsWjEaqPD" role="2XxRq1">
+                <ref role="3cqZAo" node="4JmsWjEaqP5" resolve="other" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3vlDli" id="4JmsWjEaqPE" role="3cqZAp">
+          <node concept="2OqwBi" id="4JmsWjEaqPF" role="3tpDZA">
+            <node concept="37vLTw" id="4JmsWjEaqPG" role="2Oq$k0">
+              <ref role="3cqZAo" node="4JmsWjEaqON" resolve="set" />
+            </node>
+            <node concept="34oBXx" id="4JmsWjEaqPH" role="2OqNvi" />
+          </node>
+          <node concept="3cmrfG" id="4JmsWjEaqPI" role="3tpDZB">
+            <property role="3cmrfH" value="2" />
+          </node>
+          <node concept="3_1$Yv" id="4JmsWjEaqPJ" role="3_9lra" />
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="4JmsWjEaqPK" role="1SL9yI">
+      <property role="TrG5h" value="sameNodeCopyAndDifferentNode" />
+      <node concept="3cqZAl" id="4JmsWjEaqPL" role="3clF45" />
+      <node concept="3clFbS" id="4JmsWjEaqPM" role="3clF47">
+        <node concept="3cpWs8" id="4JmsWjEaqPN" role="3cqZAp">
+          <node concept="3cpWsn" id="4JmsWjEaqPO" role="3cpWs9">
+            <property role="TrG5h" value="repository" />
+            <node concept="3uibUv" id="4JmsWjEaqPP" role="1tU5fm">
+              <ref role="3uigEE" to="lui2:~SRepository" resolve="SRepository" />
+            </node>
+            <node concept="2OqwBi" id="4JmsWjEaqPQ" role="33vP2m">
+              <node concept="1jGwE1" id="4JmsWjEaqPR" role="2Oq$k0" />
+              <node concept="liA8E" id="4JmsWjEaqPS" role="2OqNvi">
+                <ref role="37wK5l" to="mhbf:~SModel.getRepository()" resolve="getRepository" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="4JmsWjEaqPT" role="3cqZAp" />
+        <node concept="3cpWs8" id="4JmsWjEaqPU" role="3cqZAp">
+          <node concept="3cpWsn" id="4JmsWjEaqPV" role="3cpWs9">
+            <property role="TrG5h" value="set" />
+            <node concept="1s3Imc" id="4JmsWjEaqPW" role="1tU5fm">
+              <ref role="2I9WkF" to="tpee:fz12cDA" resolve="ClassConcept" />
+            </node>
+            <node concept="2ShNRf" id="4JmsWjEaqPX" role="33vP2m">
+              <node concept="2y2FIT" id="4JmsWjEaqPY" role="2ShVmc">
+                <node concept="1s3Imc" id="4JmsWjEaqPZ" role="2y2FCL">
+                  <ref role="2I9WkF" to="tpee:fz12cDA" resolve="ClassConcept" />
+                </node>
+                <node concept="2ShNRf" id="4JmsWjEaqQ0" role="2y2Q$0">
+                  <node concept="32HrFt" id="4JmsWjEaqQ1" role="2ShVmc">
+                    <node concept="3Tqbb2" id="4JmsWjEaqQ2" role="HW$YZ">
+                      <ref role="ehGHo" to="tpee:fz12cDA" resolve="ClassConcept" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="4JmsWjEaqQ3" role="3cqZAp" />
+        <node concept="3cpWs8" id="4JmsWjEaqQ4" role="3cqZAp">
+          <node concept="3cpWsn" id="4JmsWjEaqQ5" role="3cpWs9">
+            <property role="TrG5h" value="cls" />
+            <node concept="3Tqbb2" id="4JmsWjEaqQ6" role="1tU5fm">
+              <ref role="ehGHo" to="tpee:fz12cDA" resolve="ClassConcept" />
+            </node>
+            <node concept="2OqwBi" id="4JmsWjEaqQ7" role="33vP2m">
+              <node concept="2tJFMh" id="4JmsWjEaqQ8" role="2Oq$k0">
+                <node concept="ZC_QK" id="4JmsWjEaqQ9" role="2tJFKM">
+                  <ref role="2aWVGs" to="co:5wNjLS4lSKq" resolve="EquivalenceHashSet" />
+                </node>
+              </node>
+              <node concept="Vyspw" id="4JmsWjEaqQa" role="2OqNvi">
+                <node concept="37vLTw" id="4JmsWjEaqQb" role="Vysub">
+                  <ref role="3cqZAo" node="4JmsWjEaqPO" resolve="repository" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="4JmsWjEaqQc" role="3cqZAp">
+          <node concept="3cpWsn" id="4JmsWjEaqQd" role="3cpWs9">
+            <property role="TrG5h" value="other" />
+            <node concept="3Tqbb2" id="4JmsWjEaqQe" role="1tU5fm">
+              <ref role="ehGHo" to="tpee:g7pOWCK" resolve="Classifier" />
+            </node>
+            <node concept="2OqwBi" id="4JmsWjEaqQf" role="33vP2m">
+              <node concept="2tJFMh" id="4JmsWjEaqQg" role="2Oq$k0">
+                <node concept="ZC_QK" id="4JmsWjEaqQh" role="2tJFKM">
+                  <ref role="2aWVGs" to="co:68F0OxjVEW9" resolve="NodeEquivalence" />
+                </node>
+              </node>
+              <node concept="Vyspw" id="4JmsWjEaqQi" role="2OqNvi">
+                <node concept="37vLTw" id="4JmsWjEaqQj" role="Vysub">
+                  <ref role="3cqZAo" node="4JmsWjEaqPO" resolve="repository" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="4JmsWjEaqQk" role="3cqZAp" />
+        <node concept="3vwNmj" id="4JmsWjEaqQl" role="3cqZAp">
+          <node concept="2OqwBi" id="4JmsWjEaqQm" role="3vwVQn">
+            <node concept="37vLTw" id="4JmsWjEaqQn" role="2Oq$k0">
+              <ref role="3cqZAo" node="4JmsWjEaqPV" resolve="set" />
+            </node>
+            <node concept="1v1jN8" id="4JmsWjEaqQo" role="2OqNvi" />
+          </node>
+        </node>
+        <node concept="3clFbH" id="4JmsWjEaqQp" role="3cqZAp" />
+        <node concept="3clFbF" id="4JmsWjEaqQq" role="3cqZAp">
+          <node concept="2OqwBi" id="4JmsWjEaqQr" role="3clFbG">
+            <node concept="2WthIp" id="4JmsWjEaqQs" role="2Oq$k0" />
+            <node concept="2XshWL" id="4JmsWjEaqQt" role="2OqNvi">
+              <ref role="2WH_rO" node="4JmsWjEaqOh" resolve="addMultipleTimes" />
+              <node concept="37vLTw" id="4JmsWjEaqQu" role="2XxRq1">
+                <ref role="3cqZAo" node="4JmsWjEaqPV" resolve="set" />
+              </node>
+              <node concept="37vLTw" id="4JmsWjEaqQv" role="2XxRq1">
+                <ref role="3cqZAo" node="4JmsWjEaqQ5" resolve="cls" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3vlDli" id="4JmsWjEaqQw" role="3cqZAp">
+          <node concept="3cmrfG" id="4JmsWjEaqQx" role="3tpDZB">
+            <property role="3cmrfH" value="1" />
+          </node>
+          <node concept="2OqwBi" id="4JmsWjEaqQy" role="3tpDZA">
+            <node concept="37vLTw" id="4JmsWjEaqQz" role="2Oq$k0">
+              <ref role="3cqZAo" node="4JmsWjEaqPV" resolve="set" />
+            </node>
+            <node concept="34oBXx" id="4JmsWjEaqQ$" role="2OqNvi" />
+          </node>
+          <node concept="3_1$Yv" id="4JmsWjEaqQ_" role="3_9lra" />
+        </node>
+        <node concept="3clFbH" id="4JmsWjEaqQA" role="3cqZAp" />
+        <node concept="3clFbF" id="4JmsWjEaqQB" role="3cqZAp">
+          <node concept="2OqwBi" id="4JmsWjEaqQC" role="3clFbG">
+            <node concept="2WthIp" id="4JmsWjEaqQD" role="2Oq$k0" />
+            <node concept="2XshWL" id="4JmsWjEaqQE" role="2OqNvi">
+              <ref role="2WH_rO" node="4JmsWjEaqOh" resolve="addMultipleTimes" />
+              <node concept="37vLTw" id="4JmsWjEaqQF" role="2XxRq1">
+                <ref role="3cqZAo" node="4JmsWjEaqPV" resolve="set" />
+              </node>
+              <node concept="2OqwBi" id="4JmsWjEaqQG" role="2XxRq1">
+                <node concept="37vLTw" id="4JmsWjEaqQH" role="2Oq$k0">
+                  <ref role="3cqZAo" node="4JmsWjEaqQ5" resolve="cls" />
+                </node>
+                <node concept="1$rogu" id="4JmsWjEaqQI" role="2OqNvi" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3vlDli" id="4JmsWjEaqQJ" role="3cqZAp">
+          <node concept="3cmrfG" id="4JmsWjEaqQK" role="3tpDZB">
+            <property role="3cmrfH" value="1" />
+          </node>
+          <node concept="2OqwBi" id="4JmsWjEaqQL" role="3tpDZA">
+            <node concept="37vLTw" id="4JmsWjEaqQM" role="2Oq$k0">
+              <ref role="3cqZAo" node="4JmsWjEaqPV" resolve="set" />
+            </node>
+            <node concept="34oBXx" id="4JmsWjEaqQN" role="2OqNvi" />
+          </node>
+          <node concept="3_1$Yv" id="4JmsWjEaqQO" role="3_9lra" />
+        </node>
+        <node concept="3clFbH" id="4JmsWjEaqQP" role="3cqZAp" />
+        <node concept="3clFbF" id="4JmsWjEaqQQ" role="3cqZAp">
+          <node concept="2OqwBi" id="4JmsWjEaqQR" role="3clFbG">
+            <node concept="2WthIp" id="4JmsWjEaqQS" role="2Oq$k0" />
+            <node concept="2XshWL" id="4JmsWjEaqQT" role="2OqNvi">
+              <ref role="2WH_rO" node="4JmsWjEaqOh" resolve="addMultipleTimes" />
+              <node concept="37vLTw" id="4JmsWjEaqQU" role="2XxRq1">
+                <ref role="3cqZAo" node="4JmsWjEaqPV" resolve="set" />
+              </node>
+              <node concept="37vLTw" id="4JmsWjEaqQV" role="2XxRq1">
+                <ref role="3cqZAo" node="4JmsWjEaqQd" resolve="other" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3vlDli" id="4JmsWjEaqQW" role="3cqZAp">
+          <node concept="2OqwBi" id="4JmsWjEaqQX" role="3tpDZA">
+            <node concept="37vLTw" id="4JmsWjEaqQY" role="2Oq$k0">
+              <ref role="3cqZAo" node="4JmsWjEaqPV" resolve="set" />
+            </node>
+            <node concept="34oBXx" id="4JmsWjEaqQZ" role="2OqNvi" />
+          </node>
+          <node concept="3cmrfG" id="4JmsWjEaqR0" role="3tpDZB">
+            <property role="3cmrfH" value="2" />
+          </node>
+          <node concept="3_1$Yv" id="4JmsWjEaqR1" role="3_9lra" />
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="4JmsWjEaqR2" role="1SL9yI">
+      <property role="TrG5h" value="index" />
+      <node concept="3cqZAl" id="4JmsWjEaqR3" role="3clF45" />
+      <node concept="3clFbS" id="4JmsWjEaqR4" role="3clF47">
+        <node concept="3cpWs8" id="4JmsWjEaqR5" role="3cqZAp">
+          <node concept="3cpWsn" id="4JmsWjEaqR6" role="3cpWs9">
+            <property role="TrG5h" value="repository" />
+            <node concept="3uibUv" id="4JmsWjEaqR7" role="1tU5fm">
+              <ref role="3uigEE" to="lui2:~SRepository" resolve="SRepository" />
+            </node>
+            <node concept="2OqwBi" id="4JmsWjEaqR8" role="33vP2m">
+              <node concept="1jGwE1" id="4JmsWjEaqR9" role="2Oq$k0" />
+              <node concept="liA8E" id="4JmsWjEaqRa" role="2OqNvi">
+                <ref role="37wK5l" to="mhbf:~SModel.getRepository()" resolve="getRepository" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="4JmsWjEaqRb" role="3cqZAp" />
+        <node concept="3cpWs8" id="4JmsWjEaqRc" role="3cqZAp">
+          <node concept="3cpWsn" id="4JmsWjEaqRd" role="3cpWs9">
+            <property role="TrG5h" value="set" />
+            <node concept="1s3Imc" id="4JmsWjEaqRe" role="1tU5fm">
+              <ref role="2I9WkF" to="tpee:fz12cDA" resolve="ClassConcept" />
+            </node>
+            <node concept="2ShNRf" id="4JmsWjEaqRf" role="33vP2m">
+              <node concept="2y2FIT" id="4JmsWjEaqRg" role="2ShVmc">
+                <node concept="1s3Imc" id="4JmsWjEaqRh" role="2y2FCL">
+                  <ref role="2I9WkF" to="tpee:fz12cDA" resolve="ClassConcept" />
+                </node>
+                <node concept="2ShNRf" id="4JmsWjEaqRi" role="2y2Q$0">
+                  <node concept="32HrFt" id="4JmsWjEaqRj" role="2ShVmc">
+                    <node concept="3Tqbb2" id="4JmsWjEaqRk" role="HW$YZ">
+                      <ref role="ehGHo" to="tpee:fz12cDA" resolve="ClassConcept" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="4JmsWjEaqRl" role="3cqZAp" />
+        <node concept="3cpWs8" id="4JmsWjEaqRm" role="3cqZAp">
+          <node concept="3cpWsn" id="4JmsWjEaqRn" role="3cpWs9">
+            <property role="TrG5h" value="cls" />
+            <node concept="3Tqbb2" id="4JmsWjEaqRo" role="1tU5fm">
+              <ref role="ehGHo" to="tpee:fz12cDA" resolve="ClassConcept" />
+            </node>
+            <node concept="2OqwBi" id="4JmsWjEaqRp" role="33vP2m">
+              <node concept="2tJFMh" id="4JmsWjEaqRq" role="2Oq$k0">
+                <node concept="ZC_QK" id="4JmsWjEaqRr" role="2tJFKM">
+                  <ref role="2aWVGs" to="co:5wNjLS4lSKq" resolve="EquivalenceHashSet" />
+                </node>
+              </node>
+              <node concept="Vyspw" id="4JmsWjEaqRs" role="2OqNvi">
+                <node concept="37vLTw" id="4JmsWjEaqRt" role="Vysub">
+                  <ref role="3cqZAo" node="4JmsWjEaqR6" resolve="repository" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="4JmsWjEaqRu" role="3cqZAp">
+          <node concept="3cpWsn" id="4JmsWjEaqRv" role="3cpWs9">
+            <property role="TrG5h" value="other" />
+            <node concept="3Tqbb2" id="4JmsWjEaqRw" role="1tU5fm">
+              <ref role="ehGHo" to="tpee:fz12cDA" resolve="ClassConcept" />
+            </node>
+            <node concept="2OqwBi" id="4JmsWjEaqRx" role="33vP2m">
+              <node concept="2tJFMh" id="4JmsWjEaqRy" role="2Oq$k0">
+                <node concept="ZC_QK" id="4JmsWjEaqRz" role="2tJFKM">
+                  <ref role="2aWVGs" to="co:68F0OxjVEW9" resolve="NodeEquivalence" />
+                </node>
+              </node>
+              <node concept="Vyspw" id="4JmsWjEaqR$" role="2OqNvi">
+                <node concept="37vLTw" id="4JmsWjEaqR_" role="Vysub">
+                  <ref role="3cqZAo" node="4JmsWjEaqR6" resolve="repository" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="4JmsWjEaqRA" role="3cqZAp" />
+        <node concept="3vwNmj" id="4JmsWjEaqRB" role="3cqZAp">
+          <node concept="2OqwBi" id="4JmsWjEaqRC" role="3vwVQn">
+            <node concept="37vLTw" id="4JmsWjEaqRD" role="2Oq$k0">
+              <ref role="3cqZAo" node="4JmsWjEaqRd" resolve="set" />
+            </node>
+            <node concept="1v1jN8" id="4JmsWjEaqRE" role="2OqNvi" />
+          </node>
+        </node>
+        <node concept="3clFbH" id="4JmsWjEaqRF" role="3cqZAp" />
+        <node concept="3clFbF" id="4JmsWjEaqRG" role="3cqZAp">
+          <node concept="2OqwBi" id="4JmsWjEaqRH" role="3clFbG">
+            <node concept="2WthIp" id="4JmsWjEaqRI" role="2Oq$k0" />
+            <node concept="2XshWL" id="4JmsWjEaqRJ" role="2OqNvi">
+              <ref role="2WH_rO" node="4JmsWjEaqOh" resolve="addMultipleTimes" />
+              <node concept="37vLTw" id="4JmsWjEaqRK" role="2XxRq1">
+                <ref role="3cqZAo" node="4JmsWjEaqRd" resolve="set" />
+              </node>
+              <node concept="37vLTw" id="4JmsWjEaqRL" role="2XxRq1">
+                <ref role="3cqZAo" node="4JmsWjEaqRn" resolve="cls" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4JmsWjEaqRM" role="3cqZAp">
+          <node concept="2OqwBi" id="4JmsWjEaqRN" role="3clFbG">
+            <node concept="2WthIp" id="4JmsWjEaqRO" role="2Oq$k0" />
+            <node concept="2XshWL" id="4JmsWjEaqRP" role="2OqNvi">
+              <ref role="2WH_rO" node="4JmsWjEaqOh" resolve="addMultipleTimes" />
+              <node concept="37vLTw" id="4JmsWjEaqRQ" role="2XxRq1">
+                <ref role="3cqZAo" node="4JmsWjEaqRd" resolve="set" />
+              </node>
+              <node concept="37vLTw" id="4JmsWjEaqRR" role="2XxRq1">
+                <ref role="3cqZAo" node="4JmsWjEaqRv" resolve="other" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="4JmsWjEaqRS" role="3cqZAp" />
+        <node concept="3vlDli" id="4JmsWjEaqRT" role="3cqZAp">
+          <node concept="3cmrfG" id="4JmsWjEaqRU" role="3tpDZB">
+            <property role="3cmrfH" value="0" />
+          </node>
+          <node concept="2OqwBi" id="4JmsWjEaqRV" role="3tpDZA">
+            <node concept="37vLTw" id="4JmsWjEaqRW" role="2Oq$k0">
+              <ref role="3cqZAo" node="4JmsWjEaqRd" resolve="set" />
+            </node>
+            <node concept="2WmjW8" id="4JmsWjEaqRX" role="2OqNvi">
+              <node concept="37vLTw" id="4JmsWjEaqRY" role="25WWJ7">
+                <ref role="3cqZAo" node="4JmsWjEaqRn" resolve="cls" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3vlDli" id="4JmsWjEaqRZ" role="3cqZAp">
+          <node concept="2OqwBi" id="4JmsWjEaqS0" role="3tpDZA">
+            <node concept="37vLTw" id="4JmsWjEaqS1" role="2Oq$k0">
+              <ref role="3cqZAo" node="4JmsWjEaqRd" resolve="set" />
+            </node>
+            <node concept="2WmjW8" id="4JmsWjEaqS2" role="2OqNvi">
+              <node concept="37vLTw" id="4JmsWjEaqS3" role="25WWJ7">
+                <ref role="3cqZAo" node="4JmsWjEaqRv" resolve="other" />
+              </node>
+            </node>
+          </node>
+          <node concept="3cmrfG" id="4JmsWjEaqS4" role="3tpDZB">
+            <property role="3cmrfH" value="1" />
+          </node>
+        </node>
+        <node concept="3clFbH" id="4JmsWjEmmTV" role="3cqZAp" />
+        <node concept="3vlDli" id="4JmsWjEmmTX" role="3cqZAp">
+          <node concept="2OqwBi" id="4JmsWjEmmTY" role="3tpDZA">
+            <node concept="37vLTw" id="4JmsWjEmmTZ" role="2Oq$k0">
+              <ref role="3cqZAo" node="4JmsWjEaqRd" resolve="set" />
+            </node>
+            <node concept="2WmjW8" id="4JmsWjEmmU0" role="2OqNvi">
+              <node concept="10Nm6u" id="4JmsWjEmn6Q" role="25WWJ7" />
+            </node>
+          </node>
+          <node concept="3cmrfG" id="4JmsWjEmmU2" role="3tpDZB">
+            <property role="3cmrfH" value="-1" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="4JmsWjEaqS5" role="1SL9yI">
+      <property role="TrG5h" value="remove" />
+      <node concept="3cqZAl" id="4JmsWjEaqS6" role="3clF45" />
+      <node concept="3clFbS" id="4JmsWjEaqS7" role="3clF47">
+        <node concept="3cpWs8" id="4JmsWjEaqS8" role="3cqZAp">
+          <node concept="3cpWsn" id="4JmsWjEaqS9" role="3cpWs9">
+            <property role="TrG5h" value="repository" />
+            <node concept="3uibUv" id="4JmsWjEaqSa" role="1tU5fm">
+              <ref role="3uigEE" to="lui2:~SRepository" resolve="SRepository" />
+            </node>
+            <node concept="2OqwBi" id="4JmsWjEaqSb" role="33vP2m">
+              <node concept="1jGwE1" id="4JmsWjEaqSc" role="2Oq$k0" />
+              <node concept="liA8E" id="4JmsWjEaqSd" role="2OqNvi">
+                <ref role="37wK5l" to="mhbf:~SModel.getRepository()" resolve="getRepository" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="4JmsWjEaqSe" role="3cqZAp" />
+        <node concept="3cpWs8" id="4JmsWjEaqSf" role="3cqZAp">
+          <node concept="3cpWsn" id="4JmsWjEaqSg" role="3cpWs9">
+            <property role="TrG5h" value="set" />
+            <node concept="1s3Imc" id="4JmsWjEaqSh" role="1tU5fm">
+              <ref role="2I9WkF" to="tpee:fz12cDA" resolve="ClassConcept" />
+            </node>
+            <node concept="2ShNRf" id="4JmsWjEaqSi" role="33vP2m">
+              <node concept="2y2FIT" id="4JmsWjEaqSj" role="2ShVmc">
+                <node concept="1s3Imc" id="4JmsWjEaqSk" role="2y2FCL">
+                  <ref role="2I9WkF" to="tpee:fz12cDA" resolve="ClassConcept" />
+                </node>
+                <node concept="2ShNRf" id="4JmsWjEaqSl" role="2y2Q$0">
+                  <node concept="32HrFt" id="4JmsWjEaqSm" role="2ShVmc">
+                    <node concept="3Tqbb2" id="4JmsWjEaqSn" role="HW$YZ">
+                      <ref role="ehGHo" to="tpee:fz12cDA" resolve="ClassConcept" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="4JmsWjEaqSo" role="3cqZAp" />
+        <node concept="3cpWs8" id="4JmsWjEaqSp" role="3cqZAp">
+          <node concept="3cpWsn" id="4JmsWjEaqSq" role="3cpWs9">
+            <property role="TrG5h" value="cls" />
+            <node concept="3Tqbb2" id="4JmsWjEaqSr" role="1tU5fm">
+              <ref role="ehGHo" to="tpee:fz12cDA" resolve="ClassConcept" />
+            </node>
+            <node concept="2OqwBi" id="4JmsWjEaqSs" role="33vP2m">
+              <node concept="2tJFMh" id="4JmsWjEaqSt" role="2Oq$k0">
+                <node concept="ZC_QK" id="4JmsWjEaqSu" role="2tJFKM">
+                  <ref role="2aWVGs" to="co:5wNjLS4lSKq" resolve="EquivalenceHashSet" />
+                </node>
+              </node>
+              <node concept="Vyspw" id="4JmsWjEaqSv" role="2OqNvi">
+                <node concept="37vLTw" id="4JmsWjEaqSw" role="Vysub">
+                  <ref role="3cqZAo" node="4JmsWjEaqS9" resolve="repository" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="4JmsWjEaqSx" role="3cqZAp">
+          <node concept="3cpWsn" id="4JmsWjEaqSy" role="3cpWs9">
+            <property role="TrG5h" value="other" />
+            <node concept="3Tqbb2" id="4JmsWjEaqSz" role="1tU5fm">
+              <ref role="ehGHo" to="tpee:fz12cDA" resolve="ClassConcept" />
+            </node>
+            <node concept="2OqwBi" id="4JmsWjEaqS$" role="33vP2m">
+              <node concept="2tJFMh" id="4JmsWjEaqS_" role="2Oq$k0">
+                <node concept="ZC_QK" id="4JmsWjEaqSA" role="2tJFKM">
+                  <ref role="2aWVGs" to="co:68F0OxjVEW9" resolve="NodeEquivalence" />
+                </node>
+              </node>
+              <node concept="Vyspw" id="4JmsWjEaqSB" role="2OqNvi">
+                <node concept="37vLTw" id="4JmsWjEaqSC" role="Vysub">
+                  <ref role="3cqZAo" node="4JmsWjEaqS9" resolve="repository" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="4JmsWjEaqSD" role="3cqZAp" />
+        <node concept="3vlDli" id="4JmsWjEaqSE" role="3cqZAp">
+          <node concept="3cmrfG" id="4JmsWjEaqSF" role="3tpDZB">
+            <property role="3cmrfH" value="0" />
+          </node>
+          <node concept="2OqwBi" id="4JmsWjEaqSG" role="3tpDZA">
+            <node concept="37vLTw" id="4JmsWjEaqSH" role="2Oq$k0">
+              <ref role="3cqZAo" node="4JmsWjEaqSg" resolve="set" />
+            </node>
+            <node concept="34oBXx" id="4JmsWjEaqSI" role="2OqNvi" />
+          </node>
+        </node>
+        <node concept="3clFbH" id="4JmsWjEaqSJ" role="3cqZAp" />
+        <node concept="3clFbF" id="4JmsWjEaqSK" role="3cqZAp">
+          <node concept="2OqwBi" id="4JmsWjEaqSL" role="3clFbG">
+            <node concept="2WthIp" id="4JmsWjEaqSM" role="2Oq$k0" />
+            <node concept="2XshWL" id="4JmsWjEaqSN" role="2OqNvi">
+              <ref role="2WH_rO" node="4JmsWjEaqOh" resolve="addMultipleTimes" />
+              <node concept="37vLTw" id="4JmsWjEaqSO" role="2XxRq1">
+                <ref role="3cqZAo" node="4JmsWjEaqSg" resolve="set" />
+              </node>
+              <node concept="37vLTw" id="4JmsWjEaqSP" role="2XxRq1">
+                <ref role="3cqZAo" node="4JmsWjEaqSq" resolve="cls" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4JmsWjEaqSQ" role="3cqZAp">
+          <node concept="2OqwBi" id="4JmsWjEaqSR" role="3clFbG">
+            <node concept="2WthIp" id="4JmsWjEaqSS" role="2Oq$k0" />
+            <node concept="2XshWL" id="4JmsWjEaqST" role="2OqNvi">
+              <ref role="2WH_rO" node="4JmsWjEaqOh" resolve="addMultipleTimes" />
+              <node concept="37vLTw" id="4JmsWjEaqSU" role="2XxRq1">
+                <ref role="3cqZAo" node="4JmsWjEaqSg" resolve="set" />
+              </node>
+              <node concept="37vLTw" id="4JmsWjEaqSV" role="2XxRq1">
+                <ref role="3cqZAo" node="4JmsWjEaqSy" resolve="other" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="4JmsWjEaqSW" role="3cqZAp" />
+        <node concept="3vlDli" id="4JmsWjEaqSX" role="3cqZAp">
+          <node concept="3cmrfG" id="4JmsWjEaqSY" role="3tpDZB">
+            <property role="3cmrfH" value="2" />
+          </node>
+          <node concept="2OqwBi" id="4JmsWjEaqSZ" role="3tpDZA">
+            <node concept="37vLTw" id="4JmsWjEaqT0" role="2Oq$k0">
+              <ref role="3cqZAo" node="4JmsWjEaqSg" resolve="set" />
+            </node>
+            <node concept="34oBXx" id="4JmsWjEaqT1" role="2OqNvi" />
+          </node>
+        </node>
+        <node concept="3clFbH" id="4JmsWjEaqT2" role="3cqZAp" />
+        <node concept="3clFbF" id="4JmsWjEaqT3" role="3cqZAp">
+          <node concept="2OqwBi" id="4JmsWjEaqT4" role="3clFbG">
+            <node concept="37vLTw" id="4JmsWjEaqT5" role="2Oq$k0">
+              <ref role="3cqZAo" node="4JmsWjEaqSg" resolve="set" />
+            </node>
+            <node concept="3dhRuq" id="4JmsWjEaqT6" role="2OqNvi">
+              <node concept="37vLTw" id="4JmsWjEaqT7" role="25WWJ7">
+                <ref role="3cqZAo" node="4JmsWjEaqSq" resolve="cls" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4JmsWjEaqT8" role="3cqZAp">
+          <node concept="2OqwBi" id="4JmsWjEaqT9" role="3clFbG">
+            <node concept="37vLTw" id="4JmsWjEaqTa" role="2Oq$k0">
+              <ref role="3cqZAo" node="4JmsWjEaqSg" resolve="set" />
+            </node>
+            <node concept="3dhRuq" id="4JmsWjEaqTb" role="2OqNvi">
+              <node concept="37vLTw" id="4JmsWjEaqTc" role="25WWJ7">
+                <ref role="3cqZAo" node="4JmsWjEaqSy" resolve="other" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4JmsWjEn64b" role="3cqZAp">
+          <node concept="2OqwBi" id="4JmsWjEnxHv" role="3clFbG">
+            <node concept="37vLTw" id="4JmsWjEn649" role="2Oq$k0">
+              <ref role="3cqZAo" node="4JmsWjEaqSg" resolve="set" />
+            </node>
+            <node concept="3dhRuq" id="4JmsWjEnS0N" role="2OqNvi">
+              <node concept="10Nm6u" id="4JmsWjEo9xa" role="25WWJ7" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="4JmsWjEaqTd" role="3cqZAp" />
+        <node concept="3vlDli" id="4JmsWjEaqTe" role="3cqZAp">
+          <node concept="3cmrfG" id="4JmsWjEaqTf" role="3tpDZB">
+            <property role="3cmrfH" value="0" />
+          </node>
+          <node concept="2OqwBi" id="4JmsWjEaqTg" role="3tpDZA">
+            <node concept="37vLTw" id="4JmsWjEaqTh" role="2Oq$k0">
+              <ref role="3cqZAo" node="4JmsWjEaqSg" resolve="set" />
+            </node>
+            <node concept="34oBXx" id="4JmsWjEaqTi" role="2OqNvi" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="4JmsWjEaqTj" role="1SL9yI">
+      <property role="TrG5h" value="removeAll" />
+      <node concept="3cqZAl" id="4JmsWjEaqTk" role="3clF45" />
+      <node concept="3clFbS" id="4JmsWjEaqTl" role="3clF47">
+        <node concept="3cpWs8" id="4JmsWjEaqTm" role="3cqZAp">
+          <node concept="3cpWsn" id="4JmsWjEaqTn" role="3cpWs9">
+            <property role="TrG5h" value="repository" />
+            <node concept="3uibUv" id="4JmsWjEaqTo" role="1tU5fm">
+              <ref role="3uigEE" to="lui2:~SRepository" resolve="SRepository" />
+            </node>
+            <node concept="2OqwBi" id="4JmsWjEaqTp" role="33vP2m">
+              <node concept="1jGwE1" id="4JmsWjEaqTq" role="2Oq$k0" />
+              <node concept="liA8E" id="4JmsWjEaqTr" role="2OqNvi">
+                <ref role="37wK5l" to="mhbf:~SModel.getRepository()" resolve="getRepository" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="4JmsWjEaqTs" role="3cqZAp" />
+        <node concept="3cpWs8" id="4JmsWjEaqTt" role="3cqZAp">
+          <node concept="3cpWsn" id="4JmsWjEaqTu" role="3cpWs9">
+            <property role="TrG5h" value="set" />
+            <node concept="1s3Imc" id="4JmsWjEaqTv" role="1tU5fm">
+              <ref role="2I9WkF" to="tpck:gw2VY9q" resolve="BaseConcept" />
+            </node>
+            <node concept="2ShNRf" id="4JmsWjEaqTw" role="33vP2m">
+              <node concept="2y2FIT" id="4JmsWjEaqTx" role="2ShVmc">
+                <node concept="1s3Imc" id="4JmsWjEaqTy" role="2y2FCL">
+                  <ref role="2I9WkF" to="tpck:gw2VY9q" resolve="BaseConcept" />
+                </node>
+                <node concept="2ShNRf" id="4JmsWjEaqTz" role="2y2Q$0">
+                  <node concept="32HrFt" id="4JmsWjEaqT$" role="2ShVmc">
+                    <node concept="3Tqbb2" id="4JmsWjEaqT_" role="HW$YZ">
+                      <ref role="ehGHo" to="tpck:gw2VY9q" resolve="BaseConcept" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="4JmsWjEaqTA" role="3cqZAp" />
+        <node concept="3cpWs8" id="4JmsWjEaqTB" role="3cqZAp">
+          <node concept="3cpWsn" id="4JmsWjEaqTC" role="3cpWs9">
+            <property role="TrG5h" value="cls" />
+            <node concept="3Tqbb2" id="4JmsWjEaqTD" role="1tU5fm">
+              <ref role="ehGHo" to="tpee:fz12cDA" resolve="ClassConcept" />
+            </node>
+            <node concept="2OqwBi" id="4JmsWjEaqTE" role="33vP2m">
+              <node concept="2tJFMh" id="4JmsWjEaqTF" role="2Oq$k0">
+                <node concept="ZC_QK" id="4JmsWjEaqTG" role="2tJFKM">
+                  <ref role="2aWVGs" to="co:5wNjLS4lSKq" resolve="EquivalenceHashSet" />
+                </node>
+              </node>
+              <node concept="Vyspw" id="4JmsWjEaqTH" role="2OqNvi">
+                <node concept="37vLTw" id="4JmsWjEaqTI" role="Vysub">
+                  <ref role="3cqZAo" node="4JmsWjEaqTn" resolve="repository" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="4JmsWjEaqTJ" role="3cqZAp">
+          <node concept="3cpWsn" id="4JmsWjEaqTK" role="3cpWs9">
+            <property role="TrG5h" value="other" />
+            <node concept="3Tqbb2" id="4JmsWjEaqTL" role="1tU5fm">
+              <ref role="ehGHo" to="tpee:g7pOWCK" resolve="Classifier" />
+            </node>
+            <node concept="2OqwBi" id="4JmsWjEaqTM" role="33vP2m">
+              <node concept="2tJFMh" id="4JmsWjEaqTN" role="2Oq$k0">
+                <node concept="ZC_QK" id="4JmsWjEaqTO" role="2tJFKM">
+                  <ref role="2aWVGs" to="co:68F0OxjVEW9" resolve="NodeEquivalence" />
+                </node>
+              </node>
+              <node concept="Vyspw" id="4JmsWjEaqTP" role="2OqNvi">
+                <node concept="37vLTw" id="4JmsWjEaqTQ" role="Vysub">
+                  <ref role="3cqZAo" node="4JmsWjEaqTn" resolve="repository" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="4JmsWjEaqTR" role="3cqZAp" />
+        <node concept="3vlDli" id="4JmsWjEaqTS" role="3cqZAp">
+          <node concept="3cmrfG" id="4JmsWjEaqTT" role="3tpDZB">
+            <property role="3cmrfH" value="0" />
+          </node>
+          <node concept="2OqwBi" id="4JmsWjEaqTU" role="3tpDZA">
+            <node concept="37vLTw" id="4JmsWjEaqTV" role="2Oq$k0">
+              <ref role="3cqZAo" node="4JmsWjEaqTu" resolve="set" />
+            </node>
+            <node concept="34oBXx" id="4JmsWjEaqTW" role="2OqNvi" />
+          </node>
+        </node>
+        <node concept="3clFbH" id="4JmsWjEaqTX" role="3cqZAp" />
+        <node concept="3clFbF" id="4JmsWjEaqTY" role="3cqZAp">
+          <node concept="2OqwBi" id="4JmsWjEaqTZ" role="3clFbG">
+            <node concept="2WthIp" id="4JmsWjEaqU0" role="2Oq$k0" />
+            <node concept="2XshWL" id="4JmsWjEaqU1" role="2OqNvi">
+              <ref role="2WH_rO" node="4JmsWjEaqOh" resolve="addMultipleTimes" />
+              <node concept="37vLTw" id="4JmsWjEaqU2" role="2XxRq1">
+                <ref role="3cqZAo" node="4JmsWjEaqTu" resolve="set" />
+              </node>
+              <node concept="37vLTw" id="4JmsWjEaqU3" role="2XxRq1">
+                <ref role="3cqZAo" node="4JmsWjEaqTC" resolve="cls" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4JmsWjEaqU4" role="3cqZAp">
+          <node concept="2OqwBi" id="4JmsWjEaqU5" role="3clFbG">
+            <node concept="2WthIp" id="4JmsWjEaqU6" role="2Oq$k0" />
+            <node concept="2XshWL" id="4JmsWjEaqU7" role="2OqNvi">
+              <ref role="2WH_rO" node="4JmsWjEaqOh" resolve="addMultipleTimes" />
+              <node concept="37vLTw" id="4JmsWjEaqU8" role="2XxRq1">
+                <ref role="3cqZAo" node="4JmsWjEaqTu" resolve="set" />
+              </node>
+              <node concept="37vLTw" id="4JmsWjEaqU9" role="2XxRq1">
+                <ref role="3cqZAo" node="4JmsWjEaqTK" resolve="other" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="4JmsWjEaqUa" role="3cqZAp" />
+        <node concept="3vlDli" id="4JmsWjEaqUb" role="3cqZAp">
+          <node concept="3cmrfG" id="4JmsWjEaqUc" role="3tpDZB">
+            <property role="3cmrfH" value="2" />
+          </node>
+          <node concept="2OqwBi" id="4JmsWjEaqUd" role="3tpDZA">
+            <node concept="37vLTw" id="4JmsWjEaqUe" role="2Oq$k0">
+              <ref role="3cqZAo" node="4JmsWjEaqTu" resolve="set" />
+            </node>
+            <node concept="34oBXx" id="4JmsWjEaqUf" role="2OqNvi" />
+          </node>
+        </node>
+        <node concept="3clFbH" id="4JmsWjEaqUg" role="3cqZAp" />
+        <node concept="3cpWs8" id="4JmsWjEaqUh" role="3cqZAp">
+          <node concept="3cpWsn" id="4JmsWjEaqUi" role="3cpWs9">
+            <property role="TrG5h" value="list" />
+            <node concept="2I9FWS" id="4JmsWjEaqUj" role="1tU5fm">
+              <ref role="2I9WkG" to="tpck:gw2VY9q" resolve="BaseConcept" />
+            </node>
+            <node concept="2ShNRf" id="4JmsWjEaqUk" role="33vP2m">
+              <node concept="2T8Vx0" id="4JmsWjEaqUl" role="2ShVmc">
+                <node concept="2I9FWS" id="4JmsWjEaqUm" role="2T96Bj">
+                  <ref role="2I9WkG" to="tpck:gw2VY9q" resolve="BaseConcept" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4JmsWjEaqUn" role="3cqZAp">
+          <node concept="2OqwBi" id="4JmsWjEaqUo" role="3clFbG">
+            <node concept="37vLTw" id="4JmsWjEaqUp" role="2Oq$k0">
+              <ref role="3cqZAo" node="4JmsWjEaqUi" resolve="list" />
+            </node>
+            <node concept="TSZUe" id="4JmsWjEaqUq" role="2OqNvi">
+              <node concept="37vLTw" id="4JmsWjEaqUr" role="25WWJ7">
+                <ref role="3cqZAo" node="4JmsWjEaqTC" resolve="cls" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4JmsWjEaqUs" role="3cqZAp">
+          <node concept="2OqwBi" id="4JmsWjEaqUt" role="3clFbG">
+            <node concept="37vLTw" id="4JmsWjEaqUu" role="2Oq$k0">
+              <ref role="3cqZAo" node="4JmsWjEaqUi" resolve="list" />
+            </node>
+            <node concept="TSZUe" id="4JmsWjEaqUv" role="2OqNvi">
+              <node concept="37vLTw" id="4JmsWjEaqUw" role="25WWJ7">
+                <ref role="3cqZAo" node="4JmsWjEaqTK" resolve="other" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4JmsWjEp6Ad" role="3cqZAp">
+          <node concept="2OqwBi" id="4JmsWjEp8oS" role="3clFbG">
+            <node concept="37vLTw" id="4JmsWjEp6Ab" role="2Oq$k0">
+              <ref role="3cqZAo" node="4JmsWjEaqUi" resolve="list" />
+            </node>
+            <node concept="TSZUe" id="4JmsWjEpahz" role="2OqNvi">
+              <node concept="10Nm6u" id="4JmsWjEpaLD" role="25WWJ7" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="4JmsWjEaqUx" role="3cqZAp" />
+        <node concept="3clFbF" id="4JmsWjEaqUy" role="3cqZAp">
+          <node concept="2OqwBi" id="4JmsWjEaqUz" role="3clFbG">
+            <node concept="37vLTw" id="4JmsWjEaqU$" role="2Oq$k0">
+              <ref role="3cqZAo" node="4JmsWjEaqTu" resolve="set" />
+            </node>
+            <node concept="1kEaZ2" id="4JmsWjEaqU_" role="2OqNvi">
+              <node concept="37vLTw" id="4JmsWjEaqUA" role="25WWJ7">
+                <ref role="3cqZAo" node="4JmsWjEaqUi" resolve="list" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="4JmsWjEaqUB" role="3cqZAp" />
+        <node concept="3vlDli" id="4JmsWjEaqUC" role="3cqZAp">
+          <node concept="3cmrfG" id="4JmsWjEaqUD" role="3tpDZB">
+            <property role="3cmrfH" value="0" />
+          </node>
+          <node concept="2OqwBi" id="4JmsWjEaqUE" role="3tpDZA">
+            <node concept="37vLTw" id="4JmsWjEaqUF" role="2Oq$k0">
+              <ref role="3cqZAo" node="4JmsWjEaqTu" resolve="set" />
+            </node>
+            <node concept="34oBXx" id="4JmsWjEaqUG" role="2OqNvi" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="4JmsWjEaqUH" role="1SL9yI">
+      <property role="TrG5h" value="contains" />
+      <node concept="3cqZAl" id="4JmsWjEaqUI" role="3clF45" />
+      <node concept="3clFbS" id="4JmsWjEaqUJ" role="3clF47">
+        <node concept="3cpWs8" id="4JmsWjEaqUK" role="3cqZAp">
+          <node concept="3cpWsn" id="4JmsWjEaqUL" role="3cpWs9">
+            <property role="TrG5h" value="repository" />
+            <node concept="3uibUv" id="4JmsWjEaqUM" role="1tU5fm">
+              <ref role="3uigEE" to="lui2:~SRepository" resolve="SRepository" />
+            </node>
+            <node concept="2OqwBi" id="4JmsWjEaqUN" role="33vP2m">
+              <node concept="1jGwE1" id="4JmsWjEaqUO" role="2Oq$k0" />
+              <node concept="liA8E" id="4JmsWjEaqUP" role="2OqNvi">
+                <ref role="37wK5l" to="mhbf:~SModel.getRepository()" resolve="getRepository" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="4JmsWjEaqUQ" role="3cqZAp" />
+        <node concept="3cpWs8" id="4JmsWjEaqUR" role="3cqZAp">
+          <node concept="3cpWsn" id="4JmsWjEaqUS" role="3cpWs9">
+            <property role="TrG5h" value="set" />
+            <node concept="1s3Imc" id="4JmsWjEaqUT" role="1tU5fm">
+              <ref role="2I9WkF" to="tpee:fz12cDA" resolve="ClassConcept" />
+            </node>
+            <node concept="2ShNRf" id="4JmsWjEaqUU" role="33vP2m">
+              <node concept="2y2FIT" id="4JmsWjEaqUV" role="2ShVmc">
+                <node concept="1s3Imc" id="4JmsWjEaqUW" role="2y2FCL">
+                  <ref role="2I9WkF" to="tpee:fz12cDA" resolve="ClassConcept" />
+                </node>
+                <node concept="2ShNRf" id="4JmsWjEaqUX" role="2y2Q$0">
+                  <node concept="32HrFt" id="4JmsWjEaqUY" role="2ShVmc">
+                    <node concept="3Tqbb2" id="4JmsWjEaqUZ" role="HW$YZ">
+                      <ref role="ehGHo" to="tpee:fz12cDA" resolve="ClassConcept" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="4JmsWjEaqV0" role="3cqZAp" />
+        <node concept="3cpWs8" id="4JmsWjEaqV1" role="3cqZAp">
+          <node concept="3cpWsn" id="4JmsWjEaqV2" role="3cpWs9">
+            <property role="TrG5h" value="cls" />
+            <node concept="3Tqbb2" id="4JmsWjEaqV3" role="1tU5fm">
+              <ref role="ehGHo" to="tpee:fz12cDA" resolve="ClassConcept" />
+            </node>
+            <node concept="2OqwBi" id="4JmsWjEaqV4" role="33vP2m">
+              <node concept="2tJFMh" id="4JmsWjEaqV5" role="2Oq$k0">
+                <node concept="ZC_QK" id="4JmsWjEaqV6" role="2tJFKM">
+                  <ref role="2aWVGs" to="co:5wNjLS4lSKq" resolve="EquivalenceHashSet" />
+                </node>
+              </node>
+              <node concept="Vyspw" id="4JmsWjEaqV7" role="2OqNvi">
+                <node concept="37vLTw" id="4JmsWjEaqV8" role="Vysub">
+                  <ref role="3cqZAo" node="4JmsWjEaqUL" resolve="repository" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="4JmsWjEaqV9" role="3cqZAp">
+          <node concept="3cpWsn" id="4JmsWjEaqVa" role="3cpWs9">
+            <property role="TrG5h" value="other" />
+            <node concept="3Tqbb2" id="4JmsWjEaqVb" role="1tU5fm">
+              <ref role="ehGHo" to="tpee:fz12cDA" resolve="ClassConcept" />
+            </node>
+            <node concept="2OqwBi" id="4JmsWjEaqVc" role="33vP2m">
+              <node concept="2tJFMh" id="4JmsWjEaqVd" role="2Oq$k0">
+                <node concept="ZC_QK" id="4JmsWjEaqVe" role="2tJFKM">
+                  <ref role="2aWVGs" to="co:68F0OxjVEW9" resolve="NodeEquivalence" />
+                </node>
+              </node>
+              <node concept="Vyspw" id="4JmsWjEaqVf" role="2OqNvi">
+                <node concept="37vLTw" id="4JmsWjEaqVg" role="Vysub">
+                  <ref role="3cqZAo" node="4JmsWjEaqUL" resolve="repository" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="4JmsWjEaqVh" role="3cqZAp" />
+        <node concept="3vlDli" id="4JmsWjEaqVi" role="3cqZAp">
+          <node concept="3cmrfG" id="4JmsWjEaqVj" role="3tpDZB">
+            <property role="3cmrfH" value="0" />
+          </node>
+          <node concept="2OqwBi" id="4JmsWjEaqVk" role="3tpDZA">
+            <node concept="37vLTw" id="4JmsWjEaqVl" role="2Oq$k0">
+              <ref role="3cqZAo" node="4JmsWjEaqUS" resolve="set" />
+            </node>
+            <node concept="34oBXx" id="4JmsWjEaqVm" role="2OqNvi" />
+          </node>
+        </node>
+        <node concept="3clFbH" id="4JmsWjEaqVn" role="3cqZAp" />
+        <node concept="3clFbF" id="4JmsWjEaqVo" role="3cqZAp">
+          <node concept="2OqwBi" id="4JmsWjEaqVp" role="3clFbG">
+            <node concept="2WthIp" id="4JmsWjEaqVq" role="2Oq$k0" />
+            <node concept="2XshWL" id="4JmsWjEaqVr" role="2OqNvi">
+              <ref role="2WH_rO" node="4JmsWjEaqOh" resolve="addMultipleTimes" />
+              <node concept="37vLTw" id="4JmsWjEaqVs" role="2XxRq1">
+                <ref role="3cqZAo" node="4JmsWjEaqUS" resolve="set" />
+              </node>
+              <node concept="37vLTw" id="4JmsWjEaqVt" role="2XxRq1">
+                <ref role="3cqZAo" node="4JmsWjEaqV2" resolve="cls" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4JmsWjEaqVu" role="3cqZAp">
+          <node concept="2OqwBi" id="4JmsWjEaqVv" role="3clFbG">
+            <node concept="2WthIp" id="4JmsWjEaqVw" role="2Oq$k0" />
+            <node concept="2XshWL" id="4JmsWjEaqVx" role="2OqNvi">
+              <ref role="2WH_rO" node="4JmsWjEaqOh" resolve="addMultipleTimes" />
+              <node concept="37vLTw" id="4JmsWjEaqVy" role="2XxRq1">
+                <ref role="3cqZAo" node="4JmsWjEaqUS" resolve="set" />
+              </node>
+              <node concept="37vLTw" id="4JmsWjEaqVz" role="2XxRq1">
+                <ref role="3cqZAo" node="4JmsWjEaqVa" resolve="other" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="4JmsWjEaqV$" role="3cqZAp" />
+        <node concept="3vwNmj" id="4JmsWjEaqV_" role="3cqZAp">
+          <node concept="2OqwBi" id="4JmsWjEaqVA" role="3vwVQn">
+            <node concept="37vLTw" id="4JmsWjEaqVB" role="2Oq$k0">
+              <ref role="3cqZAo" node="4JmsWjEaqUS" resolve="set" />
+            </node>
+            <node concept="3JPx81" id="4JmsWjEaqVC" role="2OqNvi">
+              <node concept="37vLTw" id="4JmsWjEaqVD" role="25WWJ7">
+                <ref role="3cqZAo" node="4JmsWjEaqV2" resolve="cls" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3vwNmj" id="4JmsWjEaqVE" role="3cqZAp">
+          <node concept="2OqwBi" id="4JmsWjEaqVF" role="3vwVQn">
+            <node concept="37vLTw" id="4JmsWjEaqVG" role="2Oq$k0">
+              <ref role="3cqZAo" node="4JmsWjEaqUS" resolve="set" />
+            </node>
+            <node concept="3JPx81" id="4JmsWjEaqVH" role="2OqNvi">
+              <node concept="37vLTw" id="4JmsWjEaqVI" role="25WWJ7">
+                <ref role="3cqZAo" node="4JmsWjEaqVa" resolve="other" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3vFxKo" id="4JmsWjEpVc6" role="3cqZAp">
+          <node concept="2OqwBi" id="4JmsWjEq09p" role="3vFALc">
+            <node concept="37vLTw" id="4JmsWjEpVhb" role="2Oq$k0">
+              <ref role="3cqZAo" node="4JmsWjEaqUS" resolve="set" />
+            </node>
+            <node concept="3JPx81" id="4JmsWjEq7Sr" role="2OqNvi">
+              <node concept="10Nm6u" id="4JmsWjEq7YG" role="25WWJ7" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="4JmsWjEaqVK" role="1SL9yI">
+      <property role="TrG5h" value="retainAll" />
+      <node concept="3cqZAl" id="4JmsWjEaqVL" role="3clF45" />
+      <node concept="3clFbS" id="4JmsWjEaqVM" role="3clF47">
+        <node concept="3cpWs8" id="4JmsWjEaqVN" role="3cqZAp">
+          <node concept="3cpWsn" id="4JmsWjEaqVO" role="3cpWs9">
+            <property role="TrG5h" value="repository" />
+            <node concept="3uibUv" id="4JmsWjEaqVP" role="1tU5fm">
+              <ref role="3uigEE" to="lui2:~SRepository" resolve="SRepository" />
+            </node>
+            <node concept="2OqwBi" id="4JmsWjEaqVQ" role="33vP2m">
+              <node concept="1jGwE1" id="4JmsWjEaqVR" role="2Oq$k0" />
+              <node concept="liA8E" id="4JmsWjEaqVS" role="2OqNvi">
+                <ref role="37wK5l" to="mhbf:~SModel.getRepository()" resolve="getRepository" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="4JmsWjEaqVT" role="3cqZAp" />
+        <node concept="3cpWs8" id="4JmsWjEaqVU" role="3cqZAp">
+          <node concept="3cpWsn" id="4JmsWjEaqVV" role="3cpWs9">
+            <property role="TrG5h" value="set" />
+            <node concept="1s3Imc" id="4JmsWjEaqVW" role="1tU5fm">
+              <ref role="2I9WkF" to="tpee:fz12cDA" resolve="ClassConcept" />
+            </node>
+            <node concept="2ShNRf" id="4JmsWjEaqVX" role="33vP2m">
+              <node concept="2y2FIT" id="4JmsWjEaqVY" role="2ShVmc">
+                <node concept="1s3Imc" id="4JmsWjEaqVZ" role="2y2FCL">
+                  <ref role="2I9WkF" to="tpee:fz12cDA" resolve="ClassConcept" />
+                </node>
+                <node concept="2ShNRf" id="4JmsWjEaqW0" role="2y2Q$0">
+                  <node concept="32HrFt" id="4JmsWjEaqW1" role="2ShVmc">
+                    <node concept="3Tqbb2" id="4JmsWjEaqW2" role="HW$YZ">
+                      <ref role="ehGHo" to="tpee:fz12cDA" resolve="ClassConcept" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="4JmsWjEaqW3" role="3cqZAp">
+          <node concept="3cpWsn" id="4JmsWjEaqW4" role="3cpWs9">
+            <property role="TrG5h" value="set2" />
+            <node concept="1s3Imc" id="4JmsWjEaqW5" role="1tU5fm">
+              <ref role="2I9WkF" to="tpee:fz12cDA" resolve="ClassConcept" />
+            </node>
+            <node concept="2ShNRf" id="4JmsWjEaqW6" role="33vP2m">
+              <node concept="2y2FIT" id="4JmsWjEaqW7" role="2ShVmc">
+                <node concept="1s3Imc" id="4JmsWjEaqW8" role="2y2FCL">
+                  <ref role="2I9WkF" to="tpee:fz12cDA" resolve="ClassConcept" />
+                </node>
+                <node concept="2ShNRf" id="4JmsWjEaqW9" role="2y2Q$0">
+                  <node concept="32HrFt" id="4JmsWjEaqWa" role="2ShVmc">
+                    <node concept="3Tqbb2" id="4JmsWjEaqWb" role="HW$YZ">
+                      <ref role="ehGHo" to="tpee:fz12cDA" resolve="ClassConcept" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="4JmsWjEaqWc" role="3cqZAp" />
+        <node concept="3cpWs8" id="4JmsWjEaqWd" role="3cqZAp">
+          <node concept="3cpWsn" id="4JmsWjEaqWe" role="3cpWs9">
+            <property role="TrG5h" value="cls" />
+            <node concept="3Tqbb2" id="4JmsWjEaqWf" role="1tU5fm">
+              <ref role="ehGHo" to="tpee:fz12cDA" resolve="ClassConcept" />
+            </node>
+            <node concept="2OqwBi" id="4JmsWjEaqWg" role="33vP2m">
+              <node concept="2tJFMh" id="4JmsWjEaqWh" role="2Oq$k0">
+                <node concept="ZC_QK" id="4JmsWjEaqWi" role="2tJFKM">
+                  <ref role="2aWVGs" to="co:5wNjLS4lSKq" resolve="EquivalenceHashSet" />
+                </node>
+              </node>
+              <node concept="Vyspw" id="4JmsWjEaqWj" role="2OqNvi">
+                <node concept="37vLTw" id="4JmsWjEaqWk" role="Vysub">
+                  <ref role="3cqZAo" node="4JmsWjEaqVO" resolve="repository" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="4JmsWjEaqWl" role="3cqZAp">
+          <node concept="3cpWsn" id="4JmsWjEaqWm" role="3cpWs9">
+            <property role="TrG5h" value="other" />
+            <node concept="3Tqbb2" id="4JmsWjEaqWn" role="1tU5fm">
+              <ref role="ehGHo" to="tpee:fz12cDA" resolve="ClassConcept" />
+            </node>
+            <node concept="2OqwBi" id="4JmsWjEaqWo" role="33vP2m">
+              <node concept="2tJFMh" id="4JmsWjEaqWp" role="2Oq$k0">
+                <node concept="ZC_QK" id="4JmsWjEaqWq" role="2tJFKM">
+                  <ref role="2aWVGs" to="co:68F0OxjVEW9" resolve="NodeEquivalence" />
+                </node>
+              </node>
+              <node concept="Vyspw" id="4JmsWjEaqWr" role="2OqNvi">
+                <node concept="37vLTw" id="4JmsWjEaqWs" role="Vysub">
+                  <ref role="3cqZAo" node="4JmsWjEaqVO" resolve="repository" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="4JmsWjEaqWt" role="3cqZAp" />
+        <node concept="3vlDli" id="4JmsWjEaqWu" role="3cqZAp">
+          <node concept="3cmrfG" id="4JmsWjEaqWv" role="3tpDZB">
+            <property role="3cmrfH" value="0" />
+          </node>
+          <node concept="2OqwBi" id="4JmsWjEaqWw" role="3tpDZA">
+            <node concept="37vLTw" id="4JmsWjEaqWx" role="2Oq$k0">
+              <ref role="3cqZAo" node="4JmsWjEaqVV" resolve="set" />
+            </node>
+            <node concept="34oBXx" id="4JmsWjEaqWy" role="2OqNvi" />
+          </node>
+        </node>
+        <node concept="3clFbH" id="4JmsWjEaqWz" role="3cqZAp" />
+        <node concept="3clFbF" id="4JmsWjEaqW$" role="3cqZAp">
+          <node concept="2OqwBi" id="4JmsWjEaqW_" role="3clFbG">
+            <node concept="2WthIp" id="4JmsWjEaqWA" role="2Oq$k0" />
+            <node concept="2XshWL" id="4JmsWjEaqWB" role="2OqNvi">
+              <ref role="2WH_rO" node="4JmsWjEaqOh" resolve="addMultipleTimes" />
+              <node concept="37vLTw" id="4JmsWjEaqWC" role="2XxRq1">
+                <ref role="3cqZAo" node="4JmsWjEaqVV" resolve="set" />
+              </node>
+              <node concept="37vLTw" id="4JmsWjEaqWD" role="2XxRq1">
+                <ref role="3cqZAo" node="4JmsWjEaqWe" resolve="cls" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4JmsWjEaqWE" role="3cqZAp">
+          <node concept="2OqwBi" id="4JmsWjEaqWF" role="3clFbG">
+            <node concept="2WthIp" id="4JmsWjEaqWG" role="2Oq$k0" />
+            <node concept="2XshWL" id="4JmsWjEaqWH" role="2OqNvi">
+              <ref role="2WH_rO" node="4JmsWjEaqOh" resolve="addMultipleTimes" />
+              <node concept="37vLTw" id="4JmsWjEaqWI" role="2XxRq1">
+                <ref role="3cqZAo" node="4JmsWjEaqVV" resolve="set" />
+              </node>
+              <node concept="37vLTw" id="4JmsWjEaqWJ" role="2XxRq1">
+                <ref role="3cqZAo" node="4JmsWjEaqWm" resolve="other" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="4JmsWjEaqWX" role="3cqZAp" />
+        <node concept="3vwNmj" id="4JmsWjEaqWY" role="3cqZAp">
+          <node concept="2OqwBi" id="4JmsWjEaqWZ" role="3vwVQn">
+            <node concept="3S9uib" id="4JmsWjEaqX0" role="2Oq$k0">
+              <node concept="37vLTw" id="4JmsWjEaqX1" role="3S9DZi">
+                <ref role="3cqZAo" node="4JmsWjEaqVV" resolve="set" />
+              </node>
+            </node>
+            <node concept="liA8E" id="4JmsWjEaqX2" role="2OqNvi">
+              <ref role="37wK5l" to="33ny:~Set.retainAll(java.util.Collection)" resolve="retainAll" />
+              <node concept="37vLTw" id="4JmsWjEaqX3" role="37wK5m">
+                <ref role="3cqZAo" node="4JmsWjEaqW4" resolve="set2" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="4JmsWjEaqX4" role="3cqZAp" />
+      </node>
+    </node>
+    <node concept="1LZb2c" id="4JmsWjEaqX5" role="1SL9yI">
+      <property role="TrG5h" value="toArray" />
+      <node concept="3cqZAl" id="4JmsWjEaqX6" role="3clF45" />
+      <node concept="3clFbS" id="4JmsWjEaqX7" role="3clF47">
+        <node concept="3cpWs8" id="4JmsWjEaqX8" role="3cqZAp">
+          <node concept="3cpWsn" id="4JmsWjEaqX9" role="3cpWs9">
+            <property role="TrG5h" value="repository" />
+            <node concept="3uibUv" id="4JmsWjEaqXa" role="1tU5fm">
+              <ref role="3uigEE" to="lui2:~SRepository" resolve="SRepository" />
+            </node>
+            <node concept="2OqwBi" id="4JmsWjEaqXb" role="33vP2m">
+              <node concept="1jGwE1" id="4JmsWjEaqXc" role="2Oq$k0" />
+              <node concept="liA8E" id="4JmsWjEaqXd" role="2OqNvi">
+                <ref role="37wK5l" to="mhbf:~SModel.getRepository()" resolve="getRepository" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="4JmsWjEaqXe" role="3cqZAp" />
+        <node concept="3cpWs8" id="4JmsWjEaqXf" role="3cqZAp">
+          <node concept="3cpWsn" id="4JmsWjEaqXg" role="3cpWs9">
+            <property role="TrG5h" value="set" />
+            <node concept="1s3Imc" id="4JmsWjEaqXh" role="1tU5fm" />
+            <node concept="2ShNRf" id="4JmsWjEaqXi" role="33vP2m">
+              <node concept="2y2FIT" id="4JmsWjEaqXj" role="2ShVmc">
+                <node concept="1s3Imc" id="4JmsWjEaqXk" role="2y2FCL">
+                  <ref role="2I9WkF" to="tpee:fz12cDA" resolve="ClassConcept" />
+                </node>
+                <node concept="2ShNRf" id="4JmsWjEaqXl" role="2y2Q$0">
+                  <node concept="32HrFt" id="4JmsWjEaqXm" role="2ShVmc">
+                    <node concept="3Tqbb2" id="4JmsWjEaqXn" role="HW$YZ">
+                      <ref role="ehGHo" to="tpee:fz12cDA" resolve="ClassConcept" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="4JmsWjEaqXo" role="3cqZAp" />
+        <node concept="3cpWs8" id="4JmsWjEaqXp" role="3cqZAp">
+          <node concept="3cpWsn" id="4JmsWjEaqXq" role="3cpWs9">
+            <property role="TrG5h" value="cls" />
+            <node concept="3Tqbb2" id="4JmsWjEaqXr" role="1tU5fm">
+              <ref role="ehGHo" to="tpee:fz12cDA" resolve="ClassConcept" />
+            </node>
+            <node concept="2OqwBi" id="4JmsWjEaqXs" role="33vP2m">
+              <node concept="2tJFMh" id="4JmsWjEaqXt" role="2Oq$k0">
+                <node concept="ZC_QK" id="4JmsWjEaqXu" role="2tJFKM">
+                  <ref role="2aWVGs" to="co:5wNjLS4lSKq" resolve="EquivalenceHashSet" />
+                </node>
+              </node>
+              <node concept="Vyspw" id="4JmsWjEaqXv" role="2OqNvi">
+                <node concept="37vLTw" id="4JmsWjEaqXw" role="Vysub">
+                  <ref role="3cqZAo" node="4JmsWjEaqX9" resolve="repository" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="4JmsWjEaqXx" role="3cqZAp">
+          <node concept="3cpWsn" id="4JmsWjEaqXy" role="3cpWs9">
+            <property role="TrG5h" value="other" />
+            <node concept="3Tqbb2" id="4JmsWjEaqXz" role="1tU5fm">
+              <ref role="ehGHo" to="tpee:g7pOWCK" resolve="Classifier" />
+            </node>
+            <node concept="2OqwBi" id="4JmsWjEaqX$" role="33vP2m">
+              <node concept="2tJFMh" id="4JmsWjEaqX_" role="2Oq$k0">
+                <node concept="ZC_QK" id="4JmsWjEaqXA" role="2tJFKM">
+                  <ref role="2aWVGs" to="co:68F0OxjVEW9" resolve="NodeEquivalence" />
+                </node>
+              </node>
+              <node concept="Vyspw" id="4JmsWjEaqXB" role="2OqNvi">
+                <node concept="37vLTw" id="4JmsWjEaqXC" role="Vysub">
+                  <ref role="3cqZAo" node="4JmsWjEaqX9" resolve="repository" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="4JmsWjEaqXD" role="3cqZAp" />
+        <node concept="3vlDli" id="4JmsWjEaqXE" role="3cqZAp">
+          <node concept="3cmrfG" id="4JmsWjEaqXF" role="3tpDZB">
+            <property role="3cmrfH" value="0" />
+          </node>
+          <node concept="2OqwBi" id="4JmsWjEaqXG" role="3tpDZA">
+            <node concept="37vLTw" id="4JmsWjEaqXH" role="2Oq$k0">
+              <ref role="3cqZAo" node="4JmsWjEaqXg" resolve="set" />
+            </node>
+            <node concept="34oBXx" id="4JmsWjEaqXI" role="2OqNvi" />
+          </node>
+        </node>
+        <node concept="3clFbH" id="4JmsWjEaqXJ" role="3cqZAp" />
+        <node concept="3clFbF" id="4JmsWjEaqXK" role="3cqZAp">
+          <node concept="2OqwBi" id="4JmsWjEaqXL" role="3clFbG">
+            <node concept="2WthIp" id="4JmsWjEaqXM" role="2Oq$k0" />
+            <node concept="2XshWL" id="4JmsWjEaqXN" role="2OqNvi">
+              <ref role="2WH_rO" node="4JmsWjEaqOh" resolve="addMultipleTimes" />
+              <node concept="37vLTw" id="4JmsWjEaqXO" role="2XxRq1">
+                <ref role="3cqZAo" node="4JmsWjEaqXg" resolve="set" />
+              </node>
+              <node concept="37vLTw" id="4JmsWjEaqXP" role="2XxRq1">
+                <ref role="3cqZAo" node="4JmsWjEaqXq" resolve="cls" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4JmsWjEaqXQ" role="3cqZAp">
+          <node concept="2OqwBi" id="4JmsWjEaqXR" role="3clFbG">
+            <node concept="2WthIp" id="4JmsWjEaqXS" role="2Oq$k0" />
+            <node concept="2XshWL" id="4JmsWjEaqXT" role="2OqNvi">
+              <ref role="2WH_rO" node="4JmsWjEaqOh" resolve="addMultipleTimes" />
+              <node concept="37vLTw" id="4JmsWjEaqXU" role="2XxRq1">
+                <ref role="3cqZAo" node="4JmsWjEaqXg" resolve="set" />
+              </node>
+              <node concept="37vLTw" id="4JmsWjEaqXV" role="2XxRq1">
+                <ref role="3cqZAo" node="4JmsWjEaqXy" resolve="other" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="4JmsWjEaqXW" role="3cqZAp" />
+        <node concept="3clFbF" id="4JmsWjEaqXX" role="3cqZAp">
+          <node concept="2OqwBi" id="4JmsWjEaqXY" role="3clFbG">
+            <node concept="2WthIp" id="4JmsWjEaqXZ" role="2Oq$k0" />
+            <node concept="2XshWL" id="4JmsWjEaqY0" role="2OqNvi">
+              <ref role="2WH_rO" node="4JmsWjEaqOh" resolve="addMultipleTimes" />
+              <node concept="37vLTw" id="4JmsWjEaqY1" role="2XxRq1">
+                <ref role="3cqZAo" node="4JmsWjEaqXg" resolve="set" />
+              </node>
+              <node concept="37vLTw" id="4JmsWjEaqY2" role="2XxRq1">
+                <ref role="3cqZAo" node="4JmsWjEaqXq" resolve="cls" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4JmsWjEaqY3" role="3cqZAp">
+          <node concept="2OqwBi" id="4JmsWjEaqY4" role="3clFbG">
+            <node concept="2WthIp" id="4JmsWjEaqY5" role="2Oq$k0" />
+            <node concept="2XshWL" id="4JmsWjEaqY6" role="2OqNvi">
+              <ref role="2WH_rO" node="4JmsWjEaqOh" resolve="addMultipleTimes" />
+              <node concept="37vLTw" id="4JmsWjEaqY7" role="2XxRq1">
+                <ref role="3cqZAo" node="4JmsWjEaqXg" resolve="set" />
+              </node>
+              <node concept="37vLTw" id="4JmsWjEaqY8" role="2XxRq1">
+                <ref role="3cqZAo" node="4JmsWjEaqXy" resolve="other" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="4JmsWjEaqY9" role="3cqZAp" />
+        <node concept="3vlDli" id="4JmsWjEaqYa" role="3cqZAp">
+          <node concept="3cmrfG" id="4JmsWjEaqYb" role="3tpDZB">
+            <property role="3cmrfH" value="2" />
+          </node>
+          <node concept="2OqwBi" id="4JmsWjEaqYc" role="3tpDZA">
+            <node concept="2OqwBi" id="4JmsWjEaqYd" role="2Oq$k0">
+              <node concept="3S9uib" id="4JmsWjEaqYe" role="2Oq$k0">
+                <node concept="37vLTw" id="4JmsWjEaqYf" role="3S9DZi">
+                  <ref role="3cqZAo" node="4JmsWjEaqXg" resolve="set" />
+                </node>
+              </node>
+              <node concept="liA8E" id="4JmsWjEaqYg" role="2OqNvi">
+                <ref role="37wK5l" to="33ny:~Set.toArray()" resolve="toArray" />
+              </node>
+            </node>
+            <node concept="1Rwk04" id="4JmsWjEaqYh" role="2OqNvi" />
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/code/languages/com.mbeddr.mpsutil/solutions/test.com.mbeddr.mpsutil.collections.runtime/models/test.com.mbeddr.mpsutil.collections.runtime.mps
+++ b/code/languages/com.mbeddr.mpsutil/solutions/test.com.mbeddr.mpsutil.collections.runtime/models/test.com.mbeddr.mpsutil.collections.runtime.mps
@@ -333,6 +333,31 @@
             </node>
           </node>
         </node>
+        <node concept="3clFbH" id="1OJeGyIxtes" role="3cqZAp" />
+        <node concept="3vlDli" id="7Pm1OAZkSlO" role="3cqZAp">
+          <node concept="2OqwBi" id="7Pm1OAZkTnI" role="3tpDZB">
+            <node concept="37vLTw" id="7Pm1OAZkT4M" role="2Oq$k0">
+              <ref role="3cqZAo" node="68F0Oxkgi7p" resolve="equivalence" />
+            </node>
+            <node concept="liA8E" id="7Pm1OAZkTSF" role="2OqNvi">
+              <ref role="37wK5l" to="gyfg:~Equivalence.hash(java.lang.Object)" resolve="hash" />
+              <node concept="37vLTw" id="7Pm1OAZkU33" role="37wK5m">
+                <ref role="3cqZAo" node="68F0OxkgjHV" resolve="cl1" />
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="7Pm1OAZkUi5" role="3tpDZA">
+            <node concept="37vLTw" id="7Pm1OAZkUi6" role="2Oq$k0">
+              <ref role="3cqZAo" node="68F0Oxkgi7p" resolve="equivalence" />
+            </node>
+            <node concept="liA8E" id="7Pm1OAZkUi7" role="2OqNvi">
+              <ref role="37wK5l" to="gyfg:~Equivalence.hash(java.lang.Object)" resolve="hash" />
+              <node concept="37vLTw" id="7Pm1OAZkUi8" role="37wK5m">
+                <ref role="3cqZAo" node="68F0Oxkgozz" resolve="cl2" />
+              </node>
+            </node>
+          </node>
+        </node>
       </node>
     </node>
     <node concept="1LZb2c" id="4JmsWjEldxq" role="1SL9yI">
@@ -424,6 +449,31 @@
             </node>
           </node>
         </node>
+        <node concept="3clFbH" id="7Pm1OAZkQFZ" role="3cqZAp" />
+        <node concept="3vlDli" id="7Pm1OAZkQV5" role="3cqZAp">
+          <node concept="2OqwBi" id="7Pm1OAZkUTa" role="3tpDZB">
+            <node concept="37vLTw" id="7Pm1OAZkUBC" role="2Oq$k0">
+              <ref role="3cqZAo" node="4JmsWjEldxu" resolve="equivalence" />
+            </node>
+            <node concept="liA8E" id="7Pm1OAZkVq7" role="2OqNvi">
+              <ref role="37wK5l" to="gyfg:~Equivalence.hash(java.lang.Object)" resolve="hash" />
+              <node concept="37vLTw" id="7Pm1OAZkV$C" role="37wK5m">
+                <ref role="3cqZAo" node="4JmsWjEldxz" resolve="cl1" />
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="7Pm1OAZkVIo" role="3tpDZA">
+            <node concept="37vLTw" id="7Pm1OAZkVF3" role="2Oq$k0">
+              <ref role="3cqZAo" node="4JmsWjEldxu" resolve="equivalence" />
+            </node>
+            <node concept="liA8E" id="7Pm1OAZkVS4" role="2OqNvi">
+              <ref role="37wK5l" to="gyfg:~Equivalence.hash(java.lang.Object)" resolve="hash" />
+              <node concept="37vLTw" id="7Pm1OAZkW3w" role="37wK5m">
+                <ref role="3cqZAo" node="4JmsWjEldxF" resolve="cl2" />
+              </node>
+            </node>
+          </node>
+        </node>
       </node>
     </node>
     <node concept="1LZb2c" id="68F0OxkguH0" role="1SL9yI">
@@ -499,6 +549,35 @@
             </node>
           </node>
         </node>
+        <node concept="3clFbH" id="7Pm1OAZkWaQ" role="3cqZAp" />
+        <node concept="3vlDli" id="7Pm1OAZkWjT" role="3cqZAp">
+          <node concept="2OqwBi" id="7Pm1OAZkWjU" role="3tpDZB">
+            <node concept="37vLTw" id="7Pm1OAZkWjV" role="2Oq$k0">
+              <ref role="3cqZAo" node="68F0OxkguH4" resolve="equivalence" />
+            </node>
+            <node concept="liA8E" id="7Pm1OAZkWjW" role="2OqNvi">
+              <ref role="37wK5l" to="gyfg:~Equivalence.hash(java.lang.Object)" resolve="hash" />
+              <node concept="37vLTw" id="7Pm1OAZkWjX" role="37wK5m">
+                <ref role="3cqZAo" node="68F0OxkgwBU" resolve="cls" />
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="7Pm1OAZkWjY" role="3tpDZA">
+            <node concept="37vLTw" id="7Pm1OAZkWjZ" role="2Oq$k0">
+              <ref role="3cqZAo" node="68F0OxkguH4" resolve="equivalence" />
+            </node>
+            <node concept="liA8E" id="7Pm1OAZkWk0" role="2OqNvi">
+              <ref role="37wK5l" to="gyfg:~Equivalence.hash(java.lang.Object)" resolve="hash" />
+              <node concept="2OqwBi" id="7Pm1OAZkX9Y" role="37wK5m">
+                <node concept="37vLTw" id="7Pm1OAZkX9Z" role="2Oq$k0">
+                  <ref role="3cqZAo" node="68F0OxkgwBU" resolve="cls" />
+                </node>
+                <node concept="1$rogu" id="7Pm1OAZkXa0" role="2OqNvi" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="7Pm1OAZkWjS" role="3cqZAp" />
       </node>
     </node>
     <node concept="1LZb2c" id="68F0Oxkgr15" role="1SL9yI">
@@ -585,6 +664,33 @@
                   <node concept="37vLTw" id="68F0OxkgsGa" role="37wK5m">
                     <ref role="3cqZAo" node="68F0Oxkgr1m" resolve="cl2" />
                   </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="7Pm1OAZlijv" role="3cqZAp" />
+        <node concept="3vFxKo" id="7Pm1OAZliM2" role="3cqZAp">
+          <node concept="17R0WA" id="7Pm1OAZlli3" role="3vFALc">
+            <node concept="2OqwBi" id="7Pm1OAZllOC" role="3uHU7w">
+              <node concept="37vLTw" id="7Pm1OAZllvz" role="2Oq$k0">
+                <ref role="3cqZAo" node="68F0Oxkgr19" resolve="equivalence" />
+              </node>
+              <node concept="liA8E" id="7Pm1OAZllYn" role="2OqNvi">
+                <ref role="37wK5l" to="gyfg:~Equivalence.hash(java.lang.Object)" resolve="hash" />
+                <node concept="37vLTw" id="7Pm1OAZlmcE" role="37wK5m">
+                  <ref role="3cqZAo" node="68F0Oxkgr1m" resolve="cl2" />
+                </node>
+              </node>
+            </node>
+            <node concept="2OqwBi" id="7Pm1OAZljGr" role="3uHU7B">
+              <node concept="37vLTw" id="7Pm1OAZljpv" role="2Oq$k0">
+                <ref role="3cqZAo" node="68F0Oxkgr19" resolve="equivalence" />
+              </node>
+              <node concept="liA8E" id="7Pm1OAZlkfl" role="2OqNvi">
+                <ref role="37wK5l" to="gyfg:~Equivalence.hash(java.lang.Object)" resolve="hash" />
+                <node concept="37vLTw" id="7Pm1OAZlkxq" role="37wK5m">
+                  <ref role="3cqZAo" node="68F0Oxkgr1e" resolve="cl1" />
                 </node>
               </node>
             </node>

--- a/code/languages/com.mbeddr.mpsutil/solutions/test.com.mbeddr.mpsutil.collections.runtime/models/test.com.mbeddr.mpsutil.collections.runtime.mps
+++ b/code/languages/com.mbeddr.mpsutil/solutions/test.com.mbeddr.mpsutil.collections.runtime/models/test.com.mbeddr.mpsutil.collections.runtime.mps
@@ -92,7 +92,6 @@
       </concept>
       <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
       <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
-      <concept id="1225271283259" name="jetbrains.mps.baseLanguage.structure.NPEEqualsExpression" flags="nn" index="17R0WA" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
       </concept>
@@ -101,6 +100,7 @@
         <child id="1068580123134" name="parameter" index="3clF46" />
         <child id="1068580123135" name="body" index="3clF47" />
       </concept>
+      <concept id="1068580123152" name="jetbrains.mps.baseLanguage.structure.EqualsExpression" flags="nn" index="3clFbC" />
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
@@ -669,33 +669,6 @@
             </node>
           </node>
         </node>
-        <node concept="3clFbH" id="7Pm1OAZlijv" role="3cqZAp" />
-        <node concept="3vFxKo" id="7Pm1OAZliM2" role="3cqZAp">
-          <node concept="17R0WA" id="7Pm1OAZlli3" role="3vFALc">
-            <node concept="2OqwBi" id="7Pm1OAZllOC" role="3uHU7w">
-              <node concept="37vLTw" id="7Pm1OAZllvz" role="2Oq$k0">
-                <ref role="3cqZAo" node="68F0Oxkgr19" resolve="equivalence" />
-              </node>
-              <node concept="liA8E" id="7Pm1OAZllYn" role="2OqNvi">
-                <ref role="37wK5l" to="gyfg:~Equivalence.hash(java.lang.Object)" resolve="hash" />
-                <node concept="37vLTw" id="7Pm1OAZlmcE" role="37wK5m">
-                  <ref role="3cqZAo" node="68F0Oxkgr1m" resolve="cl2" />
-                </node>
-              </node>
-            </node>
-            <node concept="2OqwBi" id="7Pm1OAZljGr" role="3uHU7B">
-              <node concept="37vLTw" id="7Pm1OAZljpv" role="2Oq$k0">
-                <ref role="3cqZAo" node="68F0Oxkgr19" resolve="equivalence" />
-              </node>
-              <node concept="liA8E" id="7Pm1OAZlkfl" role="2OqNvi">
-                <ref role="37wK5l" to="gyfg:~Equivalence.hash(java.lang.Object)" resolve="hash" />
-                <node concept="37vLTw" id="7Pm1OAZlkxq" role="37wK5m">
-                  <ref role="3cqZAo" node="68F0Oxkgr1e" resolve="cl1" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
       </node>
     </node>
   </node>
@@ -834,89 +807,6 @@
             <property role="3cmrfH" value="2" />
           </node>
           <node concept="3_1$Yv" id="68F0OxkflNt" role="3_9lra" />
-        </node>
-      </node>
-    </node>
-    <node concept="1LZb2c" id="68F0Oxkf9KS" role="1SL9yI">
-      <property role="TrG5h" value="sameNodeCopyAndDifferentNode" />
-      <node concept="3cqZAl" id="68F0Oxkf9KT" role="3clF45" />
-      <node concept="3clFbS" id="68F0Oxkf9KU" role="3clF47">
-        <node concept="3cpWs8" id="4JmsWjEfWV7" role="3cqZAp">
-          <node concept="3cpWsn" id="4JmsWjEfWV8" role="3cpWs9">
-            <property role="TrG5h" value="set" />
-            <node concept="2hMVRd" id="4JmsWjEfWV9" role="1tU5fm">
-              <node concept="17QB3L" id="4JmsWjEfWVa" role="2hN53Y" />
-            </node>
-            <node concept="2ShNRf" id="4JmsWjEfWVb" role="33vP2m">
-              <node concept="1pGfFk" id="4JmsWjEfWVc" role="2ShVmc">
-                <property role="373rjd" value="true" />
-                <ref role="37wK5l" to="co:6WJM9CJzpYH" resolve="EquivalenceHashSet" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbH" id="68F0Oxkf9Lj" role="3cqZAp" />
-        <node concept="3vwNmj" id="68F0Oxkf9L_" role="3cqZAp">
-          <node concept="2OqwBi" id="68F0Oxkf9LA" role="3vwVQn">
-            <node concept="37vLTw" id="68F0Oxkf9LB" role="2Oq$k0">
-              <ref role="3cqZAo" node="4JmsWjEfWV8" resolve="set" />
-            </node>
-            <node concept="1v1jN8" id="68F0Oxkf9LC" role="2OqNvi" />
-          </node>
-        </node>
-        <node concept="3clFbH" id="68F0Oxkf9LD" role="3cqZAp" />
-        <node concept="3clFbF" id="3jVUTQDfSWL" role="3cqZAp">
-          <node concept="2OqwBi" id="3jVUTQDfSWF" role="3clFbG">
-            <node concept="2WthIp" id="3jVUTQDfSWI" role="2Oq$k0" />
-            <node concept="2XshWL" id="3jVUTQDfSWK" role="2OqNvi">
-              <ref role="2WH_rO" node="3jVUTQDfPQ9" resolve="addMultipleTimes" />
-              <node concept="37vLTw" id="3jVUTQDfSWN" role="2XxRq1">
-                <ref role="3cqZAo" node="4JmsWjEfWV8" resolve="set" />
-              </node>
-              <node concept="Xl_RD" id="4JmsWjEga9C" role="2XxRq1">
-                <property role="Xl_RC" value="hello" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3vlDli" id="68F0Oxkf9LJ" role="3cqZAp">
-          <node concept="3cmrfG" id="68F0Oxkf9LK" role="3tpDZB">
-            <property role="3cmrfH" value="1" />
-          </node>
-          <node concept="2OqwBi" id="68F0Oxkf9LL" role="3tpDZA">
-            <node concept="37vLTw" id="68F0Oxkf9LM" role="2Oq$k0">
-              <ref role="3cqZAo" node="4JmsWjEfWV8" resolve="set" />
-            </node>
-            <node concept="34oBXx" id="68F0Oxkf9LN" role="2OqNvi" />
-          </node>
-          <node concept="3_1$Yv" id="68F0OxkfoHc" role="3_9lra" />
-        </node>
-        <node concept="3clFbH" id="3jVUTQDfVmd" role="3cqZAp" />
-        <node concept="3clFbF" id="3jVUTQDfZ7a" role="3cqZAp">
-          <node concept="2OqwBi" id="3jVUTQDfZ7b" role="3clFbG">
-            <node concept="2WthIp" id="3jVUTQDfZ7c" role="2Oq$k0" />
-            <node concept="2XshWL" id="3jVUTQDfZ7d" role="2OqNvi">
-              <ref role="2WH_rO" node="3jVUTQDfPQ9" resolve="addMultipleTimes" />
-              <node concept="37vLTw" id="3jVUTQDfZ7e" role="2XxRq1">
-                <ref role="3cqZAo" node="4JmsWjEfWV8" resolve="set" />
-              </node>
-              <node concept="Xl_RD" id="4JmsWjEgbVE" role="2XxRq1">
-                <property role="Xl_RC" value="world" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3vlDli" id="68F0Oxkf9M5" role="3cqZAp">
-          <node concept="2OqwBi" id="68F0Oxkf9M6" role="3tpDZA">
-            <node concept="37vLTw" id="68F0Oxkf9M7" role="2Oq$k0">
-              <ref role="3cqZAo" node="4JmsWjEfWV8" resolve="set" />
-            </node>
-            <node concept="34oBXx" id="68F0Oxkf9M8" role="2OqNvi" />
-          </node>
-          <node concept="3cmrfG" id="68F0Oxkf9M9" role="3tpDZB">
-            <property role="3cmrfH" value="2" />
-          </node>
-          <node concept="3_1$Yv" id="68F0Oxkfsh6" role="3_9lra" />
         </node>
       </node>
     </node>
@@ -1102,30 +992,31 @@
           </node>
         </node>
         <node concept="3clFbH" id="6uHwNxlf9Lx" role="3cqZAp" />
-        <node concept="3vlDli" id="6uHwNxlfcnz" role="3cqZAp">
-          <node concept="3cmrfG" id="6uHwNxlfcnD" role="3tpDZB">
-            <property role="3cmrfH" value="2" />
+        <node concept="3clFbF" id="7Pm1OAZlUd7" role="3cqZAp">
+          <node concept="2OqwBi" id="7Pm1OAZlWII" role="3clFbG">
+            <node concept="37vLTw" id="7Pm1OAZlUd5" role="2Oq$k0">
+              <ref role="3cqZAo" node="4JmsWjEfXkM" resolve="set" />
+            </node>
+            <node concept="3dhRuq" id="7Pm1OAZm0do" role="2OqNvi">
+              <node concept="Xl_RD" id="7Pm1OAZm3pl" role="25WWJ7">
+                <property role="Xl_RC" value="hello" />
+              </node>
+            </node>
           </node>
+        </node>
+        <node concept="3clFbH" id="7Pm1OAZlIKh" role="3cqZAp" />
+        <node concept="3vlDli" id="6uHwNxlfcnz" role="3cqZAp">
           <node concept="2OqwBi" id="6uHwNxlfdzv" role="3tpDZA">
             <node concept="37vLTw" id="6uHwNxlfcnE" role="2Oq$k0">
               <ref role="3cqZAo" node="4JmsWjEfXkM" resolve="set" />
             </node>
             <node concept="34oBXx" id="6uHwNxlfeEB" role="2OqNvi" />
           </node>
-        </node>
-        <node concept="3clFbH" id="6uHwNxlffbu" role="3cqZAp" />
-        <node concept="3clFbF" id="6uHwNxlffb_" role="3cqZAp">
-          <node concept="2OqwBi" id="6uHwNxlfgtk" role="3clFbG">
-            <node concept="37vLTw" id="6uHwNxlffbz" role="2Oq$k0">
-              <ref role="3cqZAo" node="4JmsWjEfXkM" resolve="set" />
-            </node>
-            <node concept="3dhRuq" id="6uHwNxlfhyc" role="2OqNvi">
-              <node concept="Xl_RD" id="4JmsWjEgoWX" role="25WWJ7">
-                <property role="Xl_RC" value="hello" />
-              </node>
-            </node>
+          <node concept="3cmrfG" id="7Pm1OAZm5TB" role="3tpDZB">
+            <property role="3cmrfH" value="1" />
           </node>
         </node>
+        <node concept="3clFbH" id="6uHwNxlffbu" role="3cqZAp" />
         <node concept="3clFbF" id="6uHwNxlfiit" role="3cqZAp">
           <node concept="2OqwBi" id="6uHwNxlfiiu" role="3clFbG">
             <node concept="37vLTw" id="6uHwNxlfiiv" role="2Oq$k0">
@@ -1874,7 +1765,7 @@
           </node>
         </node>
         <node concept="3vFxKo" id="13oTmDlxgHv" role="3cqZAp">
-          <node concept="17R0WA" id="13oTmDlxj3a" role="3vFALc">
+          <node concept="3clFbC" id="7Pm1OAZmoiH" role="3vFALc">
             <node concept="2OqwBi" id="13oTmDlxgOC" role="3uHU7B">
               <node concept="37vLTw" id="13oTmDlxgOD" role="2Oq$k0">
                 <ref role="3cqZAo" node="13oTmDlxayN" resolve="equivalence" />

--- a/code/languages/com.mbeddr.mpsutil/solutions/test.com.mbeddr.mpsutil.collections.runtime/test.com.mbeddr.mpsutil.collections.runtime.msd
+++ b/code/languages/com.mbeddr.mpsutil/solutions/test.com.mbeddr.mpsutil.collections.runtime/test.com.mbeddr.mpsutil.collections.runtime.msd
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<solution name="test.com.mbeddr.mpsutil.collections.runtime" uuid="f88d18b6-41df-491c-ad99-c292037bf751" moduleVersion="0" compileInMPS="true">
+  <models>
+    <modelRoot type="default" contentPath="${module}">
+      <sourceRoot location="models" />
+    </modelRoot>
+  </models>
+  <facets>
+    <facet compile="mps" classes="mps" ext="no" type="java">
+      <classes generated="true" path="${module}/classes_gen" />
+    </facet>
+  </facets>
+  <sourcePath />
+  <dependencies>
+    <dependency reexport="false">8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)</dependency>
+    <dependency reexport="false">ecfb9949-7433-4db5-85de-0f84d172e4ce(de.q60.mps.collections.libs)</dependency>
+    <dependency reexport="false">ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)</dependency>
+    <dependency reexport="false">f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)</dependency>
+    <dependency reexport="false">3f2dbc2e-ad41-470f-b5f1-2869513d2b58(com.mbeddr.mpsutil.collections.runtime)</dependency>
+    <dependency reexport="false">8585453e-6bfb-4d80-98de-b16074f1d86c(jetbrains.mps.lang.test)</dependency>
+    <dependency reexport="false">83888646-71ce-4f1c-9c53-c54016f6ad4f(jetbrains.mps.baseLanguage.collections)</dependency>
+    <dependency reexport="false">e89e1550-b8fe-4f0d-a7fd-487968b42405(com.mbeddr.mpsutil.collections)</dependency>
+  </dependencies>
+  <languageVersions>
+    <language slang="l:e89e1550-b8fe-4f0d-a7fd-487968b42405:com.mbeddr.mpsutil.collections" version="0" />
+    <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
+    <language slang="l:443f4c36-fcf5-4eb6-9500-8d06ed259e3e:jetbrains.mps.baseLanguage.classifiers" version="0" />
+    <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
+    <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
+    <language slang="l:f61473f9-130f-42f6-b98d-6c438812c2f6:jetbrains.mps.baseLanguage.unitTest" version="1" />
+    <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
+    <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
+    <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="5" />
+    <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="19" />
+    <language slang="l:8585453e-6bfb-4d80-98de-b16074f1d86c:jetbrains.mps.lang.test" version="6" />
+    <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
+  </languageVersions>
+  <dependencyVersions>
+    <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
+    <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
+    <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
+    <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
+    <module reference="e89e1550-b8fe-4f0d-a7fd-487968b42405(com.mbeddr.mpsutil.collections)" version="0" />
+    <module reference="3f2dbc2e-ad41-470f-b5f1-2869513d2b58(com.mbeddr.mpsutil.collections.runtime)" version="0" />
+    <module reference="ecfb9949-7433-4db5-85de-0f84d172e4ce(de.q60.mps.collections.libs)" version="0" />
+    <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
+    <module reference="443f4c36-fcf5-4eb6-9500-8d06ed259e3e(jetbrains.mps.baseLanguage.classifiers)" version="0" />
+    <module reference="fd392034-7849-419d-9071-12563d152375(jetbrains.mps.baseLanguage.closures)" version="0" />
+    <module reference="83888646-71ce-4f1c-9c53-c54016f6ad4f(jetbrains.mps.baseLanguage.collections)" version="0" />
+    <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
+    <module reference="f61473f9-130f-42f6-b98d-6c438812c2f6(jetbrains.mps.baseLanguage.unitTest)" version="0" />
+    <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
+    <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
+    <module reference="8585453e-6bfb-4d80-98de-b16074f1d86c(jetbrains.mps.lang.test)" version="0" />
+    <module reference="9ded098b-ad6a-4657-bfd9-48636cfe8bc3(jetbrains.mps.lang.traceable)" version="0" />
+    <module reference="f88d18b6-41df-491c-ad99-c292037bf751(test.com.mbeddr.mpsutil.collections.runtime)" version="0" />
+  </dependencyVersions>
+</solution>
+


### PR DESCRIPTION
A new language `com.mbeddr.mpsutil.collections` was added that adds support for a set type `nset` that use nodes as the values of the set. Equivalence of nodes is checked structurally. The hash code calculation is done for all properties and children and the first level of references. The runtime solution also contains a more general class `EquivalenceHashSet` to implement hash sets with arbitrary `equals` and `hashcode` methods. `nset<>` is also compatible with `set<node>` and can be used as its type instead.

Implementation note: I didn't use the built-in implementation like the matches statement and the StructuralNodeSet from MPS because it deals poorly with copied nodes. For example, a copy of a class sometimes is not structural equal to the class itself: https://youtrack.jetbrains.com/issue/MPS-37894/matches-operation-not-working-for-type-variables


<img width="974" alt="Screenshot 2024-11-04 at 19 54 33" src="https://github.com/user-attachments/assets/27ef7dec-61c9-4f21-890b-f2c0d54edc2c">

<img width="974" alt="Screenshot 2024-11-04 at 19 56 47" src="https://github.com/user-attachments/assets/6d935a4f-b197-4e3d-a6f3-2c8763aafa49">
