### PR TITLE
make sure all typechecks in mpsutil.compare have a node to report

### DIFF
--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.compare/languageModels/typesystem.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.compare/languageModels/typesystem.mps
@@ -112,6 +112,9 @@
             </node>
           </node>
         </node>
+        <node concept="1YBJjd" id="77BxNvs6uQY" role="1ZmcU8">
+          <ref role="1YBMHb" node="2lpUxXMeGs5" resolve="assertNodeEquals" />
+        </node>
       </node>
       <node concept="1Z5TYs" id="3qPjHtYqU7C" role="3cqZAp">
         <node concept="mw_s8" id="3qPjHtYqU7D" role="1ZfhKB">
@@ -135,6 +138,9 @@
             </node>
           </node>
         </node>
+        <node concept="1YBJjd" id="77BxNvs6uR1" role="1ZmcU8">
+          <ref role="1YBMHb" node="2lpUxXMeGs5" resolve="assertNodeEquals" />
+        </node>
       </node>
       <node concept="1ZobV4" id="2lpUxXMeYl$" role="3cqZAp">
         <property role="3wDh2S" value="true" />
@@ -155,6 +161,9 @@
             <node concept="3Tqbb2" id="2lpUxXMeYlC" role="2c44tc" />
           </node>
         </node>
+        <node concept="1YBJjd" id="77BxNvs6uR4" role="1ZmcU8">
+          <ref role="1YBMHb" node="2lpUxXMeGs5" resolve="assertNodeEquals" />
+        </node>
       </node>
       <node concept="1ZobV4" id="2lpUxXMf6TB" role="3cqZAp">
         <property role="3wDh2S" value="true" />
@@ -174,6 +183,9 @@
           <node concept="2c44tf" id="2lpUxXMf6TE" role="mwGJk">
             <node concept="3Tqbb2" id="2lpUxXMf6TF" role="2c44tc" />
           </node>
+        </node>
+        <node concept="1YBJjd" id="77BxNvs6uR7" role="1ZmcU8">
+          <ref role="1YBMHb" node="2lpUxXMeGs5" resolve="assertNodeEquals" />
         </node>
       </node>
     </node>
@@ -203,6 +215,9 @@
             </node>
           </node>
         </node>
+        <node concept="1YBJjd" id="77BxNvs6uX2" role="1ZmcU8">
+          <ref role="1YBMHb" node="3C6_kMLO7Z1" resolve="assertHasElements" />
+        </node>
       </node>
       <node concept="1ZobV4" id="3C6_kMLOf2c" role="3cqZAp">
         <property role="3wDh2S" value="true" />
@@ -222,6 +237,9 @@
           <node concept="2c44tf" id="3C6_kMLOf2k" role="mwGJk">
             <node concept="10Oyi0" id="3C6_kMM0LZF" role="2c44tc" />
           </node>
+        </node>
+        <node concept="1YBJjd" id="77BxNvs6uWZ" role="1ZmcU8">
+          <ref role="1YBMHb" node="3C6_kMLO7Z1" resolve="assertHasElements" />
         </node>
       </node>
     </node>
@@ -256,6 +274,9 @@
             </node>
           </node>
         </node>
+        <node concept="1YBJjd" id="77BxNvs6v4$" role="1ZmcU8">
+          <ref role="1YBMHb" node="1_DWnhqnLJ$" resolve="areEqualExpression" />
+        </node>
       </node>
       <node concept="1Z5TYs" id="3qPjHtY$at_" role="3cqZAp">
         <node concept="mw_s8" id="3qPjHtY$atA" role="1ZfhKB">
@@ -279,6 +300,9 @@
             </node>
           </node>
         </node>
+        <node concept="1YBJjd" id="77BxNvs6v4x" role="1ZmcU8">
+          <ref role="1YBMHb" node="1_DWnhqnLJ$" resolve="areEqualExpression" />
+        </node>
       </node>
       <node concept="1ZobV4" id="1_DWnhqnLLU" role="3cqZAp">
         <property role="3wDh2S" value="true" />
@@ -298,6 +322,9 @@
           <node concept="2c44tf" id="1_DWnhqnLM1" role="mwGJk">
             <node concept="3Tqbb2" id="1_DWnhqnLM2" role="2c44tc" />
           </node>
+        </node>
+        <node concept="1YBJjd" id="77BxNvs6v4u" role="1ZmcU8">
+          <ref role="1YBMHb" node="1_DWnhqnLJ$" resolve="areEqualExpression" />
         </node>
       </node>
       <node concept="1ZobV4" id="1_DWnhqnLM3" role="3cqZAp">
@@ -319,6 +346,9 @@
             <node concept="3Tqbb2" id="1_DWnhqnLMb" role="2c44tc" />
           </node>
         </node>
+        <node concept="1YBJjd" id="77BxNvs6v4r" role="1ZmcU8">
+          <ref role="1YBMHb" node="1_DWnhqnLJ$" resolve="areEqualExpression" />
+        </node>
       </node>
       <node concept="1Z5TYs" id="1_DWnhqnOv$" role="3cqZAp">
         <node concept="mw_s8" id="1_DWnhqnOCu" role="1ZfhKB">
@@ -336,6 +366,9 @@
               <ref role="1YBMHb" node="1_DWnhqnLJ$" resolve="areEqualExpression" />
             </node>
           </node>
+        </node>
+        <node concept="1YBJjd" id="77BxNvs6v4o" role="1ZmcU8">
+          <ref role="1YBMHb" node="1_DWnhqnLJ$" resolve="areEqualExpression" />
         </node>
       </node>
       <node concept="1ZoVOM" id="5qLQfLPiBfo" role="3cqZAp">


### PR DESCRIPTION
We've got a lot of errors like

```
[launchtests] [ 195231] SEVERE - jetbrains.mps.newTypesystem.context.ReportingTypecheckingContext - Typing equation did not provide node to report. Error will be ignored. Equation 3942143736278655464 from model r:f7b641c7-0327-4513-80ee-fa0921b93a79(com.mbeddr.mpsutil.compare.typesystem)
```

This PR fixes them by assigning a proper node to all typesystem checks in `com.mbeddr.mpsutil.compare`.