### PR TITLE
doc.aspect.runtime: depend on a IntelliJ platform library for the cache instead of de.q60.mps.collections.libs

### DIFF
--- a/code/languages/com.mbeddr.build/solutions/com.mbeddr.platform/models/com/mbeddr/platform/build.mps
+++ b/code/languages/com.mbeddr.build/solutions/com.mbeddr.platform/models/com/mbeddr/platform/build.mps
@@ -18411,9 +18411,9 @@
             <ref role="3bR37D" to="ffeo:7Kfy9QB6L4p" resolve="jetbrains.mps.lang.behavior" />
           </node>
         </node>
-        <node concept="1SiIV0" id="7VnJHsAbmDt" role="3bR37C">
-          <node concept="3bR9La" id="7VnJHsAbmDu" role="1SiIV1">
-            <ref role="3bR37D" to="90a9:6fQhGuklQWU" resolve="de.q60.mps.collections.libs" />
+        <node concept="1SiIV0" id="3BP506vp1ec" role="3bR37C">
+          <node concept="3bR9La" id="3BP506vp1ed" role="1SiIV1">
+            <ref role="3bR37D" to="90a9:3$A0JaN5bpX" resolve="MPS.ThirdParty" />
           </node>
         </node>
       </node>

--- a/code/languages/com.mbeddr.doc.aspect/languages/com.mbeddr.doc.aspect.exampleLanguage/models/com/mbeddr/doc/aspect/exampleLanguage/structure.mps
+++ b/code/languages/com.mbeddr.doc.aspect/languages/com.mbeddr.doc.aspect.exampleLanguage/models/com/mbeddr/doc/aspect/exampleLanguage/structure.mps
@@ -40,7 +40,7 @@
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
-      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
     </language>

--- a/code/languages/com.mbeddr.doc.aspect/solutions/com.mbeddr.doc.aspect.runtime/com.mbeddr.doc.aspect.runtime.msd
+++ b/code/languages/com.mbeddr.doc.aspect/solutions/com.mbeddr.doc.aspect.runtime/com.mbeddr.doc.aspect.runtime.msd
@@ -17,7 +17,7 @@
     <dependency reexport="false">c72da2b9-7cce-4447-8389-f407dc1158b7(jetbrains.mps.lang.structure)</dependency>
     <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
     <dependency reexport="false">af65afd8-f0dd-4942-87d9-63a55f2a9db1(jetbrains.mps.lang.behavior)</dependency>
-    <dependency reexport="false">ecfb9949-7433-4db5-85de-0f84d172e4ce(de.q60.mps.collections.libs)</dependency>
+    <dependency reexport="false">39983771-4e9b-401b-a1a9-1da6c777c843(MPS.ThirdParty)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:654422bf-e75f-44dc-936d-188890a746ce:de.slisson.mps.reflection" version="0" />
@@ -40,6 +40,7 @@
     <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
     <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
+    <module reference="39983771-4e9b-401b-a1a9-1da6c777c843(MPS.ThirdParty)" version="0" />
     <module reference="d4280a54-f6df-4383-aa41-d1b2bffa7eb1(com.mbeddr.core.base)" version="3" />
     <module reference="2374bc90-7e37-41f1-a9c4-c2e35194c36a(com.mbeddr.doc)" version="0" />
     <module reference="38a074ed-e5ad-4b2d-be31-ca436911b8aa(com.mbeddr.doc.aspect)" version="0" />
@@ -52,7 +53,6 @@
     <module reference="24c96a96-b7a1-4f30-82da-0f8e279a2661(de.itemis.mps.editor.celllayout.styles)" version="0" />
     <module reference="5c13c612-0f7b-4f0a-ab8b-565186b418de(de.itemis.mps.mouselistener.runtime)" version="0" />
     <module reference="cce85e64-7b37-4ad5-b0e6-9d18324cdfb3(de.itemis.mps.selection.runtime)" version="0" />
-    <module reference="ecfb9949-7433-4db5-85de-0f84d172e4ce(de.q60.mps.collections.libs)" version="0" />
     <module reference="dc038ceb-b7ea-4fea-ac12-55f7400e97ba(de.slisson.mps.editor.multiline.runtime)" version="0" />
     <module reference="f0fff802-6d26-4d2e-b89d-391357265626(de.slisson.mps.hacks.editor)" version="0" />
     <module reference="92d2ea16-5a42-4fdf-a676-c7604efe3504(de.slisson.mps.richtext)" version="0" />

--- a/code/languages/com.mbeddr.doc.aspect/solutions/com.mbeddr.doc.aspect.runtime/models/com/mbeddr/doc/aspect/runtime.mps
+++ b/code/languages/com.mbeddr.doc.aspect/solutions/com.mbeddr.doc.aspect.runtime/models/com/mbeddr/doc/aspect/runtime.mps
@@ -22,7 +22,7 @@
     <import index="pgte" ref="r:e361f9f2-2afa-4fbe-b895-bdd4fbfe44fa(com.mbeddr.doc.aspect.plugin)" />
     <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
     <import index="1i04" ref="r:3270011d-8b2d-4938-8dff-d256a759e017(jetbrains.mps.lang.behavior.structure)" />
-    <import index="sgh3" ref="ecfb9949-7433-4db5-85de-0f84d172e4ce/java:com.google.common.cache(de.q60.mps.collections.libs/)" />
+    <import index="itts" ref="39983771-4e9b-401b-a1a9-1da6c777c843/java:com.github.benmanes.caffeine.cache(MPS.ThirdParty/)" />
     <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" implicit="true" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
     <import index="4gky" ref="r:e1dfab1d-c7a7-43e7-9f26-028afd483e82(com.mbeddr.doc.behavior)" implicit="true" />
@@ -1062,7 +1062,7 @@
       <property role="TrG5h" value="cache" />
       <node concept="3Tm6S6" id="2DFA9RLl1cR" role="1B3o_S" />
       <node concept="3uibUv" id="2DFA9RLkRkP" role="1tU5fm">
-        <ref role="3uigEE" to="sgh3:~Cache" resolve="Cache" />
+        <ref role="3uigEE" to="itts:~Cache" resolve="Cache" />
         <node concept="1LlUBW" id="2DFA9RLkRLr" role="11_B2D">
           <node concept="3bZ5Sz" id="2DFA9RLkSej" role="1Lm7xW" />
           <node concept="3uibUv" id="2DFA9RLkSFc" role="1Lm7xW">
@@ -1074,37 +1074,37 @@
           <node concept="3Tqbb2" id="1GfgNpVSGmN" role="11_B2D" />
         </node>
       </node>
-      <node concept="2OqwBi" id="2DFA9RLkXKB" role="33vP2m">
-        <node concept="2OqwBi" id="2DFA9RLkVrI" role="2Oq$k0">
-          <node concept="2YIFZM" id="2DFA9RLkV2x" role="2Oq$k0">
-            <ref role="37wK5l" to="sgh3:~CacheBuilder.newBuilder()" resolve="newBuilder" />
-            <ref role="1Pybhc" to="sgh3:~CacheBuilder" resolve="CacheBuilder" />
-          </node>
-          <node concept="liA8E" id="2DFA9RLkWu4" role="2OqNvi">
-            <ref role="37wK5l" to="sgh3:~CacheBuilder.maximumSize(long)" resolve="maximumSize" />
-            <node concept="3cmrfG" id="2DFA9RLkWMO" role="37wK5m">
-              <property role="3cmrfH" value="5000" />
-            </node>
-          </node>
-        </node>
-        <node concept="liA8E" id="2DFA9RLkYWI" role="2OqNvi">
-          <ref role="37wK5l" to="sgh3:~CacheBuilder.build()" resolve="build" />
-          <node concept="1LlUBW" id="2DFA9RLl0fN" role="3PaCim">
-            <node concept="3bZ5Sz" id="2DFA9RLl0fO" role="1Lm7xW" />
-            <node concept="3uibUv" id="2DFA9RLl0fP" role="1Lm7xW">
-              <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
-            </node>
-          </node>
-          <node concept="3uibUv" id="1GfgNpVSIDz" role="3PaCim">
-            <ref role="3uigEE" to="33ny:~Optional" resolve="Optional" />
-            <node concept="3Tqbb2" id="1GfgNpVSID$" role="11_B2D" />
-          </node>
-        </node>
-      </node>
       <node concept="z59LJ" id="1GfgNpVVt$C" role="lGtFl">
         <node concept="TZ5HA" id="1GfgNpVVt$D" role="TZ5H$">
           <node concept="1dT_AC" id="1GfgNpVVt$E" role="1dT_Ay">
             <property role="1dT_AB" value="Cache for concept/property to corresponding node in documentation." />
+          </node>
+        </node>
+      </node>
+      <node concept="2OqwBi" id="3BP506voh2s" role="33vP2m">
+        <node concept="2OqwBi" id="3BP506vod_p" role="2Oq$k0">
+          <node concept="2YIFZM" id="3BP506vocKt" role="2Oq$k0">
+            <ref role="37wK5l" to="itts:~Caffeine.newBuilder()" resolve="newBuilder" />
+            <ref role="1Pybhc" to="itts:~Caffeine" resolve="Caffeine" />
+          </node>
+          <node concept="liA8E" id="3BP506voeAa" role="2OqNvi">
+            <ref role="37wK5l" to="itts:~Caffeine.maximumSize(long)" resolve="maximumSize" />
+            <node concept="3cmrfG" id="3BP506voflv" role="37wK5m">
+              <property role="3cmrfH" value="5000" />
+            </node>
+          </node>
+        </node>
+        <node concept="liA8E" id="3BP506voi04" role="2OqNvi">
+          <ref role="37wK5l" to="itts:~Caffeine.build()" resolve="build" />
+          <node concept="1LlUBW" id="3BP506voyGc" role="3PaCim">
+            <node concept="3bZ5Sz" id="3BP506voyGd" role="1Lm7xW" />
+            <node concept="3uibUv" id="3BP506voyGe" role="1Lm7xW">
+              <ref role="3uigEE" to="c17a:~SProperty" resolve="SProperty" />
+            </node>
+          </node>
+          <node concept="3uibUv" id="3BP506vo$tk" role="3PaCim">
+            <ref role="3uigEE" to="33ny:~Optional" resolve="Optional" />
+            <node concept="3Tqbb2" id="3BP506vo$tl" role="11_B2D" />
           </node>
         </node>
       </node>
@@ -1159,7 +1159,7 @@
                 <ref role="3cqZAo" node="2DFA9RLkOfY" resolve="cache" />
               </node>
               <node concept="liA8E" id="1GfgNpVOgQm" role="2OqNvi">
-                <ref role="37wK5l" to="sgh3:~Cache.getIfPresent(java.lang.Object)" resolve="getIfPresent" />
+                <ref role="37wK5l" to="itts:~Cache.getIfPresent(java.lang.Object)" resolve="getIfPresent" />
                 <node concept="37vLTw" id="1GfgNpVOWOX" role="37wK5m">
                   <ref role="3cqZAo" node="1GfgNpVOWOT" resolve="key" />
                 </node>
@@ -1239,7 +1239,7 @@
                   <ref role="3cqZAo" node="2DFA9RLkOfY" resolve="cache" />
                 </node>
                 <node concept="liA8E" id="1GfgNpVQoOd" role="2OqNvi">
-                  <ref role="37wK5l" to="sgh3:~Cache.put(java.lang.Object,java.lang.Object)" resolve="put" />
+                  <ref role="37wK5l" to="itts:~Cache.put(java.lang.Object,java.lang.Object)" resolve="put" />
                   <node concept="37vLTw" id="1GfgNpVQrcc" role="37wK5m">
                     <ref role="3cqZAo" node="1GfgNpVOWOT" resolve="key" />
                   </node>


### PR DESCRIPTION
This is an attempt to fix https://youtrack.jetbrains.com/issue/MPS-37663/Failed-to-instantiate-aspect-interface-jetbrains.mps.smodel.runtime.StructureAspectDescriptor-in-language-my.language.