### PR TITLE
Renovate configuration updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -5,6 +5,9 @@
   ],
   "enabledManagers": ["gradle", "gradle-wrapper"],
 
+  // Renovate master and recent maintenance branches
+  "baseBranches": ["master", "/maintenance/mps202[4-9][0-9]/"],
+
   "packageRules": [
     {
       "matchPackageNames": ["download-jbr:download-jbr.gradle.plugin", "de.itemis.mps.gradle.common:de.itemis.mps.gradle.common.gradle.plugin"],
@@ -15,10 +18,32 @@
       "matchPackageNames": ["org.apache.ant:*"],
       "groupName": "ant"
     },
+
     {
-      "matchBaseBranches": ["master"],
+      // MPS libraries: do not treat letters in the commit hash suffix as alpha/beta/etc. unstable versions.
       "matchPackageNames": ["de.itemis.mps:extensions"],
-      "ignoreUnstable": false,
+      "versioning": "loose",
+    },
+
+    {
+      // MPS and libraries: separate minor and patch updates in order to disable minor but leave patch updates enabled
+      "matchPackageNames": ["de.itemis.mps:extensions", "com.jetbrains:mps"],
+      "separateMinorPatch": true,
+    },
+
+    {
+      // MPS and libraries: disable major and minor updates, only enable patch updates
+      "matchPackageNames": ["de.itemis.mps:extensions", "com.jetbrains:mps"],
+      "matchUpdateTypes": ["major", "minor"],
+      "enabled": false
+    },
+
+    {
+      // MPS and libraries: merge PRs on Wednesday morning
+      "matchPackageNames": ["de.itemis.mps:extensions", "com.jetbrains:mps"],
+      "automerge": true,
+      "platformAutomerge": false,
+      "automergeSchedule": "* 4-6 * * 3"
     }
   ]
 }


### PR DESCRIPTION
* Enable MPS and MPS-extensions updates on maintenance/mps2024x branches.
* Enable only patch updates of MPS and libraries.
* Configure 'loose' versioning for MPS extensions to ignore 'a'/'b' letters in commit hashes. The default Gradle versioning would treat them as prereleases and Renovate would skip them (on maintenance branches).
* Automerge Renovate PRs on Wednesday mornings.
