### PR TITLE
Bugfix/mbeddr build

### DIFF
--- a/code/applications/tutorial/.mps/libraries.xml
+++ b/code/applications/tutorial/.mps/libraries.xml
@@ -7,7 +7,7 @@
           <value>
             <Library>
               <option name="name" value="dependencies" />
-              <option name="path" value="${mbeddr.github.core.home}/artifacts/de.itemis.mps.extensions" />
+              <option name="path" value="${mbeddr.github.core.home}/build/dependencies/de.itemis.mps.extensions" />
             </Library>
           </value>
         </entry>

--- a/code/languages/com.mbeddr.build/.mps/libraries.xml
+++ b/code/languages/com.mbeddr.build/.mps/libraries.xml
@@ -7,7 +7,7 @@
           <value>
             <Library>
               <option name="name" value="mps.extensions" />
-              <option name="path" value="${mbeddr.github.core.home}/artifacts/de.itemis.mps.extensions" />
+              <option name="path" value="${mbeddr.github.core.home}/build/dependencies/de.itemis.mps.extensions" />
             </Library>
           </value>
         </entry>

--- a/code/languages/com.mbeddr.build/solutions/com.mbeddr.platform.tests.build/models/com.mbeddr.platform.tests.build.mps
+++ b/code/languages/com.mbeddr.build/solutions/com.mbeddr.platform.tests.build/models/com.mbeddr.platform.tests.build.mps
@@ -223,12 +223,15 @@
         </node>
       </node>
     </node>
-    <node concept="398rNT" id="4hvHh3QXKHO" role="1l3spd">
-      <property role="TrG5h" value="platform.sl-all" />
-      <node concept="398BVA" id="5ueaxoTp$uT" role="398pKh">
-        <ref role="398BVh" node="5ueaxoTn61l" resolve="artifacts.root" />
-        <node concept="2Ry0Ak" id="5ueaxoTp$uU" role="iGT6I">
-          <property role="2Ry0Am" value="de.itemis.mps.extensions" />
+    <node concept="398rNT" id="1OEbLwd81mk" role="1l3spd">
+      <property role="TrG5h" value="dependencies.root" />
+      <node concept="398BVA" id="1OEbLwd81ml" role="398pKh">
+        <ref role="398BVh" node="7eF9rfAnzU3" resolve="mbeddr.github.core.home" />
+        <node concept="2Ry0Ak" id="1OEbLwd81mm" role="iGT6I">
+          <property role="2Ry0Am" value="build" />
+          <node concept="2Ry0Ak" id="1OEbLwd81mn" role="2Ry0An">
+            <property role="2Ry0Am" value="dependencies" />
+          </node>
         </node>
       </node>
     </node>
@@ -259,7 +262,10 @@
     <node concept="2sgV4H" id="4hvHh3QXKNz" role="1l3spa">
       <ref role="1l3spb" to="90a9:2Xjt3l56m0V" resolve="de.itemis.mps.extensions" />
       <node concept="398BVA" id="4hvHh3QXKSB" role="2JcizS">
-        <ref role="398BVh" node="4hvHh3QXKHO" resolve="platform.sl-all" />
+        <ref role="398BVh" node="1OEbLwd81mk" resolve="dependencies.root" />
+        <node concept="2Ry0Ak" id="1OEbLwd81nI" role="iGT6I">
+          <property role="2Ry0Am" value="de.itemis.mps.extensions" />
+        </node>
       </node>
     </node>
     <node concept="1l3spV" id="7eF9rfAnzV1" role="1l3spN">
@@ -841,25 +847,6 @@
             <ref role="3bR37D" to="al5i:4gGXGcLVNj$" resolve="com.mbeddr.mpsutil.multilingual.baseLanguage" />
           </node>
         </node>
-        <node concept="1SiIV0" id="2GRHOLITefh" role="3bR37C">
-          <node concept="1BurEX" id="2GRHOLITefi" role="1SiIV1">
-            <node concept="398BVA" id="2GRHOLITeeW" role="1BurEY">
-              <ref role="398BVh" node="7hVsScEQJ6E" resolve="mbeddr.mpsutil" />
-              <node concept="2Ry0Ak" id="2GRHOLITeeX" role="iGT6I">
-                <property role="2Ry0Am" value="tests" />
-                <node concept="2Ry0Ak" id="2GRHOLITeeY" role="2Ry0An">
-                  <property role="2Ry0Am" value="test.ts.mpsutil.multilingual" />
-                  <node concept="2Ry0Ak" id="2GRHOLITeeZ" role="2Ry0An">
-                    <property role="2Ry0Am" value="resources" />
-                    <node concept="2Ry0Ak" id="2GRHOLITef0" role="2Ry0An">
-                      <property role="2Ry0Am" value="test.ts.mpsutil.multilingual.resources.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
         <node concept="1BupzO" id="$Kq8MetEY0" role="3bR31x">
           <property role="3ZfqAx" value="models" />
           <property role="1Hdu6h" value="true" />
@@ -879,6 +866,25 @@
             </node>
             <node concept="3qWCbU" id="$Kq8MetEY2" role="3LXTna">
               <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2GRHOLITefh" role="3bR37C">
+          <node concept="1BurEX" id="2GRHOLITefi" role="1SiIV1">
+            <node concept="398BVA" id="2GRHOLITeeW" role="1BurEY">
+              <ref role="398BVh" node="7hVsScEQJ6E" resolve="mbeddr.mpsutil" />
+              <node concept="2Ry0Ak" id="2GRHOLITeeX" role="iGT6I">
+                <property role="2Ry0Am" value="tests" />
+                <node concept="2Ry0Ak" id="2GRHOLITeeY" role="2Ry0An">
+                  <property role="2Ry0Am" value="test.ts.mpsutil.multilingual" />
+                  <node concept="2Ry0Ak" id="2GRHOLITeeZ" role="2Ry0An">
+                    <property role="2Ry0Am" value="resources" />
+                    <node concept="2Ry0Ak" id="2GRHOLITef0" role="2Ry0An">
+                      <property role="2Ry0Am" value="test.ts.mpsutil.multilingual.resources.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -980,25 +986,6 @@
             </node>
           </node>
         </node>
-        <node concept="1SiIV0" id="2GRHOLITegx" role="3bR37C">
-          <node concept="1BurEX" id="2GRHOLITegy" role="1SiIV1">
-            <node concept="398BVA" id="2GRHOLITegc" role="1BurEY">
-              <ref role="398BVh" node="7hVsScEQJ6E" resolve="mbeddr.mpsutil" />
-              <node concept="2Ry0Ak" id="2GRHOLITegd" role="iGT6I">
-                <property role="2Ry0Am" value="tests" />
-                <node concept="2Ry0Ak" id="2GRHOLITege" role="2Ry0An">
-                  <property role="2Ry0Am" value="test.ts.mpsutil.multilingual.editor.sandbox" />
-                  <node concept="2Ry0Ak" id="2GRHOLITegf" role="2Ry0An">
-                    <property role="2Ry0Am" value="resources" />
-                    <node concept="2Ry0Ak" id="2GRHOLITegg" role="2Ry0An">
-                      <property role="2Ry0Am" value="test.ts.mpsutil.multilingual.editor.sandbox.resources.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
         <node concept="1BupzO" id="$Kq8MetEZn" role="3bR31x">
           <property role="3ZfqAx" value="languageModels" />
           <property role="1Hdu6h" value="true" />
@@ -1018,6 +1005,25 @@
             </node>
             <node concept="3qWCbU" id="$Kq8MetEZp" role="3LXTna">
               <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2GRHOLITegx" role="3bR37C">
+          <node concept="1BurEX" id="2GRHOLITegy" role="1SiIV1">
+            <node concept="398BVA" id="2GRHOLITegc" role="1BurEY">
+              <ref role="398BVh" node="7hVsScEQJ6E" resolve="mbeddr.mpsutil" />
+              <node concept="2Ry0Ak" id="2GRHOLITegd" role="iGT6I">
+                <property role="2Ry0Am" value="tests" />
+                <node concept="2Ry0Ak" id="2GRHOLITege" role="2Ry0An">
+                  <property role="2Ry0Am" value="test.ts.mpsutil.multilingual.editor.sandbox" />
+                  <node concept="2Ry0Ak" id="2GRHOLITegf" role="2Ry0An">
+                    <property role="2Ry0Am" value="resources" />
+                    <node concept="2Ry0Ak" id="2GRHOLITegg" role="2Ry0An">
+                      <property role="2Ry0Am" value="test.ts.mpsutil.multilingual.editor.sandbox.resources.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -1538,16 +1544,6 @@
             <ref role="3bR37D" to="ffeo:7Kfy9QB6L9O" resolve="jetbrains.mps.lang.smodel" />
           </node>
         </node>
-        <node concept="1SiIV0" id="bHMJKhDDfd" role="3bR37C">
-          <node concept="3bR9La" id="bHMJKhDDfe" role="1SiIV1">
-            <ref role="3bR37D" to="al5i:vOGyTeKPEA" resolve="com.mbeddr.mpsutil.ecore.testing" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="bHMJKhDDff" role="3bR37C">
-          <node concept="3bR9La" id="bHMJKhDDfg" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:7Kfy9QB6LaO" resolve="jetbrains.mps.lang.structure" />
-          </node>
-        </node>
         <node concept="398BVA" id="bHMJKhDAXY" role="3LF7KH">
           <ref role="398BVh" node="7hVsScEQJ6E" resolve="mbeddr.mpsutil" />
           <node concept="2Ry0Ak" id="bHMJKhDAYF" role="iGT6I">
@@ -1596,6 +1592,16 @@
             <node concept="3qWCbU" id="5Ap$XSqW8TG" role="3LXTna">
               <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
             </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="bHMJKhDDfd" role="3bR37C">
+          <node concept="3bR9La" id="bHMJKhDDfe" role="1SiIV1">
+            <ref role="3bR37D" to="al5i:vOGyTeKPEA" resolve="com.mbeddr.mpsutil.ecore.testing" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="bHMJKhDDff" role="3bR37C">
+          <node concept="3bR9La" id="bHMJKhDDfg" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:7Kfy9QB6LaO" resolve="jetbrains.mps.lang.structure" />
           </node>
         </node>
       </node>
@@ -3160,6 +3166,18 @@
         </node>
       </node>
     </node>
+    <node concept="398rNT" id="1OEbLwd81bU" role="1l3spd">
+      <property role="TrG5h" value="dependencies.root" />
+      <node concept="398BVA" id="1OEbLwd81ei" role="398pKh">
+        <ref role="398BVh" node="E0fxGqls7d" resolve="mbeddr.github.core.home" />
+        <node concept="2Ry0Ak" id="1OEbLwd81i5" role="iGT6I">
+          <property role="2Ry0Am" value="build" />
+          <node concept="2Ry0Ak" id="1OEbLwd81jj" role="2Ry0An">
+            <property role="2Ry0Am" value="dependencies" />
+          </node>
+        </node>
+      </node>
+    </node>
     <node concept="398rNT" id="E0fxGqls7k" role="1l3spd">
       <property role="TrG5h" value="mbeddr.mpsutil" />
       <node concept="398BVA" id="E0fxGqls7l" role="398pKh">
@@ -3193,7 +3211,7 @@
     <node concept="2sgV4H" id="E0fxGqls5t" role="1l3spa">
       <ref role="1l3spb" to="90a9:2Xjt3l56m0V" resolve="de.itemis.mps.extensions" />
       <node concept="398BVA" id="E0fxGqls6j" role="2JcizS">
-        <ref role="398BVh" node="E0fxGqls73" resolve="artifacts.root" />
+        <ref role="398BVh" node="1OEbLwd81bU" resolve="dependencies.root" />
         <node concept="2Ry0Ak" id="E0fxGqls6k" role="iGT6I">
           <property role="2Ry0Am" value="de.itemis.mps.extensions" />
         </node>
@@ -4107,6 +4125,50 @@
           <ref role="3bR37D" to="al5i:2N1CSrzSJt4" resolve="com.mbeddr.mpsutil.plantuml.pluginSolution" />
         </node>
       </node>
+      <node concept="1BupzO" id="3SrAMjiLn7s" role="3bR31x">
+        <property role="3ZfqAx" value="models" />
+        <property role="1Hdu6h" value="true" />
+        <property role="1HemKv" value="true" />
+        <node concept="3LXTmp" id="3SrAMjiLn7t" role="1HemKq">
+          <node concept="398BVA" id="3SrAMjiLn7f" role="3LXTmr">
+            <ref role="398BVh" node="E0fxGqls7k" resolve="mbeddr.mpsutil" />
+            <node concept="2Ry0Ak" id="3SrAMjiLn7g" role="iGT6I">
+              <property role="2Ry0Am" value="languages" />
+              <node concept="2Ry0Ak" id="3SrAMjiLn7h" role="2Ry0An">
+                <property role="2Ry0Am" value="com.mbeddr.mpsutil.graphstream" />
+                <node concept="2Ry0Ak" id="3SrAMjiLn7i" role="2Ry0An">
+                  <property role="2Ry0Am" value="runtime" />
+                  <node concept="2Ry0Ak" id="3SrAMjiLn7j" role="2Ry0An">
+                    <property role="2Ry0Am" value="models" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3qWCbU" id="3SrAMjiLn7u" role="3LXTna">
+            <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+          </node>
+        </node>
+      </node>
+      <node concept="3rtmxn" id="3SrAMjiLnc0" role="3bR31x">
+        <node concept="3LXTmp" id="3SrAMjiLnc1" role="3rtmxm">
+          <node concept="398BVA" id="3SrAMjiLnc2" role="3LXTmr">
+            <ref role="398BVh" node="E0fxGqls7k" resolve="mbeddr.mpsutil" />
+            <node concept="2Ry0Ak" id="3SrAMjiLnc3" role="iGT6I">
+              <property role="2Ry0Am" value="languages" />
+              <node concept="2Ry0Ak" id="3SrAMjiLnc4" role="2Ry0An">
+                <property role="2Ry0Am" value="com.mbeddr.mpsutil.graphstream" />
+                <node concept="2Ry0Ak" id="3SrAMjiLnc5" role="2Ry0An">
+                  <property role="2Ry0Am" value="runtime" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3qWCbU" id="3SrAMjiLnc7" role="3LXTna">
+            <property role="3qWCbO" value="icons/**, resources/**" />
+          </node>
+        </node>
+      </node>
       <node concept="1SiIV0" id="3SrAMjiLn5S" role="3bR37C">
         <node concept="1BurEX" id="3SrAMjiLn5T" role="1SiIV1">
           <node concept="398BVA" id="3SrAMjiLn5D" role="1BurEY">
@@ -4236,50 +4298,6 @@
                 </node>
               </node>
             </node>
-          </node>
-        </node>
-      </node>
-      <node concept="1BupzO" id="3SrAMjiLn7s" role="3bR31x">
-        <property role="3ZfqAx" value="models" />
-        <property role="1Hdu6h" value="true" />
-        <property role="1HemKv" value="true" />
-        <node concept="3LXTmp" id="3SrAMjiLn7t" role="1HemKq">
-          <node concept="398BVA" id="3SrAMjiLn7f" role="3LXTmr">
-            <ref role="398BVh" node="E0fxGqls7k" resolve="mbeddr.mpsutil" />
-            <node concept="2Ry0Ak" id="3SrAMjiLn7g" role="iGT6I">
-              <property role="2Ry0Am" value="languages" />
-              <node concept="2Ry0Ak" id="3SrAMjiLn7h" role="2Ry0An">
-                <property role="2Ry0Am" value="com.mbeddr.mpsutil.graphstream" />
-                <node concept="2Ry0Ak" id="3SrAMjiLn7i" role="2Ry0An">
-                  <property role="2Ry0Am" value="runtime" />
-                  <node concept="2Ry0Ak" id="3SrAMjiLn7j" role="2Ry0An">
-                    <property role="2Ry0Am" value="models" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="3qWCbU" id="3SrAMjiLn7u" role="3LXTna">
-            <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-          </node>
-        </node>
-      </node>
-      <node concept="3rtmxn" id="3SrAMjiLnc0" role="3bR31x">
-        <node concept="3LXTmp" id="3SrAMjiLnc1" role="3rtmxm">
-          <node concept="398BVA" id="3SrAMjiLnc2" role="3LXTmr">
-            <ref role="398BVh" node="E0fxGqls7k" resolve="mbeddr.mpsutil" />
-            <node concept="2Ry0Ak" id="3SrAMjiLnc3" role="iGT6I">
-              <property role="2Ry0Am" value="languages" />
-              <node concept="2Ry0Ak" id="3SrAMjiLnc4" role="2Ry0An">
-                <property role="2Ry0Am" value="com.mbeddr.mpsutil.graphstream" />
-                <node concept="2Ry0Ak" id="3SrAMjiLnc5" role="2Ry0An">
-                  <property role="2Ry0Am" value="runtime" />
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="3qWCbU" id="3SrAMjiLnc7" role="3LXTna">
-            <property role="3qWCbO" value="icons/**, resources/**" />
           </node>
         </node>
       </node>

--- a/code/languages/com.mbeddr.build/solutions/com.mbeddr.platform/models/com/mbeddr/platform/build.mps
+++ b/code/languages/com.mbeddr.build/solutions/com.mbeddr.platform/models/com/mbeddr/platform/build.mps
@@ -1790,6 +1790,12 @@
             </node>
           </node>
         </node>
+        <node concept="1SiIV0" id="46XBvPMFwgD" role="3bR37C">
+          <node concept="3bR9La" id="46XBvPMFwgE" role="1SiIV1">
+            <property role="3bR36h" value="true" />
+            <ref role="3bR37D" to="ffeo:1ia2VB5guYy" resolve="MPS.IDEA" />
+          </node>
+        </node>
         <node concept="1BupzO" id="4PRpvcZJN7E" role="3bR31x">
           <property role="3ZfqAx" value="models" />
           <property role="1Hdu6h" value="true" />
@@ -1810,12 +1816,6 @@
             <node concept="3qWCbU" id="4PRpvcZJN7G" role="3LXTna">
               <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
             </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="46XBvPMFwgD" role="3bR37C">
-          <node concept="3bR9La" id="46XBvPMFwgE" role="1SiIV1">
-            <property role="3bR36h" value="true" />
-            <ref role="3bR37D" to="ffeo:1ia2VB5guYy" resolve="MPS.IDEA" />
           </node>
         </node>
       </node>
@@ -2539,6 +2539,34 @@
             <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
           </node>
         </node>
+        <node concept="1BupzO" id="4PRpvcZJNb5" role="3bR31x">
+          <property role="3ZfqAx" value="models" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="4PRpvcZJNb6" role="1HemKq">
+            <node concept="398BVA" id="4PRpvcZJNaQ" role="3LXTmr">
+              <ref role="398BVh" node="7uZw0yZ2_Lj" resolve="mpsutil" />
+              <node concept="2Ry0Ak" id="4PRpvcZJNaR" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="4PRpvcZJNaS" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mbeddr.mpsutil.plantuml" />
+                  <node concept="2Ry0Ak" id="4PRpvcZJNaT" role="2Ry0An">
+                    <property role="2Ry0Am" value="solutions" />
+                    <node concept="2Ry0Ak" id="4PRpvcZJNaU" role="2Ry0An">
+                      <property role="2Ry0Am" value="pluginSolution" />
+                      <node concept="2Ry0Ak" id="4PRpvcZJNaV" role="2Ry0An">
+                        <property role="2Ry0Am" value="models" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="4PRpvcZJNb7" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
         <node concept="1SiIV0" id="2N1CSrzST4B" role="3bR37C">
           <node concept="1BurEX" id="2N1CSrzST4C" role="1SiIV1">
             <node concept="398BVA" id="2N1CSrzST4m" role="1BurEY">
@@ -2598,34 +2626,6 @@
           <node concept="3bR9La" id="35JynOkFDOg" role="1SiIV1">
             <property role="3bR36h" value="true" />
             <ref role="3bR37D" node="35JynOkF_BM" resolve="org.apache.batik" />
-          </node>
-        </node>
-        <node concept="1BupzO" id="4PRpvcZJNb5" role="3bR31x">
-          <property role="3ZfqAx" value="models" />
-          <property role="1Hdu6h" value="true" />
-          <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="4PRpvcZJNb6" role="1HemKq">
-            <node concept="398BVA" id="4PRpvcZJNaQ" role="3LXTmr">
-              <ref role="398BVh" node="7uZw0yZ2_Lj" resolve="mpsutil" />
-              <node concept="2Ry0Ak" id="4PRpvcZJNaR" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="4PRpvcZJNaS" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mbeddr.mpsutil.plantuml" />
-                  <node concept="2Ry0Ak" id="4PRpvcZJNaT" role="2Ry0An">
-                    <property role="2Ry0Am" value="solutions" />
-                    <node concept="2Ry0Ak" id="4PRpvcZJNaU" role="2Ry0An">
-                      <property role="2Ry0Am" value="pluginSolution" />
-                      <node concept="2Ry0Ak" id="4PRpvcZJNaV" role="2Ry0An">
-                        <property role="2Ry0Am" value="models" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="4PRpvcZJNb7" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
           </node>
         </node>
       </node>
@@ -2719,21 +2719,21 @@
       <node concept="m$f5U" id="64SK4bcJwhC" role="m$_yh">
         <ref role="m$f5T" node="3quoVcnL8hF" resolve="group.plantuml" />
       </node>
-      <node concept="m$f5U" id="11w71XmfHEh" role="m$_yh">
-        <ref role="m$f5T" node="11w71XmfwQH" resolve="group.apis" />
-      </node>
       <node concept="m$_yC" id="64SK4bcJmGX" role="m$_yJ">
         <ref role="m$_y1" to="ffeo:4k71ibbKLe8" resolve="jetbrains.mps.core" />
       </node>
       <node concept="m$_yC" id="64SK4bcJyxn" role="m$_yJ">
         <ref role="m$_y1" to="90a9:6860Y5_ZW8e" resolve="de.itemis.mps.utils" />
       </node>
-      <node concept="m$_yC" id="64SK4bcJ_T5" role="m$_yJ">
-        <ref role="m$_y1" to="ffeo:5xhjlkpPhJu" resolve="jetbrains.mps.ide.httpsupport" />
-      </node>
       <node concept="2iUeEo" id="7yAshxDt$n$" role="2iVFfd">
         <property role="2iUeEt" value="mbeddr" />
         <property role="2iUeEu" value="http://mbeddr.com" />
+      </node>
+      <node concept="m$f5U" id="11w71XmfHEh" role="m$_yh">
+        <ref role="m$f5T" node="11w71XmfwQH" resolve="group.apis" />
+      </node>
+      <node concept="m$_yC" id="64SK4bcJ_T5" role="m$_yJ">
+        <ref role="m$_y1" to="ffeo:5xhjlkpPhJu" resolve="jetbrains.mps.ide.httpsupport" />
       </node>
     </node>
     <node concept="2G$12M" id="4VgGsUqP22z" role="3989C9">
@@ -14923,11 +14923,6 @@
               <ref role="3bR37D" node="$bJ0jguQfr" resolve="com.mbeddr.core.base" />
             </node>
           </node>
-          <node concept="1SiIV0" id="30hqvrsTBX8" role="3bR37C">
-            <node concept="3bR9La" id="30hqvrsTBX9" role="1SiIV1">
-              <ref role="3bR37D" to="ffeo:568PkTlOK5Q" resolve="jetbrains.mps.core.xml" />
-            </node>
-          </node>
           <node concept="1BupzO" id="4PRpvcZJNX6" role="3bR31x">
             <property role="3ZfqAx" value="generator/template" />
             <property role="1Hdu6h" value="true" />
@@ -14951,6 +14946,11 @@
               <node concept="3qWCbU" id="4PRpvcZJNX8" role="3LXTna">
                 <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
               </node>
+            </node>
+          </node>
+          <node concept="1SiIV0" id="30hqvrsTBX8" role="3bR37C">
+            <node concept="3bR9La" id="30hqvrsTBX9" role="1SiIV1">
+              <ref role="3bR37D" to="ffeo:568PkTlOK5Q" resolve="jetbrains.mps.core.xml" />
             </node>
           </node>
         </node>
@@ -16424,9 +16424,9 @@
         </node>
       </node>
       <node concept="1E1JtD" id="4aKYPQyr67s" role="2G$12L">
-        <property role="BnDLt" value="true" />
         <property role="TrG5h" value="com.mbeddr.spreadsheat" />
         <property role="3LESm3" value="1d891f7b-dc93-42f9-a4bc-b016656b14e2" />
+        <property role="BnDLt" value="true" />
         <node concept="3rtmxn" id="3xFG3bj5cXc" role="3bR31x">
           <node concept="3LXTmp" id="3xFG3bj5cXd" role="3rtmxm">
             <node concept="3qWCbU" id="3xFG3bj5cXe" role="3LXTna">
@@ -16696,25 +16696,6 @@
             <ref role="3bR37D" to="ffeo:1TaHNgiIbIQ" resolve="MPS.Core" />
           </node>
         </node>
-        <node concept="1SiIV0" id="5xsBLDL_Y5_" role="3bR37C">
-          <node concept="1BurEX" id="5xsBLDL_Y5A" role="1SiIV1">
-            <node concept="398BVA" id="5xsBLDL_Y5o" role="1BurEY">
-              <ref role="398BVh" node="1m4fy7Kxwst" resolve="mbeddr.doc" />
-              <node concept="2Ry0Ak" id="5xsBLDL_Y5p" role="iGT6I">
-                <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="5xsBLDL_Y5q" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mbeddr.doc.gen_markdown" />
-                  <node concept="2Ry0Ak" id="5xsBLDL_Y5r" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="5xsBLDL_Y5s" role="2Ry0An">
-                      <property role="2Ry0Am" value="commonmark-0.17.1.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
         <node concept="1BupzO" id="5xsBLDL_Y5M" role="3bR31x">
           <property role="3ZfqAx" value="models" />
           <property role="1Hdu6h" value="true" />
@@ -16734,6 +16715,25 @@
             </node>
             <node concept="3qWCbU" id="5xsBLDL_Y5O" role="3LXTna">
               <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="5xsBLDL_Y5_" role="3bR37C">
+          <node concept="1BurEX" id="5xsBLDL_Y5A" role="1SiIV1">
+            <node concept="398BVA" id="5xsBLDL_Y5o" role="1BurEY">
+              <ref role="398BVh" node="1m4fy7Kxwst" resolve="mbeddr.doc" />
+              <node concept="2Ry0Ak" id="5xsBLDL_Y5p" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="5xsBLDL_Y5q" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.mbeddr.doc.gen_markdown" />
+                  <node concept="2Ry0Ak" id="5xsBLDL_Y5r" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                    <node concept="2Ry0Ak" id="5xsBLDL_Y5s" role="2Ry0An">
+                      <property role="2Ry0Am" value="commonmark-0.17.1.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -18794,12 +18794,15 @@
         </node>
       </node>
     </node>
-    <node concept="398rNT" id="3AVJcIMlF95" role="1l3spd">
-      <property role="TrG5h" value="artifacts.sl-all" />
-      <node concept="398BVA" id="4MR$$QmqtJh" role="398pKh">
-        <ref role="398BVh" node="4MR$$QmqomQ" resolve="artifacts.root" />
-        <node concept="2Ry0Ak" id="3AjhVMbHu4r" role="iGT6I">
-          <property role="2Ry0Am" value="de.itemis.mps.extensions" />
+    <node concept="398rNT" id="1OEbLwd7XEw" role="1l3spd">
+      <property role="TrG5h" value="dependencies.root" />
+      <node concept="398BVA" id="1OEbLwd7YgW" role="398pKh">
+        <ref role="398BVh" node="3AVJcIMlF8p" resolve="mbeddr.github.core.home" />
+        <node concept="2Ry0Ak" id="1OEbLwd7YJR" role="iGT6I">
+          <property role="2Ry0Am" value="build" />
+          <node concept="2Ry0Ak" id="1OEbLwd7Z37" role="2Ry0An">
+            <property role="2Ry0Am" value="dependencies" />
+          </node>
         </node>
       </node>
     </node>
@@ -18938,8 +18941,11 @@
     </node>
     <node concept="2sgV4H" id="6ucYLjotvKQ" role="1l3spa">
       <ref role="1l3spb" to="90a9:2Xjt3l56m0V" resolve="de.itemis.mps.extensions" />
-      <node concept="398BVA" id="6ucYLjotvKR" role="2JcizS">
-        <ref role="398BVh" node="3AVJcIMlF95" resolve="artifacts.sl-all" />
+      <node concept="398BVA" id="4MR$$QmqtJh" role="2JcizS">
+        <ref role="398BVh" node="1OEbLwd7XEw" resolve="dependencies.root" />
+        <node concept="2Ry0Ak" id="3AjhVMbHu4r" role="iGT6I">
+          <property role="2Ry0Am" value="de.itemis.mps.extensions" />
+        </node>
       </node>
     </node>
     <node concept="2sgV4H" id="1vIw1eCEpNB" role="1l3spa">

--- a/code/languages/com.mbeddr.cc/.mps/libraries.xml
+++ b/code/languages/com.mbeddr.cc/.mps/libraries.xml
@@ -15,7 +15,7 @@
           <value>
             <Library>
               <option name="name" value="mps.extensions" />
-              <option name="path" value="${mbeddr.github.core.home}/artifacts/de.itemis.mps.extensions" />
+              <option name="path" value="${mbeddr.github.core.home}/build/dependencies/de.itemis.mps.extensions" />
             </Library>
           </value>
         </entry>

--- a/code/languages/com.mbeddr.core/.mps/libraries.xml
+++ b/code/languages/com.mbeddr.core/.mps/libraries.xml
@@ -15,7 +15,7 @@
           <value>
             <Library>
               <option name="name" value="mps.extensions" />
-              <option name="path" value="${mbeddr.github.core.home}/artifacts/de.itemis.mps.extensions" />
+              <option name="path" value="${mbeddr.github.core.home}/build/dependencies/de.itemis.mps.extensions" />
             </Library>
           </value>
         </entry>

--- a/code/languages/com.mbeddr.doc.aspect/.mps/libraries.xml
+++ b/code/languages/com.mbeddr.doc.aspect/.mps/libraries.xml
@@ -15,7 +15,7 @@
           <value>
             <Library>
               <option name="name" value="mps.extensions" />
-              <option name="path" value="${mbeddr.github.core.home}/artifacts/de.itemis.mps.extensions" />
+              <option name="path" value="${mbeddr.github.core.home}/build/dependencies/de.itemis.mps.extensions" />
             </Library>
           </value>
         </entry>

--- a/code/languages/com.mbeddr.doc/.mps/libraries.xml
+++ b/code/languages/com.mbeddr.doc/.mps/libraries.xml
@@ -15,7 +15,7 @@
           <value>
             <Library>
               <option name="name" value="mps.extensions" />
-              <option name="path" value="${mbeddr.github.core.home}/artifacts/de.itemis.mps.extensions" />
+              <option name="path" value="${mbeddr.github.core.home}/build/dependencies/de.itemis.mps.extensions" />
             </Library>
           </value>
         </entry>

--- a/code/languages/com.mbeddr.ext/.mps/libraries.xml
+++ b/code/languages/com.mbeddr.ext/.mps/libraries.xml
@@ -15,7 +15,7 @@
           <value>
             <Library>
               <option name="name" value="mps.extensions" />
-              <option name="path" value="${mbeddr.github.core.home}/artifacts/de.itemis.mps.extensions" />
+              <option name="path" value="${mbeddr.github.core.home}/build/dependencies/de.itemis.mps.extensions" />
             </Library>
           </value>
         </entry>

--- a/code/languages/com.mbeddr.mpsutil/.mps/libraries.xml
+++ b/code/languages/com.mbeddr.mpsutil/.mps/libraries.xml
@@ -7,7 +7,7 @@
           <value>
             <Library>
               <option name="name" value="mps.extensions" />
-              <option name="path" value="${mbeddr.github.core.home}/artifacts/de.itemis.mps.extensions" />
+              <option name="path" value="${mbeddr.github.core.home}/build/dependencies/de.itemis.mps.extensions" />
             </Library>
           </value>
         </entry>

--- a/subprojects/com.mbeddr/platform/build.gradle
+++ b/subprojects/com.mbeddr/platform/build.gradle
@@ -46,6 +46,7 @@ if (project.hasProperty('mpsExtensionsZip')) {
 }
 
 tasks.register('build_allScripts', MpsGenerate) {
+    javaLauncher = jbrToolchain.javaLauncher
     environmentKind = EnvironmentKind.MPS
     mpsHome.fileProvider(tasks.named('resolve_mps', Copy).map { it.destinationDir })
 

--- a/subprojects/com.mbeddr/platform/build.gradle
+++ b/subprojects/com.mbeddr/platform/build.gradle
@@ -26,12 +26,14 @@ if (project.skipresolve_mps) {
     }
 }
 
+ext.dependenciesDir = rootProject.layout.buildDirectory.dir('dependencies')
+
 if (project.hasProperty('mpsExtensionsZip')) {
     task resolve_mps_extensions(type: Copy) {
         from {
             zipTree(project.property('mpsExtensionsZip'))
         }
-        into artifactsDir
+        into dependenciesDir
     }
 } else {
     task resolve_mps_extensions(type: Copy) {
@@ -39,7 +41,7 @@ if (project.hasProperty('mpsExtensionsZip')) {
         from {
             configurations.mpsExtensions.resolve().collect { zipTree(it) }
         }
-        into artifactsDir
+        into dependenciesDir
     }
 }
 

--- a/tools/BigProject/.mps/libraries.xml
+++ b/tools/BigProject/.mps/libraries.xml
@@ -7,7 +7,7 @@
           <value>
             <Library>
               <option name="name" value="mps-extensions" />
-              <option name="path" value="${mbeddr.github.core.home}/artifacts/de.itemis.mps.extensions" />
+              <option name="path" value="${mbeddr.github.core.home}/build/dependencies/de.itemis.mps.extensions" />
             </Library>
           </value>
         </entry>


### PR DESCRIPTION
When mbeddr is built on CI the pre-built mbeddr platform is downloaded to `artifacts`. This means that the `com.mbeddr.build` project sees the platform build scripts twice, once from its own modules and once from the artifacts. This confuses the build script generation.

The fix is to make sure that `pluginRoots` passed to the build script generation do not contain the mbeddr platform artifact.

One way to achieve it would be to simply pass `artifacts/de.itemis.mps.extensions` instead of `artifacts` but we can also use this opportunity to separate dependencies (MPS-extensions) from sibling project artifacts (mbeddr platform) and download dependencies to `build/dependencies`.

Another improvement is to use the JBR for `build_allScripts`.