### PR TITLE
Fix exception on FindAction-action

### DIFF
--- a/code/languages/com.mbeddr.build/solutions/com.mbeddr.allScripts/models/com/mbeddr/allScripts/build.mps
+++ b/code/languages/com.mbeddr.build/solutions/com.mbeddr.allScripts/models/com/mbeddr/allScripts/build.mps
@@ -115,7 +115,6 @@
       </concept>
       <concept id="868032131020265945" name="jetbrains.mps.build.mps.structure.BuildMPSPlugin" flags="ng" index="3b7kt6" />
       <concept id="5253498789149381388" name="jetbrains.mps.build.mps.structure.BuildMps_Module" flags="ng" index="3bQrTs">
-        <property id="1500819558096356884" name="doNotCompile" index="2GAjPV" />
         <child id="5253498789149547825" name="sources" index="3bR31x" />
         <child id="5253498789149547704" name="dependencies" index="3bR37C" />
       </concept>
@@ -234,7 +233,6 @@
         <property role="BnDLt" value="true" />
         <property role="TrG5h" value="com.mbeddr.allScripts" />
         <property role="3LESm3" value="752496a0-da43-4b5e-bd15-ea1a5aa211f6" />
-        <property role="2GAjPV" value="true" />
         <node concept="1SiIV0" id="1RubBbpfBdf" role="3bR37C">
           <node concept="3bR9La" id="1RubBbpfBdg" role="1SiIV1">
             <ref role="3bR37D" to="ffeo:5xa9wY2vhb7" resolve="jetbrains.mps.execution.configurations.implementation.plugin" />
@@ -305,7 +303,6 @@
         <property role="BnDLt" value="true" />
         <property role="TrG5h" value="com.mbeddr.core.tests.build" />
         <property role="3LESm3" value="d47a3921-8b42-4664-bed6-25e3e4fd6efb" />
-        <property role="2GAjPV" value="true" />
         <node concept="1SiIV0" id="2coa6XmWDD_" role="3bR37C">
           <node concept="3bR9La" id="2coa6XmWDDA" role="1SiIV1">
             <ref role="3bR37D" to="ffeo:78GwwOvB3tw" resolve="jetbrains.mps.ide.build" />
@@ -378,7 +375,6 @@
         <property role="BnDLt" value="true" />
         <property role="TrG5h" value="com.mbeddr.core.tests.performance.build" />
         <property role="3LESm3" value="b4b96a11-a253-4152-8bd6-6444c1b087e8" />
-        <property role="2GAjPV" value="true" />
         <node concept="1SiIV0" id="2coa6XmWDsP" role="3bR37C">
           <node concept="3bR9La" id="2coa6XmWDsQ" role="1SiIV1">
             <ref role="3bR37D" to="ffeo:78GwwOvB3tw" resolve="jetbrains.mps.ide.build" />
@@ -451,7 +447,6 @@
         <property role="BnDLt" value="true" />
         <property role="TrG5h" value="com.mbeddr.cc.tests.dev.build" />
         <property role="3LESm3" value="ffd31df9-5187-4c9a-bb4f-d84e5f59ffd5" />
-        <property role="2GAjPV" value="true" />
         <node concept="1SiIV0" id="2UI1wmC2X8U" role="3bR37C">
           <node concept="3bR9La" id="2UI1wmC2X8V" role="1SiIV1">
             <ref role="3bR37D" to="ffeo:78GwwOvB3tw" resolve="jetbrains.mps.ide.build" />
@@ -524,7 +519,6 @@
         <property role="BnDLt" value="true" />
         <property role="TrG5h" value="com.mbeddr.ext.tests.build" />
         <property role="3LESm3" value="06f4ccb3-313d-4d48-9667-87a8fb963fb2" />
-        <property role="2GAjPV" value="true" />
         <node concept="1SiIV0" id="2UI1wmC2Qwz" role="3bR37C">
           <node concept="3bR9La" id="2UI1wmC2Qw$" role="1SiIV1">
             <ref role="3bR37D" to="ffeo:78GwwOvB3tw" resolve="jetbrains.mps.ide.build" />
@@ -600,7 +594,6 @@
         <property role="BnDLt" value="true" />
         <property role="TrG5h" value="com.mbeddr.platform" />
         <property role="3LESm3" value="3ae9cfda-f938-4524-b4ca-fbcba3b0525b" />
-        <property role="2GAjPV" value="true" />
         <node concept="1SiIV0" id="6ucYLjoxZFR" role="3bR37C">
           <node concept="3bR9La" id="6ucYLjoxZFS" role="1SiIV1">
             <ref role="3bR37D" to="90a9:PE3B26VOkn" resolve="de.itemis.mps.extensions.build" />
@@ -663,7 +656,6 @@
         <property role="BnDLt" value="true" />
         <property role="TrG5h" value="com.mbeddr.platform.tests.build" />
         <property role="3LESm3" value="c0ea564d-353d-4607-8b37-02e98106a159" />
-        <property role="2GAjPV" value="true" />
         <node concept="55IIr" id="5WPcUZfpqH_" role="3LF7KH">
           <node concept="2Ry0Ak" id="5WPcUZfpqHK" role="iGT6I">
             <property role="2Ry0Am" value="solutions" />
@@ -734,7 +726,6 @@
         <property role="BnDLt" value="true" />
         <property role="TrG5h" value="com.mbeddr.build" />
         <property role="3LESm3" value="7ac0dfb8-7d5f-4573-ab80-81af2106ce03" />
-        <property role="2GAjPV" value="true" />
         <node concept="1SiIV0" id="3AVJcIMl$Ko" role="3bR37C">
           <node concept="3bR9La" id="3AVJcIMl$Kp" role="1SiIV1">
             <ref role="3bR37D" to="90a9:PE3B26VOkn" resolve="de.itemis.mps.extensions.build" />
@@ -807,7 +798,6 @@
         <property role="BnDLt" value="true" />
         <property role="TrG5h" value="com.mbeddr.xmodel.build" />
         <property role="3LESm3" value="f784c90b-1ff6-440a-9cf3-266de03c53ec" />
-        <property role="2GAjPV" value="true" />
         <node concept="1SiIV0" id="3qyGNHcUY08" role="3bR37C">
           <node concept="3bR9La" id="3qyGNHcUY09" role="1SiIV1">
             <ref role="3bR37D" node="2coa6XmWDDt" resolve="com.mbeddr.core.tests.build" />

--- a/code/languages/com.mbeddr.build/solutions/com.mbeddr.platform.tests.build/models/com.mbeddr.platform.tests.build.mps
+++ b/code/languages/com.mbeddr.build/solutions/com.mbeddr.platform.tests.build/models/com.mbeddr.platform.tests.build.mps
@@ -1555,9 +1555,29 @@
             <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
           </node>
         </node>
+        <node concept="1SiIV0" id="bHMJKhDDf7" role="3bR37C">
+          <node concept="3bR9La" id="bHMJKhDDf8" role="1SiIV1">
+            <ref role="3bR37D" to="al5i:776vT$mQZbf" resolve="com.mbeddr.mpsutil.comparator" />
+          </node>
+        </node>
         <node concept="1SiIV0" id="bHMJKhDDf9" role="3bR37C">
           <node concept="3bR9La" id="bHMJKhDDfa" role="1SiIV1">
             <ref role="3bR37D" to="ffeo:7Kfy9QB6KXW" resolve="jetbrains.mps.lang.core" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="bHMJKhDDfb" role="3bR37C">
+          <node concept="3bR9La" id="bHMJKhDDfc" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:7Kfy9QB6L9O" resolve="jetbrains.mps.lang.smodel" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="bHMJKhDDfd" role="3bR37C">
+          <node concept="3bR9La" id="bHMJKhDDfe" role="1SiIV1">
+            <ref role="3bR37D" to="al5i:vOGyTeKPEA" resolve="com.mbeddr.mpsutil.ecore.testing" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="bHMJKhDDff" role="3bR37C">
+          <node concept="3bR9La" id="bHMJKhDDfg" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:7Kfy9QB6LaO" resolve="jetbrains.mps.lang.structure" />
           </node>
         </node>
         <node concept="398BVA" id="bHMJKhDAXY" role="3LF7KH">

--- a/code/languages/com.mbeddr.build/solutions/com.mbeddr.platform.tests.build/models/com.mbeddr.platform.tests.build.mps
+++ b/code/languages/com.mbeddr.build/solutions/com.mbeddr.platform.tests.build/models/com.mbeddr.platform.tests.build.mps
@@ -1555,29 +1555,9 @@
             <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
           </node>
         </node>
-        <node concept="1SiIV0" id="bHMJKhDDf7" role="3bR37C">
-          <node concept="3bR9La" id="bHMJKhDDf8" role="1SiIV1">
-            <ref role="3bR37D" to="al5i:776vT$mQZbf" resolve="com.mbeddr.mpsutil.comparator" />
-          </node>
-        </node>
         <node concept="1SiIV0" id="bHMJKhDDf9" role="3bR37C">
           <node concept="3bR9La" id="bHMJKhDDfa" role="1SiIV1">
             <ref role="3bR37D" to="ffeo:7Kfy9QB6KXW" resolve="jetbrains.mps.lang.core" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="bHMJKhDDfb" role="3bR37C">
-          <node concept="3bR9La" id="bHMJKhDDfc" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:7Kfy9QB6L9O" resolve="jetbrains.mps.lang.smodel" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="bHMJKhDDfd" role="3bR37C">
-          <node concept="3bR9La" id="bHMJKhDDfe" role="1SiIV1">
-            <ref role="3bR37D" to="al5i:vOGyTeKPEA" resolve="com.mbeddr.mpsutil.ecore.testing" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="bHMJKhDDff" role="3bR37C">
-          <node concept="3bR9La" id="bHMJKhDDfg" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:7Kfy9QB6LaO" resolve="jetbrains.mps.lang.structure" />
           </node>
         </node>
         <node concept="398BVA" id="bHMJKhDAXY" role="3LF7KH">

--- a/code/languages/com.mbeddr.build/solutions/com.mbeddr.platform/models/com/mbeddr/platform/build.mps
+++ b/code/languages/com.mbeddr.build/solutions/com.mbeddr.platform/models/com/mbeddr/platform/build.mps
@@ -11803,8 +11803,8 @@
               </node>
             </node>
           </node>
-          <node concept="1SiIV0" id="nCjUNn5mBT" role="3bR37C">
-            <node concept="3bR9La" id="nCjUNn5mBU" role="1SiIV1">
+          <node concept="1SiIV0" id="1k8mMQapuLg" role="3bR37C">
+            <node concept="3bR9La" id="1k8mMQapuLh" role="1SiIV1">
               <ref role="3bR37D" to="ffeo:44LXwdzyvTi" resolve="Annotations" />
             </node>
           </node>

--- a/code/languages/com.mbeddr.build/solutions/com.mbeddr.platform/models/com/mbeddr/platform/build.mps
+++ b/code/languages/com.mbeddr.build/solutions/com.mbeddr.platform/models/com/mbeddr/platform/build.mps
@@ -11803,6 +11803,11 @@
               </node>
             </node>
           </node>
+          <node concept="1SiIV0" id="nCjUNn5mBT" role="3bR37C">
+            <node concept="3bR9La" id="nCjUNn5mBU" role="1SiIV1">
+              <ref role="3bR37D" to="ffeo:44LXwdzyvTi" resolve="Annotations" />
+            </node>
+          </node>
         </node>
         <node concept="1SiIV0" id="7Hbe8h75E73" role="3bR37C">
           <node concept="3bR9La" id="7Hbe8h75E74" role="1SiIV1">

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.preferenceform/com.mbeddr.mpsutil.preferenceform.mpl
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.preferenceform/com.mbeddr.mpsutil.preferenceform.mpl
@@ -40,6 +40,7 @@
         <dependency reexport="false">1d6e05d7-9de9-40a7-9dad-7b8444280942(jetbrains.mps.lang.plugin#1203080439937)</dependency>
         <dependency reexport="false">443f4c36-fcf5-4eb6-9500-8d06ed259e3e(jetbrains.mps.baseLanguage.classifiers)</dependency>
         <dependency reexport="false">8d29d73f-ed99-4652-ae0a-083cdfe53c34(jetbrains.mps.ide.platform)</dependency>
+        <dependency reexport="false">3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)</dependency>
       </dependencies>
       <languageVersions>
         <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.preferenceform/generator/template/main@generator.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.preferenceform/generator/template/main@generator.mps
@@ -6733,7 +6733,7 @@
         </node>
       </node>
       <node concept="2AHcQZ" id="nCjUNn4Elu" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" />
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
     <node concept="3Tm1VV" id="4vnGofEtmpA" role="1B3o_S" />

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.preferenceform/generator/template/main@generator.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.preferenceform/generator/template/main@generator.mps
@@ -40,7 +40,9 @@
     <import index="rh18" ref="32addf6f-1f14-40cb-991d-e0fddb7506c1/r:7c73bcc0-050a-46cb-bba5-d10598f1b9f2(com.mbeddr.mpsutil.preferenceform.runtime/com.mbeddr.mpsutil.preferenceform.runtime)" />
     <import index="bd8o" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.application(MPS.IDEA/)" />
     <import index="zn9m" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.util(MPS.IDEA/)" />
+    <import index="mhfm" ref="3f233e7f-b8a6-46d2-a57f-795d56775243/java:org.jetbrains.annotations(Annotations/)" />
     <import index="tp4h" ref="r:00000000-0000-4000-0000-011c8959036d(jetbrains.mps.baseLanguage.classifiers.behavior)" implicit="true" />
+    <import index="mhbf" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.model(MPS.OpenAPI/)" implicit="true" />
   </imports>
   <registry>
     <language id="28f9e497-3b42-4291-aeba-0a1039153ab1" name="jetbrains.mps.lang.plugin">
@@ -6687,6 +6689,53 @@
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
+    <node concept="2tJIrI" id="nCjUNn4Elb" role="jymVt" />
+    <node concept="3clFb_" id="nCjUNn4Elc" role="jymVt">
+      <property role="TrG5h" value="getId" />
+      <node concept="3Tm1VV" id="nCjUNn4Eld" role="1B3o_S" />
+      <node concept="2AHcQZ" id="nCjUNn4Ele" role="2AJF6D">
+        <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+      </node>
+      <node concept="2AHcQZ" id="nCjUNn4Elf" role="2AJF6D">
+        <ref role="2AI5Lk" to="mhfm:~NonNls" resolve="NonNls" />
+      </node>
+      <node concept="3uibUv" id="nCjUNn4Elg" role="3clF45">
+        <ref role="3uigEE" to="wyt6:~String" resolve="String" />
+      </node>
+      <node concept="3clFbS" id="nCjUNn4Elh" role="3clF47">
+        <node concept="3clFbF" id="nCjUNn4Eli" role="3cqZAp">
+          <node concept="Xl_RD" id="nCjUNn4Elj" role="3clFbG">
+            <property role="Xl_RC" value="" />
+            <node concept="17Uvod" id="nCjUNn4Elk" role="lGtFl">
+              <property role="2qtEX9" value="value" />
+              <property role="P4ACc" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1070475926800/1070475926801" />
+              <node concept="3zFVjK" id="nCjUNn4Ell" role="3zH0cK">
+                <node concept="3clFbS" id="nCjUNn4Elm" role="2VODD2">
+                  <node concept="3clFbF" id="nCjUNn4Eln" role="3cqZAp">
+                    <node concept="2OqwBi" id="nCjUNn4Elo" role="3clFbG">
+                      <node concept="2OqwBi" id="nCjUNn4Elp" role="2Oq$k0">
+                        <node concept="2JrnkZ" id="nCjUNn4Elq" role="2Oq$k0">
+                          <node concept="30H73N" id="nCjUNn4Elr" role="2JrQYb" />
+                        </node>
+                        <node concept="liA8E" id="nCjUNn4Els" role="2OqNvi">
+                          <ref role="37wK5l" to="mhbf:~SNode.getNodeId()" resolve="getNodeId" />
+                        </node>
+                      </node>
+                      <node concept="liA8E" id="nCjUNn4Elt" role="2OqNvi">
+                        <ref role="37wK5l" to="wyt6:~Object.toString()" resolve="toString" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="nCjUNn4Elu" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" />
+      </node>
+    </node>
     <node concept="3Tm1VV" id="4vnGofEtmpA" role="1B3o_S" />
     <node concept="n94m4" id="4vnGofEtmpB" role="lGtFl">
       <ref role="n9lRv" to="3iid:86yKXFERvb" resolve="PreferenceForm" />
@@ -8666,6 +8715,7 @@
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
+    <node concept="2tJIrI" id="nCjUNn3FJh" role="jymVt" />
     <node concept="3Tm1VV" id="hI3naNM" role="1B3o_S" />
     <node concept="n94m4" id="hI3naNR" role="lGtFl">
       <ref role="n9lRv" to="3iid:86yKXFERvb" resolve="PreferenceForm" />
@@ -8687,6 +8737,52 @@
             </node>
           </node>
         </node>
+      </node>
+    </node>
+    <node concept="3clFb_" id="3GLOsuShDHo" role="jymVt">
+      <property role="TrG5h" value="getId" />
+      <node concept="3Tm1VV" id="3GLOsuShDHp" role="1B3o_S" />
+      <node concept="2AHcQZ" id="3GLOsuShDHr" role="2AJF6D">
+        <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+      </node>
+      <node concept="2AHcQZ" id="3GLOsuShDHs" role="2AJF6D">
+        <ref role="2AI5Lk" to="mhfm:~NonNls" resolve="NonNls" />
+      </node>
+      <node concept="3uibUv" id="3GLOsuShDHt" role="3clF45">
+        <ref role="3uigEE" to="wyt6:~String" resolve="String" />
+      </node>
+      <node concept="3clFbS" id="3GLOsuShDHB" role="3clF47">
+        <node concept="3clFbF" id="3GLOsuShDHE" role="3cqZAp">
+          <node concept="Xl_RD" id="3GLOsuShZu_" role="3clFbG">
+            <property role="Xl_RC" value="" />
+            <node concept="17Uvod" id="3GLOsuSi6Th" role="lGtFl">
+              <property role="2qtEX9" value="value" />
+              <property role="P4ACc" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1070475926800/1070475926801" />
+              <node concept="3zFVjK" id="3GLOsuSi6Ti" role="3zH0cK">
+                <node concept="3clFbS" id="3GLOsuSi6Tj" role="2VODD2">
+                  <node concept="3clFbF" id="3GLOsuSi_Qx" role="3cqZAp">
+                    <node concept="2OqwBi" id="3GLOsuSjp7Q" role="3clFbG">
+                      <node concept="2OqwBi" id="3GLOsuSjcCO" role="2Oq$k0">
+                        <node concept="2JrnkZ" id="3GLOsuSj6AP" role="2Oq$k0">
+                          <node concept="30H73N" id="3GLOsuSiN4K" role="2JrQYb" />
+                        </node>
+                        <node concept="liA8E" id="3GLOsuSjiMN" role="2OqNvi">
+                          <ref role="37wK5l" to="mhbf:~SNode.getNodeId()" resolve="getNodeId" />
+                        </node>
+                      </node>
+                      <node concept="liA8E" id="3GLOsuSjwrh" role="2OqNvi">
+                        <ref role="37wK5l" to="wyt6:~Object.toString()" resolve="toString" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="3GLOsuShDHC" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
   </node>

--- a/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.preferenceform.runtime/models/AbstractPreferenceFormConfigurable.mpsr
+++ b/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.preferenceform.runtime/models/AbstractPreferenceFormConfigurable.mpsr
@@ -199,6 +199,9 @@
     <node concept="3uibUv" id="X7OD3Wrikr" role="EKbjA">
       <ref role="3uigEE" to="hq8m:~Configurable" resolve="Configurable" />
     </node>
+    <node concept="3uibUv" id="3dMezZ0ymKN" role="EKbjA">
+      <ref role="3uigEE" to="hq8m:~SearchableConfigurable" resolve="SearchableConfigurable" />
+    </node>
     <node concept="Wx3nA" id="4vnGofEqMD3" role="jymVt">
       <property role="2dlcS1" value="false" />
       <property role="TrG5h" value="OWN_CLIENT_PROPERTY_KEY" />


### PR DESCRIPTION
Prevent message when pressing Ctrl-Shift-A: "No display name specified in plugin descriptor XML file for configurable XXX; specify it using 'displayName' or 'key' attribute to avoid necessity to load the configurable class when Settings dialog is opened"

Happened for every PreferenceForm