### PR TITLE
Use indent layout for element documentation

### DIFF
--- a/code/languages/com.mbeddr.core/languages/com.mbeddr.core.base/languageModels/editor.mps
+++ b/code/languages/com.mbeddr.core/languages/com.mbeddr.core.base/languageModels/editor.mps
@@ -986,7 +986,7 @@
             </node>
           </node>
         </node>
-        <node concept="2iRfu4" id="7sHl0myfC36" role="2iSdaV" />
+        <node concept="l2Vlx" id="1OEjBB5gGtQ" role="2iSdaV" />
         <node concept="2tOxIa" id="4Oh$x0pl_Z9" role="3F10Kt">
           <property role="1lJzqX" value="-1" />
         </node>


### PR DESCRIPTION
Without it, line wrapping doesn't work properly.