### PR TITLE
Removed unavailable jcommon jar

### DIFF
--- a/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.jfreechart.runtime/com.mbeddr.mpsutil.jfreechart.runtime.msd
+++ b/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.jfreechart.runtime/com.mbeddr.mpsutil.jfreechart.runtime.msd
@@ -1,18 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <solution name="com.mbeddr.mpsutil.jfreechart.runtime" uuid="7fe13e34-8620-4d5d-92c7-df091b0ed628" moduleVersion="0">
   <models>
-    <modelRoot type="default" contentPath="${module}">
+    <modelRoot contentPath="${module}" type="default">
       <sourceRoot location="models" />
     </modelRoot>
-    <modelRoot type="java_classes" contentPath="${module}/lib">
-      <sourceRoot location="jcommon.jar" />
+    <modelRoot contentPath="${module}/lib" type="java_classes">
       <sourceRoot location="jfreechart.jar" />
     </modelRoot>
   </models>
   <facets>
     <facet type="java" compile="mps" classes="mps" ext="yes">
       <classes generated="true" path="${module}/classes_gen" />
-      <library location="${module}/lib/jcommon.jar" />
       <library location="${module}/lib/jfreechart.jar" />
     </facet>
   </facets>

--- a/code/languages/com.mbeddr.platform.build/solutions/com.mbeddr.platform/models/com/mbeddr/platform/build.mps
+++ b/code/languages/com.mbeddr.platform.build/solutions/com.mbeddr.platform/models/com/mbeddr/platform/build.mps
@@ -16085,25 +16085,6 @@
             <ref role="3bR37D" to="ffeo:1TaHNgiIbJb" resolve="MPS.Platform" />
           </node>
         </node>
-        <node concept="1SiIV0" id="Cwh4MJ0sWc" role="3bR37C">
-          <node concept="1BurEX" id="Cwh4MJ0sWd" role="1SiIV1">
-            <node concept="398BVA" id="Cwh4MJ0sVZ" role="1BurEY">
-              <ref role="398BVh" node="7uZw0yZ2_Lj" resolve="mpsutil" />
-              <node concept="2Ry0Ak" id="Cwh4MJ0sW0" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="Cwh4MJ0sW1" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mbeddr.mpsutil.jfreechart.runtime" />
-                  <node concept="2Ry0Ak" id="Cwh4MJ0sW2" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="Cwh4MJ0sW3" role="2Ry0An">
-                      <property role="2Ry0Am" value="jcommon.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
         <node concept="1SiIV0" id="Cwh4MJ0sWr" role="3bR37C">
           <node concept="1BurEX" id="Cwh4MJ0sWs" role="1SiIV1">
             <node concept="398BVA" id="Cwh4MJ0sWe" role="1BurEY">


### PR DESCRIPTION
`jcommon.jar` is not available anymore as transitive dependency with the recent used jfreechart version and has been therefore removed from the `c.m.mpsutil.jfreechart.runtime` solution