### PR TITLE
Inline SNodeUtil.getResolveInfo()

### DIFF
--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.extensionclass/languageModels/constraints.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.extensionclass/languageModels/constraints.mps
@@ -412,16 +412,17 @@
                           <node concept="3uibUv" id="14X7KHJtEEM" role="1tU5fm">
                             <ref role="3uigEE" to="wyt6:~String" resolve="String" />
                           </node>
-                          <node concept="2YIFZM" id="14X7KHJuTZK" role="33vP2m">
-                            <ref role="37wK5l" to="cttk:FmAKtTFKin" resolve="getResolveInfo" />
-                            <ref role="1Pybhc" to="cttk:1YioXbrr5pb" resolve="SNodeUtil" />
-                            <node concept="1PxgMI" id="14X7KHJuZqi" role="37wK5m">
+                          <node concept="2OqwBi" id="7cby6PPOvf2" role="33vP2m">
+                            <node concept="1PxgMI" id="14X7KHJuZqi" role="2Oq$k0">
                               <node concept="chp4Y" id="14X7KHJv0wm" role="3oSUPX">
                                 <ref role="cht4Q" to="tpck:hqLv6T6" resolve="IResolveInfo" />
                               </node>
                               <node concept="37vLTw" id="14X7KHJuV8y" role="1m5AlR">
                                 <ref role="3cqZAo" node="14X7KHJtpdm" resolve="node" />
                               </node>
+                            </node>
+                            <node concept="3TrcHB" id="7cby6PPOxzG" role="2OqNvi">
+                              <ref role="3TsBF5" to="tpck:hqLvdgl" resolve="resolveInfo" />
                             </node>
                           </node>
                         </node>


### PR DESCRIPTION
There's no need to use long-time deprecated utility method to access a property.
The method has been removed in MPS master (upcoming 25.1 release)