### PR TITLE
build: fix building with custom MPS (JetBrains Teamcity)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@
 /build/
 /artifacts/
 /.gradle/
-/MPS/
 /tmp/
 
 .idea/

--- a/subprojects/com.mbeddr/build.gradle
+++ b/subprojects/com.mbeddr/build.gradle
@@ -9,7 +9,7 @@ plugins {
 // If mpsHomeDir is set explicitly, skip the MPS resolution step and use the explicit path (which may be relative from
 // the root directory).
 ext.skipresolve_mps = project.hasProperty('mpsHomeDir')
-ext.mpsHomeDir = rootProject.file(project.findProperty('mpsHomeDir') ?: "MPS/MPS-mbeddr-$mpsBuild/")
+ext.mpsHomeDir = rootProject.file(project.findProperty('mpsHomeDir') ?: "build/mps")
 
 def userHome = System.properties['user.home']
 def mpsPluginsDirPattern

--- a/subprojects/com.mbeddr/platform/build.gradle
+++ b/subprojects/com.mbeddr/platform/build.gradle
@@ -10,20 +10,27 @@ import de.itemis.mps.gradle.tasks.MpsGenerate
 def script_test_mbeddrPlatform = new File(scriptsBasePath, "com.mbeddr.platform/build-ts-tests.xml")
 def script_mbeddrPlatform_sandboxes = new File(scriptsBasePath, "com.mbeddr.platform/build-sandboxes.xml")
 
-if (project.skipresolve_mps) {
-    task resolve_mps {
-        doLast {
-            logger.info "MPS resolution skipped"
+configurations.create('mpsHome') {
+    // Contains the MPS home directory to use for the build.
+    canBeConsumed = false
+}
+
+// The MPS home directory as a provider, for use in tasks supporting lazy configuration. The provider carries along
+// the dependency information (i.e. any tasks necessary to produce the directory).
+Provider<File> mpsHomeProvider = configurations.mpsHome.elements.map {it.first().asFile }
+
+dependencies {
+    def mpsHomeFiles = files(mpsHomeDir)
+    if (!project.skipresolve_mps) {
+        def resolve_mps = tasks.register('resolve_mps', Sync) {
+            dependsOn configurations.mps
+            from zipTree({ configurations.mps.singleFile })
+            into mpsHomeDir
         }
+        mpsHomeFiles.builtBy(resolve_mps)
     }
-} else {
-    task resolve_mps(type: Copy) {
-        dependsOn configurations.mps
-        from {
-            configurations.mps.resolve().collect { zipTree(it) }
-        }
-        into mpsHomeDir
-    }
+
+    mpsHome(mpsHomeFiles)
 }
 
 ext.dependenciesDir = rootProject.layout.buildDirectory.dir('dependencies')
@@ -48,7 +55,7 @@ if (project.hasProperty('mpsExtensionsZip')) {
 tasks.register('build_allScripts', MpsGenerate) {
     javaLauncher = jbrToolchain.javaLauncher
     environmentKind = EnvironmentKind.MPS
-    mpsHome.fileProvider(tasks.named('resolve_mps', Copy).map { it.destinationDir })
+    mpsHome.fileProvider(mpsHomeProvider)
 
     projectLocation = rootProject.file('code/languages/com.mbeddr.build')
     pluginRoots.from(tasks.named('resolve_mps_extensions', Copy).map { it.destinationDir })


### PR DESCRIPTION
* Use a configuration for MPS home. A Gradle configuration is a better abstraction for the location of MPS
than a task whose type changes depending on some condition.

* Change MPS extraction directory to `build/mps` to avoid polluting the project directory. Since `resolve_mps` is now a `Sync` rather than `Copy`, there is no risk of accidentally using an incorrect MPS version.