### PR TITLE
genfacade: use RegularPlanBuilder instead of RigidPlanBuilder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is _loosely_ based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). The project does _not_ follow
 Semantic Versioning and the changes are simply documented in reverse chronological order, grouped by calendar month.
 
+# December 2024
+
+## com.mbeddr.mpsutil
+
+### Fixed
+
+- Updated `GeneratorFacade` helper class to support execution of genplans with Transform steps that have multiple entries (migrated from the old, deprecated languages list) which have to be executed all together in one single generation step.
+
 # November 2024
 
 ## com.mbeddr.mpsutil

--- a/code/languages/com.mbeddr.build/solutions/com.mbeddr.platform/models/com/mbeddr/platform/build.mps
+++ b/code/languages/com.mbeddr.build/solutions/com.mbeddr.platform/models/com/mbeddr/platform/build.mps
@@ -19410,21 +19410,6 @@
             <ref role="3bR37D" to="ffeo:44LXwdzyvTi" resolve="Annotations" />
           </node>
         </node>
-        <node concept="1SiIV0" id="58oUBCRFXvg" role="3bR37C">
-          <node concept="3bR9La" id="58oUBCRFXvh" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:1TaHNgiIbIZ" resolve="MPS.Editor" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="58oUBCRFXvi" role="3bR37C">
-          <node concept="3bR9La" id="58oUBCRFXvj" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:1TaHNgiIbJb" resolve="MPS.Platform" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="58oUBCRFXvk" role="3bR37C">
-          <node concept="3bR9La" id="58oUBCRFXvl" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:7Kfy9QB6Lfi" resolve="jetbrains.mps.generator" />
-          </node>
-        </node>
         <node concept="1SiIV0" id="58oUBCRFXvm" role="3bR37C">
           <node concept="3bR9La" id="58oUBCRFXvn" role="1SiIV1">
             <ref role="3bR37D" to="ffeo:307DWrMiIBc" resolve="jetbrains.mps.lang.generator.plan" />

--- a/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.generatorfacade/com.mbeddr.mpsutil.generatorfacade.msd
+++ b/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.generatorfacade/com.mbeddr.mpsutil.generatorfacade.msd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <solution name="com.mbeddr.mpsutil.generatorfacade" uuid="2c9058b6-7cd8-4623-82a3-e4c07c3eddff" moduleVersion="0">
   <models>
-    <modelRoot contentPath="${module}" type="default">
+    <modelRoot type="default" contentPath="${module}">
       <sourceRoot location="models" />
     </modelRoot>
   </models>
@@ -14,10 +14,7 @@
     <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
     <dependency reexport="false">3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)</dependency>
     <dependency reexport="true">6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)</dependency>
-    <dependency reexport="false">742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)</dependency>
     <dependency reexport="false">498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)</dependency>
-    <dependency reexport="false">1ed103c3-3aa6-49b7-9c21-6765ee11f224(MPS.Editor)</dependency>
-    <dependency reexport="false">5fa23c0a-216d-4571-a163-e286643e6f5f(jetbrains.mps.generator)</dependency>
     <dependency reexport="false">8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)</dependency>
     <dependency reexport="false">7ab1a6fa-0a11-4b95-9e48-75f363d6cb00(jetbrains.mps.lang.generator.plan)</dependency>
     <dependency reexport="false">215c4c45-ba99-49f5-9ab7-4b6901a63cfd(MPS.Generator)</dependency>
@@ -41,13 +38,10 @@
     <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
     <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
     <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
-    <module reference="1ed103c3-3aa6-49b7-9c21-6765ee11f224(MPS.Editor)" version="0" />
     <module reference="215c4c45-ba99-49f5-9ab7-4b6901a63cfd(MPS.Generator)" version="0" />
     <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
-    <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
     <module reference="2c9058b6-7cd8-4623-82a3-e4c07c3eddff(com.mbeddr.mpsutil.generatorfacade)" version="0" />
-    <module reference="5fa23c0a-216d-4571-a163-e286643e6f5f(jetbrains.mps.generator)" version="0" />
     <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
     <module reference="7ab1a6fa-0a11-4b95-9e48-75f363d6cb00(jetbrains.mps.lang.generator.plan)" version="0" />
   </dependencyVersions>

--- a/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.generatorfacade/models/com/mbeddr/mpsutil/generatorfacade/runtime.mps
+++ b/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.generatorfacade/models/com/mbeddr/mpsutil/generatorfacade/runtime.mps
@@ -8,7 +8,6 @@
   </languages>
   <imports>
     <import index="et5u" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.messages(MPS.Core/)" />
-    <import index="i30" ref="r:ab837574-aa54-4b18-9762-b783ef089263(jetbrains.mps.generator.impl)" />
     <import index="mk8z" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.progress(MPS.Core/)" />
     <import index="vndm" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel.language(MPS.Core/)" />
     <import index="lui2" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.module(MPS.OpenAPI/)" />
@@ -18,7 +17,6 @@
     <import index="4nm9" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.project(MPS.IDEA/)" />
     <import index="guwi" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.io(JDK/)" />
     <import index="mhfm" ref="3f233e7f-b8a6-46d2-a57f-795d56775243/java:org.jetbrains.annotations(Annotations/)" />
-    <import index="tft2" ref="215c4c45-ba99-49f5-9ab7-4b6901a63cfd/java:jetbrains.mps.generator.impl.plan(MPS.Generator/)" />
     <import index="ap4t" ref="215c4c45-ba99-49f5-9ab7-4b6901a63cfd/java:jetbrains.mps.generator(MPS.Generator/)" />
     <import index="1m72" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.components(MPS.IDEA/)" implicit="true" />
   </imports>
@@ -71,6 +69,9 @@
         <property id="1176718929932" name="isFinal" index="3TUv4t" />
         <child id="1068431790190" name="initializer" index="33vP2m" />
       </concept>
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ngI" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
+      </concept>
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
@@ -120,6 +121,9 @@
       <concept id="1079359253375" name="jetbrains.mps.baseLanguage.structure.ParenthesizedExpression" flags="nn" index="1eOMI4">
         <child id="1079359253376" name="expression" index="1eOMHV" />
       </concept>
+      <concept id="1160998861373" name="jetbrains.mps.baseLanguage.structure.AssertStatement" flags="nn" index="1gVbGN">
+        <child id="1160998896846" name="condition" index="1gVkn0" />
+      </concept>
       <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
@@ -153,6 +157,7 @@
       </concept>
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="5045161044515397667" name="jetbrains.mps.lang.smodel.structure.Node_PointerOperation" flags="ng" index="iZEcu" />
       <concept id="1143226024141" name="jetbrains.mps.lang.smodel.structure.SModelType" flags="in" index="H_c77" />
       <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
         <reference id="1138405853777" name="concept" index="ehGHo" />
@@ -427,51 +432,35 @@
       <property role="2aFKle" value="false" />
       <node concept="3clFbS" id="2_w5$M94NDQ" role="3clF47">
         <node concept="3clFbH" id="2_w5$M94NDR" role="3cqZAp" />
-        <node concept="3cpWs8" id="2_w5$M94NDS" role="3cqZAp">
-          <node concept="3cpWsn" id="2_w5$M94NDT" role="3cpWs9">
-            <property role="TrG5h" value="planBuilder" />
-            <node concept="3uibUv" id="2_w5$M94NDU" role="1tU5fm">
-              <ref role="3uigEE" to="tft2:~RigidPlanBuilder" resolve="RigidPlanBuilder" />
+        <node concept="3cpWs8" id="1zLDpTpog5v" role="3cqZAp">
+          <node concept="3cpWsn" id="1zLDpTpog5w" role="3cpWs9">
+            <property role="TrG5h" value="planProvider" />
+            <node concept="3uibUv" id="1zLDpTpofGX" role="1tU5fm">
+              <ref role="3uigEE" to="ap4t:~InterpretedPlanProvider" resolve="InterpretedPlanProvider" />
             </node>
-            <node concept="2ShNRf" id="2_w5$M94NDV" role="33vP2m">
-              <node concept="1pGfFk" id="2_w5$M94NDW" role="2ShVmc">
-                <ref role="37wK5l" to="tft2:~RigidPlanBuilder.&lt;init&gt;(jetbrains.mps.smodel.language.LanguageRegistry)" resolve="RigidPlanBuilder" />
-                <node concept="2YIFZM" id="2_w5$M94NDX" role="37wK5m">
+            <node concept="2ShNRf" id="1zLDpTpog5x" role="33vP2m">
+              <node concept="1pGfFk" id="1zLDpTpog5y" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="ap4t:~InterpretedPlanProvider.&lt;init&gt;(jetbrains.mps.smodel.language.LanguageRegistry,jetbrains.mps.messages.IMessageHandler,org.jetbrains.mps.openapi.model.SNodeReference,org.jetbrains.mps.openapi.module.SRepository)" resolve="InterpretedPlanProvider" />
+                <node concept="2YIFZM" id="1zLDpTpog5z" role="37wK5m">
                   <ref role="37wK5l" to="vndm:~LanguageRegistry.getInstance(org.jetbrains.mps.openapi.module.SRepository)" resolve="getInstance" />
                   <ref role="1Pybhc" to="vndm:~LanguageRegistry" resolve="LanguageRegistry" />
-                  <node concept="37vLTw" id="2_w5$M94NDY" role="37wK5m">
+                  <node concept="37vLTw" id="1zLDpTpog5$" role="37wK5m">
                     <ref role="3cqZAo" node="2_w5$M94NFy" resolve="repo" />
                   </node>
                 </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3cpWs8" id="2_w5$M94NDZ" role="3cqZAp">
-          <node concept="3cpWsn" id="2_w5$M94NE0" role="3cpWs9">
-            <property role="TrG5h" value="planTranslator" />
-            <node concept="3uibUv" id="2_w5$M94NE1" role="1tU5fm">
-              <ref role="3uigEE" to="i30:1UVrAZQmEH$" resolve="GenPlanTranslator" />
-            </node>
-            <node concept="2ShNRf" id="2_w5$M94NE2" role="33vP2m">
-              <node concept="1pGfFk" id="2_w5$M94NE3" role="2ShVmc">
-                <ref role="37wK5l" to="i30:1UVrAZQmUpe" resolve="GenPlanTranslator" />
-                <node concept="37vLTw" id="2_w5$M94NE4" role="37wK5m">
-                  <ref role="3cqZAo" node="2_w5$M94NF$" resolve="plan" />
+                <node concept="37vLTw" id="1zLDpTpog5_" role="37wK5m">
+                  <ref role="3cqZAo" node="2_w5$M94NFE" resolve="messageHandler" />
                 </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="2_w5$M94NE5" role="3cqZAp">
-          <node concept="2OqwBi" id="2_w5$M94NE6" role="3clFbG">
-            <node concept="37vLTw" id="2_w5$M94NE7" role="2Oq$k0">
-              <ref role="3cqZAo" node="2_w5$M94NE0" resolve="planTranslator" />
-            </node>
-            <node concept="liA8E" id="2_w5$M94NE8" role="2OqNvi">
-              <ref role="37wK5l" to="i30:1UVrAZQmU_x" resolve="feed" />
-              <node concept="37vLTw" id="2_w5$M94NE9" role="37wK5m">
-                <ref role="3cqZAo" node="2_w5$M94NDT" resolve="planBuilder" />
+                <node concept="2OqwBi" id="1zLDpTpog5A" role="37wK5m">
+                  <node concept="37vLTw" id="1zLDpTpog5B" role="2Oq$k0">
+                    <ref role="3cqZAo" node="2_w5$M94NF$" resolve="plan" />
+                  </node>
+                  <node concept="iZEcu" id="1zLDpTpog5C" role="2OqNvi" />
+                </node>
+                <node concept="37vLTw" id="1zLDpTpog5D" role="37wK5m">
+                  <ref role="3cqZAo" node="2_w5$M94NFy" resolve="repo" />
+                </node>
               </node>
             </node>
           </node>
@@ -482,21 +471,24 @@
             <node concept="3uibUv" id="2_w5$M94NEc" role="1tU5fm">
               <ref role="3uigEE" to="ap4t:~ModelGenerationPlan" resolve="ModelGenerationPlan" />
             </node>
-            <node concept="2OqwBi" id="2_w5$M94NEd" role="33vP2m">
-              <node concept="37vLTw" id="2_w5$M94NEe" role="2Oq$k0">
-                <ref role="3cqZAo" node="2_w5$M94NDT" resolve="planBuilder" />
+            <node concept="2OqwBi" id="1zLDpTpoiUa" role="33vP2m">
+              <node concept="37vLTw" id="1zLDpTpoieR" role="2Oq$k0">
+                <ref role="3cqZAo" node="1zLDpTpog5w" resolve="planProvider" />
               </node>
-              <node concept="liA8E" id="2_w5$M94NEf" role="2OqNvi">
-                <ref role="37wK5l" to="tft2:~RigidPlanBuilder.wrapUp(jetbrains.mps.generator.plan.PlanIdentity)" resolve="wrapUp" />
-                <node concept="2OqwBi" id="2_w5$M94NEg" role="37wK5m">
-                  <node concept="37vLTw" id="2_w5$M94NEh" role="2Oq$k0">
-                    <ref role="3cqZAo" node="2_w5$M94NE0" resolve="planTranslator" />
-                  </node>
-                  <node concept="liA8E" id="2_w5$M94NEi" role="2OqNvi">
-                    <ref role="37wK5l" to="i30:1UVrAZQp80f" resolve="getPlanIdentity" />
-                  </node>
+              <node concept="liA8E" id="1zLDpTpok1C" role="2OqNvi">
+                <ref role="37wK5l" to="ap4t:~InterpretedPlanProvider.getPlan(org.jetbrains.mps.openapi.model.SModel)" resolve="getPlan" />
+                <node concept="37vLTw" id="1zLDpTpokox" role="37wK5m">
+                  <ref role="3cqZAo" node="2_w5$M94NFA" resolve="modelToGenerate" />
                 </node>
               </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1gVbGN" id="1zLDpTpomCt" role="3cqZAp">
+          <node concept="3y3z36" id="1zLDpTpont7" role="1gVkn0">
+            <node concept="10Nm6u" id="1zLDpTpoo77" role="3uHU7w" />
+            <node concept="37vLTw" id="1zLDpTpon0C" role="3uHU7B">
+              <ref role="3cqZAo" node="2_w5$M94NEb" resolve="genPlan" />
             </node>
           </node>
         </node>


### PR DESCRIPTION
Use RegularPlanBuilder instead of RigidPlanBuilder in [GeneratorFacade](http://127.0.0.1:63320/node?ref=r%3A00bd75cf-1225-4ef5-9a7e-390aed8718dd%28com.mbeddr.mpsutil.generatorfacade.runtime%29%2F5915735921188775088) to properly support enhanced Transform generation plan steps with multiple Transform.entries that should be executed in one single step (RigidPlanBuilder doesn't support this). Previously multiple languages specified in the Transform.languages were always combined in one generation step.