### PR TITLE
Automerge cascading PRs

### DIFF
--- a/.github/workflows/PR-into-next-version.yml
+++ b/.github/workflows/PR-into-next-version.yml
@@ -7,6 +7,11 @@ on:
 
 jobs:
   create-pr:
-    uses: specificlanguages/cascading-merge/.github/workflows/workflow.yml@v1
-    with:
-      exclude_branch_prefix: maintenance/mps3
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create PR
+        uses: specificlanguages/cascading-merge@v2
+        with:
+          exclude_branch_prefix: maintenance/mps3
+          automerge_new_prs: 'true'
+          token: ${{ secrets.MPS_CI_BUILD_BOT_ACCESS_TOKEN }}


### PR DESCRIPTION
Upgrade cascading-merge action to v2 and enable automerge of cascading PRs. This also changes the naming of branches from `merge/[source]` to `merge/[target]`.