### PR TITLE
[breaking] mpsutil.json: improve exporting of files and make parser and export options customizable through an extension point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,13 @@ Semantic Versioning and the changes are simply documented in reverse chronologic
 
 # January 2025
 
-# December 2024
-
 ## com.mbeddr.mpsutil
 
 ### Fixed
 
 - The text generator output of `com.mbeddr.mpsutil.json` was improved and escaping of special characters was implemented. The output options and JSON parsing can now also be configured through the extension point `json` in the method JsonConfig#getFactory. For more information read: https://github.com/fasterxml/jackson-core/wiki/JsonFactory-Features, https://github.com/fasterxml/jackson-core/wiki/JsonGenerator-Features and https://github.com/fasterxml/jackson-core/wiki/JsonParser-Features.
+
+# December 2024
 
 ## com.mbeddr.core.base
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is _loosely_ based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). The project does _not_ follow
 Semantic Versioning and the changes are simply documented in reverse chronological order, grouped by calendar month.
 
+# January 2025
+
 # December 2024
+
+## com.mbeddr.mpsutil
+
+### Fixed
+
+- The text generator output of `com.mbeddr.mpsutil.json` was improved and escaping of special characters was implemented. The output options and JSON parsing can now also be configured through the extension point `json` in the method JsonConfig#getFactory. For more information read: https://github.com/fasterxml/jackson-core/wiki/JsonFactory-Features, https://github.com/fasterxml/jackson-core/wiki/JsonGenerator-Features and https://github.com/fasterxml/jackson-core/wiki/JsonParser-Features.
 
 ## com.mbeddr.core.base
 

--- a/code/languages/com.mbeddr.build/solutions/com.mbeddr.platform.tests.build/models/com.mbeddr.platform.tests.build.mps
+++ b/code/languages/com.mbeddr.build/solutions/com.mbeddr.platform.tests.build/models/com.mbeddr.platform.tests.build.mps
@@ -1615,6 +1615,12 @@
             </node>
           </node>
         </node>
+        <node concept="1SiIV0" id="2SeJqc6Ohp2" role="3bR37C">
+          <node concept="3bR9La" id="2SeJqc6Ohp3" role="1SiIV1">
+            <property role="3bR36h" value="true" />
+            <ref role="3bR37D" to="al5i:776vT$mQZbf" resolve="com.mbeddr.mpsutil.comparator" />
+          </node>
+        </node>
       </node>
       <node concept="1E1JtD" id="4JHJliM0jp_" role="2G$12L">
         <property role="BnDLt" value="true" />

--- a/code/languages/com.mbeddr.build/solutions/com.mbeddr.platform.tests.build/models/com.mbeddr.platform.tests.build.mps
+++ b/code/languages/com.mbeddr.build/solutions/com.mbeddr.platform.tests.build/models/com.mbeddr.platform.tests.build.mps
@@ -450,11 +450,6 @@
             </node>
           </node>
         </node>
-        <node concept="1SiIV0" id="75qFqB43eJz" role="3bR37C">
-          <node concept="3bR9La" id="75qFqB43eJ$" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:1TaHNgiIbIQ" resolve="MPS.Core" />
-          </node>
-        </node>
         <node concept="1SiIV0" id="75qFqB43eJ_" role="3bR37C">
           <node concept="3bR9La" id="75qFqB43eJA" role="1SiIV1">
             <ref role="3bR37D" to="al5i:6o5cjw5gEyi" resolve="com.mbeddr.mpsutil.json" />
@@ -517,6 +512,16 @@
                 </node>
               </node>
             </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="3PmL$ALj5Nt" role="3bR37C">
+          <node concept="3bR9La" id="3PmL$ALj5Nu" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="3PmL$ALj5Nv" role="3bR37C">
+          <node concept="3bR9La" id="3PmL$ALj5Nw" role="1SiIV1">
+            <ref role="3bR37D" to="90a9:3$A0JaN5bpX" resolve="MPS.ThirdParty" />
           </node>
         </node>
       </node>
@@ -1555,29 +1560,9 @@
             <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
           </node>
         </node>
-        <node concept="1SiIV0" id="bHMJKhDDf7" role="3bR37C">
-          <node concept="3bR9La" id="bHMJKhDDf8" role="1SiIV1">
-            <ref role="3bR37D" to="al5i:776vT$mQZbf" resolve="com.mbeddr.mpsutil.comparator" />
-          </node>
-        </node>
         <node concept="1SiIV0" id="bHMJKhDDf9" role="3bR37C">
           <node concept="3bR9La" id="bHMJKhDDfa" role="1SiIV1">
             <ref role="3bR37D" to="ffeo:7Kfy9QB6KXW" resolve="jetbrains.mps.lang.core" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="bHMJKhDDfb" role="3bR37C">
-          <node concept="3bR9La" id="bHMJKhDDfc" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:7Kfy9QB6L9O" resolve="jetbrains.mps.lang.smodel" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="bHMJKhDDfd" role="3bR37C">
-          <node concept="3bR9La" id="bHMJKhDDfe" role="1SiIV1">
-            <ref role="3bR37D" to="al5i:vOGyTeKPEA" resolve="com.mbeddr.mpsutil.ecore.testing" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="bHMJKhDDff" role="3bR37C">
-          <node concept="3bR9La" id="bHMJKhDDfg" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:7Kfy9QB6LaO" resolve="jetbrains.mps.lang.structure" />
           </node>
         </node>
         <node concept="398BVA" id="bHMJKhDAXY" role="3LF7KH">

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.json/com.mbeddr.mpsutil.json.mpl
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.json/com.mbeddr.mpsutil.json.mpl
@@ -30,6 +30,7 @@
     <language slang="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" version="2" />
     <language slang="l:c7d5b9dd-a05f-4be2-bc73-f2e16994cc67:jetbrains.mps.baseLanguage.lightweightdsl" version="1" />
     <language slang="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" version="0" />
+    <language slang="l:daafa647-f1f7-4b0b-b096-69cd7c8408c0:jetbrains.mps.baseLanguage.regexp" version="0" />
     <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
     <language slang="l:63650c59-16c8-498a-99c8-005c7ee9515d:jetbrains.mps.lang.access" version="0" />
     <language slang="l:aee9cad2-acd4-4608-aef2-0004f6a1cdbd:jetbrains.mps.lang.actions" version="4" />

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.json/com.mbeddr.mpsutil.json.mpl
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.json/com.mbeddr.mpsutil.json.mpl
@@ -20,6 +20,7 @@
     <dependency reexport="true">39983771-4e9b-401b-a1a9-1da6c777c843(MPS.ThirdParty)</dependency>
   </dependencies>
   <languageVersions>
+    <language slang="l:63e0e566-5131-447e-90e3-12ea330e1a00:com.mbeddr.mpsutil.blutil" version="3" />
     <language slang="l:9d69e719-78c8-4286-90db-fb19c107d049:com.mbeddr.mpsutil.grammarcells" version="2" />
     <language slang="l:b4f35ed8-45af-4efa-abe4-00ac26956e69:com.mbeddr.mpsutil.grammarcells.runtimelang" version="0" />
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
@@ -27,6 +28,7 @@
     <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
     <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="2" />
     <language slang="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" version="2" />
+    <language slang="l:c7d5b9dd-a05f-4be2-bc73-f2e16994cc67:jetbrains.mps.baseLanguage.lightweightdsl" version="1" />
     <language slang="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" version="0" />
     <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
     <language slang="l:63650c59-16c8-498a-99c8-005c7ee9515d:jetbrains.mps.lang.access" version="0" />
@@ -42,6 +44,7 @@
     <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
     <language slang="l:f4ad079d-bc71-4ffb-9600-9328705cf998:jetbrains.mps.lang.descriptor" version="0" />
     <language slang="l:18bc6592-03a6-4e29-a83a-7ff23bde13ba:jetbrains.mps.lang.editor" version="14" />
+    <language slang="l:c0080a47-7e37-4558-bee9-9ae18e690549:jetbrains.mps.lang.extension" version="2" />
     <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
     <language slang="l:d4615e3b-d671-4ba9-af01-2b78369b0ba7:jetbrains.mps.lang.pattern" version="2" />
     <language slang="l:28f9e497-3b42-4291-aeba-0a1039153ab1:jetbrains.mps.lang.plugin" version="6" />

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.json/models/com.mbeddr.mpsutil.json.behavior.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.json/models/com.mbeddr.mpsutil.json.behavior.mps
@@ -1476,7 +1476,7 @@
         <node concept="3clFbH" id="2JDrrqkBE06" role="3cqZAp" />
         <node concept="3clFbF" id="2JDrrqkB$yV" role="3cqZAp">
           <node concept="1rXfSq" id="2JDrrqkB$yW" role="3clFbG">
-            <ref role="37wK5l" node="2JDrrqjMk5u" resolve="getJSONFromObject" />
+            <ref role="37wK5l" node="2JDrrqjMk5u" resolve="getJsonNodeFromValue" />
             <node concept="2OqwBi" id="2JDrrqkB$yX" role="37wK5m">
               <node concept="37vLTw" id="2JDrrqkB$yY" role="2Oq$k0">
                 <ref role="3cqZAo" node="2JDrrqkB$z2" resolve="file" />
@@ -1491,7 +1491,7 @@
                   <ref role="3cqZAo" node="2JDrrqkBE08" resolve="config" />
                 </node>
                 <node concept="liA8E" id="2JDrrqkBHzB" role="2OqNvi">
-                  <ref role="37wK5l" to="zhzw:2JDrrqkBGIw" resolve="numbersAsText" />
+                  <ref role="37wK5l" to="zhzw:2JDrrqkBGIw" resolve="exportNumbersAsText" />
                 </node>
               </node>
               <node concept="3clFbT" id="2JDrrqkDFTP" role="3K4GZi" />
@@ -1522,7 +1522,7 @@
       <node concept="3clFbS" id="2JDrrqjM80R" role="3clF47">
         <node concept="3clFbF" id="2JDrrqjMsz1" role="3cqZAp">
           <node concept="1rXfSq" id="2JDrrqjMsz0" role="3clFbG">
-            <ref role="37wK5l" node="2JDrrqjMk5u" resolve="getJSONFromObject" />
+            <ref role="37wK5l" node="2JDrrqjMk5u" resolve="getJsonNodeFromValue" />
             <node concept="2OqwBi" id="2JDrrqjMsIi" role="37wK5m">
               <node concept="37vLTw" id="2JDrrqjMs$B" role="2Oq$k0">
                 <ref role="3cqZAo" node="2JDrrqjMc2j" resolve="file" />
@@ -1581,7 +1581,7 @@
                   <ref role="3cqZAo" node="2JDrrqkCfbb" resolve="config" />
                 </node>
                 <node concept="liA8E" id="2JDrrqkCe7t" role="2OqNvi">
-                  <ref role="37wK5l" to="zhzw:2JDrrqkBGIw" resolve="numbersAsText" />
+                  <ref role="37wK5l" to="zhzw:2JDrrqkBGIw" resolve="exportNumbersAsText" />
                 </node>
               </node>
               <node concept="3clFbT" id="2JDrrqkCe7u" role="3K4GZi" />
@@ -1676,7 +1676,7 @@
                               </node>
                             </node>
                             <node concept="1rXfSq" id="2JDrrqjO435" role="37wK5m">
-                              <ref role="37wK5l" node="2JDrrqjMk5u" resolve="getJSONFromValue" />
+                              <ref role="37wK5l" node="2JDrrqjMk5u" resolve="getJsonNodeFromValue" />
                               <node concept="2OqwBi" id="2JDrrqjO5dI" role="37wK5m">
                                 <node concept="37vLTw" id="2JDrrqjO4Zl" role="2Oq$k0">
                                   <ref role="3cqZAo" node="2JDrrqjNjgp" resolve="variable" />
@@ -1751,9 +1751,9 @@
                             <node concept="liA8E" id="2JDrrqjNZk2" role="2OqNvi">
                               <ref role="37wK5l" to="lhlt:~ArrayNode.add(com.fasterxml.jackson.databind.JsonNode)" resolve="add" />
                               <node concept="1rXfSq" id="2JDrrqjNZuu" role="37wK5m">
-                                <ref role="37wK5l" node="2JDrrqjMk5u" resolve="getJSONFromValue" />
+                                <ref role="37wK5l" node="2JDrrqjMk5u" resolve="getJsonNodeFromValue" />
                                 <node concept="37vLTw" id="2JDrrqjO0j2" role="37wK5m">
-                                  <ref role="3cqZAo" node="2JDrrqjNWjG" resolve="it" />
+                                  <ref role="3cqZAo" node="2JDrrqjNWjG" resolve="arrayValue" />
                                 </node>
                                 <node concept="37vLTw" id="2JDrrqk_ywb" role="37wK5m">
                                   <ref role="3cqZAo" node="2JDrrqk_v0f" resolve="numberAsText" />
@@ -2059,7 +2059,7 @@
               <ref role="3cqZAo" node="2JDrrqk1btK" resolve="file" />
             </node>
             <node concept="1rXfSq" id="2JDrrqk1P1k" role="37wK5m">
-              <ref role="37wK5l" node="2JDrrqk1Fu1" resolve="getDefaultFactory" />
+              <ref role="37wK5l" node="2JDrrqk1Fu1" resolve="getFactory" />
             </node>
           </node>
         </node>
@@ -2120,7 +2120,7 @@
               <ref role="3cqZAo" node="2JDrrqk1WoA" resolve="value" />
             </node>
             <node concept="1rXfSq" id="2JDrrqk2c1Q" role="37wK5m">
-              <ref role="37wK5l" node="2JDrrqk1Fu1" resolve="getDefaultFactory" />
+              <ref role="37wK5l" node="2JDrrqk1Fu1" resolve="getFactory" />
             </node>
           </node>
         </node>

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.json/models/com.mbeddr.mpsutil.json.behavior.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.json/models/com.mbeddr.mpsutil.json.behavior.mps
@@ -10,6 +10,7 @@
     <use id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures" version="0" />
     <use id="3a13115c-633c-4c5c-bbcc-75c4219e9555" name="jetbrains.mps.lang.quotation" version="5" />
     <use id="760a0a8c-eabb-4521-8bfd-65db761a9ba3" name="jetbrains.mps.baseLanguage.logging" version="0" />
+    <use id="63e0e566-5131-447e-90e3-12ea330e1a00" name="com.mbeddr.mpsutil.blutil" version="3" />
   </languages>
   <imports>
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" />
@@ -21,6 +22,10 @@
     <import index="guwi" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.io(JDK/)" />
     <import index="mhfm" ref="3f233e7f-b8a6-46d2-a57f-795d56775243/java:org.jetbrains.annotations(Annotations/)" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" />
+    <import index="lhlt" ref="39983771-4e9b-401b-a1a9-1da6c777c843/java:com.fasterxml.jackson.databind.node(MPS.ThirdParty/)" />
+    <import index="xlxw" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.math(JDK/)" />
+    <import index="8g4p" ref="39983771-4e9b-401b-a1a9-1da6c777c843/java:com.fasterxml.jackson.core.util(MPS.ThirdParty/)" />
+    <import index="zhzw" ref="r:6492a138-3e52-4756-96b0-7e3c330fe78e(com.mbeddr.mpsutil.json.plugin)" />
     <import index="mhbf" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.model(MPS.OpenAPI/)" implicit="true" />
   </imports>
   <registry>
@@ -86,6 +91,12 @@
       <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
         <reference id="1144433194310" name="classConcept" index="1Pybhc" />
       </concept>
+      <concept id="1164991038168" name="jetbrains.mps.baseLanguage.structure.ThrowStatement" flags="nn" index="YS8fn">
+        <child id="1164991057263" name="throwable" index="YScLw" />
+      </concept>
+      <concept id="1070533707846" name="jetbrains.mps.baseLanguage.structure.StaticFieldReference" flags="nn" index="10M0yZ">
+        <reference id="1144433057691" name="classifier" index="1PxDUh" />
+      </concept>
       <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
       <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
       <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
@@ -93,6 +104,9 @@
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <property id="1176718929932" name="isFinal" index="3TUv4t" />
         <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ngI" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
       </concept>
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
@@ -122,6 +136,7 @@
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
       </concept>
+      <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT" />
       <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
         <property id="1068580320021" name="value" index="3cmrfH" />
       </concept>
@@ -176,13 +191,30 @@
         <child id="1163668922816" name="ifTrue" index="3K4E3e" />
         <child id="1163668934364" name="ifFalse" index="3K4GZi" />
       </concept>
+      <concept id="5497648299878491908" name="jetbrains.mps.baseLanguage.structure.BaseVariableReference" flags="nn" index="1M0zk4">
+        <reference id="5497648299878491909" name="baseVariableDeclaration" index="1M0zk5" />
+      </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
       <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
+      <concept id="1116615150612" name="jetbrains.mps.baseLanguage.structure.ClassifierClassExpression" flags="nn" index="3VsKOn">
+        <reference id="1116615189566" name="classifier" index="3VsUkX" />
+      </concept>
       <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
       <concept id="1200397529627" name="jetbrains.mps.baseLanguage.structure.CharConstant" flags="nn" index="1Xhbcc">
         <property id="1200397540847" name="charConstant" index="1XhdNS" />
       </concept>
       <concept id="8064396509828172209" name="jetbrains.mps.baseLanguage.structure.UnaryMinus" flags="nn" index="1ZRNhn" />
+    </language>
+    <language id="63e0e566-5131-447e-90e3-12ea330e1a00" name="com.mbeddr.mpsutil.blutil">
+      <concept id="8718469662507237778" name="com.mbeddr.mpsutil.blutil.structure.IfInstanceOfElseIfClause" flags="ng" index="1afrx_">
+        <reference id="1883223317721008712" name="nodeConcept" index="JncvD" />
+        <child id="1883223317721008709" name="body" index="Jncv$" />
+        <child id="1883223317721008711" name="variable" index="JncvA" />
+      </concept>
+      <concept id="8718469662504613132" name="com.mbeddr.mpsutil.blutil.structure.IfInstanceOfStatement" flags="ng" index="1apkNV">
+        <child id="8718469662505188633" name="elseifClauses" index="1amwjI" />
+      </concept>
+      <concept id="8718469662516823847" name="com.mbeddr.mpsutil.blutil.structure.IfInstanceOfVarReference" flags="ng" index="1bEZVg" />
     </language>
     <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
       <concept id="2524418899405758586" name="jetbrains.mps.baseLanguage.closures.structure.InferredClosureParameterDeclaration" flags="ig" index="gl6BB" />
@@ -226,6 +258,13 @@
       <concept id="1145383075378" name="jetbrains.mps.lang.smodel.structure.SNodeListType" flags="in" index="2I9FWS">
         <reference id="1145383142433" name="elementConcept" index="2I9WkF" />
       </concept>
+      <concept id="1883223317721008708" name="jetbrains.mps.lang.smodel.structure.IfInstanceOfStatement" flags="nn" index="Jncv_">
+        <reference id="1883223317721008712" name="nodeConcept" index="JncvE" />
+        <child id="1883223317721008709" name="body" index="Jncv_" />
+        <child id="1883223317721008711" name="variable" index="JncvB" />
+        <child id="1883223317721008710" name="nodeExpression" index="JncvC" />
+      </concept>
+      <concept id="1883223317721008713" name="jetbrains.mps.lang.smodel.structure.IfInstanceOfVariable" flags="ng" index="JncvC" />
       <concept id="1145404486709" name="jetbrains.mps.lang.smodel.structure.SemanticDowncastExpression" flags="nn" index="2JrnkZ">
         <child id="1145404616321" name="leftExpression" index="2JrQYb" />
       </concept>
@@ -237,6 +276,9 @@
       </concept>
       <concept id="1138056022639" name="jetbrains.mps.lang.smodel.structure.SPropertyAccess" flags="nn" index="3TrcHB">
         <reference id="1138056395725" name="property" index="3TsBF5" />
+      </concept>
+      <concept id="1138056143562" name="jetbrains.mps.lang.smodel.structure.SLinkAccess" flags="nn" index="3TrEf2">
+        <reference id="1138056516764" name="link" index="3Tt5mk" />
       </concept>
       <concept id="1138056282393" name="jetbrains.mps.lang.smodel.structure.SLinkListAccess" flags="nn" index="3Tsc0h">
         <reference id="1138056546658" name="link" index="3TtcxE" />
@@ -747,7 +789,10 @@
             </node>
             <node concept="2ShNRf" id="6V56CwaCgUe" role="33vP2m">
               <node concept="1pGfFk" id="6V56CwaCgUf" role="2ShVmc">
-                <ref role="37wK5l" to="7k8f:~ObjectMapper.&lt;init&gt;()" resolve="ObjectMapper" />
+                <ref role="37wK5l" to="7k8f:~ObjectMapper.&lt;init&gt;(com.fasterxml.jackson.core.JsonFactory)" resolve="ObjectMapper" />
+                <node concept="1rXfSq" id="55TmvgEz4MV" role="37wK5m">
+                  <ref role="37wK5l" node="2JDrrqk1Fu1" resolve="getFactory" />
+                </node>
               </node>
             </node>
           </node>
@@ -879,38 +924,6 @@
               </node>
             </node>
           </node>
-          <node concept="3eNFk2" id="72Ne6StbGXY" role="3eNLev">
-            <node concept="2OqwBi" id="72Ne6StbNdp" role="3eO9$A">
-              <node concept="37vLTw" id="72Ne6StbMFk" role="2Oq$k0">
-                <ref role="3cqZAo" node="3eUX6LRW7Kz" resolve="jsonNode" />
-              </node>
-              <node concept="liA8E" id="72Ne6StbOgb" role="2OqNvi">
-                <ref role="37wK5l" to="7k8f:~JsonNode.isTextual()" resolve="isTextual" />
-              </node>
-            </node>
-            <node concept="3clFbS" id="72Ne6StbGY0" role="3eOfB_">
-              <node concept="3cpWs6" id="72Ne6StbJ9F" role="3cqZAp">
-                <node concept="2pJPEk" id="72Ne6Stc1kh" role="3cqZAk">
-                  <node concept="2pJPED" id="72Ne6Stc1kn" role="2pJPEn">
-                    <ref role="2pJxaS" to="21pk:3L4lRB2Gdrb" resolve="String" />
-                    <node concept="2pJxcG" id="1Alud3KUk5Q" role="2pJxcM">
-                      <ref role="2pJxcJ" to="21pk:3L4lRB2Gdre" resolve="value" />
-                      <node concept="WxPPo" id="20iAftur$tb" role="28ntcv">
-                        <node concept="2OqwBi" id="72Ne6Stc2x5" role="WxPPp">
-                          <node concept="37vLTw" id="72Ne6Stc1rE" role="2Oq$k0">
-                            <ref role="3cqZAo" node="3eUX6LRW7Kz" resolve="jsonNode" />
-                          </node>
-                          <node concept="liA8E" id="72Ne6Stc2Vi" role="2OqNvi">
-                            <ref role="37wK5l" to="7k8f:~JsonNode.asText()" resolve="asText" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
           <node concept="3eNFk2" id="72Ne6StbSvk" role="3eNLev">
             <node concept="3clFbS" id="72Ne6StbSvm" role="3eOfB_">
               <node concept="3cpWs6" id="72Ne6StbTjC" role="3cqZAp">
@@ -972,8 +985,40 @@
                               <ref role="3cqZAo" node="3eUX6LRW7Kz" resolve="jsonNode" />
                             </node>
                             <node concept="liA8E" id="55Y4t6SR_oz" role="2OqNvi">
-                              <ref role="37wK5l" to="7k8f:~JsonNode.isFloatingPointNumber()" resolve="isFloatingPointNumber" />
+                              <ref role="37wK5l" to="7k8f:~JsonNode.floatValue()" resolve="floatValue" />
                             </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3eNFk2" id="2JDrrqkTv3S" role="3eNLev">
+            <node concept="2OqwBi" id="2JDrrqkTxM7" role="3eO9$A">
+              <node concept="37vLTw" id="2JDrrqkTvW$" role="2Oq$k0">
+                <ref role="3cqZAo" node="3eUX6LRW7Kz" resolve="jsonNode" />
+              </node>
+              <node concept="liA8E" id="2JDrrqkT$c6" role="2OqNvi">
+                <ref role="37wK5l" to="7k8f:~JsonNode.isTextual()" resolve="isTextual" />
+              </node>
+            </node>
+            <node concept="3clFbS" id="2JDrrqkTv3U" role="3eOfB_">
+              <node concept="3cpWs6" id="72Ne6StbJ9F" role="3cqZAp">
+                <node concept="2pJPEk" id="72Ne6Stc1kh" role="3cqZAk">
+                  <node concept="2pJPED" id="72Ne6Stc1kn" role="2pJPEn">
+                    <ref role="2pJxaS" to="21pk:3L4lRB2Gdrb" resolve="String" />
+                    <node concept="2pJxcG" id="1Alud3KUk5Q" role="2pJxcM">
+                      <ref role="2pJxcJ" to="21pk:3L4lRB2Gdre" resolve="value" />
+                      <node concept="WxPPo" id="20iAftur$tb" role="28ntcv">
+                        <node concept="2OqwBi" id="72Ne6Stc2x5" role="WxPPp">
+                          <node concept="37vLTw" id="72Ne6Stc1rE" role="2Oq$k0">
+                            <ref role="3cqZAo" node="3eUX6LRW7Kz" resolve="jsonNode" />
+                          </node>
+                          <node concept="liA8E" id="72Ne6Stc2Vi" role="2OqNvi">
+                            <ref role="37wK5l" to="7k8f:~JsonNode.asText()" resolve="asText" />
                           </node>
                         </node>
                       </node>
@@ -1362,6 +1407,7 @@
         <node concept="17QB3L" id="75qFqB42eDx" role="1tU5fm" />
       </node>
     </node>
+    <node concept="2tJIrI" id="2JDrrqjM1d2" role="jymVt" />
     <node concept="2YIFZL" id="4iy1HTC68bV" role="jymVt">
       <property role="TrG5h" value="isValidFile" />
       <node concept="3clFbS" id="4iy1HTC68bY" role="3clF47">
@@ -1411,6 +1457,854 @@
         </node>
       </node>
     </node>
+    <node concept="2tJIrI" id="2JDrrqjM4MC" role="jymVt" />
+    <node concept="2YIFZL" id="2JDrrqkB$yT" role="jymVt">
+      <property role="TrG5h" value="getJsonNodeFromFile" />
+      <node concept="3clFbS" id="2JDrrqkB$yU" role="3clF47">
+        <node concept="3cpWs8" id="2JDrrqkBE07" role="3cqZAp">
+          <node concept="3cpWsn" id="2JDrrqkBE08" role="3cpWs9">
+            <property role="TrG5h" value="config" />
+            <node concept="3uibUv" id="2JDrrqkBE09" role="1tU5fm">
+              <ref role="3uigEE" to="zhzw:2Qbt$1tSnqh" resolve="JsonConfig" />
+            </node>
+            <node concept="2YIFZM" id="2JDrrqkBE0a" role="33vP2m">
+              <ref role="37wK5l" to="zhzw:4qv99IrBnzk" resolve="getConfig" />
+              <ref role="1Pybhc" to="zhzw:4qv99IrBkzE" resolve="JsonConfigHelper" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="2JDrrqkBE06" role="3cqZAp" />
+        <node concept="3clFbF" id="2JDrrqkB$yV" role="3cqZAp">
+          <node concept="1rXfSq" id="2JDrrqkB$yW" role="3clFbG">
+            <ref role="37wK5l" node="2JDrrqjMk5u" resolve="getJSONFromObject" />
+            <node concept="2OqwBi" id="2JDrrqkB$yX" role="37wK5m">
+              <node concept="37vLTw" id="2JDrrqkB$yY" role="2Oq$k0">
+                <ref role="3cqZAo" node="2JDrrqkB$z2" resolve="file" />
+              </node>
+              <node concept="3TrEf2" id="2JDrrqkB$yZ" role="2OqNvi">
+                <ref role="3Tt5mk" to="21pk:3L4lRB2GtfY" resolve="object" />
+              </node>
+            </node>
+            <node concept="3K4zz7" id="2JDrrqkBFaL" role="37wK5m">
+              <node concept="2OqwBi" id="2JDrrqkBHhf" role="3K4E3e">
+                <node concept="37vLTw" id="2JDrrqkBHbz" role="2Oq$k0">
+                  <ref role="3cqZAo" node="2JDrrqkBE08" resolve="config" />
+                </node>
+                <node concept="liA8E" id="2JDrrqkBHzB" role="2OqNvi">
+                  <ref role="37wK5l" to="zhzw:2JDrrqkBGIw" resolve="numbersAsText" />
+                </node>
+              </node>
+              <node concept="3clFbT" id="2JDrrqkDFTP" role="3K4GZi" />
+              <node concept="3y3z36" id="2JDrrqkBE_M" role="3K4Cdx">
+                <node concept="10Nm6u" id="2JDrrqkBEXE" role="3uHU7w" />
+                <node concept="37vLTw" id="2JDrrqkB$z0" role="3uHU7B">
+                  <ref role="3cqZAo" node="2JDrrqkBE08" resolve="config" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="2JDrrqkB$z1" role="1B3o_S" />
+      <node concept="37vLTG" id="2JDrrqkB$z2" role="3clF46">
+        <property role="TrG5h" value="file" />
+        <node concept="3Tqbb2" id="2JDrrqkB$z3" role="1tU5fm">
+          <ref role="ehGHo" to="21pk:3L4lRB2Gtfz" resolve="JsonFile" />
+        </node>
+      </node>
+      <node concept="3uibUv" id="2JDrrqkB$z6" role="3clF45">
+        <ref role="3uigEE" to="7k8f:~JsonNode" resolve="JsonNode" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="2JDrrqkBweH" role="jymVt" />
+    <node concept="2YIFZL" id="2JDrrqjM80O" role="jymVt">
+      <property role="TrG5h" value="getJsonNodeFromFile" />
+      <node concept="3clFbS" id="2JDrrqjM80R" role="3clF47">
+        <node concept="3clFbF" id="2JDrrqjMsz1" role="3cqZAp">
+          <node concept="1rXfSq" id="2JDrrqjMsz0" role="3clFbG">
+            <ref role="37wK5l" node="2JDrrqjMk5u" resolve="getJSONFromObject" />
+            <node concept="2OqwBi" id="2JDrrqjMsIi" role="37wK5m">
+              <node concept="37vLTw" id="2JDrrqjMs$B" role="2Oq$k0">
+                <ref role="3cqZAo" node="2JDrrqjMc2j" resolve="file" />
+              </node>
+              <node concept="3TrEf2" id="2JDrrqjMuBe" role="2OqNvi">
+                <ref role="3Tt5mk" to="21pk:3L4lRB2GtfY" resolve="object" />
+              </node>
+            </node>
+            <node concept="37vLTw" id="2JDrrqkBw3g" role="37wK5m">
+              <ref role="3cqZAo" node="2JDrrqkBvvr" resolve="numberAsText" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="2JDrrqjM5gg" role="1B3o_S" />
+      <node concept="37vLTG" id="2JDrrqjMc2j" role="3clF46">
+        <property role="TrG5h" value="file" />
+        <node concept="3Tqbb2" id="2JDrrqjMc2i" role="1tU5fm">
+          <ref role="ehGHo" to="21pk:3L4lRB2Gtfz" resolve="JsonFile" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="2JDrrqkBvvr" role="3clF46">
+        <property role="TrG5h" value="numberAsText" />
+        <node concept="10P_77" id="2JDrrqkBvvs" role="1tU5fm" />
+      </node>
+      <node concept="3uibUv" id="2JDrrqjMccP" role="3clF45">
+        <ref role="3uigEE" to="7k8f:~JsonNode" resolve="JsonNode" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="2JDrrqjMcQC" role="jymVt" />
+    <node concept="2YIFZL" id="2JDrrqkBZfz" role="jymVt">
+      <property role="TrG5h" value="getJsonNodeFromValue" />
+      <node concept="3clFbS" id="2JDrrqkBZf$" role="3clF47">
+        <node concept="3cpWs8" id="2JDrrqkCfba" role="3cqZAp">
+          <node concept="3cpWsn" id="2JDrrqkCfbb" role="3cpWs9">
+            <property role="TrG5h" value="config" />
+            <node concept="3uibUv" id="2JDrrqkCfbc" role="1tU5fm">
+              <ref role="3uigEE" to="zhzw:2Qbt$1tSnqh" resolve="JsonConfig" />
+            </node>
+            <node concept="2YIFZM" id="2JDrrqkCfbd" role="33vP2m">
+              <ref role="37wK5l" to="zhzw:4qv99IrBnzk" resolve="getConfig" />
+              <ref role="1Pybhc" to="zhzw:4qv99IrBkzE" resolve="JsonConfigHelper" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="2JDrrqkCfb9" role="3cqZAp" />
+        <node concept="3clFbF" id="2JDrrqkCc_x" role="3cqZAp">
+          <node concept="1rXfSq" id="2JDrrqkCc_w" role="3clFbG">
+            <ref role="37wK5l" node="2JDrrqjMk5u" resolve="getJsonNodeFromValue" />
+            <node concept="37vLTw" id="2JDrrqkCqgY" role="37wK5m">
+              <ref role="3cqZAo" node="2JDrrqkBZgM" resolve="value" />
+            </node>
+            <node concept="3K4zz7" id="2JDrrqkCe7q" role="37wK5m">
+              <node concept="2OqwBi" id="2JDrrqkCe7r" role="3K4E3e">
+                <node concept="37vLTw" id="2JDrrqkCe7s" role="2Oq$k0">
+                  <ref role="3cqZAo" node="2JDrrqkCfbb" resolve="config" />
+                </node>
+                <node concept="liA8E" id="2JDrrqkCe7t" role="2OqNvi">
+                  <ref role="37wK5l" to="zhzw:2JDrrqkBGIw" resolve="numbersAsText" />
+                </node>
+              </node>
+              <node concept="3clFbT" id="2JDrrqkCe7u" role="3K4GZi" />
+              <node concept="3y3z36" id="2JDrrqkCe7v" role="3K4Cdx">
+                <node concept="10Nm6u" id="2JDrrqkCe7w" role="3uHU7w" />
+                <node concept="37vLTw" id="2JDrrqkCe7x" role="3uHU7B">
+                  <ref role="3cqZAo" node="2JDrrqkCfbb" resolve="config" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="2JDrrqkBZgK" role="1B3o_S" />
+      <node concept="3uibUv" id="2JDrrqkBZgL" role="3clF45">
+        <ref role="3uigEE" to="7k8f:~JsonNode" resolve="JsonNode" />
+      </node>
+      <node concept="37vLTG" id="2JDrrqkBZgM" role="3clF46">
+        <property role="TrG5h" value="value" />
+        <node concept="3Tqbb2" id="2JDrrqkBZgN" role="1tU5fm">
+          <ref role="ehGHo" to="21pk:3L4lRB2GdnB" resolve="IValue" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="2JDrrqkBQUq" role="jymVt" />
+    <node concept="2YIFZL" id="2JDrrqjMk5u" role="jymVt">
+      <property role="TrG5h" value="getJsonNodeFromValue" />
+      <node concept="3clFbS" id="2JDrrqjMk5x" role="3clF47">
+        <node concept="3cpWs8" id="2JDrrqjMcl7" role="3cqZAp">
+          <node concept="3cpWsn" id="2JDrrqjMcl8" role="3cpWs9">
+            <property role="TrG5h" value="mapper" />
+            <node concept="3uibUv" id="2JDrrqjMcl9" role="1tU5fm">
+              <ref role="3uigEE" to="7k8f:~ObjectMapper" resolve="ObjectMapper" />
+            </node>
+            <node concept="2ShNRf" id="2JDrrqjMctS" role="33vP2m">
+              <node concept="1pGfFk" id="2JDrrqjMcEK" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="7k8f:~ObjectMapper.&lt;init&gt;()" resolve="ObjectMapper" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="2JDrrqjNM09" role="3cqZAp" />
+        <node concept="1apkNV" id="2JDrrqjNbEu" role="3cqZAp">
+          <ref role="JncvE" to="21pk:3L4lRB2GdlQ" resolve="JSONObject" />
+          <node concept="37vLTw" id="2JDrrqjNbYj" role="JncvC">
+            <ref role="3cqZAo" node="2JDrrqjMl4V" resolve="value" />
+          </node>
+          <node concept="3clFbS" id="2JDrrqjNbEy" role="Jncv_">
+            <node concept="3cpWs8" id="2JDrrqjNm2P" role="3cqZAp">
+              <node concept="3cpWsn" id="2JDrrqjNm2Q" role="3cpWs9">
+                <property role="TrG5h" value="jsonObject" />
+                <node concept="3uibUv" id="2JDrrqjNm2R" role="1tU5fm">
+                  <ref role="3uigEE" to="lhlt:~ObjectNode" resolve="ObjectNode" />
+                </node>
+                <node concept="2OqwBi" id="2JDrrqjNn19" role="33vP2m">
+                  <node concept="37vLTw" id="2JDrrqjNm_h" role="2Oq$k0">
+                    <ref role="3cqZAo" node="2JDrrqjMcl8" resolve="mapper" />
+                  </node>
+                  <node concept="liA8E" id="2JDrrqjNnBN" role="2OqNvi">
+                    <ref role="37wK5l" to="7k8f:~ObjectMapper.createObjectNode()" resolve="createObjectNode" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="2JDrrqjNehg" role="3cqZAp">
+              <node concept="2OqwBi" id="2JDrrqjNh2O" role="3clFbG">
+                <node concept="2OqwBi" id="2JDrrqjNeqX" role="2Oq$k0">
+                  <node concept="1bEZVg" id="2JDrrqjNehf" role="2Oq$k0">
+                    <ref role="1M0zk5" node="2JDrrqjNbE$" resolve="obj" />
+                  </node>
+                  <node concept="3Tsc0h" id="2JDrrqjNeDK" role="2OqNvi">
+                    <ref role="3TtcxE" to="21pk:3L4lRB2Gdr9" resolve="variables" />
+                  </node>
+                </node>
+                <node concept="2es0OD" id="2JDrrqjNjgl" role="2OqNvi">
+                  <node concept="1bVj0M" id="2JDrrqjNjgn" role="23t8la">
+                    <node concept="3clFbS" id="2JDrrqjNjgo" role="1bW5cS">
+                      <node concept="3clFbF" id="2JDrrqjNk0R" role="3cqZAp">
+                        <node concept="2OqwBi" id="2JDrrqjNqR2" role="3clFbG">
+                          <node concept="37vLTw" id="2JDrrqjNprM" role="2Oq$k0">
+                            <ref role="3cqZAo" node="2JDrrqjNm2Q" resolve="jsonObject" />
+                          </node>
+                          <node concept="liA8E" id="2JDrrqjNrVC" role="2OqNvi">
+                            <ref role="37wK5l" to="lhlt:~ObjectNode.set(java.lang.String,com.fasterxml.jackson.databind.JsonNode)" resolve="set" />
+                            <node concept="2OqwBi" id="2JDrrqjO2wo" role="37wK5m">
+                              <node concept="37vLTw" id="2JDrrqjO1zO" role="2Oq$k0">
+                                <ref role="3cqZAo" node="2JDrrqjNjgp" resolve="variable" />
+                              </node>
+                              <node concept="3TrcHB" id="2JDrrqjO3tc" role="2OqNvi">
+                                <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                              </node>
+                            </node>
+                            <node concept="1rXfSq" id="2JDrrqjO435" role="37wK5m">
+                              <ref role="37wK5l" node="2JDrrqjMk5u" resolve="getJSONFromValue" />
+                              <node concept="2OqwBi" id="2JDrrqjO5dI" role="37wK5m">
+                                <node concept="37vLTw" id="2JDrrqjO4Zl" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="2JDrrqjNjgp" resolve="variable" />
+                                </node>
+                                <node concept="3TrEf2" id="2JDrrqjO5IN" role="2OqNvi">
+                                  <ref role="3Tt5mk" to="21pk:3L4lRB2GdnC" resolve="value" />
+                                </node>
+                              </node>
+                              <node concept="37vLTw" id="2JDrrqk_xvv" role="37wK5m">
+                                <ref role="3cqZAo" node="2JDrrqk_v0f" resolve="numberAsText" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="gl6BB" id="2JDrrqjNjgp" role="1bW2Oz">
+                      <property role="TrG5h" value="variable" />
+                      <node concept="2jxLKc" id="2JDrrqjNjgq" role="1tU5fm" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs6" id="2JDrrqjVbKe" role="3cqZAp">
+              <node concept="37vLTw" id="2JDrrqjVcf6" role="3cqZAk">
+                <ref role="3cqZAo" node="2JDrrqjNm2Q" resolve="jsonObject" />
+              </node>
+            </node>
+          </node>
+          <node concept="JncvC" id="2JDrrqjNbE$" role="JncvB">
+            <property role="TrG5h" value="obj" />
+            <node concept="2jxLKc" id="2JDrrqjNbE_" role="1tU5fm" />
+          </node>
+          <node concept="1afrx_" id="2JDrrqjNK35" role="1amwjI">
+            <ref role="JncvD" to="21pk:3L4lRB2GdnJ" resolve="Array" />
+            <node concept="3clFbS" id="2JDrrqjNK36" role="Jncv$">
+              <node concept="3cpWs8" id="2JDrrqjNQ4$" role="3cqZAp">
+                <node concept="3cpWsn" id="2JDrrqjNQ4_" role="3cpWs9">
+                  <property role="TrG5h" value="arrayNode" />
+                  <node concept="3uibUv" id="2JDrrqjNQ4A" role="1tU5fm">
+                    <ref role="3uigEE" to="lhlt:~ArrayNode" resolve="ArrayNode" />
+                  </node>
+                  <node concept="2OqwBi" id="2JDrrqjNP4P" role="33vP2m">
+                    <node concept="37vLTw" id="2JDrrqjNOw5" role="2Oq$k0">
+                      <ref role="3cqZAo" node="2JDrrqjMcl8" resolve="mapper" />
+                    </node>
+                    <node concept="liA8E" id="2JDrrqjNPJx" role="2OqNvi">
+                      <ref role="37wK5l" to="7k8f:~ObjectMapper.createArrayNode()" resolve="createArrayNode" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbF" id="2JDrrqjNRNs" role="3cqZAp">
+                <node concept="2OqwBi" id="2JDrrqjNUoA" role="3clFbG">
+                  <node concept="2OqwBi" id="2JDrrqjNS0C" role="2Oq$k0">
+                    <node concept="1bEZVg" id="2JDrrqjNRNr" role="2Oq$k0">
+                      <ref role="1M0zk5" node="2JDrrqjNK37" resolve="array" />
+                    </node>
+                    <node concept="3Tsc0h" id="2JDrrqjNSu2" role="2OqNvi">
+                      <ref role="3TtcxE" to="21pk:3L4lRB2GdnM" resolve="values" />
+                    </node>
+                  </node>
+                  <node concept="2es0OD" id="2JDrrqjNWjC" role="2OqNvi">
+                    <node concept="1bVj0M" id="2JDrrqjNWjE" role="23t8la">
+                      <node concept="3clFbS" id="2JDrrqjNWjF" role="1bW5cS">
+                        <node concept="3clFbF" id="2JDrrqjNWAr" role="3cqZAp">
+                          <node concept="2OqwBi" id="2JDrrqjNY3E" role="3clFbG">
+                            <node concept="37vLTw" id="2JDrrqjNWAq" role="2Oq$k0">
+                              <ref role="3cqZAo" node="2JDrrqjNQ4_" resolve="arrayNode" />
+                            </node>
+                            <node concept="liA8E" id="2JDrrqjNZk2" role="2OqNvi">
+                              <ref role="37wK5l" to="lhlt:~ArrayNode.add(com.fasterxml.jackson.databind.JsonNode)" resolve="add" />
+                              <node concept="1rXfSq" id="2JDrrqjNZuu" role="37wK5m">
+                                <ref role="37wK5l" node="2JDrrqjMk5u" resolve="getJSONFromValue" />
+                                <node concept="37vLTw" id="2JDrrqjO0j2" role="37wK5m">
+                                  <ref role="3cqZAo" node="2JDrrqjNWjG" resolve="it" />
+                                </node>
+                                <node concept="37vLTw" id="2JDrrqk_ywb" role="37wK5m">
+                                  <ref role="3cqZAo" node="2JDrrqk_v0f" resolve="numberAsText" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="gl6BB" id="2JDrrqjNWjG" role="1bW2Oz">
+                        <property role="TrG5h" value="arrayValue" />
+                        <node concept="2jxLKc" id="2JDrrqjNWjH" role="1tU5fm" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3cpWs6" id="2JDrrqjVb2E" role="3cqZAp">
+                <node concept="37vLTw" id="2JDrrqjVbsA" role="3cqZAk">
+                  <ref role="3cqZAo" node="2JDrrqjNQ4_" resolve="arrayNode" />
+                </node>
+              </node>
+            </node>
+            <node concept="JncvC" id="2JDrrqjNK37" role="JncvA">
+              <property role="TrG5h" value="array" />
+              <node concept="2jxLKc" id="2JDrrqjNK38" role="1tU5fm" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="2JDrrqjNKhB" role="3cqZAp" />
+        <node concept="3cpWs6" id="2JDrrqjNKjZ" role="3cqZAp">
+          <node concept="1rXfSq" id="2JDrrqjO1as" role="3cqZAk">
+            <ref role="37wK5l" node="2JDrrqjNxMc" resolve="getObjectFromLiteral" />
+            <node concept="37vLTw" id="2JDrrqjO1gN" role="37wK5m">
+              <ref role="3cqZAo" node="2JDrrqjMl4V" resolve="value" />
+            </node>
+            <node concept="37vLTw" id="2JDrrqk_$oK" role="37wK5m">
+              <ref role="3cqZAo" node="2JDrrqk_v0f" resolve="numberAsText" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="2JDrrqjMiV9" role="1B3o_S" />
+      <node concept="3uibUv" id="2JDrrqjMjXK" role="3clF45">
+        <ref role="3uigEE" to="7k8f:~JsonNode" resolve="JsonNode" />
+      </node>
+      <node concept="37vLTG" id="2JDrrqjMl4V" role="3clF46">
+        <property role="TrG5h" value="value" />
+        <node concept="3Tqbb2" id="2JDrrqjMl4U" role="1tU5fm">
+          <ref role="ehGHo" to="21pk:3L4lRB2GdnB" resolve="IValue" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="2JDrrqk_v0f" role="3clF46">
+        <property role="TrG5h" value="numberAsText" />
+        <node concept="10P_77" id="2JDrrqk_vvB" role="1tU5fm" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="2JDrrqjNEEC" role="jymVt" />
+    <node concept="2tJIrI" id="2JDrrqjNs8O" role="jymVt" />
+    <node concept="2YIFZL" id="2JDrrqjNxMc" role="jymVt">
+      <property role="TrG5h" value="getObjectFromLiteral" />
+      <node concept="3clFbS" id="2JDrrqjNxMf" role="3clF47">
+        <node concept="1apkNV" id="2JDrrqjN_gS" role="3cqZAp">
+          <ref role="JncvE" to="21pk:3L4lRB2GdnE" resolve="Boolean" />
+          <node concept="37vLTw" id="2JDrrqjN_p2" role="JncvC">
+            <ref role="3cqZAo" node="2JDrrqjNyVF" resolve="value" />
+          </node>
+          <node concept="3clFbS" id="2JDrrqjN_gU" role="Jncv_">
+            <node concept="3cpWs6" id="2JDrrqjN_X$" role="3cqZAp">
+              <node concept="2YIFZM" id="2JDrrqjOpBn" role="3cqZAk">
+                <ref role="37wK5l" to="lhlt:~BooleanNode.valueOf(boolean)" resolve="valueOf" />
+                <ref role="1Pybhc" to="lhlt:~BooleanNode" resolve="BooleanNode" />
+                <node concept="2OqwBi" id="2JDrrqjNAc3" role="37wK5m">
+                  <node concept="1bEZVg" id="2JDrrqjNA3k" role="2Oq$k0">
+                    <ref role="1M0zk5" node="2JDrrqjN_gV" resolve="booleanLiteral" />
+                  </node>
+                  <node concept="3TrcHB" id="2JDrrqjNAql" role="2OqNvi">
+                    <ref role="3TsBF5" to="21pk:3L4lRB2GdnH" resolve="value" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="JncvC" id="2JDrrqjN_gV" role="JncvB">
+            <property role="TrG5h" value="booleanLiteral" />
+            <node concept="2jxLKc" id="2JDrrqjN_gW" role="1tU5fm" />
+          </node>
+          <node concept="1afrx_" id="2JDrrqjNCkD" role="1amwjI">
+            <ref role="JncvD" to="21pk:3L4lRB2Gdrg" resolve="Number" />
+            <node concept="3clFbS" id="2JDrrqjNCkE" role="Jncv$">
+              <node concept="3clFbJ" id="2JDrrqk$Rey" role="3cqZAp">
+                <node concept="3clFbS" id="2JDrrqk$Re$" role="3clFbx">
+                  <node concept="3cpWs6" id="2JDrrqk$V7G" role="3cqZAp">
+                    <node concept="2YIFZM" id="2JDrrqk$thw" role="3cqZAk">
+                      <ref role="37wK5l" to="lhlt:~TextNode.valueOf(java.lang.String)" resolve="valueOf" />
+                      <ref role="1Pybhc" to="lhlt:~TextNode" resolve="TextNode" />
+                      <node concept="2OqwBi" id="2JDrrqk$thx" role="37wK5m">
+                        <node concept="3TrcHB" id="2JDrrqk$thz" role="2OqNvi">
+                          <ref role="3TsBF5" to="21pk:6Cwq1JbSTxh" resolve="value" />
+                        </node>
+                        <node concept="1bEZVg" id="2JDrrqk_h_N" role="2Oq$k0">
+                          <ref role="1M0zk5" node="2JDrrqjNCkF" resolve="numberLiteral" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="37vLTw" id="2JDrrqk$Uu3" role="3clFbw">
+                  <ref role="3cqZAo" node="2JDrrqk$Nga" resolve="numberAsText" />
+                </node>
+                <node concept="9aQIb" id="2JDrrqk$YS6" role="9aQIa">
+                  <node concept="3clFbS" id="2JDrrqk$YS7" role="9aQI4">
+                    <node concept="3J1_TO" id="2JDrrqjQTip" role="3cqZAp">
+                      <node concept="3clFbS" id="2JDrrqjQTiq" role="1zxBo7">
+                        <node concept="3cpWs8" id="2JDrrqkiR_v" role="3cqZAp">
+                          <node concept="3cpWsn" id="2JDrrqkiR_w" role="3cpWs9">
+                            <property role="TrG5h" value="mapper" />
+                            <node concept="3uibUv" id="2JDrrqkiyDY" role="1tU5fm">
+                              <ref role="3uigEE" to="7k8f:~ObjectMapper" resolve="ObjectMapper" />
+                            </node>
+                            <node concept="2ShNRf" id="2JDrrqkiR_x" role="33vP2m">
+                              <node concept="1pGfFk" id="2JDrrqkiR_y" role="2ShVmc">
+                                <property role="373rjd" value="true" />
+                                <ref role="37wK5l" to="7k8f:~ObjectMapper.&lt;init&gt;()" resolve="ObjectMapper" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3cpWs6" id="2JDrrqjNCyX" role="3cqZAp">
+                          <node concept="2OqwBi" id="2JDrrqkj5vt" role="3cqZAk">
+                            <node concept="10M0yZ" id="2JDrrqkj4HU" role="2Oq$k0">
+                              <ref role="3cqZAo" to="lhlt:~JsonNodeFactory.instance" resolve="instance" />
+                              <ref role="1PxDUh" to="lhlt:~JsonNodeFactory" resolve="JsonNodeFactory" />
+                            </node>
+                            <node concept="liA8E" id="2JDrrqkja18" role="2OqNvi">
+                              <ref role="37wK5l" to="lhlt:~JsonNodeFactory.numberNode(java.math.BigDecimal)" resolve="numberNode" />
+                              <node concept="2OqwBi" id="2JDrrqjQI2f" role="37wK5m">
+                                <node concept="37vLTw" id="2JDrrqkiR_z" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="2JDrrqkiR_w" resolve="mapper" />
+                                </node>
+                                <node concept="liA8E" id="2JDrrqjQIRM" role="2OqNvi">
+                                  <ref role="37wK5l" to="7k8f:~ObjectMapper.readValue(java.lang.String,java.lang.Class)" resolve="readValue" />
+                                  <node concept="2OqwBi" id="2JDrrqjNCJM" role="37wK5m">
+                                    <node concept="1bEZVg" id="2JDrrqjNCAp" role="2Oq$k0">
+                                      <ref role="1M0zk5" node="2JDrrqjNCkF" resolve="numberLiteral" />
+                                    </node>
+                                    <node concept="3TrcHB" id="2JDrrqjNCZ$" role="2OqNvi">
+                                      <ref role="3TsBF5" to="21pk:6Cwq1JbSTxh" resolve="value" />
+                                    </node>
+                                  </node>
+                                  <node concept="3VsKOn" id="2JDrrqkg$e$" role="37wK5m">
+                                    <ref role="3VsUkX" to="xlxw:~BigDecimal" resolve="BigDecimal" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3uVAMA" id="2JDrrqjQTis" role="1zxBo5">
+                        <node concept="3clFbS" id="2JDrrqjQTit" role="1zc67A">
+                          <node concept="3cpWs6" id="2JDrrqjQTLn" role="3cqZAp">
+                            <node concept="10Nm6u" id="2JDrrqjQTN1" role="3cqZAk" />
+                          </node>
+                        </node>
+                        <node concept="XOnhg" id="2JDrrqjQTiu" role="1zc67B">
+                          <property role="TrG5h" value="e" />
+                          <node concept="nSUau" id="2JDrrqjQTiv" role="1tU5fm">
+                            <node concept="3uibUv" id="2JDrrqjQTir" role="nSUat">
+                              <ref role="3uigEE" to="i4mf:~JsonProcessingException" resolve="JsonProcessingException" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="JncvC" id="2JDrrqjNCkF" role="JncvA">
+              <property role="TrG5h" value="numberLiteral" />
+              <node concept="2jxLKc" id="2JDrrqjNCkG" role="1tU5fm" />
+            </node>
+          </node>
+          <node concept="1afrx_" id="2JDrrqjNDlm" role="1amwjI">
+            <ref role="JncvD" to="21pk:3L4lRB2Gdrb" resolve="String" />
+            <node concept="3clFbS" id="2JDrrqjNDln" role="Jncv$">
+              <node concept="3cpWs6" id="2JDrrqjNDE3" role="3cqZAp">
+                <node concept="2YIFZM" id="2JDrrqjRhb1" role="3cqZAk">
+                  <ref role="37wK5l" to="lhlt:~TextNode.valueOf(java.lang.String)" resolve="valueOf" />
+                  <ref role="1Pybhc" to="lhlt:~TextNode" resolve="TextNode" />
+                  <node concept="2OqwBi" id="2JDrrqjNEeB" role="37wK5m">
+                    <node concept="1bEZVg" id="2JDrrqjNE2h" role="2Oq$k0">
+                      <ref role="1M0zk5" node="2JDrrqjNDlo" resolve="stringLiteral" />
+                    </node>
+                    <node concept="3TrcHB" id="2JDrrqjNExO" role="2OqNvi">
+                      <ref role="3TsBF5" to="21pk:3L4lRB2Gdre" resolve="value" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="JncvC" id="2JDrrqjNDlo" role="JncvA">
+              <property role="TrG5h" value="stringLiteral" />
+              <node concept="2jxLKc" id="2JDrrqjNDlp" role="1tU5fm" />
+            </node>
+          </node>
+          <node concept="1afrx_" id="2JDrrqjNB39" role="1amwjI">
+            <ref role="JncvD" to="21pk:3L4lRB2Gdrn" resolve="Null" />
+            <node concept="3clFbS" id="2JDrrqjNB3a" role="Jncv$">
+              <node concept="3cpWs6" id="2JDrrqjNBF8" role="3cqZAp">
+                <node concept="10Nm6u" id="2JDrrqjNBMN" role="3cqZAk" />
+              </node>
+            </node>
+            <node concept="JncvC" id="2JDrrqjNB3b" role="JncvA">
+              <property role="TrG5h" value="nullLiteral" />
+              <node concept="2jxLKc" id="2JDrrqjNB3c" role="1tU5fm" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="2JDrrqjNBYo" role="3cqZAp" />
+        <node concept="3cpWs6" id="2JDrrqjNC1j" role="3cqZAp">
+          <node concept="10Nm6u" id="2JDrrqjNC32" role="3cqZAk" />
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="2JDrrqjNsNm" role="1B3o_S" />
+      <node concept="37vLTG" id="2JDrrqjNyVF" role="3clF46">
+        <property role="TrG5h" value="value" />
+        <node concept="3Tqbb2" id="2JDrrqjNyVE" role="1tU5fm">
+          <ref role="ehGHo" to="21pk:3L4lRB2GdnB" resolve="IValue" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="2JDrrqk$Nga" role="3clF46">
+        <property role="TrG5h" value="numberAsText" />
+        <node concept="10P_77" id="2JDrrqk$Ngj" role="1tU5fm" />
+      </node>
+      <node concept="3uibUv" id="2JDrrqjNz1j" role="3clF45">
+        <ref role="3uigEE" to="7k8f:~JsonNode" resolve="JsonNode" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="2JDrrqk1$iA" role="jymVt" />
+    <node concept="2YIFZL" id="2JDrrqk1Fu1" role="jymVt">
+      <property role="TrG5h" value="getFactory" />
+      <node concept="3clFbS" id="2JDrrqk1Fu4" role="3clF47">
+        <node concept="3cpWs8" id="2JDrrqkBkVJ" role="3cqZAp">
+          <node concept="3cpWsn" id="2JDrrqkBkVK" role="3cpWs9">
+            <property role="TrG5h" value="config" />
+            <node concept="3uibUv" id="2JDrrqkBkKx" role="1tU5fm">
+              <ref role="3uigEE" to="zhzw:2Qbt$1tSnqh" resolve="JsonConfig" />
+            </node>
+            <node concept="2YIFZM" id="2JDrrqkBkVL" role="33vP2m">
+              <ref role="37wK5l" to="zhzw:4qv99IrBnzk" resolve="getConfig" />
+              <ref role="1Pybhc" to="zhzw:4qv99IrBkzE" resolve="JsonConfigHelper" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="2JDrrqkBlyX" role="3cqZAp">
+          <node concept="3clFbS" id="2JDrrqkBlyZ" role="3clFbx">
+            <node concept="3cpWs6" id="2JDrrqkBmYc" role="3cqZAp">
+              <node concept="2OqwBi" id="2JDrrqkBnsw" role="3cqZAk">
+                <node concept="37vLTw" id="2JDrrqkBndk" role="2Oq$k0">
+                  <ref role="3cqZAo" node="2JDrrqkBkVK" resolve="config" />
+                </node>
+                <node concept="liA8E" id="2JDrrqkBnRR" role="2OqNvi">
+                  <ref role="37wK5l" to="zhzw:2JDrrqkBcJH" resolve="getFactory" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3y3z36" id="2JDrrqkBmeu" role="3clFbw">
+            <node concept="10Nm6u" id="2JDrrqkBm_Y" role="3uHU7w" />
+            <node concept="37vLTw" id="2JDrrqkBlK8" role="3uHU7B">
+              <ref role="3cqZAo" node="2JDrrqkBkVK" resolve="config" />
+            </node>
+          </node>
+          <node concept="9aQIb" id="2JDrrqkBofX" role="9aQIa">
+            <node concept="3clFbS" id="2JDrrqkBofY" role="9aQI4">
+              <node concept="3cpWs6" id="2JDrrqkBopf" role="3cqZAp">
+                <node concept="2ShNRf" id="2JDrrqk3NtD" role="3cqZAk">
+                  <node concept="1pGfFk" id="2JDrrqk3NHC" role="2ShVmc">
+                    <property role="373rjd" value="true" />
+                    <ref role="37wK5l" to="i4mf:~JsonFactory.&lt;init&gt;()" resolve="JsonFactory" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="2JDrrqk1AmT" role="1B3o_S" />
+      <node concept="3uibUv" id="2JDrrqk1C37" role="3clF45">
+        <ref role="3uigEE" to="i4mf:~JsonFactory" resolve="JsonFactory" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="2JDrrqjY_WF" role="jymVt" />
+    <node concept="2YIFZL" id="2JDrrqk1btA" role="jymVt">
+      <property role="TrG5h" value="fileToString" />
+      <node concept="3clFbS" id="2JDrrqk1btB" role="3clF47">
+        <node concept="3clFbF" id="2JDrrqk1btC" role="3cqZAp">
+          <node concept="1rXfSq" id="2JDrrqk1btD" role="3clFbG">
+            <ref role="37wK5l" node="2JDrrqjYZht" resolve="fileToString" />
+            <node concept="37vLTw" id="2JDrrqk1btF" role="37wK5m">
+              <ref role="3cqZAo" node="2JDrrqk1btK" resolve="file" />
+            </node>
+            <node concept="1rXfSq" id="2JDrrqk1P1k" role="37wK5m">
+              <ref role="37wK5l" node="2JDrrqk1Fu1" resolve="getDefaultFactory" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="2JDrrqk1btI" role="1B3o_S" />
+      <node concept="17QB3L" id="2JDrrqk1btJ" role="3clF45" />
+      <node concept="37vLTG" id="2JDrrqk1btK" role="3clF46">
+        <property role="TrG5h" value="file" />
+        <node concept="3Tqbb2" id="2JDrrqk1btL" role="1tU5fm">
+          <ref role="ehGHo" to="21pk:3L4lRB2Gtfz" resolve="JsonFile" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="2JDrrqk1btu" role="jymVt" />
+    <node concept="2YIFZL" id="2JDrrqjYZht" role="jymVt">
+      <property role="TrG5h" value="fileToString" />
+      <node concept="3clFbS" id="2JDrrqjYZhu" role="3clF47">
+        <node concept="3clFbF" id="2JDrrqjZc9P" role="3cqZAp">
+          <node concept="1rXfSq" id="2JDrrqjZc9N" role="3clFbG">
+            <ref role="37wK5l" node="2JDrrqjYHhL" resolve="valueToString" />
+            <node concept="2OqwBi" id="2JDrrqjZcXx" role="37wK5m">
+              <node concept="37vLTw" id="2JDrrqjZcCW" role="2Oq$k0">
+                <ref role="3cqZAo" node="2JDrrqjYZhV" resolve="file" />
+              </node>
+              <node concept="3TrEf2" id="2JDrrqjZdeE" role="2OqNvi">
+                <ref role="3Tt5mk" to="21pk:3L4lRB2GtfY" resolve="object" />
+              </node>
+            </node>
+            <node concept="37vLTw" id="2JDrrqk1axO" role="37wK5m">
+              <ref role="3cqZAo" node="2JDrrqk16sr" resolve="factory" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="2JDrrqjYZhT" role="1B3o_S" />
+      <node concept="17QB3L" id="2JDrrqjYZhU" role="3clF45" />
+      <node concept="37vLTG" id="2JDrrqjYZhV" role="3clF46">
+        <property role="TrG5h" value="file" />
+        <node concept="3Tqbb2" id="2JDrrqjYZhW" role="1tU5fm">
+          <ref role="ehGHo" to="21pk:3L4lRB2Gtfz" resolve="JsonFile" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="2JDrrqk16sr" role="3clF46">
+        <property role="TrG5h" value="factory" />
+        <node concept="3uibUv" id="2JDrrqk16ss" role="1tU5fm">
+          <ref role="3uigEE" to="i4mf:~JsonFactory" resolve="JsonFactory" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="2JDrrqk1WnR" role="jymVt" />
+    <node concept="2YIFZL" id="2JDrrqk1Wo7" role="jymVt">
+      <property role="TrG5h" value="valueToString" />
+      <node concept="3clFbS" id="2JDrrqk1Wo8" role="3clF47">
+        <node concept="3clFbF" id="2JDrrqk2b$Q" role="3cqZAp">
+          <node concept="1rXfSq" id="2JDrrqk2b$P" role="3clFbG">
+            <ref role="37wK5l" node="2JDrrqjYHhL" resolve="valueToString" />
+            <node concept="37vLTw" id="2JDrrqk2bO_" role="37wK5m">
+              <ref role="3cqZAo" node="2JDrrqk1WoA" resolve="value" />
+            </node>
+            <node concept="1rXfSq" id="2JDrrqk2c1Q" role="37wK5m">
+              <ref role="37wK5l" node="2JDrrqk1Fu1" resolve="getDefaultFactory" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="2JDrrqk1Wo$" role="1B3o_S" />
+      <node concept="17QB3L" id="2JDrrqk1Wo_" role="3clF45" />
+      <node concept="37vLTG" id="2JDrrqk1WoA" role="3clF46">
+        <property role="TrG5h" value="value" />
+        <node concept="3Tqbb2" id="2JDrrqk1WoB" role="1tU5fm">
+          <ref role="ehGHo" to="21pk:3L4lRB2GdnB" resolve="IValue" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="2JDrrqjYUvo" role="jymVt" />
+    <node concept="2YIFZL" id="2JDrrqjYHhL" role="jymVt">
+      <property role="TrG5h" value="valueToString" />
+      <node concept="3clFbS" id="2JDrrqjYHhO" role="3clF47">
+        <node concept="3cpWs8" id="2JDrrqjSt$0" role="3cqZAp">
+          <node concept="3cpWsn" id="2JDrrqjSt$1" role="3cpWs9">
+            <property role="TrG5h" value="mapper" />
+            <node concept="3uibUv" id="2JDrrqjSt$2" role="1tU5fm">
+              <ref role="3uigEE" to="7k8f:~ObjectMapper" resolve="ObjectMapper" />
+            </node>
+            <node concept="2ShNRf" id="2JDrrqjSt_8" role="33vP2m">
+              <node concept="1pGfFk" id="2JDrrqjStE7" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="7k8f:~ObjectMapper.&lt;init&gt;(com.fasterxml.jackson.core.JsonFactory)" resolve="ObjectMapper" />
+                <node concept="37vLTw" id="2JDrrqk0U$J" role="37wK5m">
+                  <ref role="3cqZAo" node="2JDrrqk0QzB" resolve="factory" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="3PmL$ALk3BX" role="3cqZAp">
+          <node concept="3cpWsn" id="3PmL$ALk3BY" role="3cpWs9">
+            <property role="TrG5h" value="config" />
+            <node concept="3uibUv" id="3PmL$ALk3BZ" role="1tU5fm">
+              <ref role="3uigEE" to="zhzw:2Qbt$1tSnqh" resolve="JsonConfig" />
+            </node>
+            <node concept="2YIFZM" id="3PmL$ALk5M1" role="33vP2m">
+              <ref role="37wK5l" to="zhzw:4qv99IrBnzk" resolve="getConfig" />
+              <ref role="1Pybhc" to="zhzw:4qv99IrBkzE" resolve="JsonConfigHelper" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="3PmL$ALk7xQ" role="3cqZAp">
+          <node concept="3cpWsn" id="3PmL$ALk7xR" role="3cpWs9">
+            <property role="TrG5h" value="writer" />
+            <node concept="3uibUv" id="3PmL$ALk7xS" role="1tU5fm">
+              <ref role="3uigEE" to="7k8f:~ObjectWriter" resolve="ObjectWriter" />
+            </node>
+            <node concept="3K4zz7" id="3PmL$ALkasY" role="33vP2m">
+              <node concept="2OqwBi" id="3PmL$ALkaZz" role="3K4E3e">
+                <node concept="37vLTw" id="3PmL$ALkaMq" role="2Oq$k0">
+                  <ref role="3cqZAo" node="3PmL$ALk3BY" resolve="config" />
+                </node>
+                <node concept="liA8E" id="3PmL$ALkbz1" role="2OqNvi">
+                  <ref role="37wK5l" to="zhzw:3PmL$ALjpfg" resolve="getWriter" />
+                  <node concept="37vLTw" id="3PmL$ALkbSG" role="37wK5m">
+                    <ref role="3cqZAo" node="2JDrrqjSt$1" resolve="mapper" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3y3z36" id="3PmL$ALk9b7" role="3K4Cdx">
+                <node concept="10Nm6u" id="3PmL$ALka6r" role="3uHU7w" />
+                <node concept="37vLTw" id="3PmL$ALk8D4" role="3uHU7B">
+                  <ref role="3cqZAo" node="3PmL$ALk3BY" resolve="config" />
+                </node>
+              </node>
+              <node concept="2OqwBi" id="2JDrrqk8TNf" role="3K4GZi">
+                <node concept="37vLTw" id="2JDrrqjSQst" role="2Oq$k0">
+                  <ref role="3cqZAo" node="2JDrrqjSt$1" resolve="mapper" />
+                </node>
+                <node concept="liA8E" id="2JDrrqk8Uvn" role="2OqNvi">
+                  <ref role="37wK5l" to="7k8f:~ObjectMapper.writerWithDefaultPrettyPrinter()" resolve="writerWithDefaultPrettyPrinter" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="3PmL$ALkwcY" role="3cqZAp">
+          <node concept="1rXfSq" id="3PmL$ALkwcW" role="3clFbG">
+            <ref role="37wK5l" node="3PmL$ALkhYZ" resolve="valueToString" />
+            <node concept="37vLTw" id="3PmL$ALkzv7" role="37wK5m">
+              <ref role="3cqZAo" node="2JDrrqjYITX" resolve="value" />
+            </node>
+            <node concept="37vLTw" id="3PmL$ALkzXa" role="37wK5m">
+              <ref role="3cqZAo" node="3PmL$ALk7xR" resolve="writer" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="2JDrrqjYFJi" role="1B3o_S" />
+      <node concept="17QB3L" id="2JDrrqjYHbY" role="3clF45" />
+      <node concept="37vLTG" id="2JDrrqjYITX" role="3clF46">
+        <property role="TrG5h" value="value" />
+        <node concept="3Tqbb2" id="2JDrrqjYITW" role="1tU5fm">
+          <ref role="ehGHo" to="21pk:3L4lRB2GdnB" resolve="IValue" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="2JDrrqk0QzB" role="3clF46">
+        <property role="TrG5h" value="factory" />
+        <node concept="3uibUv" id="2JDrrqk0QJm" role="1tU5fm">
+          <ref role="3uigEE" to="i4mf:~JsonFactory" resolve="JsonFactory" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="3PmL$ALkhYX" role="jymVt" />
+    <node concept="2YIFZL" id="3PmL$ALkhYZ" role="jymVt">
+      <property role="TrG5h" value="valueToString" />
+      <node concept="3clFbS" id="3PmL$ALkhZ0" role="3clF47">
+        <node concept="3cpWs8" id="3PmL$ALkhZ7" role="3cqZAp">
+          <node concept="3cpWsn" id="3PmL$ALkhZ8" role="3cpWs9">
+            <property role="TrG5h" value="node" />
+            <node concept="3uibUv" id="3PmL$ALkhZ9" role="1tU5fm">
+              <ref role="3uigEE" to="7k8f:~JsonNode" resolve="JsonNode" />
+            </node>
+            <node concept="2YIFZM" id="3PmL$ALkhZa" role="33vP2m">
+              <ref role="37wK5l" node="2JDrrqkBZfz" resolve="getJsonNodeFromValue" />
+              <ref role="1Pybhc" node="6Sh7xm2KsCp" resolve="JsonHelper" />
+              <node concept="37vLTw" id="3PmL$ALkhZb" role="37wK5m">
+                <ref role="3cqZAo" node="3PmL$ALkhZK" resolve="value" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3J1_TO" id="3PmL$ALkhZu" role="3cqZAp">
+          <node concept="3uVAMA" id="3PmL$ALkhZv" role="1zxBo5">
+            <node concept="XOnhg" id="3PmL$ALkhZw" role="1zc67B">
+              <property role="TrG5h" value="exception" />
+              <node concept="nSUau" id="3PmL$ALkhZx" role="1tU5fm">
+                <node concept="3uibUv" id="3PmL$ALkhZy" role="nSUat">
+                  <ref role="3uigEE" to="i4mf:~JsonProcessingException" resolve="JsonProcessingException" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbS" id="3PmL$ALkhZz" role="1zc67A">
+              <node concept="YS8fn" id="3PmL$ALkhZ$" role="3cqZAp">
+                <node concept="2ShNRf" id="3PmL$ALkhZ_" role="YScLw">
+                  <node concept="1pGfFk" id="3PmL$ALkhZA" role="2ShVmc">
+                    <property role="373rjd" value="true" />
+                    <ref role="37wK5l" to="wyt6:~RuntimeException.&lt;init&gt;(java.lang.Throwable)" resolve="RuntimeException" />
+                    <node concept="37vLTw" id="3PmL$ALkhZB" role="37wK5m">
+                      <ref role="3cqZAo" node="3PmL$ALkhZw" resolve="exception" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbS" id="3PmL$ALkhZC" role="1zxBo7">
+            <node concept="3cpWs6" id="3PmL$ALkhZD" role="3cqZAp">
+              <node concept="2OqwBi" id="3PmL$ALkhZE" role="3cqZAk">
+                <node concept="37vLTw" id="3PmL$ALkhZF" role="2Oq$k0">
+                  <ref role="3cqZAo" node="3PmL$ALkpJc" resolve="writer" />
+                </node>
+                <node concept="liA8E" id="3PmL$ALkhZG" role="2OqNvi">
+                  <ref role="37wK5l" to="7k8f:~ObjectWriter.writeValueAsString(java.lang.Object)" resolve="writeValueAsString" />
+                  <node concept="37vLTw" id="3PmL$ALkhZH" role="37wK5m">
+                    <ref role="3cqZAo" node="3PmL$ALkhZ8" resolve="node" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="3PmL$ALkhZI" role="1B3o_S" />
+      <node concept="17QB3L" id="3PmL$ALkhZJ" role="3clF45" />
+      <node concept="37vLTG" id="3PmL$ALkhZK" role="3clF46">
+        <property role="TrG5h" value="value" />
+        <node concept="3Tqbb2" id="3PmL$ALkhZL" role="1tU5fm">
+          <ref role="ehGHo" to="21pk:3L4lRB2GdnB" resolve="IValue" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="3PmL$ALkpJc" role="3clF46">
+        <property role="TrG5h" value="writer" />
+        <node concept="3uibUv" id="3PmL$ALkr1s" role="1tU5fm">
+          <ref role="3uigEE" to="7k8f:~ObjectWriter" resolve="ObjectWriter" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="3PmL$ALkhYY" role="jymVt" />
   </node>
 </model>
 

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.json/models/com.mbeddr.mpsutil.json.textGen.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.json/models/com.mbeddr.mpsutil.json.textGen.mps
@@ -2,21 +2,18 @@
 <model ref="r:1e09a3c7-cdde-4c14-9dd4-a2f37f88cbb0(com.mbeddr.mpsutil.json.textGen)">
   <persistence version="9" />
   <languages>
+    <use id="b83431fe-5c8f-40bc-8a36-65e25f4dd253" name="jetbrains.mps.lang.textGen" version="1" />
     <devkit ref="fa73d85a-ac7f-447b-846c-fcdc41caa600(jetbrains.mps.devkit.aspect.textgen)" />
   </languages>
   <imports>
+    <import index="41ey" ref="r:f005c0ad-4467-4fc6-b611-c9d0774d1591(com.mbeddr.mpsutil.json.behavior)" />
+    <import index="7k8f" ref="39983771-4e9b-401b-a1a9-1da6c777c843/java:com.fasterxml.jackson.databind(MPS.ThirdParty/)" />
+    <import index="i4mf" ref="39983771-4e9b-401b-a1a9-1da6c777c843/java:com.fasterxml.jackson.core(MPS.ThirdParty/)" />
     <import index="21pk" ref="r:be665d13-1e1d-44cd-9817-8bd4d610f422(com.mbeddr.mpsutil.json.structure)" implicit="true" />
-    <import index="41ey" ref="r:f005c0ad-4467-4fc6-b611-c9d0774d1591(com.mbeddr.mpsutil.json.behavior)" implicit="true" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
-      <concept id="1082485599095" name="jetbrains.mps.baseLanguage.structure.BlockStatement" flags="nn" index="9aQIb">
-        <child id="1082485599096" name="statements" index="9aQI4" />
-      </concept>
-      <concept id="1154032098014" name="jetbrains.mps.baseLanguage.structure.AbstractLoopStatement" flags="nn" index="2LF5Ji">
-        <child id="1154032183016" name="body" index="2LFqv$" />
-      </concept>
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
@@ -27,21 +24,20 @@
       <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
         <property id="1070475926801" name="value" index="Xl_RC" />
       </concept>
+      <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
+        <reference id="1144433194310" name="classConcept" index="1Pybhc" />
+      </concept>
       <concept id="1225271369338" name="jetbrains.mps.baseLanguage.structure.IsEmptyOperation" flags="nn" index="17RlXB" />
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
       <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
-      <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
-        <child id="1082485599094" name="ifFalseStatement" index="9aQIa" />
-        <child id="1068580123160" name="condition" index="3clFbw" />
-        <child id="1068580123161" name="ifTrue" index="3clFbx" />
-      </concept>
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
       </concept>
       <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
       <concept id="1163668896201" name="jetbrains.mps.baseLanguage.structure.TernaryOperatorExpression" flags="nn" index="3K4zz7">
         <child id="1163668914799" name="condition" index="3K4Cdx" />
@@ -51,7 +47,6 @@
     </language>
     <language id="b83431fe-5c8f-40bc-8a36-65e25f4dd253" name="jetbrains.mps.lang.textGen">
       <concept id="8931911391946696733" name="jetbrains.mps.lang.textGen.structure.ExtensionDeclaration" flags="in" index="9MYSb" />
-      <concept id="1237305208784" name="jetbrains.mps.lang.textGen.structure.NewLineAppendPart" flags="ng" index="l8MVK" />
       <concept id="1237305334312" name="jetbrains.mps.lang.textGen.structure.NodeAppendPart" flags="ng" index="l9hG8">
         <child id="1237305790512" name="value" index="lb14g" />
       </concept>
@@ -61,7 +56,6 @@
       <concept id="1237306079178" name="jetbrains.mps.lang.textGen.structure.AppendOperation" flags="nn" index="lc7rE">
         <child id="1237306115446" name="part" index="lcghm" />
       </concept>
-      <concept id="4357423944233036906" name="jetbrains.mps.lang.textGen.structure.IndentPart" flags="ng" index="2BGw6n" />
       <concept id="1233670071145" name="jetbrains.mps.lang.textGen.structure.ConceptTextGenDeclaration" flags="ig" index="WtQ9Q">
         <reference id="1233670257997" name="conceptDeclaration" index="WuzLi" />
         <child id="1233749296504" name="textGenBlock" index="11c4hB" />
@@ -70,40 +64,16 @@
       </concept>
       <concept id="1233748055915" name="jetbrains.mps.lang.textGen.structure.NodeParameter" flags="nn" index="117lpO" />
       <concept id="1233749247888" name="jetbrains.mps.lang.textGen.structure.GenerateTextDeclaration" flags="in" index="11bSqf" />
-      <concept id="1236188139846" name="jetbrains.mps.lang.textGen.structure.WithIndentOperation" flags="nn" index="3izx1p">
-        <child id="1236188238861" name="list" index="3izTki" />
-      </concept>
       <concept id="7844911294523361055" name="jetbrains.mps.lang.textGen.structure.FilePathQuery" flags="ig" index="1KnnTt" />
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
       <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
-      <concept id="1143512015885" name="jetbrains.mps.lang.smodel.structure.Node_GetNextSiblingOperation" flags="nn" index="YCak7" />
-      <concept id="1172008320231" name="jetbrains.mps.lang.smodel.structure.Node_IsNotNullOperation" flags="nn" index="3x8VRR" />
       <concept id="1138056022639" name="jetbrains.mps.lang.smodel.structure.SPropertyAccess" flags="nn" index="3TrcHB">
         <reference id="1138056395725" name="property" index="3TsBF5" />
       </concept>
       <concept id="1138056143562" name="jetbrains.mps.lang.smodel.structure.SLinkAccess" flags="nn" index="3TrEf2">
         <reference id="1138056516764" name="link" index="3Tt5mk" />
       </concept>
-      <concept id="1138056282393" name="jetbrains.mps.lang.smodel.structure.SLinkListAccess" flags="nn" index="3Tsc0h">
-        <reference id="1138056546658" name="link" index="3TtcxE" />
-      </concept>
-    </language>
-    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
-      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
-        <property id="1169194664001" name="name" index="TrG5h" />
-      </concept>
-    </language>
-    <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
-      <concept id="1153943597977" name="jetbrains.mps.baseLanguage.collections.structure.ForEachStatement" flags="nn" index="2Gpval">
-        <child id="1153944400369" name="variable" index="2Gsz3X" />
-        <child id="1153944424730" name="inputSequence" index="2GsD0m" />
-      </concept>
-      <concept id="1153944193378" name="jetbrains.mps.baseLanguage.collections.structure.ForEachVariable" flags="nr" index="2GrKxI" />
-      <concept id="1153944233411" name="jetbrains.mps.baseLanguage.collections.structure.ForEachVariableReference" flags="nn" index="2GrUjf">
-        <reference id="1153944258490" name="variable" index="2Gs0qQ" />
-      </concept>
-      <concept id="1176501494711" name="jetbrains.mps.baseLanguage.collections.structure.IsNotEmptyOperation" flags="nn" index="3GX2aA" />
     </language>
   </registry>
   <node concept="WtQ9Q" id="3L4lRB2Gv5B">
@@ -119,13 +89,12 @@
     </node>
     <node concept="11bSqf" id="3L4lRB2Gv9s" role="11c4hB">
       <node concept="3clFbS" id="3L4lRB2Gv9t" role="2VODD2">
-        <node concept="lc7rE" id="3L4lRB2GvaT" role="3cqZAp">
-          <node concept="l9hG8" id="3L4lRB2Gvbu" role="lcghm">
-            <node concept="2OqwBi" id="3L4lRB2Gwef" role="lb14g">
-              <node concept="117lpO" id="3L4lRB2Gwbp" role="2Oq$k0" />
-              <node concept="3TrEf2" id="3L4lRB2GwpM" role="2OqNvi">
-                <ref role="3Tt5mk" to="21pk:3L4lRB2GtfY" resolve="object" />
-              </node>
+        <node concept="lc7rE" id="2JDrrqk8iij" role="3cqZAp">
+          <node concept="l9hG8" id="2JDrrqk8iik" role="lcghm">
+            <node concept="2YIFZM" id="2JDrrqk8ioj" role="lb14g">
+              <ref role="37wK5l" to="41ey:2JDrrqk1btA" resolve="fileToString" />
+              <ref role="1Pybhc" to="41ey:6Sh7xm2KsCp" resolve="JsonHelper" />
+              <node concept="117lpO" id="2JDrrqk8iok" role="37wK5m" />
             </node>
           </node>
         </node>
@@ -166,75 +135,13 @@
     <ref role="WuzLi" to="21pk:3L4lRB2GdlQ" resolve="JSONObject" />
     <node concept="11bSqf" id="3L4lRB2Gwr7" role="11c4hB">
       <node concept="3clFbS" id="3L4lRB2Gwr8" role="2VODD2">
-        <node concept="lc7rE" id="3L4lRB2Gwrm" role="3cqZAp">
-          <node concept="la8eA" id="3L4lRB2Gwr$" role="lcghm">
-            <property role="lacIc" value="{" />
-          </node>
-        </node>
-        <node concept="3izx1p" id="fIiyXFEO0A" role="3cqZAp">
-          <node concept="3clFbS" id="fIiyXFEO0C" role="3izTki">
-            <node concept="2Gpval" id="3L4lRB2GEBh" role="3cqZAp">
-              <node concept="2GrKxI" id="3L4lRB2GEBj" role="2Gsz3X">
-                <property role="TrG5h" value="var" />
-              </node>
-              <node concept="3clFbS" id="3L4lRB2GEBl" role="2LFqv$">
-                <node concept="lc7rE" id="3L4lRB2GHfl" role="3cqZAp">
-                  <node concept="l8MVK" id="4gPdtuDyTZT" role="lcghm" />
-                  <node concept="2BGw6n" id="4gPdtuDySCm" role="lcghm" />
-                  <node concept="l9hG8" id="3L4lRB2GHfz" role="lcghm">
-                    <node concept="2GrUjf" id="3L4lRB2GHgj" role="lb14g">
-                      <ref role="2Gs0qQ" node="3L4lRB2GEBj" resolve="var" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="3clFbJ" id="3L4lRB2GEJC" role="3cqZAp">
-                  <node concept="3clFbS" id="3L4lRB2GEJD" role="3clFbx">
-                    <node concept="lc7rE" id="3L4lRB2GHnl" role="3cqZAp">
-                      <node concept="la8eA" id="3L4lRB2GHnz" role="lcghm">
-                        <property role="lacIc" value="," />
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="2OqwBi" id="4gPdtuDyIjA" role="3clFbw">
-                    <node concept="2OqwBi" id="4gPdtuDyHH8" role="2Oq$k0">
-                      <node concept="2GrUjf" id="4gPdtuDyHvv" role="2Oq$k0">
-                        <ref role="2Gs0qQ" node="3L4lRB2GEBj" resolve="var" />
-                      </node>
-                      <node concept="YCak7" id="4gPdtuDyI47" role="2OqNvi" />
-                    </node>
-                    <node concept="3x8VRR" id="4gPdtuDyI$1" role="2OqNvi" />
-                  </node>
-                </node>
-              </node>
-              <node concept="2OqwBi" id="3L4lRB2GEEP" role="2GsD0m">
-                <node concept="117lpO" id="3L4lRB2GECA" role="2Oq$k0" />
-                <node concept="3Tsc0h" id="3L4lRB2GEIA" role="2OqNvi">
-                  <ref role="3TtcxE" to="21pk:3L4lRB2Gdr9" resolve="variables" />
-                </node>
-              </node>
+        <node concept="lc7rE" id="2JDrrqk8ir1" role="3cqZAp">
+          <node concept="l9hG8" id="2JDrrqk8ir2" role="lcghm">
+            <node concept="2YIFZM" id="2JDrrqk8ir3" role="lb14g">
+              <ref role="37wK5l" to="41ey:2JDrrqk1Wo7" resolve="valueToString" />
+              <ref role="1Pybhc" to="41ey:6Sh7xm2KsCp" resolve="JsonHelper" />
+              <node concept="117lpO" id="2JDrrqk8ir4" role="37wK5m" />
             </node>
-          </node>
-        </node>
-        <node concept="3clFbJ" id="4gPdtuDyIBU" role="3cqZAp">
-          <node concept="2OqwBi" id="4gPdtuDyKOA" role="3clFbw">
-            <node concept="2OqwBi" id="4gPdtuDyIS4" role="2Oq$k0">
-              <node concept="117lpO" id="4gPdtuDyIKd" role="2Oq$k0" />
-              <node concept="3Tsc0h" id="4gPdtuDyJ8e" role="2OqNvi">
-                <ref role="3TtcxE" to="21pk:3L4lRB2Gdr9" resolve="variables" />
-              </node>
-            </node>
-            <node concept="3GX2aA" id="4gPdtuDyNxr" role="2OqNvi" />
-          </node>
-          <node concept="3clFbS" id="4gPdtuDyIBW" role="3clFbx">
-            <node concept="lc7rE" id="4gPdtuDyNBw" role="3cqZAp">
-              <node concept="l8MVK" id="4gPdtuDyNBT" role="lcghm" />
-              <node concept="2BGw6n" id="4gPdtuDyUjc" role="lcghm" />
-            </node>
-          </node>
-        </node>
-        <node concept="lc7rE" id="3L4lRB2Gw$x" role="3cqZAp">
-          <node concept="la8eA" id="3L4lRB2Gw_r" role="lcghm">
-            <property role="lacIc" value="}" />
           </node>
         </node>
       </node>
@@ -262,11 +169,17 @@
           <node concept="la8eA" id="3L4lRB2GwZg" role="lcghm">
             <property role="lacIc" value=": " />
           </node>
-          <node concept="l9hG8" id="3L4lRB2Gx1x" role="lcghm">
-            <node concept="2OqwBi" id="3L4lRB2Gx5d" role="lb14g">
-              <node concept="117lpO" id="3L4lRB2Gx3a" role="2Oq$k0" />
-              <node concept="3TrEf2" id="3L4lRB2GxcW" role="2OqNvi">
-                <ref role="3Tt5mk" to="21pk:3L4lRB2GdnC" resolve="value" />
+        </node>
+        <node concept="lc7rE" id="2JDrrqjTvRU" role="3cqZAp">
+          <node concept="l9hG8" id="2JDrrqjTvRV" role="lcghm">
+            <node concept="2YIFZM" id="2JDrrqjZlJu" role="lb14g">
+              <ref role="37wK5l" to="41ey:2JDrrqk1Wo7" resolve="valueToString" />
+              <ref role="1Pybhc" to="41ey:6Sh7xm2KsCp" resolve="JsonHelper" />
+              <node concept="2OqwBi" id="2JDrrqjZlRN" role="37wK5m">
+                <node concept="117lpO" id="2JDrrqjZlJv" role="2Oq$k0" />
+                <node concept="3TrEf2" id="2JDrrqjZm2L" role="2OqNvi">
+                  <ref role="3Tt5mk" to="21pk:3L4lRB2GdnC" resolve="value" />
+                </node>
               </node>
             </node>
           </node>
@@ -278,75 +191,13 @@
     <ref role="WuzLi" to="21pk:3L4lRB2GdnJ" resolve="Array" />
     <node concept="11bSqf" id="3L4lRB2Gxe5" role="11c4hB">
       <node concept="3clFbS" id="3L4lRB2Gxe6" role="2VODD2">
-        <node concept="lc7rE" id="3L4lRB2Gxek" role="3cqZAp">
-          <node concept="la8eA" id="3L4lRB2Gxiv" role="lcghm">
-            <property role="lacIc" value="[" />
-          </node>
-        </node>
-        <node concept="3izx1p" id="fIiyXFEQCF" role="3cqZAp">
-          <node concept="3clFbS" id="fIiyXFEQCH" role="3izTki">
-            <node concept="2Gpval" id="3L4lRB2GxJC" role="3cqZAp">
-              <node concept="2GrKxI" id="3L4lRB2GxJE" role="2Gsz3X">
-                <property role="TrG5h" value="entry" />
-              </node>
-              <node concept="3clFbS" id="3L4lRB2GxJG" role="2LFqv$">
-                <node concept="lc7rE" id="3L4lRB2G_pl" role="3cqZAp">
-                  <node concept="l8MVK" id="4gPdtuDyVPC" role="lcghm" />
-                  <node concept="2BGw6n" id="4gPdtuDyVOU" role="lcghm" />
-                  <node concept="l9hG8" id="3L4lRB2G_s6" role="lcghm">
-                    <node concept="2GrUjf" id="3L4lRB2G_sT" role="lb14g">
-                      <ref role="2Gs0qQ" node="3L4lRB2GxJE" resolve="entry" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="3clFbJ" id="3L4lRB2GxY0" role="3cqZAp">
-                  <node concept="3clFbS" id="3L4lRB2GxY2" role="3clFbx">
-                    <node concept="lc7rE" id="3L4lRB2G_tv" role="3cqZAp">
-                      <node concept="la8eA" id="3L4lRB2G_tM" role="lcghm">
-                        <property role="lacIc" value="," />
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="2OqwBi" id="4gPdtuDwc4X" role="3clFbw">
-                    <node concept="2OqwBi" id="4gPdtuDwbo6" role="2Oq$k0">
-                      <node concept="2GrUjf" id="3L4lRB2G_fB" role="2Oq$k0">
-                        <ref role="2Gs0qQ" node="3L4lRB2GxJE" resolve="entry" />
-                      </node>
-                      <node concept="YCak7" id="4gPdtuDwbJv" role="2OqNvi" />
-                    </node>
-                    <node concept="3x8VRR" id="4gPdtuDwcp0" role="2OqNvi" />
-                  </node>
-                </node>
-              </node>
-              <node concept="2OqwBi" id="3L4lRB2GxNt" role="2GsD0m">
-                <node concept="117lpO" id="3L4lRB2GxL6" role="2Oq$k0" />
-                <node concept="3Tsc0h" id="3L4lRB2GxRl" role="2OqNvi">
-                  <ref role="3TtcxE" to="21pk:3L4lRB2GdnM" resolve="values" />
-                </node>
-              </node>
+        <node concept="lc7rE" id="2JDrrqk8h$3" role="3cqZAp">
+          <node concept="l9hG8" id="2JDrrqk8h$t" role="lcghm">
+            <node concept="2YIFZM" id="2JDrrqjZgYR" role="lb14g">
+              <ref role="37wK5l" to="41ey:2JDrrqk1Wo7" resolve="valueToString" />
+              <ref role="1Pybhc" to="41ey:6Sh7xm2KsCp" resolve="JsonHelper" />
+              <node concept="117lpO" id="2JDrrqjZh0C" role="37wK5m" />
             </node>
-          </node>
-        </node>
-        <node concept="3clFbJ" id="4gPdtuDxjzj" role="3cqZAp">
-          <node concept="3clFbS" id="4gPdtuDxjzl" role="3clFbx">
-            <node concept="lc7rE" id="4gPdtuDxnij" role="3cqZAp">
-              <node concept="l8MVK" id="4gPdtuDxniF" role="lcghm" />
-              <node concept="2BGw6n" id="4gPdtuDyVU2" role="lcghm" />
-            </node>
-          </node>
-          <node concept="2OqwBi" id="4gPdtuDxlir" role="3clFbw">
-            <node concept="2OqwBi" id="4gPdtuDxjMT" role="2Oq$k0">
-              <node concept="117lpO" id="4gPdtuDxjF2" role="2Oq$k0" />
-              <node concept="3Tsc0h" id="4gPdtuDxk33" role="2OqNvi">
-                <ref role="3TtcxE" to="21pk:3L4lRB2GdnM" resolve="values" />
-              </node>
-            </node>
-            <node concept="3GX2aA" id="4gPdtuDxnfs" role="2OqNvi" />
-          </node>
-        </node>
-        <node concept="lc7rE" id="3L4lRB2GxAU" role="3cqZAp">
-          <node concept="la8eA" id="3L4lRB2GxBO" role="lcghm">
-            <property role="lacIc" value="]" />
           </node>
         </node>
       </node>
@@ -356,13 +207,12 @@
     <ref role="WuzLi" to="21pk:3L4lRB2Gdrg" resolve="Number" />
     <node concept="11bSqf" id="3L4lRB2G_x5" role="11c4hB">
       <node concept="3clFbS" id="3L4lRB2G_x6" role="2VODD2">
-        <node concept="lc7rE" id="3L4lRB2G_xk" role="3cqZAp">
-          <node concept="l9hG8" id="3L4lRB2G_xy" role="lcghm">
-            <node concept="2OqwBi" id="3L4lRB2G_$l" role="lb14g">
-              <node concept="117lpO" id="3L4lRB2G_yi" role="2Oq$k0" />
-              <node concept="3TrcHB" id="6Cwq1JbSVVz" role="2OqNvi">
-                <ref role="3TsBF5" to="21pk:6Cwq1JbSTxh" resolve="value" />
-              </node>
+        <node concept="lc7rE" id="2JDrrqk8iya" role="3cqZAp">
+          <node concept="l9hG8" id="2JDrrqk8iyb" role="lcghm">
+            <node concept="2YIFZM" id="2JDrrqk8iyc" role="lb14g">
+              <ref role="37wK5l" to="41ey:2JDrrqk1Wo7" resolve="valueToString" />
+              <ref role="1Pybhc" to="41ey:6Sh7xm2KsCp" resolve="JsonHelper" />
+              <node concept="117lpO" id="2JDrrqk8iyd" role="37wK5m" />
             </node>
           </node>
         </node>
@@ -373,9 +223,13 @@
     <ref role="WuzLi" to="21pk:3L4lRB2Gdrn" resolve="Null" />
     <node concept="11bSqf" id="3L4lRB2GAbq" role="11c4hB">
       <node concept="3clFbS" id="3L4lRB2GAbr" role="2VODD2">
-        <node concept="lc7rE" id="3L4lRB2GAbD" role="3cqZAp">
-          <node concept="la8eA" id="3L4lRB2GAbR" role="lcghm">
-            <property role="lacIc" value="null" />
+        <node concept="lc7rE" id="2JDrrqk8itW" role="3cqZAp">
+          <node concept="l9hG8" id="2JDrrqk8itX" role="lcghm">
+            <node concept="2YIFZM" id="2JDrrqk8itY" role="lb14g">
+              <ref role="37wK5l" to="41ey:2JDrrqk1Wo7" resolve="valueToString" />
+              <ref role="1Pybhc" to="41ey:6Sh7xm2KsCp" resolve="JsonHelper" />
+              <node concept="117lpO" id="2JDrrqk8itZ" role="37wK5m" />
+            </node>
           </node>
         </node>
       </node>
@@ -385,20 +239,13 @@
     <ref role="WuzLi" to="21pk:3L4lRB2Gdrb" resolve="String" />
     <node concept="11bSqf" id="3L4lRB2GAcw" role="11c4hB">
       <node concept="3clFbS" id="3L4lRB2GAcx" role="2VODD2">
-        <node concept="lc7rE" id="3L4lRB2GAcJ" role="3cqZAp">
-          <node concept="la8eA" id="3L4lRB2GAcX" role="lcghm">
-            <property role="lacIc" value="&quot;" />
-          </node>
-          <node concept="l9hG8" id="3L4lRB2GAdm" role="lcghm">
-            <node concept="2OqwBi" id="3L4lRB2GAga" role="lb14g">
-              <node concept="117lpO" id="3L4lRB2GAe7" role="2Oq$k0" />
-              <node concept="3TrcHB" id="3L4lRB2GAky" role="2OqNvi">
-                <ref role="3TsBF5" to="21pk:3L4lRB2Gdre" resolve="value" />
-              </node>
+        <node concept="lc7rE" id="2JDrrqk8iAo" role="3cqZAp">
+          <node concept="l9hG8" id="2JDrrqk8iAp" role="lcghm">
+            <node concept="2YIFZM" id="2JDrrqk8iAq" role="lb14g">
+              <ref role="37wK5l" to="41ey:2JDrrqk1Wo7" resolve="valueToString" />
+              <ref role="1Pybhc" to="41ey:6Sh7xm2KsCp" resolve="JsonHelper" />
+              <node concept="117lpO" id="2JDrrqk8iAr" role="37wK5m" />
             </node>
-          </node>
-          <node concept="la8eA" id="3L4lRB2GAm$" role="lcghm">
-            <property role="lacIc" value="&quot;" />
           </node>
         </node>
       </node>
@@ -408,27 +255,12 @@
     <ref role="WuzLi" to="21pk:3L4lRB2GdnE" resolve="Boolean" />
     <node concept="11bSqf" id="3L4lRB2GAns" role="11c4hB">
       <node concept="3clFbS" id="3L4lRB2GAnt" role="2VODD2">
-        <node concept="3clFbJ" id="3L4lRB2GB2y" role="3cqZAp">
-          <node concept="3clFbS" id="3L4lRB2GB2$" role="3clFbx">
-            <node concept="lc7rE" id="3L4lRB2GB4V" role="3cqZAp">
-              <node concept="la8eA" id="3L4lRB2GB5e" role="lcghm">
-                <property role="lacIc" value="true" />
-              </node>
-            </node>
-          </node>
-          <node concept="2OqwBi" id="3L4lRB2GAqG" role="3clFbw">
-            <node concept="117lpO" id="3L4lRB2GAoD" role="2Oq$k0" />
-            <node concept="3TrcHB" id="3L4lRB2GAv0" role="2OqNvi">
-              <ref role="3TsBF5" to="21pk:3L4lRB2GdnH" resolve="value" />
-            </node>
-          </node>
-          <node concept="9aQIb" id="3L4lRB2GB5K" role="9aQIa">
-            <node concept="3clFbS" id="3L4lRB2GB5L" role="9aQI4">
-              <node concept="lc7rE" id="3L4lRB2GB6z" role="3cqZAp">
-                <node concept="la8eA" id="3L4lRB2GB6O" role="lcghm">
-                  <property role="lacIc" value="false" />
-                </node>
-              </node>
+        <node concept="lc7rE" id="2JDrrqk8hBp" role="3cqZAp">
+          <node concept="l9hG8" id="2JDrrqk8hBq" role="lcghm">
+            <node concept="2YIFZM" id="2JDrrqk8hBr" role="lb14g">
+              <ref role="37wK5l" to="41ey:2JDrrqk1Wo7" resolve="valueToString" />
+              <ref role="1Pybhc" to="41ey:6Sh7xm2KsCp" resolve="JsonHelper" />
+              <node concept="117lpO" id="2JDrrqk8hBs" role="37wK5m" />
             </node>
           </node>
         </node>

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.json/models/plugin.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.json/models/plugin.mps
@@ -5,6 +5,9 @@
     <use id="28f9e497-3b42-4291-aeba-0a1039153ab1" name="jetbrains.mps.lang.plugin" version="6" />
     <use id="ef7bf5ac-d06c-4342-b11d-e42104eb9343" name="jetbrains.mps.lang.plugin.standalone" version="0" />
     <use id="63650c59-16c8-498a-99c8-005c7ee9515d" name="jetbrains.mps.lang.access" version="0" />
+    <use id="c0080a47-7e37-4558-bee9-9ae18e690549" name="jetbrains.mps.lang.extension" version="2" />
+    <use id="c7d5b9dd-a05f-4be2-bc73-f2e16994cc67" name="jetbrains.mps.baseLanguage.lightweightdsl" version="1" />
+    <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="12" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
@@ -23,6 +26,9 @@
     <import index="18ew" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.util(MPS.Core/)" />
     <import index="zn9m" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.util(MPS.IDEA/)" />
     <import index="41ey" ref="r:f005c0ad-4467-4fc6-b611-c9d0774d1591(com.mbeddr.mpsutil.json.behavior)" />
+    <import index="90d" ref="r:421d64ed-8024-497f-aeab-8bddeb389dd2(jetbrains.mps.lang.extension.methods)" />
+    <import index="i4mf" ref="39983771-4e9b-401b-a1a9-1da6c777c843/java:com.fasterxml.jackson.core(MPS.ThirdParty/)" />
+    <import index="7k8f" ref="39983771-4e9b-401b-a1a9-1da6c777c843/java:com.fasterxml.jackson.databind(MPS.ThirdParty/)" />
     <import index="mhbf" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.model(MPS.OpenAPI/)" implicit="true" />
     <import index="tprs" ref="r:00000000-0000-4000-0000-011c895904a4(jetbrains.mps.ide.actions)" implicit="true" />
   </imports>
@@ -98,6 +104,7 @@
       <concept id="8118189177080264853" name="jetbrains.mps.baseLanguage.structure.AlternativeType" flags="ig" index="nSUau">
         <child id="8118189177080264854" name="alternative" index="nSUat" />
       </concept>
+      <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="nn" index="2tJIrI" />
       <concept id="1154032098014" name="jetbrains.mps.baseLanguage.structure.AbstractLoopStatement" flags="nn" index="2LF5Ji">
         <child id="1154032183016" name="body" index="2LFqv$" />
       </concept>
@@ -118,6 +125,7 @@
       <concept id="1182160077978" name="jetbrains.mps.baseLanguage.structure.AnonymousClassCreator" flags="nn" index="YeOm9">
         <child id="1182160096073" name="cls" index="YeSDq" />
       </concept>
+      <concept id="1081236700938" name="jetbrains.mps.baseLanguage.structure.StaticMethodDeclaration" flags="ig" index="2YIFZL" />
       <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
         <reference id="1144433194310" name="classConcept" index="1Pybhc" />
       </concept>
@@ -129,6 +137,7 @@
         <reference id="1144433057691" name="classifier" index="1PxDUh" />
       </concept>
       <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
+      <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
       <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
       <concept id="1070534760951" name="jetbrains.mps.baseLanguage.structure.ArrayType" flags="in" index="10Q1$e">
         <child id="1070534760952" name="componentType" index="10Q1$1" />
@@ -137,9 +146,15 @@
         <child id="1070534934091" name="type" index="10QFUM" />
         <child id="1070534934092" name="expression" index="10QFUP" />
       </concept>
+      <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu">
+        <property id="1075300953594" name="abstractClass" index="1sVAO0" />
+      </concept>
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <property id="1176718929932" name="isFinal" index="3TUv4t" />
         <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ngI" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
       </concept>
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
@@ -239,6 +254,18 @@
         <child id="1201186121363" name="typeParameter" index="2Ghqu4" />
       </concept>
     </language>
+    <language id="c0080a47-7e37-4558-bee9-9ae18e690549" name="jetbrains.mps.lang.extension">
+      <concept id="3729007189729192406" name="jetbrains.mps.lang.extension.structure.ExtensionPointDeclaration" flags="ng" index="vrV6u">
+        <child id="8029776554053057803" name="objectType" index="luc8K" />
+      </concept>
+      <concept id="6626851894249711936" name="jetbrains.mps.lang.extension.structure.ExtensionPointExpression" flags="nn" index="2O5UvJ">
+        <reference id="6626851894249712469" name="extensionPoint" index="2O5UnU" />
+      </concept>
+      <concept id="3175313036448560967" name="jetbrains.mps.lang.extension.structure.GetExtensionObjectsOperation" flags="nn" index="SfwO_" />
+      <concept id="3175313036448544056" name="jetbrains.mps.lang.extension.structure.ExtensionPointType" flags="in" index="Sf$Xq">
+        <reference id="3175313036448544057" name="extensionPoint" index="Sf$Xr" />
+      </concept>
+    </language>
     <language id="63650c59-16c8-498a-99c8-005c7ee9515d" name="jetbrains.mps.lang.access">
       <concept id="8974276187400348173" name="jetbrains.mps.lang.access.structure.CommandClosureLiteral" flags="nn" index="1QHqEC" />
       <concept id="8974276187400348170" name="jetbrains.mps.lang.access.structure.BaseExecuteCommandStatement" flags="nn" index="1QHqEJ">
@@ -319,6 +346,9 @@
         <child id="540871147943773366" name="argument" index="25WWJ7" />
       </concept>
       <concept id="1204980550705" name="jetbrains.mps.baseLanguage.collections.structure.VisitAllOperation" flags="nn" index="2es0OD" />
+      <concept id="1151689724996" name="jetbrains.mps.baseLanguage.collections.structure.SequenceType" flags="in" index="A3Dl8">
+        <child id="1151689745422" name="elementType" index="A3Ik2" />
+      </concept>
       <concept id="1153943597977" name="jetbrains.mps.baseLanguage.collections.structure.ForEachStatement" flags="nn" index="2Gpval">
         <child id="1153944400369" name="variable" index="2Gsz3X" />
         <child id="1153944424730" name="inputSequence" index="2GsD0m" />
@@ -327,7 +357,13 @@
       <concept id="1153944233411" name="jetbrains.mps.baseLanguage.collections.structure.ForEachVariableReference" flags="nn" index="2GrUjf">
         <reference id="1153944258490" name="variable" index="2Gs0qQ" />
       </concept>
+      <concept id="1205679737078" name="jetbrains.mps.baseLanguage.collections.structure.SortOperation" flags="nn" index="2S7cBI">
+        <child id="1205679832066" name="ascending" index="2S7zOq" />
+      </concept>
       <concept id="1160666733551" name="jetbrains.mps.baseLanguage.collections.structure.AddAllElementsOperation" flags="nn" index="X8dFx" />
+      <concept id="1178286324487" name="jetbrains.mps.baseLanguage.collections.structure.SortDirection" flags="nn" index="1nlBCl" />
+      <concept id="1165525191778" name="jetbrains.mps.baseLanguage.collections.structure.GetFirstOperation" flags="nn" index="1uHKPH" />
+      <concept id="1202120902084" name="jetbrains.mps.baseLanguage.collections.structure.WhereOperation" flags="nn" index="3zZkjj" />
     </language>
   </registry>
   <node concept="sE7Ow" id="6Sh7xm2JLAh">
@@ -1152,6 +1188,182 @@
         </node>
       </node>
     </node>
+  </node>
+  <node concept="vrV6u" id="WieAE6FJqt">
+    <property role="TrG5h" value="json" />
+    <node concept="3uibUv" id="2Qbt$1tSq3A" role="luc8K">
+      <ref role="3uigEE" node="2Qbt$1tSnqh" />
+    </node>
+  </node>
+  <node concept="312cEu" id="2Qbt$1tSnqh">
+    <property role="TrG5h" value="JsonConfig" />
+    <property role="1sVAO0" value="true" />
+    <node concept="2tJIrI" id="2Qbt$1tSq4w" role="jymVt" />
+    <node concept="3clFb_" id="2Qbt$1tSwXM" role="jymVt">
+      <property role="TrG5h" value="getPriorityLevel" />
+      <node concept="10Oyi0" id="2Qbt$1tSx7l" role="3clF45" />
+      <node concept="3Tm1VV" id="2Qbt$1tSwXP" role="1B3o_S" />
+      <node concept="3clFbS" id="2Qbt$1tSwXQ" role="3clF47">
+        <node concept="3clFbF" id="3HwHK4HNSfC" role="3cqZAp">
+          <node concept="3cmrfG" id="3HwHK4HNSfB" role="3clFbG">
+            <property role="3cmrfH" value="0" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="3HwHK4HNNrr" role="jymVt" />
+    <node concept="3clFb_" id="2JDrrqkBcJH" role="jymVt">
+      <property role="TrG5h" value="getFactory" />
+      <node concept="3clFbS" id="2JDrrqkBcJK" role="3clF47">
+        <node concept="3clFbF" id="2JDrrqkFsf1" role="3cqZAp">
+          <node concept="2ShNRf" id="2JDrrqkFseZ" role="3clFbG">
+            <node concept="1pGfFk" id="2JDrrqkFDDw" role="2ShVmc">
+              <property role="373rjd" value="true" />
+              <ref role="37wK5l" to="i4mf:~JsonFactory.&lt;init&gt;()" resolve="JsonFactory" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="2JDrrqkBb2Y" role="1B3o_S" />
+      <node concept="3uibUv" id="2JDrrqkBcSV" role="3clF45">
+        <ref role="3uigEE" to="i4mf:~JsonFactory" resolve="JsonFactory" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="3PmL$ALj$iO" role="jymVt" />
+    <node concept="3clFb_" id="3PmL$ALjpfg" role="jymVt">
+      <property role="TrG5h" value="getWriter" />
+      <node concept="3clFbS" id="3PmL$ALjpfh" role="3clF47">
+        <node concept="3clFbF" id="3PmL$ALjH1l" role="3cqZAp">
+          <node concept="2OqwBi" id="2JDrrqk8TNf" role="3clFbG">
+            <node concept="37vLTw" id="2JDrrqjSQst" role="2Oq$k0">
+              <ref role="3cqZAo" node="3PmL$ALjDTO" resolve="mapper" />
+            </node>
+            <node concept="liA8E" id="2JDrrqk8Uvn" role="2OqNvi">
+              <ref role="37wK5l" to="7k8f:~ObjectMapper.writerWithDefaultPrettyPrinter()" resolve="writerWithDefaultPrettyPrinter" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="3PmL$ALjpfl" role="1B3o_S" />
+      <node concept="3uibUv" id="3PmL$ALjpfm" role="3clF45">
+        <ref role="3uigEE" to="7k8f:~ObjectWriter" resolve="ObjectWriter" />
+      </node>
+      <node concept="37vLTG" id="3PmL$ALjDTO" role="3clF46">
+        <property role="TrG5h" value="mapper" />
+        <node concept="3uibUv" id="3PmL$ALjDTN" role="1tU5fm">
+          <ref role="3uigEE" to="7k8f:~ObjectMapper" resolve="ObjectMapper" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="2JDrrqkBFoh" role="jymVt" />
+    <node concept="3clFb_" id="2JDrrqkBGIw" role="jymVt">
+      <property role="1EzhhJ" value="true" />
+      <property role="TrG5h" value="exportNumbersAsText" />
+      <node concept="3clFbS" id="2JDrrqkBGIz" role="3clF47" />
+      <node concept="3Tm1VV" id="2JDrrqkBFLa" role="1B3o_S" />
+      <node concept="10P_77" id="2JDrrqkBGIm" role="3clF45" />
+    </node>
+    <node concept="3Tm1VV" id="2Qbt$1tSnqi" role="1B3o_S" />
+  </node>
+  <node concept="312cEu" id="4qv99IrBkzE">
+    <property role="TrG5h" value="JsonConfigHelper" />
+    <node concept="2YIFZL" id="4qv99IrBnzk" role="jymVt">
+      <property role="TrG5h" value="getConfig" />
+      <node concept="3clFbS" id="4qv99IrBnzn" role="3clF47">
+        <node concept="3cpWs8" id="H70Sn$AeRe" role="3cqZAp">
+          <node concept="3cpWsn" id="H70Sn$AeRf" role="3cpWs9">
+            <property role="TrG5h" value="ep" />
+            <node concept="Sf$Xq" id="H70Sn$AeRg" role="1tU5fm">
+              <ref role="Sf$Xr" node="WieAE6FJqt" resolve="components" />
+            </node>
+            <node concept="2O5UvJ" id="H70Sn$AeRh" role="33vP2m">
+              <ref role="2O5UnU" node="WieAE6FJqt" resolve="components" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="H70Sn$AeRi" role="3cqZAp">
+          <node concept="3cpWsn" id="H70Sn$AeRj" role="3cpWs9">
+            <property role="TrG5h" value="sortedMappers" />
+            <node concept="A3Dl8" id="H70Sn$AeRk" role="1tU5fm">
+              <node concept="3uibUv" id="H70Sn$AeRl" role="A3Ik2">
+                <ref role="3uigEE" node="2Qbt$1tSnqh" resolve="ComponentsConfig" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="H70Sn$AeRm" role="33vP2m">
+              <node concept="2OqwBi" id="2JDrrqkHgTu" role="2Oq$k0">
+                <node concept="2OqwBi" id="H70Sn$AeRn" role="2Oq$k0">
+                  <node concept="37vLTw" id="H70Sn$AeRo" role="2Oq$k0">
+                    <ref role="3cqZAo" node="H70Sn$AeRf" resolve="ep" />
+                  </node>
+                  <node concept="SfwO_" id="H70Sn$AeRp" role="2OqNvi" />
+                </node>
+                <node concept="3zZkjj" id="2JDrrqkHi5h" role="2OqNvi">
+                  <node concept="1bVj0M" id="2JDrrqkHi5j" role="23t8la">
+                    <node concept="3clFbS" id="2JDrrqkHi5k" role="1bW5cS">
+                      <node concept="3clFbF" id="2JDrrqkHiCN" role="3cqZAp">
+                        <node concept="3eOSWO" id="2JDrrqkHpEU" role="3clFbG">
+                          <node concept="3cmrfG" id="2JDrrqkHpRx" role="3uHU7w">
+                            <property role="3cmrfH" value="-1" />
+                          </node>
+                          <node concept="2OqwBi" id="2JDrrqkHjbw" role="3uHU7B">
+                            <node concept="37vLTw" id="2JDrrqkHiCM" role="2Oq$k0">
+                              <ref role="3cqZAo" node="2JDrrqkHi5l" resolve="it" />
+                            </node>
+                            <node concept="liA8E" id="2JDrrqkHjMm" role="2OqNvi">
+                              <ref role="37wK5l" node="2Qbt$1tSwXM" resolve="getPriorityLevel" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="gl6BB" id="2JDrrqkHi5l" role="1bW2Oz">
+                      <property role="TrG5h" value="it" />
+                      <node concept="2jxLKc" id="2JDrrqkHi5m" role="1tU5fm" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="2S7cBI" id="H70Sn$AeRq" role="2OqNvi">
+                <node concept="1bVj0M" id="H70Sn$AeRr" role="23t8la">
+                  <node concept="3clFbS" id="H70Sn$AeRs" role="1bW5cS">
+                    <node concept="3clFbF" id="H70Sn$AeRt" role="3cqZAp">
+                      <node concept="2OqwBi" id="H70Sn$AeRu" role="3clFbG">
+                        <node concept="37vLTw" id="H70Sn$AeRv" role="2Oq$k0">
+                          <ref role="3cqZAo" node="H70Sn$AeRx" resolve="it" />
+                        </node>
+                        <node concept="liA8E" id="H70Sn$AeRw" role="2OqNvi">
+                          <ref role="37wK5l" node="2Qbt$1tSwXM" resolve="getPriorityLevel" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="gl6BB" id="H70Sn$AeRx" role="1bW2Oz">
+                    <property role="TrG5h" value="it" />
+                    <node concept="2jxLKc" id="H70Sn$AeRy" role="1tU5fm" />
+                  </node>
+                </node>
+                <node concept="1nlBCl" id="H70Sn$AeRz" role="2S7zOq">
+                  <property role="3clFbU" value="false" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="H70Sn$Af71" role="3cqZAp">
+          <node concept="2OqwBi" id="H70Sn$AeRB" role="3clFbG">
+            <node concept="37vLTw" id="H70Sn$AeRC" role="2Oq$k0">
+              <ref role="3cqZAo" node="H70Sn$AeRj" resolve="sortedMappers" />
+            </node>
+            <node concept="1uHKPH" id="H70Sn$AeRD" role="2OqNvi" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="4qv99IrBkRE" role="1B3o_S" />
+      <node concept="3uibUv" id="4qv99IrBo4U" role="3clF45">
+        <ref role="3uigEE" node="2Qbt$1tSnqh" resolve="ComponentsConfig" />
+      </node>
+    </node>
+    <node concept="3Tm1VV" id="4qv99IrBkzF" role="1B3o_S" />
   </node>
 </model>
 

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.json/models/plugin.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.json/models/plugin.mps
@@ -1192,7 +1192,7 @@
   <node concept="vrV6u" id="WieAE6FJqt">
     <property role="TrG5h" value="json" />
     <node concept="3uibUv" id="2Qbt$1tSq3A" role="luc8K">
-      <ref role="3uigEE" node="2Qbt$1tSnqh" />
+      <ref role="3uigEE" node="2Qbt$1tSnqh" resolve="JsonConfig" />
     </node>
   </node>
   <node concept="312cEu" id="2Qbt$1tSnqh">
@@ -1274,10 +1274,10 @@
           <node concept="3cpWsn" id="H70Sn$AeRf" role="3cpWs9">
             <property role="TrG5h" value="ep" />
             <node concept="Sf$Xq" id="H70Sn$AeRg" role="1tU5fm">
-              <ref role="Sf$Xr" node="WieAE6FJqt" resolve="components" />
+              <ref role="Sf$Xr" node="WieAE6FJqt" resolve="json" />
             </node>
             <node concept="2O5UvJ" id="H70Sn$AeRh" role="33vP2m">
-              <ref role="2O5UnU" node="WieAE6FJqt" resolve="components" />
+              <ref role="2O5UnU" node="WieAE6FJqt" resolve="json" />
             </node>
           </node>
         </node>
@@ -1286,7 +1286,7 @@
             <property role="TrG5h" value="sortedMappers" />
             <node concept="A3Dl8" id="H70Sn$AeRk" role="1tU5fm">
               <node concept="3uibUv" id="H70Sn$AeRl" role="A3Ik2">
-                <ref role="3uigEE" node="2Qbt$1tSnqh" resolve="ComponentsConfig" />
+                <ref role="3uigEE" node="2Qbt$1tSnqh" resolve="JsonConfig" />
               </node>
             </node>
             <node concept="2OqwBi" id="H70Sn$AeRm" role="33vP2m">
@@ -1360,7 +1360,7 @@
       </node>
       <node concept="3Tm1VV" id="4qv99IrBkRE" role="1B3o_S" />
       <node concept="3uibUv" id="4qv99IrBo4U" role="3clF45">
-        <ref role="3uigEE" node="2Qbt$1tSnqh" resolve="ComponentsConfig" />
+        <ref role="3uigEE" node="2Qbt$1tSnqh" resolve="JsonConfig" />
       </node>
     </node>
     <node concept="3Tm1VV" id="4qv99IrBkzF" role="1B3o_S" />

--- a/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.json.sandbox/models/com.mbeddr.mpsutil.json.sandbox.model.mps
+++ b/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.json.sandbox/models/com.mbeddr.mpsutil.json.sandbox.model.mps
@@ -38,7 +38,7 @@
       <node concept="3YX88e" id="7W6mbU9gkRU" role="3YX86K">
         <property role="TrG5h" value="description" />
         <node concept="3YX86M" id="7W6mbU9gkRY" role="3YX8ah">
-          <property role="3YX86R" value="This is a json file" />
+          <property role="3YX86R" value="This &quot;hi&quot; is a json file" />
         </node>
       </node>
       <node concept="3YX88e" id="7W6mbU9gkS1" role="3YX86K">

--- a/code/languages/com.mbeddr.mpsutil/tests/test.com.mbeddr.mpsutil.ecore.metaModelImport/test.com.mbeddr.mpsutil.ecore.metaModelImport.msd
+++ b/code/languages/com.mbeddr.mpsutil/tests/test.com.mbeddr.mpsutil.ecore.metaModelImport/test.com.mbeddr.mpsutil.ecore.metaModelImport.msd
@@ -14,6 +14,7 @@
   <dependencies>
     <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
     <dependency reexport="false">ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)</dependency>
+    <dependency reexport="true">c6420b75-4569-420d-aaf7-9bc590ad7b2a(com.mbeddr.mpsutil.comparator)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:77948de3-6ef9-452d-b392-d01403e4086f:com.mbeddr.mpsutil.ecore" version="0" />
@@ -59,6 +60,7 @@
     <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
     <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
+    <module reference="c6420b75-4569-420d-aaf7-9bc590ad7b2a(com.mbeddr.mpsutil.comparator)" version="0" />
     <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
     <module reference="5da3f266-d744-4554-a337-854f76f37e5f(test.com.mbeddr.mpsutil.ecore.metaModelImport)" version="0" />
   </dependencyVersions>

--- a/code/languages/com.mbeddr.mpsutil/tests/tests.com.mbeddr.mpsutil.json/models/tests.com.mbeddr.mpsutil.json.plugin.mps
+++ b/code/languages/com.mbeddr.mpsutil/tests/tests.com.mbeddr.mpsutil.json/models/tests.com.mbeddr.mpsutil.json.plugin.mps
@@ -144,7 +144,7 @@
         </node>
       </node>
       <node concept="2AHcQZ" id="2JDrrqkF5Tp" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" />
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
     <node concept="2tJIrI" id="2JDrrqkFEU0" role="jymVt" />
@@ -158,7 +158,7 @@
         </node>
       </node>
       <node concept="2AHcQZ" id="2JDrrqkF5TD" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" />
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
   </node>
@@ -186,7 +186,7 @@
           <node concept="2ShNRf" id="2JDrrqkGx59" role="3clFbG">
             <node concept="HV5vD" id="2JDrrqkGxan" role="2ShVmc">
               <property role="373rjd" value="true" />
-              <ref role="HV5vE" node="2JDrrqkF5aP" resolve="TestJsonConfig" />
+              <ref role="HV5vE" node="2JDrrqkF5aP" resolve="DontExportNumbersAsTextConfig" />
             </node>
           </node>
         </node>
@@ -224,7 +224,7 @@
         </node>
       </node>
       <node concept="2AHcQZ" id="2JDrrqkI1WT" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" />
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
     <node concept="2tJIrI" id="2JDrrqkI1WU" role="jymVt" />
@@ -259,7 +259,7 @@
               <ref role="37wK5l" to="i4mf:~JsonFactory.configure(com.fasterxml.jackson.core.JsonGenerator$Feature,boolean)" resolve="configure" />
               <node concept="Rm8GO" id="2JDrrqkNyE5" role="37wK5m">
                 <ref role="Rm8GQ" to="i4mf:~JsonGenerator$Feature.QUOTE_FIELD_NAMES" resolve="QUOTE_FIELD_NAMES" />
-                <ref role="1Px2BO" to="i4mf:~JsonGenerator$Feature" resolve="Feature" />
+                <ref role="1Px2BO" to="i4mf:~JsonGenerator$Feature" resolve="JsonGenerator.Feature" />
               </node>
               <node concept="3clFbT" id="2JDrrqkI5j$" role="37wK5m" />
             </node>
@@ -267,7 +267,7 @@
         </node>
       </node>
       <node concept="2AHcQZ" id="2JDrrqkI2NR" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" />
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
     <node concept="2tJIrI" id="2JDrrqkI29u" role="jymVt" />
@@ -281,7 +281,7 @@
         </node>
       </node>
       <node concept="2AHcQZ" id="2JDrrqkI2br" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" />
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
   </node>
@@ -308,7 +308,7 @@
           <node concept="2ShNRf" id="2JDrrqkInGO" role="3clFbG">
             <node concept="HV5vD" id="2JDrrqkInGP" role="2ShVmc">
               <property role="373rjd" value="true" />
-              <ref role="HV5vE" node="2JDrrqkI1WF" resolve="DontEscapeConfig" />
+              <ref role="HV5vE" node="2JDrrqkI1WF" resolve="DontQuoteFieldNames" />
             </node>
           </node>
         </node>

--- a/code/languages/com.mbeddr.mpsutil/tests/tests.com.mbeddr.mpsutil.json/models/tests.com.mbeddr.mpsutil.json.plugin.mps
+++ b/code/languages/com.mbeddr.mpsutil/tests/tests.com.mbeddr.mpsutil.json/models/tests.com.mbeddr.mpsutil.json.plugin.mps
@@ -1,0 +1,323 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:e49a7608-d199-4e96-838b-fdca21adb137(tests.com.mbeddr.mpsutil.json.plugin)">
+  <persistence version="9" />
+  <languages>
+    <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="12" />
+    <use id="ef7bf5ac-d06c-4342-b11d-e42104eb9343" name="jetbrains.mps.lang.plugin.standalone" version="0" />
+    <use id="c0080a47-7e37-4558-bee9-9ae18e690549" name="jetbrains.mps.lang.extension" version="2" />
+    <use id="c7d5b9dd-a05f-4be2-bc73-f2e16994cc67" name="jetbrains.mps.baseLanguage.lightweightdsl" version="1" />
+  </languages>
+  <imports>
+    <import index="zhzw" ref="r:6492a138-3e52-4756-96b0-7e3c330fe78e(com.mbeddr.mpsutil.json.plugin)" />
+    <import index="i4mf" ref="39983771-4e9b-401b-a1a9-1da6c777c843/java:com.fasterxml.jackson.core(MPS.ThirdParty/)" />
+    <import index="90d" ref="r:421d64ed-8024-497f-aeab-8bddeb389dd2(jetbrains.mps.lang.extension.methods)" />
+    <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="ef7bf5ac-d06c-4342-b11d-e42104eb9343" name="jetbrains.mps.lang.plugin.standalone">
+      <concept id="7520713872864775836" name="jetbrains.mps.lang.plugin.standalone.structure.StandalonePluginDescriptor" flags="ng" index="2DaZZR" />
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="nn" index="2tJIrI" />
+      <concept id="1188207840427" name="jetbrains.mps.baseLanguage.structure.AnnotationInstance" flags="nn" index="2AHcQZ">
+        <reference id="1188208074048" name="annotation" index="2AI5Lk" />
+      </concept>
+      <concept id="1188208481402" name="jetbrains.mps.baseLanguage.structure.HasAnnotation" flags="ngI" index="2AJDlI">
+        <child id="1188208488637" name="annotation" index="2AJF6D" />
+      </concept>
+      <concept id="2820489544401957797" name="jetbrains.mps.baseLanguage.structure.DefaultClassCreator" flags="nn" index="HV5vD">
+        <reference id="2820489544401957798" name="classifier" index="HV5vE" />
+      </concept>
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1083260308424" name="jetbrains.mps.baseLanguage.structure.EnumConstantReference" flags="nn" index="Rm8GO">
+        <reference id="1083260308426" name="enumConstantDeclaration" index="Rm8GQ" />
+        <reference id="1144432896254" name="enumClass" index="1Px2BO" />
+      </concept>
+      <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
+        <child id="1145553007750" name="creator" index="2ShVmc" />
+      </concept>
+      <concept id="1070462154015" name="jetbrains.mps.baseLanguage.structure.StaticFieldDeclaration" flags="ig" index="Wx3nA" />
+      <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
+      <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
+      <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu">
+        <child id="1165602531693" name="superclass" index="1zkMxy" />
+      </concept>
+      <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
+        <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ngI" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
+      </concept>
+      <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
+        <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
+      </concept>
+      <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
+        <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
+      <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
+        <child id="1068580123133" name="returnType" index="3clF45" />
+        <child id="1068580123135" name="body" index="3clF47" />
+      </concept>
+      <concept id="1068580123165" name="jetbrains.mps.baseLanguage.structure.InstanceMethodDeclaration" flags="ig" index="3clFb_" />
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT" />
+      <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
+        <property id="1068580320021" name="value" index="3cmrfH" />
+      </concept>
+      <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
+        <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
+      </concept>
+      <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
+      </concept>
+      <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk" />
+      <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
+        <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
+      </concept>
+      <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
+        <reference id="1107535924139" name="classifier" index="3uigEE" />
+      </concept>
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ngI" index="1B3ioH">
+        <child id="1178549979242" name="visibility" index="1B3o_S" />
+      </concept>
+      <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
+    </language>
+    <language id="c0080a47-7e37-4558-bee9-9ae18e690549" name="jetbrains.mps.lang.extension">
+      <concept id="126958800891274162" name="jetbrains.mps.lang.extension.structure.Extension" flags="ig" index="1lYeZD">
+        <reference id="126958800891274597" name="extensionPoint" index="1lYe$Y" />
+      </concept>
+    </language>
+    <language id="c7d5b9dd-a05f-4be2-bc73-f2e16994cc67" name="jetbrains.mps.baseLanguage.lightweightdsl">
+      <concept id="3751132065236767083" name="jetbrains.mps.baseLanguage.lightweightdsl.structure.DependentTypeInstance" flags="ig" index="q3mfm">
+        <reference id="3751132065236767084" name="decl" index="q3mfh" />
+        <reference id="9097849371505568270" name="point" index="1QQUv3" />
+      </concept>
+      <concept id="3751132065236767060" name="jetbrains.mps.baseLanguage.lightweightdsl.structure.MethodInstance" flags="ig" index="q3mfD">
+        <reference id="19209059688387895" name="decl" index="2VtyIY" />
+      </concept>
+      <concept id="6478870542308703666" name="jetbrains.mps.baseLanguage.lightweightdsl.structure.MemberPlaceholder" flags="ng" index="3tTeZs">
+        <property id="6478870542308703667" name="caption" index="3tTeZt" />
+        <reference id="6478870542308703669" name="decl" index="3tTeZr" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="312cEu" id="2JDrrqkF5aP">
+    <property role="TrG5h" value="DontExportNumbersAsTextConfig" />
+    <node concept="Wx3nA" id="7TK9se3Zi4G" role="jymVt">
+      <property role="TrG5h" value="PRIORITY" />
+      <node concept="3Tm1VV" id="7TK9se3Zi4H" role="1B3o_S" />
+      <node concept="10Oyi0" id="7TK9se3Zi4I" role="1tU5fm" />
+      <node concept="3cmrfG" id="7TK9se3Zi4J" role="33vP2m">
+        <property role="3cmrfH" value="-1" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="2JDrrqkFEoX" role="jymVt" />
+    <node concept="3Tm1VV" id="2JDrrqkF5aQ" role="1B3o_S" />
+    <node concept="3uibUv" id="2JDrrqkF5Sv" role="1zkMxy">
+      <ref role="3uigEE" to="zhzw:2Qbt$1tSnqh" resolve="JsonConfig" />
+    </node>
+    <node concept="3clFb_" id="2JDrrqkF5Ti" role="jymVt">
+      <property role="TrG5h" value="getPriorityLevel" />
+      <node concept="10Oyi0" id="2JDrrqkF5Tj" role="3clF45" />
+      <node concept="3Tm1VV" id="2JDrrqkF5Tk" role="1B3o_S" />
+      <node concept="3clFbS" id="2JDrrqkF5To" role="3clF47">
+        <node concept="3clFbF" id="2JDrrqkFEuR" role="3cqZAp">
+          <node concept="37vLTw" id="2JDrrqkFEuQ" role="3clFbG">
+            <ref role="3cqZAo" node="7TK9se3Zi4G" resolve="PRIORITY" />
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="2JDrrqkF5Tp" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="2JDrrqkFEU0" role="jymVt" />
+    <node concept="3clFb_" id="2JDrrqkF5T$" role="jymVt">
+      <property role="TrG5h" value="exportNumbersAsText" />
+      <node concept="3Tm1VV" id="2JDrrqkF5TA" role="1B3o_S" />
+      <node concept="10P_77" id="2JDrrqkF5TB" role="3clF45" />
+      <node concept="3clFbS" id="2JDrrqkF5TC" role="3clF47">
+        <node concept="3clFbF" id="2JDrrqkF5TF" role="3cqZAp">
+          <node concept="3clFbT" id="2JDrrqkF5TE" role="3clFbG" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="2JDrrqkF5TD" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" />
+      </node>
+    </node>
+  </node>
+  <node concept="2DaZZR" id="C0WcYEphgd" />
+  <node concept="1lYeZD" id="2JDrrqkGgvv">
+    <property role="TrG5h" value="DontExportNumberAsTextExtension" />
+    <ref role="1lYe$Y" to="zhzw:WieAE6FJqt" resolve="json" />
+    <node concept="3Tm1VV" id="2JDrrqkGgvw" role="1B3o_S" />
+    <node concept="2tJIrI" id="2JDrrqkGgvx" role="jymVt" />
+    <node concept="3tTeZs" id="2JDrrqkGgvy" role="jymVt">
+      <property role="3tTeZt" value="activate" />
+      <ref role="3tTeZr" to="90d:3zLwYDe0CPy" resolve="activate" />
+    </node>
+    <node concept="3tTeZs" id="2JDrrqkGgvz" role="jymVt">
+      <property role="3tTeZt" value="deactivate" />
+      <ref role="3tTeZr" to="90d:3zLwYDe0BDO" resolve="deactivate" />
+    </node>
+    <node concept="2tJIrI" id="2JDrrqkGgv$" role="jymVt" />
+    <node concept="q3mfD" id="2JDrrqkGgv_" role="jymVt">
+      <property role="TrG5h" value="get" />
+      <ref role="2VtyIY" to="90d:3zLwYDe0svr" resolve="get" />
+      <node concept="3Tm1VV" id="2JDrrqkGgvB" role="1B3o_S" />
+      <node concept="3clFbS" id="2JDrrqkGgvD" role="3clF47">
+        <node concept="3clFbF" id="2JDrrqkGx5b" role="3cqZAp">
+          <node concept="2ShNRf" id="2JDrrqkGx59" role="3clFbG">
+            <node concept="HV5vD" id="2JDrrqkGxan" role="2ShVmc">
+              <property role="373rjd" value="true" />
+              <ref role="HV5vE" node="2JDrrqkF5aP" resolve="TestJsonConfig" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="q3mfm" id="2JDrrqkGgvE" role="3clF45">
+        <ref role="q3mfh" to="90d:3zLwYDe0sv$" />
+        <ref role="1QQUv3" node="2JDrrqkGgv_" resolve="get" />
+      </node>
+    </node>
+  </node>
+  <node concept="312cEu" id="2JDrrqkI1WF">
+    <property role="TrG5h" value="DontQuoteFieldNames" />
+    <node concept="Wx3nA" id="2JDrrqkI1WG" role="jymVt">
+      <property role="TrG5h" value="PRIORITY" />
+      <node concept="3Tm1VV" id="2JDrrqkI1WH" role="1B3o_S" />
+      <node concept="10Oyi0" id="2JDrrqkI1WI" role="1tU5fm" />
+      <node concept="3cmrfG" id="2JDrrqkI1WJ" role="33vP2m">
+        <property role="3cmrfH" value="-1" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="2JDrrqkI1WK" role="jymVt" />
+    <node concept="3Tm1VV" id="2JDrrqkI1WL" role="1B3o_S" />
+    <node concept="3uibUv" id="2JDrrqkI1WM" role="1zkMxy">
+      <ref role="3uigEE" to="zhzw:2Qbt$1tSnqh" resolve="JsonConfig" />
+    </node>
+    <node concept="3clFb_" id="2JDrrqkI1WN" role="jymVt">
+      <property role="TrG5h" value="getPriorityLevel" />
+      <node concept="10Oyi0" id="2JDrrqkI1WO" role="3clF45" />
+      <node concept="3Tm1VV" id="2JDrrqkI1WP" role="1B3o_S" />
+      <node concept="3clFbS" id="2JDrrqkI1WQ" role="3clF47">
+        <node concept="3clFbF" id="2JDrrqkI1WR" role="3cqZAp">
+          <node concept="37vLTw" id="2JDrrqkI1WS" role="3clFbG">
+            <ref role="3cqZAo" node="2JDrrqkI1WG" resolve="PRIORITY" />
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="2JDrrqkI1WT" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="2JDrrqkI1WU" role="jymVt" />
+    <node concept="2tJIrI" id="2JDrrqkI2Kt" role="jymVt" />
+    <node concept="3clFb_" id="2JDrrqkI2NJ" role="jymVt">
+      <property role="TrG5h" value="getFactory" />
+      <node concept="3Tm1VV" id="2JDrrqkI2NO" role="1B3o_S" />
+      <node concept="3uibUv" id="2JDrrqkI2NP" role="3clF45">
+        <ref role="3uigEE" to="i4mf:~JsonFactory" resolve="JsonFactory" />
+      </node>
+      <node concept="3clFbS" id="2JDrrqkI2NQ" role="3clF47">
+        <node concept="3cpWs8" id="2JDrrqkI3g9" role="3cqZAp">
+          <node concept="3cpWsn" id="2JDrrqkI3ga" role="3cpWs9">
+            <property role="TrG5h" value="factory" />
+            <node concept="3uibUv" id="2JDrrqkI3gb" role="1tU5fm">
+              <ref role="3uigEE" to="i4mf:~JsonFactory" resolve="JsonFactory" />
+            </node>
+            <node concept="2ShNRf" id="2JDrrqkI3gQ" role="33vP2m">
+              <node concept="1pGfFk" id="2JDrrqkI3pS" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="i4mf:~JsonFactory.&lt;init&gt;()" resolve="JsonFactory" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="2JDrrqkI3R0" role="3cqZAp">
+          <node concept="2OqwBi" id="2JDrrqkI4dw" role="3clFbG">
+            <node concept="37vLTw" id="2JDrrqkI3QY" role="2Oq$k0">
+              <ref role="3cqZAo" node="2JDrrqkI3ga" resolve="factory" />
+            </node>
+            <node concept="liA8E" id="2JDrrqkI4HN" role="2OqNvi">
+              <ref role="37wK5l" to="i4mf:~JsonFactory.configure(com.fasterxml.jackson.core.JsonGenerator$Feature,boolean)" resolve="configure" />
+              <node concept="Rm8GO" id="2JDrrqkNyE5" role="37wK5m">
+                <ref role="Rm8GQ" to="i4mf:~JsonGenerator$Feature.QUOTE_FIELD_NAMES" resolve="QUOTE_FIELD_NAMES" />
+                <ref role="1Px2BO" to="i4mf:~JsonGenerator$Feature" resolve="Feature" />
+              </node>
+              <node concept="3clFbT" id="2JDrrqkI5j$" role="37wK5m" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="2JDrrqkI2NR" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="2JDrrqkI29u" role="jymVt" />
+    <node concept="3clFb_" id="2JDrrqkI2bm" role="jymVt">
+      <property role="TrG5h" value="exportNumbersAsText" />
+      <node concept="3Tm1VV" id="2JDrrqkI2bo" role="1B3o_S" />
+      <node concept="10P_77" id="2JDrrqkI2bp" role="3clF45" />
+      <node concept="3clFbS" id="2JDrrqkI2bq" role="3clF47">
+        <node concept="3clFbF" id="2JDrrqkI2H_" role="3cqZAp">
+          <node concept="3clFbT" id="2JDrrqkI2H$" role="3clFbG" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="2JDrrqkI2br" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" />
+      </node>
+    </node>
+  </node>
+  <node concept="1lYeZD" id="2JDrrqkInGE">
+    <property role="TrG5h" value="DontQuoteFieldNamesExtension" />
+    <ref role="1lYe$Y" to="zhzw:WieAE6FJqt" resolve="json" />
+    <node concept="3Tm1VV" id="2JDrrqkInGF" role="1B3o_S" />
+    <node concept="2tJIrI" id="2JDrrqkInGG" role="jymVt" />
+    <node concept="3tTeZs" id="2JDrrqkInGH" role="jymVt">
+      <property role="3tTeZt" value="activate" />
+      <ref role="3tTeZr" to="90d:3zLwYDe0CPy" resolve="activate" />
+    </node>
+    <node concept="3tTeZs" id="2JDrrqkInGI" role="jymVt">
+      <property role="3tTeZt" value="deactivate" />
+      <ref role="3tTeZr" to="90d:3zLwYDe0BDO" resolve="deactivate" />
+    </node>
+    <node concept="2tJIrI" id="2JDrrqkInGJ" role="jymVt" />
+    <node concept="q3mfD" id="2JDrrqkInGK" role="jymVt">
+      <property role="TrG5h" value="get" />
+      <ref role="2VtyIY" to="90d:3zLwYDe0svr" resolve="get" />
+      <node concept="3Tm1VV" id="2JDrrqkInGL" role="1B3o_S" />
+      <node concept="3clFbS" id="2JDrrqkInGM" role="3clF47">
+        <node concept="3clFbF" id="2JDrrqkInGN" role="3cqZAp">
+          <node concept="2ShNRf" id="2JDrrqkInGO" role="3clFbG">
+            <node concept="HV5vD" id="2JDrrqkInGP" role="2ShVmc">
+              <property role="373rjd" value="true" />
+              <ref role="HV5vE" node="2JDrrqkI1WF" resolve="DontEscapeConfig" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="q3mfm" id="2JDrrqkInGQ" role="3clF45">
+        <ref role="q3mfh" to="90d:3zLwYDe0sv$" />
+        <ref role="1QQUv3" node="2JDrrqkInGK" resolve="get" />
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/code/languages/com.mbeddr.mpsutil/tests/tests.com.mbeddr.mpsutil.json/models/tests.com.mbeddr.mpsutil.json.tests@tests.mps
+++ b/code/languages/com.mbeddr.mpsutil/tests/tests.com.mbeddr.mpsutil.json/models/tests.com.mbeddr.mpsutil.json.tests@tests.mps
@@ -8,20 +8,26 @@
     <use id="f47b95d4-5e73-4c04-9204-18076950153b" name="com.mbeddr.mpsutil.compare" version="0" />
     <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
     <use id="c7fb639f-be78-4307-89b0-b5959c3fa8c8" name="jetbrains.mps.lang.text" version="0" />
+    <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="12" />
   </languages>
   <imports>
-    <import index="zhzw" ref="r:6492a138-3e52-4756-96b0-7e3c330fe78e(com.mbeddr.mpsutil.json.plugin)" />
     <import index="21pk" ref="r:be665d13-1e1d-44cd-9817-8bd4d610f422(com.mbeddr.mpsutil.json.structure)" />
     <import index="41ey" ref="r:f005c0ad-4467-4fc6-b611-c9d0774d1591(com.mbeddr.mpsutil.json.behavior)" />
     <import index="ao3" ref="7124e466-fc92-4803-a656-d7a6b7eb3910/java:jetbrains.mps.text(MPS.TextGen/)" />
+    <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" />
+    <import index="n8tf" ref="r:e49a7608-d199-4e96-838b-fdca21adb137(tests.com.mbeddr.mpsutil.json.plugin)" />
   </imports>
   <registry>
     <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
+      <concept id="2325284917965760583" name="jetbrains.mps.lang.test.structure.BeforeTestsMethod" flags="ig" index="0EjCn" />
+      <concept id="2325284917965760584" name="jetbrains.mps.lang.test.structure.AfterTestsMethod" flags="ig" index="0EjCo" />
       <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
         <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
       </concept>
       <concept id="1216913645126" name="jetbrains.mps.lang.test.structure.NodesTestCase" flags="lg" index="1lH9Xt">
         <property id="2616911529524314943" name="accessMode" index="3DII0k" />
+        <child id="2325284917965993569" name="beforeTests" index="0EEgL" />
+        <child id="2325284917965993580" name="afterTests" index="0EEgW" />
         <child id="1217501822150" name="nodesToCheck" index="1SKRRt" />
         <child id="1217501895093" name="testMethods" index="1SL9yI" />
       </concept>
@@ -35,11 +41,26 @@
       <concept id="1225978065297" name="jetbrains.mps.lang.test.structure.SimpleNodeTest" flags="ng" index="1LZb2c" />
     </language>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
+        <child id="1068498886297" name="rValue" index="37vLTx" />
+        <child id="1068498886295" name="lValue" index="37vLTJ" />
+      </concept>
+      <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
+        <child id="1137022507850" name="body" index="2VODD2" />
+      </concept>
       <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
         <property id="1070475926801" name="value" index="Xl_RC" />
       </concept>
       <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
         <reference id="1144433194310" name="classConcept" index="1Pybhc" />
+      </concept>
+      <concept id="1070533707846" name="jetbrains.mps.baseLanguage.structure.StaticFieldReference" flags="nn" index="10M0yZ">
+        <reference id="1144433057691" name="classifier" index="1PxDUh" />
       </concept>
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <child id="1068431790190" name="initializer" index="33vP2m" />
@@ -47,6 +68,7 @@
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
+      <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
       <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
@@ -55,8 +77,15 @@
         <child id="1068580123133" name="returnType" index="3clF45" />
         <child id="1068580123135" name="body" index="3clF47" />
       </concept>
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
+        <property id="1068580320021" name="value" index="3cmrfH" />
       </concept>
       <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
         <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
@@ -67,11 +96,18 @@
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
+      <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
+        <reference id="1107535924139" name="classifier" index="3uigEE" />
+      </concept>
       <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="nn" index="3SKdUt">
         <child id="8356039341262087992" name="line" index="1aUNEU" />
       </concept>
     </language>
     <language id="b5c0bb04-c583-4b2a-a66e-1eab92d33c68" name="com.mbeddr.mpsutil.json">
+      <concept id="4342692121161029328" name="com.mbeddr.mpsutil.json.structure.Number" flags="ng" index="3YX86D">
+        <property id="7647226635869198417" name="value" index="2xKZ1a" />
+      </concept>
+      <concept id="4342692121161029335" name="com.mbeddr.mpsutil.json.structure.Null" flags="ng" index="3YX86I" />
       <concept id="4342692121161029323" name="com.mbeddr.mpsutil.json.structure.String" flags="ng" index="3YX86M">
         <property id="4342692121161029326" name="value" index="3YX86R" />
       </concept>
@@ -80,6 +116,9 @@
       </concept>
       <concept id="4342692121161028982" name="com.mbeddr.mpsutil.json.structure.JSONObject" flags="ng" index="3YX88f">
         <child id="4342692121161029321" name="variables" index="3YX86K" />
+      </concept>
+      <concept id="4342692121161029098" name="com.mbeddr.mpsutil.json.structure.Boolean" flags="ng" index="3YX8aj">
+        <property id="4342692121161029101" name="value" index="3YX8ak" />
       </concept>
       <concept id="4342692121161029103" name="com.mbeddr.mpsutil.json.structure.Array" flags="ng" index="3YX8am">
         <child id="4342692121161029106" name="values" index="3YX8ab" />
@@ -146,6 +185,7 @@
             </node>
           </node>
         </node>
+        <node concept="3clFbH" id="2JDrrqkEeA8" role="3cqZAp" />
         <node concept="3cpWs8" id="75qFqB41vLT" role="3cqZAp">
           <node concept="3cpWsn" id="75qFqB41vLU" role="3cpWs9">
             <property role="TrG5h" value="expectedString" />
@@ -318,9 +358,331 @@
         </node>
       </node>
     </node>
+    <node concept="0EjCn" id="2JDrrqkHK5Y" role="0EEgL">
+      <node concept="3clFbS" id="2JDrrqkHK5Z" role="2VODD2">
+        <node concept="3clFbF" id="2JDrrqkHaGw" role="3cqZAp">
+          <node concept="37vLTI" id="2JDrrqkHffT" role="3clFbG">
+            <node concept="10M0yZ" id="2JDrrqkHfgZ" role="37vLTx">
+              <ref role="3cqZAo" to="wyt6:~Integer.MAX_VALUE" resolve="MAX_VALUE" />
+              <ref role="1PxDUh" to="wyt6:~Integer" resolve="Integer" />
+            </node>
+            <node concept="10M0yZ" id="2JDrrqkHaGX" role="37vLTJ">
+              <ref role="3cqZAo" to="n8tf:7TK9se3Zi4G" resolve="PRIORITY" />
+              <ref role="1PxDUh" to="n8tf:2JDrrqkF5aP" resolve="TestJsonConfig" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="0EjCo" id="2JDrrqkHKw6" role="0EEgW">
+      <node concept="3clFbS" id="2JDrrqkHKw7" role="2VODD2">
+        <node concept="3clFbF" id="2JDrrqkHKxi" role="3cqZAp">
+          <node concept="37vLTI" id="2JDrrqkHKxj" role="3clFbG">
+            <node concept="10M0yZ" id="2JDrrqkHKxl" role="37vLTJ">
+              <ref role="3cqZAo" to="n8tf:7TK9se3Zi4G" resolve="PRIORITY" />
+              <ref role="1PxDUh" to="n8tf:2JDrrqkF5aP" resolve="TestJsonConfig" />
+            </node>
+            <node concept="3cmrfG" id="2JDrrqkHKz2" role="37vLTx">
+              <property role="3cmrfH" value="-1" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
   </node>
   <node concept="2XOHcx" id="bGV79BrqtZ">
     <property role="2XOHcw" value="${mbeddr.github.core.home}/code/languages/com.mbeddr.mpsutil" />
+  </node>
+  <node concept="1lH9Xt" id="2JDrrqjTLaF">
+    <property role="3DII0k" value="2hh8MJdVwqX/command" />
+    <property role="TrG5h" value="GenerationTest" />
+    <node concept="1qefOq" id="2JDrrqjTM79" role="1SKRRt">
+      <node concept="3YX88f" id="2JDrrqjTM78" role="1qenE9">
+        <node concept="3YX88e" id="2JDrrqjTMd8" role="3YX86K">
+          <property role="TrG5h" value="stringWithEscapedCharacters" />
+          <node concept="3YX86M" id="2JDrrqjTMd7" role="3YX8ah">
+            <property role="3YX86R" value="This is a &quot;quote&quot;, a backslash: \, and a newline:&#10;" />
+          </node>
+        </node>
+        <node concept="3YX88e" id="2JDrrqjTMda" role="3YX86K">
+          <property role="TrG5h" value="unicodeCharacters" />
+          <node concept="3YX86M" id="2JDrrqjTMd9" role="3YX8ah">
+            <property role="3YX86R" value="Emoji: 😊, Chinese: 中文, Arabic: العربية" />
+          </node>
+        </node>
+        <node concept="3YX88e" id="2JDrrqjTMdc" role="3YX86K">
+          <property role="TrG5h" value="integer" />
+          <node concept="3YX86D" id="2JDrrqjTMdb" role="3YX8ah">
+            <property role="2xKZ1a" value="123" />
+          </node>
+        </node>
+        <node concept="3YX88e" id="2JDrrqjTMde" role="3YX86K">
+          <property role="TrG5h" value="negativeInteger" />
+          <node concept="3YX86D" id="2JDrrqjTMdd" role="3YX8ah">
+            <property role="2xKZ1a" value="-456" />
+          </node>
+        </node>
+        <node concept="3YX88e" id="2JDrrqjTMdg" role="3YX86K">
+          <property role="TrG5h" value="floatingPoint" />
+          <node concept="3YX86D" id="2JDrrqjTMdf" role="3YX8ah">
+            <property role="2xKZ1a" value="123.45" />
+          </node>
+        </node>
+        <node concept="3YX88e" id="2JDrrqjTMdi" role="3YX86K">
+          <property role="TrG5h" value="negativeFloatingPoint" />
+          <node concept="3YX86D" id="2JDrrqjTMdh" role="3YX8ah">
+            <property role="2xKZ1a" value="-678.9" />
+          </node>
+        </node>
+        <node concept="3YX88e" id="2JDrrqjTMdk" role="3YX86K">
+          <property role="TrG5h" value="scientificNotationPositive" />
+          <node concept="3YX86D" id="2JDrrqjTMdj" role="3YX8ah">
+            <property role="2xKZ1a" value="12300.0" />
+          </node>
+        </node>
+        <node concept="3YX88e" id="2JDrrqjTMdm" role="3YX86K">
+          <property role="TrG5h" value="scientificNotationNegative" />
+          <node concept="3YX86D" id="2JDrrqjTMdl" role="3YX8ah">
+            <property role="2xKZ1a" value="-5.67E-8" />
+          </node>
+        </node>
+        <node concept="3YX88e" id="2JDrrqjTMdo" role="3YX86K">
+          <property role="TrG5h" value="booleanTrue" />
+          <node concept="3YX8aj" id="2JDrrqjTMdn" role="3YX8ah">
+            <property role="3YX8ak" value="true" />
+          </node>
+        </node>
+        <node concept="3YX88e" id="2JDrrqjTMdq" role="3YX86K">
+          <property role="TrG5h" value="booleanFalse" />
+          <node concept="3YX8aj" id="2JDrrqjTMdp" role="3YX8ah">
+            <property role="3YX8ak" value="false" />
+          </node>
+        </node>
+        <node concept="3YX88e" id="2JDrrqjTMds" role="3YX86K">
+          <property role="TrG5h" value="nullValue" />
+          <node concept="3YX86I" id="2JDrrqjTMdr" role="3YX8ah" />
+        </node>
+        <node concept="3YX88e" id="2JDrrqjTMdz" role="3YX86K">
+          <property role="TrG5h" value="array" />
+          <node concept="3YX8am" id="2JDrrqjTMdt" role="3YX8ah">
+            <node concept="3YX86D" id="2JDrrqjTMdu" role="3YX8ab">
+              <property role="2xKZ1a" value="1" />
+            </node>
+            <node concept="3YX86M" id="2JDrrqjTMdv" role="3YX8ab">
+              <property role="3YX86R" value="two" />
+            </node>
+            <node concept="3YX86D" id="2JDrrqjTMdw" role="3YX8ab">
+              <property role="2xKZ1a" value="3.0" />
+            </node>
+            <node concept="3YX8aj" id="2JDrrqjTMdx" role="3YX8ab">
+              <property role="3YX8ak" value="true" />
+            </node>
+            <node concept="3YX86I" id="2JDrrqjTMdy" role="3YX8ab" />
+          </node>
+        </node>
+        <node concept="3YX88e" id="2JDrrqjTMdJ" role="3YX86K">
+          <property role="TrG5h" value="nestedObject" />
+          <node concept="3YX88f" id="2JDrrqjTMd$" role="3YX8ah">
+            <node concept="3YX88e" id="2JDrrqjTMdA" role="3YX86K">
+              <property role="TrG5h" value="key1" />
+              <node concept="3YX86M" id="2JDrrqjTMd_" role="3YX8ah">
+                <property role="3YX86R" value="value1" />
+              </node>
+            </node>
+            <node concept="3YX88e" id="2JDrrqjTMdC" role="3YX86K">
+              <property role="TrG5h" value="key2" />
+              <node concept="3YX86D" id="2JDrrqjTMdB" role="3YX8ah">
+                <property role="2xKZ1a" value="2" />
+              </node>
+            </node>
+            <node concept="3YX88e" id="2JDrrqjTMdI" role="3YX86K">
+              <property role="TrG5h" value="key3" />
+              <node concept="3YX88f" id="2JDrrqjTMdD" role="3YX8ah">
+                <node concept="3YX88e" id="2JDrrqjTMdF" role="3YX86K">
+                  <property role="TrG5h" value="subKey1" />
+                  <node concept="3YX86M" id="2JDrrqjTMdE" role="3YX8ah">
+                    <property role="3YX86R" value="subValue1" />
+                  </node>
+                </node>
+                <node concept="3YX88e" id="2JDrrqjTMdH" role="3YX86K">
+                  <property role="TrG5h" value="subKey2" />
+                  <node concept="3YX86D" id="2JDrrqjTMdG" role="3YX8ah">
+                    <property role="2xKZ1a" value="3.14" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3xLA65" id="2JDrrqjTMuY" role="lGtFl">
+          <property role="TrG5h" value="expectedNode" />
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="2JDrrqjTMdK" role="1SL9yI">
+      <property role="TrG5h" value="importAndGenerate" />
+      <node concept="3cqZAl" id="2JDrrqjTMdL" role="3clF45" />
+      <node concept="3clFbS" id="2JDrrqjTMdM" role="3clF47">
+        <node concept="3cpWs8" id="2JDrrqjTMeo" role="3cqZAp">
+          <node concept="3cpWsn" id="2JDrrqjTMer" role="3cpWs9">
+            <property role="TrG5h" value="expected" />
+            <node concept="17QB3L" id="2JDrrqjTMen" role="1tU5fm" />
+            <node concept="Xl_RD" id="2JDrrqjTMeE" role="33vP2m">
+              <property role="Xl_RC" value="{\n  \&quot;stringWithEscapedCharacters\&quot; : \&quot;This is a \\\&quot;quote\\\&quot;, a backslash: \\\\, and a newline:\\n\&quot;,\n  \&quot;unicodeCharacters\&quot; : \&quot;Emoji: \uD83D\uDE0A, Chinese: \u4E2D\u6587, Arabic: \u0627\u0644\u0639\u0631\u0628\u064A\u0629\&quot;,\n  \&quot;integer\&quot; : 123,\n  \&quot;negativeInteger\&quot; : -456,\n  \&quot;floatingPoint\&quot; : 123.45,\n  \&quot;negativeFloatingPoint\&quot; : -678.9,\n  \&quot;scientificNotationPositive\&quot; : 12300.0,\n  \&quot;scientificNotationNegative\&quot; : -5.67E-8,\n  \&quot;booleanTrue\&quot; : true,\n  \&quot;booleanFalse\&quot; : false,\n  \&quot;nullValue\&quot; : null,\n  \&quot;array\&quot; : [ 1, \&quot;two\&quot;, 3.0, true, null ],\n  \&quot;nestedObject\&quot; : {\n    \&quot;key1\&quot; : \&quot;value1\&quot;,\n    \&quot;key2\&quot; : 2,\n    \&quot;key3\&quot; : {\n      \&quot;subKey1\&quot; : \&quot;subValue1\&quot;,\n      \&quot;subKey2\&quot; : 3.14\n    }\n  }\n}" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="2JDrrqkqiNK" role="3cqZAp">
+          <node concept="37vLTI" id="2JDrrqkqlmC" role="3clFbG">
+            <node concept="2OqwBi" id="2JDrrqkqm1H" role="37vLTx">
+              <node concept="37vLTw" id="2JDrrqkqlqw" role="2Oq$k0">
+                <ref role="3cqZAo" node="2JDrrqjTMer" resolve="expected" />
+              </node>
+              <node concept="liA8E" id="2JDrrqkqnbD" role="2OqNvi">
+                <ref role="37wK5l" to="wyt6:~String.replaceAll(java.lang.String,java.lang.String)" resolve="replaceAll" />
+                <node concept="Xl_RD" id="2JDrrqkqoHo" role="37wK5m">
+                  <property role="Xl_RC" value="\r\n" />
+                </node>
+                <node concept="Xl_RD" id="2JDrrqkqp8O" role="37wK5m">
+                  <property role="Xl_RC" value="\n" />
+                </node>
+              </node>
+            </node>
+            <node concept="37vLTw" id="2JDrrqkqiNI" role="37vLTJ">
+              <ref role="3cqZAo" node="2JDrrqjTMer" resolve="expected" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="2JDrrqjTMjs" role="3cqZAp">
+          <node concept="3cpWsn" id="2JDrrqjTMjt" role="3cpWs9">
+            <property role="TrG5h" value="parsedNode" />
+            <node concept="3Tqbb2" id="2JDrrqjTMjj" role="1tU5fm">
+              <ref role="ehGHo" to="21pk:3L4lRB2GdlQ" resolve="JSONObject" />
+            </node>
+            <node concept="2YIFZM" id="2JDrrqjTMju" role="33vP2m">
+              <ref role="37wK5l" to="41ey:6V56CwaCfPi" resolve="importJsonObject" />
+              <ref role="1Pybhc" to="41ey:6Sh7xm2KsCp" resolve="JsonHelper" />
+              <node concept="37vLTw" id="2JDrrqjTMjv" role="37wK5m">
+                <ref role="3cqZAo" node="2JDrrqjTMer" resolve="expected" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3GXo0L" id="2JDrrqjTMtH" role="3cqZAp">
+          <node concept="3xONca" id="2JDrrqjTMuZ" role="3tpDZB">
+            <ref role="3xOPvv" node="2JDrrqjTMuY" resolve="parsedNode" />
+          </node>
+          <node concept="37vLTw" id="2JDrrqjTMyL" role="3tpDZA">
+            <ref role="3cqZAo" node="2JDrrqjTMjt" resolve="parsedNode" />
+          </node>
+        </node>
+        <node concept="3vlDli" id="2JDrrqkmcx1" role="3cqZAp">
+          <node concept="37vLTw" id="2JDrrqkmcyC" role="3tpDZB">
+            <ref role="3cqZAo" node="2JDrrqjTMer" resolve="expected" />
+          </node>
+          <node concept="2YIFZM" id="2JDrrqkmc$1" role="3tpDZA">
+            <ref role="37wK5l" to="ao3:~TextGeneratorEngine.generateText(org.jetbrains.mps.openapi.model.SNode)" resolve="generateText" />
+            <ref role="1Pybhc" to="ao3:~TextGeneratorEngine" resolve="TextGeneratorEngine" />
+            <node concept="37vLTw" id="2JDrrqkmc$2" role="37wK5m">
+              <ref role="3cqZAo" node="2JDrrqjTMjt" resolve="parsedNode" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="1lH9Xt" id="2JDrrqkImKo">
+    <property role="3DII0k" value="2hh8MJdVwqX/command" />
+    <property role="TrG5h" value="DontQuoteFieldNamesExtension" />
+    <node concept="1qefOq" id="2JDrrqkInAu" role="1SKRRt">
+      <node concept="3YXoiq" id="2JDrrqkInAU" role="1qenE9">
+        <property role="TrG5h" value="test" />
+        <node concept="3YX88f" id="2JDrrqkInB1" role="3YXoi7">
+          <node concept="3YX88e" id="2JDrrqkInB5" role="3YX86K">
+            <property role="TrG5h" value="hello" />
+            <node concept="3YX86M" id="2JDrrqkInBb" role="3YX8ah">
+              <property role="3YX86R" value="world" />
+            </node>
+          </node>
+        </node>
+        <node concept="3xLA65" id="2JDrrqkIFSy" role="lGtFl">
+          <property role="TrG5h" value="input" />
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="2JDrrqkImL5" role="1SL9yI">
+      <property role="TrG5h" value="Quote" />
+      <node concept="3cqZAl" id="2JDrrqkImL6" role="3clF45" />
+      <node concept="3clFbS" id="2JDrrqkImL7" role="3clF47">
+        <node concept="3vlDli" id="2JDrrqkImLs" role="3cqZAp">
+          <node concept="Xl_RD" id="2JDrrqkJ6bl" role="3tpDZB">
+            <property role="Xl_RC" value="{\n  \&quot;hello\&quot; : \&quot;world\&quot;\n}" />
+          </node>
+          <node concept="2YIFZM" id="2JDrrqkIFSD" role="3tpDZA">
+            <ref role="37wK5l" to="ao3:~TextGeneratorEngine.generateText(org.jetbrains.mps.openapi.model.SNode)" resolve="generateText" />
+            <ref role="1Pybhc" to="ao3:~TextGeneratorEngine" resolve="TextGeneratorEngine" />
+            <node concept="3xONca" id="2JDrrqkIFTd" role="37wK5m">
+              <ref role="3xOPvv" node="2JDrrqkIFSy" resolve="input" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="2JDrrqkKjlO" role="1SL9yI">
+      <property role="TrG5h" value="DontQuote" />
+      <node concept="3cqZAl" id="2JDrrqkKjlP" role="3clF45" />
+      <node concept="3clFbS" id="2JDrrqkKjlQ" role="3clF47">
+        <node concept="3clFbF" id="2JDrrqkKqGP" role="3cqZAp">
+          <node concept="37vLTI" id="2JDrrqkKsBZ" role="3clFbG">
+            <node concept="10M0yZ" id="2JDrrqkKsDR" role="37vLTx">
+              <ref role="3cqZAo" to="wyt6:~Integer.MAX_VALUE" resolve="MAX_VALUE" />
+              <ref role="1PxDUh" to="wyt6:~Integer" resolve="Integer" />
+            </node>
+            <node concept="10M0yZ" id="2JDrrqkKqI2" role="37vLTJ">
+              <ref role="3cqZAo" to="n8tf:2JDrrqkI1WG" resolve="PRIORITY" />
+              <ref role="1PxDUh" to="n8tf:2JDrrqkI1WF" resolve="DontQuoteFieldNames" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="2JDrrqkOUfZ" role="3cqZAp">
+          <node concept="3cpWsn" id="2JDrrqkOUg0" role="3cpWs9">
+            <property role="TrG5h" value="output" />
+            <node concept="3uibUv" id="2JDrrqkOT1h" role="1tU5fm">
+              <ref role="3uigEE" to="wyt6:~String" resolve="String" />
+            </node>
+            <node concept="2YIFZM" id="2JDrrqkOUg1" role="33vP2m">
+              <ref role="37wK5l" to="ao3:~TextGeneratorEngine.generateText(org.jetbrains.mps.openapi.model.SNode)" resolve="generateText" />
+              <ref role="1Pybhc" to="ao3:~TextGeneratorEngine" resolve="TextGeneratorEngine" />
+              <node concept="3xONca" id="2JDrrqkOUg2" role="37wK5m">
+                <ref role="3xOPvv" node="2JDrrqkIFSy" resolve="input" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="2JDrrqkKt33" role="3cqZAp">
+          <node concept="37vLTI" id="2JDrrqkKt34" role="3clFbG">
+            <node concept="10M0yZ" id="2JDrrqkKt36" role="37vLTJ">
+              <ref role="3cqZAo" to="n8tf:2JDrrqkI1WG" resolve="PRIORITY" />
+              <ref role="1PxDUh" to="n8tf:2JDrrqkI1WF" resolve="DontEscapeConfig" />
+            </node>
+            <node concept="3cmrfG" id="2JDrrqkKtt3" role="37vLTx">
+              <property role="3cmrfH" value="-1" />
+            </node>
+          </node>
+        </node>
+        <node concept="3vlDli" id="2JDrrqkKjlR" role="3cqZAp">
+          <node concept="Xl_RD" id="2JDrrqkKjlS" role="3tpDZB">
+            <property role="Xl_RC" value="{\n  hello : \&quot;world\&quot;\n}" />
+          </node>
+          <node concept="37vLTw" id="2JDrrqkOUg3" role="3tpDZA">
+            <ref role="3cqZAo" node="2JDrrqkOUg0" resolve="generateText" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="0EjCn" id="2JDrrqkPAVr" role="0EEgL">
+      <node concept="3clFbS" id="2JDrrqkPAVs" role="2VODD2" />
+    </node>
   </node>
 </model>
 

--- a/code/languages/com.mbeddr.mpsutil/tests/tests.com.mbeddr.mpsutil.json/models/tests.com.mbeddr.mpsutil.json.tests@tests.mps
+++ b/code/languages/com.mbeddr.mpsutil/tests/tests.com.mbeddr.mpsutil.json/models/tests.com.mbeddr.mpsutil.json.tests@tests.mps
@@ -368,7 +368,7 @@
             </node>
             <node concept="10M0yZ" id="2JDrrqkHaGX" role="37vLTJ">
               <ref role="3cqZAo" to="n8tf:7TK9se3Zi4G" resolve="PRIORITY" />
-              <ref role="1PxDUh" to="n8tf:2JDrrqkF5aP" resolve="TestJsonConfig" />
+              <ref role="1PxDUh" to="n8tf:2JDrrqkF5aP" resolve="DontExportNumbersAsTextConfig" />
             </node>
           </node>
         </node>
@@ -380,7 +380,7 @@
           <node concept="37vLTI" id="2JDrrqkHKxj" role="3clFbG">
             <node concept="10M0yZ" id="2JDrrqkHKxl" role="37vLTJ">
               <ref role="3cqZAo" to="n8tf:7TK9se3Zi4G" resolve="PRIORITY" />
-              <ref role="1PxDUh" to="n8tf:2JDrrqkF5aP" resolve="TestJsonConfig" />
+              <ref role="1PxDUh" to="n8tf:2JDrrqkF5aP" resolve="DontExportNumbersAsTextConfig" />
             </node>
             <node concept="3cmrfG" id="2JDrrqkHKz2" role="37vLTx">
               <property role="3cmrfH" value="-1" />
@@ -570,7 +570,7 @@
         </node>
         <node concept="3GXo0L" id="2JDrrqjTMtH" role="3cqZAp">
           <node concept="3xONca" id="2JDrrqjTMuZ" role="3tpDZB">
-            <ref role="3xOPvv" node="2JDrrqjTMuY" resolve="parsedNode" />
+            <ref role="3xOPvv" node="2JDrrqjTMuY" resolve="expectedNode" />
           </node>
           <node concept="37vLTw" id="2JDrrqjTMyL" role="3tpDZA">
             <ref role="3cqZAo" node="2JDrrqjTMjt" resolve="parsedNode" />
@@ -663,7 +663,7 @@
           <node concept="37vLTI" id="2JDrrqkKt34" role="3clFbG">
             <node concept="10M0yZ" id="2JDrrqkKt36" role="37vLTJ">
               <ref role="3cqZAo" to="n8tf:2JDrrqkI1WG" resolve="PRIORITY" />
-              <ref role="1PxDUh" to="n8tf:2JDrrqkI1WF" resolve="DontEscapeConfig" />
+              <ref role="1PxDUh" to="n8tf:2JDrrqkI1WF" resolve="DontQuoteFieldNames" />
             </node>
             <node concept="3cmrfG" id="2JDrrqkKtt3" role="37vLTx">
               <property role="3cmrfH" value="-1" />
@@ -675,7 +675,7 @@
             <property role="Xl_RC" value="{\n  hello : \&quot;world\&quot;\n}" />
           </node>
           <node concept="37vLTw" id="2JDrrqkOUg3" role="3tpDZA">
-            <ref role="3cqZAo" node="2JDrrqkOUg0" resolve="generateText" />
+            <ref role="3cqZAo" node="2JDrrqkOUg0" resolve="output" />
           </node>
         </node>
       </node>

--- a/code/languages/com.mbeddr.mpsutil/tests/tests.com.mbeddr.mpsutil.json/tests.com.mbeddr.mpsutil.json.msd
+++ b/code/languages/com.mbeddr.mpsutil/tests/tests.com.mbeddr.mpsutil.json/tests.com.mbeddr.mpsutil.json.msd
@@ -6,15 +6,16 @@
     </modelRoot>
   </models>
   <facets>
-    <facet type="java" compile="mps" classes="mps" ext="no">
+    <facet type="java" compile="mps" classes="mps" ext="yes">
       <classes generated="true" path="${module}/classes_gen" />
     </facet>
     <facet type="tests" />
   </facets>
   <dependencies>
-    <dependency reexport="false">6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)</dependency>
     <dependency reexport="false">b5c0bb04-c583-4b2a-a66e-1eab92d33c68(com.mbeddr.mpsutil.json)</dependency>
     <dependency reexport="false">7124e466-fc92-4803-a656-d7a6b7eb3910(MPS.TextGen)</dependency>
+    <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
+    <dependency reexport="false">39983771-4e9b-401b-a1a9-1da6c777c843(MPS.ThirdParty)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:f47b95d4-5e73-4c04-9204-18076950153b:com.mbeddr.mpsutil.compare" version="0" />
@@ -23,9 +24,13 @@
     <language slang="l:443f4c36-fcf5-4eb6-9500-8d06ed259e3e:jetbrains.mps.baseLanguage.classifiers" version="0" />
     <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
     <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="2" />
+    <language slang="l:c7d5b9dd-a05f-4be2-bc73-f2e16994cc67:jetbrains.mps.baseLanguage.lightweightdsl" version="1" />
     <language slang="l:f61473f9-130f-42f6-b98d-6c438812c2f6:jetbrains.mps.baseLanguage.unitTest" version="1" />
     <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
+    <language slang="l:c0080a47-7e37-4558-bee9-9ae18e690549:jetbrains.mps.lang.extension" version="2" />
     <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
+    <language slang="l:28f9e497-3b42-4291-aeba-0a1039153ab1:jetbrains.mps.lang.plugin" version="6" />
+    <language slang="l:ef7bf5ac-d06c-4342-b11d-e42104eb9343:jetbrains.mps.lang.plugin.standalone" version="0" />
     <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="19" />
     <language slang="l:8585453e-6bfb-4d80-98de-b16074f1d86c:jetbrains.mps.lang.test" version="6" />
     <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />


### PR DESCRIPTION
The text generator output of `com.mbeddr.mpsutil.json` was improved and the escaping of special characters was implemented. The output options and JSON parsing can now also be configured through the extension point `json` in the method JsonConfig#getFactory. For more information read: https://github.com/fasterxml/jackson-core/wiki/JsonFactory-Features, https://github.com/fasterxml/jackson-core/wiki/JsonGenerator-Features and https://github.com/fasterxml/jackson-core/wiki/JsonParser-Features.

The PR is breaking since escaping characters can only be disabled for non-ASCII characters (through JsonGenerator.Feature.ESCAPE_NON_ASCII) and not for the quotation character which would produce an invalid JSON file. In case there is another change regarding the output, it should be possible to restore the old behavior through modifying the generator through the extension point.

While working on the PR, I noticed that we can't parse large numbers with the Jackson library. They are parsed as "Infinity"