### PR TITLE
Ensure that packaged artifact does not contain unwanted solutions

### DIFF
--- a/code/languages/com.mbeddr.build/solutions/com.mbeddr.platform/models/com/mbeddr/platform/build.mps
+++ b/code/languages/com.mbeddr.build/solutions/com.mbeddr.platform/models/com/mbeddr/platform/build.mps
@@ -20202,18 +20202,38 @@
                 <property role="2Ry0Am" value="languages" />
                 <node concept="2Ry0Ak" id="3TSnT3Ivcei" role="2Ry0An">
                   <property role="2Ry0Am" value="com.mbeddr.mpsutil.multilingual.editor" />
-                  <node concept="2Ry0Ak" id="3TSnT3Ivcej" role="2Ry0An">
+                  <node concept="2Ry0Ak" id="5jdrrsPOhHp" role="2Ry0An">
                     <property role="2Ry0Am" value="icons" />
                   </node>
                 </node>
               </node>
             </node>
           </node>
-          <node concept="2HvfSZ" id="6VdWf6S5Df5" role="39821P">
-            <node concept="398BVA" id="6VdWf6S5E23" role="2HvfZ0">
+          <node concept="2HvfSZ" id="5jdrrsPOiZ7" role="39821P">
+            <node concept="398BVA" id="5jdrrsPOjC1" role="2HvfZ0">
               <ref role="398BVh" node="7uZw0yZ2_Lj" resolve="mpsutil" />
-              <node concept="2Ry0Ak" id="6VdWf6S5EOM" role="iGT6I">
+              <node concept="2Ry0Ak" id="5jdrrsPOkgV" role="iGT6I">
                 <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="5jdrrsPOkgZ" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mbeddr.mpsutil.editingGuide.plugin" />
+                  <node concept="2Ry0Ak" id="5jdrrsPOkh1" role="2Ry0An">
+                    <property role="2Ry0Am" value="icons" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2HvfSZ" id="5jdrrsPOkTT" role="39821P">
+            <node concept="398BVA" id="5jdrrsPOlyN" role="2HvfZ0">
+              <ref role="398BVh" node="7uZw0yZ2_Lj" resolve="mpsutil" />
+              <node concept="2Ry0Ak" id="5jdrrsPOmbH" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="5jdrrsPOmbK" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mbeddr.mpsutil.ecore.ui.modelexporter" />
+                  <node concept="2Ry0Ak" id="5jdrrsPOmbM" role="2Ry0An">
+                    <property role="2Ry0Am" value="icons" />
+                  </node>
+                </node>
               </node>
             </node>
           </node>


### PR DESCRIPTION
This solves issue #2670.

Currently, the `com.mbeddr.platform` build script specifies a folder `icons` for the plugin `com.mbeddr.mpsutils`. This folder collects all contents from various `icons` folders in the project. However, it also listed the full directory `$mpsutils/solutions`, which leads to lot of stuff being contained in the deployed `com.mbeddr.platform` artifact. This also leads to some errors and warnings in the logs when MPS is running. 

This PR replaces the item `$mpsutils/solutions` by all folders below this directory named `icons` (which are actually only two). I also checked for files below this folder with extensions `*.png` and `*.svg`, but did not find other icon files outside of the two sub-folders I added.

Risk: There might be files in the packaged folder `$mpsutils/solutions` which are required downstream, but not packaged after this PR. I do not know how to check this.

One open topic: During my analysis I found the folder 

```
com.mbeddr.mpsutil/solutions/doc.com.mbeddr.mpsutil.multilingual/images
```

which contains a couple of png-images. We have to check if they are actually needed and if yes, if they are packaged to a different folder.
