### PR TITLE
renovate: disable JBR updates on maintenance branches

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -44,6 +44,13 @@
       "automerge": true,
       "platformAutomerge": false,
       "automergeSchedule": "* 4-6 * * 3"
+    },
+
+    {
+      // Disable JBR updates on maintenance branches
+      "matchPackageNames": ["com.jetbrains.jdk:*"],
+      "matchBaseBranches": ["!/^master$/"],
+      "enabled": false
     }
   ]
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -6,7 +6,7 @@
   "enabledManagers": ["gradle", "gradle-wrapper"],
 
   // Renovate master and recent maintenance branches
-  "baseBranches": ["master", "/maintenance/mps202[4-9][0-9]/"],
+  "baseBranches": ["master", "/^maintenance/mps202[4-9][0-9]/"],
 
   "packageRules": [
     {


### PR DESCRIPTION
Also fix the regex of maintenance branches to ignore branches created by renovate (`renovate/maintenance/...`)