### PR TITLE
updated sbom.json path in the published platform zip

### DIFF
--- a/subprojects/com.mbeddr/platform/build.gradle
+++ b/subprojects/com.mbeddr/platform/build.gradle
@@ -202,6 +202,7 @@ task package_mbeddrPlatform(type: Zip, dependsOn: [build_platform, cyclonedxBom]
     }
     from(reportsDir) {
         include 'sbom.json'
+        into 'com.mbeddr.platform'
     }
 }
 


### PR DESCRIPTION
Moved sbom.json from the root folder of the published zip to avoid conflicts during extraction with other language packages.