### PR TITLE
mpsutil.collections: don't use containsKey with the soft value map

### DIFF
--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.interpreter/runtime/models/com/mbeddr/mpsutil/interpreter/rt.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.interpreter/runtime/models/com/mbeddr/mpsutil/interpreter/rt.mps
@@ -13173,15 +13173,14 @@
                 <ref role="3cqZAo" node="X_36FbMvQP" resolve="cacheInterpreter" />
               </node>
             </node>
-            <node concept="3fqX7Q" id="48h5VLcj450" role="3uHU7w">
-              <node concept="2OqwBi" id="48h5VLcj452" role="3fr31v">
-                <node concept="37vLTw" id="48h5VLcj453" role="2Oq$k0">
-                  <ref role="3cqZAo" node="48h5VLciZOf" resolve="interpreterCache" />
+            <node concept="3clFbC" id="1ueRhDee7Gc" role="3uHU7w">
+              <node concept="10Nm6u" id="1ueRhDeeacf" role="3uHU7w" />
+              <node concept="3EllGN" id="1ueRhDee4eN" role="3uHU7B">
+                <node concept="37vLTw" id="1ueRhDee5Ut" role="3ElVtu">
+                  <ref role="3cqZAo" node="50LzNoSyEwk" resolve="category" />
                 </node>
-                <node concept="2Nt0df" id="48h5VLcj64G" role="2OqNvi">
-                  <node concept="37vLTw" id="48h5VLcj6cb" role="38cxEo">
-                    <ref role="3cqZAo" node="50LzNoSyEwk" resolve="category" />
-                  </node>
+                <node concept="37vLTw" id="48h5VLcj453" role="3ElQJh">
+                  <ref role="3cqZAo" node="48h5VLciZOf" resolve="interpreterCache" />
                 </node>
               </node>
             </node>


### PR DESCRIPTION
@enikao FYI: We got the error message `com.intellij.util.IncorrectOperationException: containsKey() makes no sense for weak/soft map because GC can clear the value any moment now `