### PR TITLE
Provide base classes for instance-path classes for nested structures

### DIFF
--- a/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.common/com.mbeddr.mpsutil.common.msd
+++ b/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.common/com.mbeddr.mpsutil.common.msd
@@ -18,6 +18,7 @@
     <dependency reexport="false">3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)</dependency>
     <dependency reexport="false">498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)</dependency>
     <dependency reexport="false">ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)</dependency>
+    <dependency reexport="false">b0f8641f-bd77-4421-8425-30d9088a82f7(org.apache.commons)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
@@ -45,6 +46,7 @@
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
     <module reference="c7a315e6-1d93-4186-85bc-2dfafd1ccc21(com.mbeddr.mpsutil.common)" version="0" />
     <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
+    <module reference="b0f8641f-bd77-4421-8425-30d9088a82f7(org.apache.commons)" version="0" />
   </dependencyVersions>
 </solution>
 

--- a/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.common/models/com/mbeddr/mpsutil/common/util.mps
+++ b/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.common/models/com/mbeddr/mpsutil/common/util.mps
@@ -248,6 +248,7 @@
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
       <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
       <concept id="1146644641414" name="jetbrains.mps.baseLanguage.structure.ProtectedVisibility" flags="nn" index="3Tmbuc" />
+      <concept id="1178893518978" name="jetbrains.mps.baseLanguage.structure.ThisConstructorInvocation" flags="nn" index="1VxSAg" />
       <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
       <concept id="1170345865475" name="jetbrains.mps.baseLanguage.structure.AnonymousClass" flags="ig" index="1Y3b0j">
         <reference id="1170346070688" name="classifier" index="1Y3XeK" />
@@ -5360,32 +5361,62 @@
         </node>
       </node>
     </node>
-    <node concept="2tJIrI" id="65ATjZHx9KI" role="jymVt" />
-    <node concept="3clFb_" id="65ATjZH$y4K" role="jymVt">
-      <property role="TrG5h" value="copy" />
-      <property role="1EzhhJ" value="true" />
-      <node concept="3clFbS" id="65ATjZH$y4M" role="3clF47" />
-      <node concept="3Tmbuc" id="65ATjZH$y4N" role="1B3o_S" />
-      <node concept="16syzq" id="6USpnraqqXx" role="3clF45">
-        <ref role="16sUi3" node="6USpnrapQRs" resolve="T" />
+    <node concept="2tJIrI" id="6USpnraxvw9" role="jymVt" />
+    <node concept="3clFbW" id="6USpnraxyXp" role="jymVt">
+      <node concept="3cqZAl" id="6USpnraxyXr" role="3clF45" />
+      <node concept="3Tm1VV" id="6USpnraxyXs" role="1B3o_S" />
+      <node concept="3clFbS" id="6USpnraxyXt" role="3clF47">
+        <node concept="1VxSAg" id="6USpnraxGW9" role="3cqZAp">
+          <ref role="37wK5l" node="65ATjZHljwS" />
+          <node concept="2OqwBi" id="6USpnraxI6q" role="37wK5m">
+            <node concept="37vLTw" id="6USpnraxHAJ" role="2Oq$k0">
+              <ref role="3cqZAo" node="6USpnrax$Vq" resolve="orig" />
+            </node>
+            <node concept="2OwXpG" id="6USpnraxJ7Q" role="2OqNvi">
+              <ref role="2Oxat5" node="5LihCoMhIxN" resolve="segments" />
+            </node>
+          </node>
+        </node>
       </node>
-      <node concept="P$JXv" id="1dyouTTKxJN" role="lGtFl">
-        <node concept="TZ5HA" id="1dyouTTKxJO" role="TZ5H$">
-          <node concept="1dT_AC" id="1dyouTTKxJP" role="1dT_Ay">
-            <property role="1dT_AB" value="This is a factory method which has to create a specific object where all data" />
+      <node concept="37vLTG" id="6USpnrax$Vq" role="3clF46">
+        <property role="TrG5h" value="orig" />
+        <node concept="3uibUv" id="6USpnrax$Vp" role="1tU5fm">
+          <ref role="3uigEE" node="65ATjZHjTwL" resolve="ImmutablePath" />
+          <node concept="16syzq" id="6USpnrax_ha" role="11_B2D">
+            <ref role="16sUi3" node="65ATjZHjU$1" resolve="S" />
           </node>
-        </node>
-        <node concept="TZ5HA" id="1dyouTTKz2k" role="TZ5H$">
-          <node concept="1dT_AC" id="1dyouTTKz2l" role="1dT_Ay">
-            <property role="1dT_AB" value="except the segments is a deep copy from the &quot;this&quot; object." />
+          <node concept="16syzq" id="6USpnraxBjK" role="11_B2D">
+            <ref role="16sUi3" node="6USpnrapQRs" resolve="T" />
           </node>
-        </node>
-        <node concept="x79VA" id="1dyouTTKxJQ" role="3nqlJM">
-          <property role="x79VB" value="the deep copy" />
         </node>
       </node>
     </node>
     <node concept="2tJIrI" id="3u1rFxdD$fV" role="jymVt" />
+    <node concept="3clFb_" id="65ATjZHHdB4" role="jymVt">
+      <property role="TrG5h" value="cloneObject" />
+      <property role="1EzhhJ" value="true" />
+      <node concept="3clFbS" id="65ATjZHHdB7" role="3clF47" />
+      <node concept="3Tmbuc" id="3u1rFxep7aA" role="1B3o_S" />
+      <node concept="16syzq" id="6USpnraqxl1" role="3clF45">
+        <ref role="16sUi3" node="6USpnrapQRs" resolve="T" />
+      </node>
+      <node concept="P$JXv" id="6USpnraz8cH" role="lGtFl">
+        <node concept="TZ5HA" id="6USpnraz8cI" role="TZ5H$">
+          <node concept="1dT_AC" id="6USpnraz8cJ" role="1dT_Ay">
+            <property role="1dT_AB" value="This is a copy constructor for the application type T." />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="6USpnra$sLT" role="TZ5H$">
+          <node concept="1dT_AC" id="6USpnra$sLU" role="1dT_Ay">
+            <property role="1dT_AB" value="It would be more elegant to call a copy constructor for generic type T, but this is impossible." />
+          </node>
+        </node>
+        <node concept="x79VA" id="6USpnraz8cK" role="3nqlJM">
+          <property role="x79VB" value="the deep copy" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="65ATjZHCniu" role="jymVt" />
     <node concept="3clFb_" id="65ATjZHxexA" role="jymVt">
       <property role="TrG5h" value="lastSegment" />
       <node concept="3clFbS" id="65ATjZHxexD" role="3clF47">
@@ -5749,55 +5780,6 @@
       </node>
     </node>
     <node concept="2tJIrI" id="6USpnrat57_" role="jymVt" />
-    <node concept="3clFb_" id="65ATjZHHdB4" role="jymVt">
-      <property role="TrG5h" value="cloneObject" />
-      <node concept="3clFbS" id="65ATjZHHdB7" role="3clF47">
-        <node concept="3cpWs8" id="65ATjZHHkP6" role="3cqZAp">
-          <node concept="3cpWsn" id="65ATjZHHkP7" role="3cpWs9">
-            <property role="TrG5h" value="result" />
-            <node concept="1rXfSq" id="65ATjZHHkP8" role="33vP2m">
-              <ref role="37wK5l" node="65ATjZH$y4K" resolve="copy" />
-            </node>
-            <node concept="16syzq" id="6USpnraqz3M" role="1tU5fm">
-              <ref role="16sUi3" node="6USpnrapQRs" resolve="T" />
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="65ATjZHHkPb" role="3cqZAp">
-          <node concept="2OqwBi" id="65ATjZHHkPc" role="3clFbG">
-            <node concept="2OqwBi" id="65ATjZHHkPd" role="2Oq$k0">
-              <node concept="2OwXpG" id="65ATjZHHkPf" role="2OqNvi">
-                <ref role="2Oxat5" node="5LihCoMhIxN" resolve="segments" />
-              </node>
-              <node concept="1rXfSq" id="6USpnrauc2H" role="2Oq$k0">
-                <ref role="37wK5l" node="6USpnratakR" resolve="upcast" />
-                <node concept="37vLTw" id="6USpnraudqn" role="37wK5m">
-                  <ref role="3cqZAo" node="65ATjZHHkP7" resolve="result" />
-                </node>
-              </node>
-            </node>
-            <node concept="X8dFx" id="65ATjZHHkPg" role="2OqNvi">
-              <node concept="2OqwBi" id="65ATjZHHkPh" role="25WWJ7">
-                <node concept="Xjq3P" id="65ATjZHHkPi" role="2Oq$k0" />
-                <node concept="2OwXpG" id="65ATjZHHkPj" role="2OqNvi">
-                  <ref role="2Oxat5" node="5LihCoMhIxN" resolve="segments" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="65ATjZHHwbM" role="3cqZAp">
-          <node concept="37vLTw" id="65ATjZHHwbK" role="3clFbG">
-            <ref role="3cqZAo" node="65ATjZHHkP7" resolve="result" />
-          </node>
-        </node>
-      </node>
-      <node concept="3Tmbuc" id="3u1rFxep7aA" role="1B3o_S" />
-      <node concept="16syzq" id="6USpnraqxl1" role="3clF45">
-        <ref role="16sUi3" node="6USpnrapQRs" resolve="T" />
-      </node>
-    </node>
-    <node concept="2tJIrI" id="65ATjZHCniu" role="jymVt" />
     <node concept="3clFb_" id="6USpnratakR" role="jymVt">
       <property role="TrG5h" value="upcast" />
       <node concept="3clFbS" id="6USpnratakU" role="3clF47">
@@ -6033,6 +6015,12 @@
           <ref role="zr_51" node="65ATjZHjU$1" resolve="S" />
         </node>
       </node>
+      <node concept="TUZQ0" id="6USpnra$Spw" role="3nqlJM">
+        <property role="TUZQ4" value="the actual application type which extends ImmutablePath&lt;&gt;" />
+        <node concept="zr_56" id="6USpnra$ThP" role="zr_5Q">
+          <ref role="zr_51" node="6USpnrapQRs" resolve="T" />
+        </node>
+      </node>
     </node>
   </node>
   <node concept="312cEu" id="65ATjZHjU$h">
@@ -6140,6 +6128,52 @@
         <node concept="A3Dl8" id="65ATjZHlpTr" role="1tU5fm">
           <node concept="16syzq" id="65ATjZHlpXE" role="A3Ik2">
             <ref role="16sUi3" node="65ATjZHjU$J" resolve="T" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="6USpnrawGwa" role="jymVt" />
+    <node concept="3clFbW" id="6USpnrawOgS" role="jymVt">
+      <node concept="3cqZAl" id="6USpnrawOgU" role="3clF45" />
+      <node concept="3Tm1VV" id="6USpnrawOgV" role="1B3o_S" />
+      <node concept="3clFbS" id="6USpnrawOgW" role="3clF47">
+        <node concept="XkiVB" id="6USpnraxUnX" role="3cqZAp">
+          <ref role="37wK5l" node="6USpnraxyXp" />
+          <node concept="37vLTw" id="6USpnraxYdf" role="37wK5m">
+            <ref role="3cqZAo" node="6USpnrawVwS" resolve="orig" />
+          </node>
+        </node>
+        <node concept="3clFbF" id="6USpnrax13L" role="3cqZAp">
+          <node concept="37vLTI" id="6USpnrax6sa" role="3clFbG">
+            <node concept="2OqwBi" id="6USpnrax9Ho" role="37vLTx">
+              <node concept="37vLTw" id="6USpnrax97f" role="2Oq$k0">
+                <ref role="3cqZAo" node="6USpnrawVwS" resolve="orig" />
+              </node>
+              <node concept="2OwXpG" id="6USpnraxc8N" role="2OqNvi">
+                <ref role="2Oxat5" node="65ATjZHlp_8" resolve="root" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="6USpnrax1IM" role="37vLTJ">
+              <node concept="Xjq3P" id="6USpnrax13K" role="2Oq$k0" />
+              <node concept="2OwXpG" id="6USpnrax4Aj" role="2OqNvi">
+                <ref role="2Oxat5" node="65ATjZHlp_8" resolve="root" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="6USpnrawVwS" role="3clF46">
+        <property role="TrG5h" value="orig" />
+        <node concept="3uibUv" id="6USpnrawVwR" role="1tU5fm">
+          <ref role="3uigEE" node="65ATjZHjU$h" resolve="InstancePath" />
+          <node concept="16syzq" id="6USpnraxjyF" role="11_B2D">
+            <ref role="16sUi3" node="65ATjZHlpYF" resolve="D" />
+          </node>
+          <node concept="16syzq" id="6USpnraxopa" role="11_B2D">
+            <ref role="16sUi3" node="65ATjZHjU$J" resolve="S" />
+          </node>
+          <node concept="16syzq" id="6USpnraxtem" role="11_B2D">
+            <ref role="16sUi3" node="6USpnrapFVg" resolve="T" />
           </node>
         </node>
       </node>
@@ -7229,6 +7263,12 @@
         <property role="TUZQ4" value="the type of the path's segments (the &quot;segment&quot; type)" />
         <node concept="zr_56" id="1dyouTTKIS0" role="zr_5Q">
           <ref role="zr_51" node="65ATjZHjU$J" resolve="S" />
+        </node>
+      </node>
+      <node concept="TUZQ0" id="6USpnra_3ot" role="3nqlJM">
+        <property role="TUZQ4" value="the actual application type which extends InstancePath&lt;&gt;" />
+        <node concept="zr_56" id="6USpnra_3ou" role="zr_5Q">
+          <ref role="zr_51" node="6USpnrapFVg" resolve="T" />
         </node>
       </node>
     </node>

--- a/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.common/models/com/mbeddr/mpsutil/common/util.mps
+++ b/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.common/models/com/mbeddr/mpsutil/common/util.mps
@@ -5329,7 +5329,30 @@
     <node concept="3clFbW" id="65ATjZHltzI" role="jymVt">
       <node concept="3cqZAl" id="65ATjZHltzK" role="3clF45" />
       <node concept="3Tm1VV" id="65ATjZHltzL" role="1B3o_S" />
-      <node concept="3clFbS" id="65ATjZHltzM" role="3clF47" />
+      <node concept="3clFbS" id="65ATjZHltzM" role="3clF47">
+        <node concept="3SKdUt" id="710iChRYqGx" role="3cqZAp">
+          <node concept="1PaTwC" id="710iChRYqGy" role="1aUNEU">
+            <node concept="3oM_SD" id="710iChRYqGz" role="1PaTwD">
+              <property role="3oM_SC" value="constructs" />
+            </node>
+            <node concept="3oM_SD" id="710iChRYrgZ" role="1PaTwD">
+              <property role="3oM_SC" value="a" />
+            </node>
+            <node concept="3oM_SD" id="710iChRYrh1" role="1PaTwD">
+              <property role="3oM_SC" value="path" />
+            </node>
+            <node concept="3oM_SD" id="710iChRYrri" role="1PaTwD">
+              <property role="3oM_SC" value="without" />
+            </node>
+            <node concept="3oM_SD" id="710iChRYrJz" role="1PaTwD">
+              <property role="3oM_SC" value="any" />
+            </node>
+            <node concept="3oM_SD" id="710iChRYrJO" role="1PaTwD">
+              <property role="3oM_SC" value="segments" />
+            </node>
+          </node>
+        </node>
+      </node>
     </node>
     <node concept="2tJIrI" id="65ATjZHltI7" role="jymVt" />
     <node concept="3clFbW" id="65ATjZHljwS" role="jymVt">
@@ -5364,7 +5387,7 @@
     <node concept="2tJIrI" id="6USpnraxvw9" role="jymVt" />
     <node concept="3clFbW" id="6USpnraxyXp" role="jymVt">
       <node concept="3cqZAl" id="6USpnraxyXr" role="3clF45" />
-      <node concept="3Tm1VV" id="6USpnraxyXs" role="1B3o_S" />
+      <node concept="3Tmbuc" id="710iChRXAQG" role="1B3o_S" />
       <node concept="3clFbS" id="6USpnraxyXt" role="3clF47">
         <node concept="1VxSAg" id="6USpnraxGW9" role="3cqZAp">
           <ref role="37wK5l" node="65ATjZHljwS" />
@@ -6135,7 +6158,7 @@
     <node concept="2tJIrI" id="6USpnrawGwa" role="jymVt" />
     <node concept="3clFbW" id="6USpnrawOgS" role="jymVt">
       <node concept="3cqZAl" id="6USpnrawOgU" role="3clF45" />
-      <node concept="3Tm1VV" id="6USpnrawOgV" role="1B3o_S" />
+      <node concept="3Tmbuc" id="710iChRXxx9" role="1B3o_S" />
       <node concept="3clFbS" id="6USpnrawOgW" role="3clF47">
         <node concept="XkiVB" id="6USpnraxUnX" role="3cqZAp">
           <ref role="37wK5l" node="6USpnraxyXp" />

--- a/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.common/models/com/mbeddr/mpsutil/common/util.mps
+++ b/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.common/models/com/mbeddr/mpsutil/common/util.mps
@@ -23,10 +23,15 @@
     <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" />
     <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
     <import index="82uw" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util.function(JDK/)" />
+    <import index="qt06" ref="b0f8641f-bd77-4421-8425-30d9088a82f7/java:org.apache.commons.lang3.builder(org.apache.commons/)" />
     <import index="bd8o" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.application(MPS.IDEA/)" implicit="true" />
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1224071154655" name="jetbrains.mps.baseLanguage.structure.AsExpression" flags="nn" index="0kSF2">
+        <child id="1224071154657" name="classifierType" index="0kSFW" />
+        <child id="1224071154656" name="expression" index="0kSFX" />
+      </concept>
       <concept id="1080223426719" name="jetbrains.mps.baseLanguage.structure.OrExpression" flags="nn" index="22lmx$" />
       <concept id="1082485599095" name="jetbrains.mps.baseLanguage.structure.BlockStatement" flags="nn" index="9aQIb">
         <child id="1082485599096" name="statements" index="9aQI4" />
@@ -57,6 +62,7 @@
         <child id="1154032183016" name="body" index="2LFqv$" />
       </concept>
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <property id="2523873803623706117" name="isMultiline" index="hSjvv" />
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
       </concept>
@@ -85,6 +91,9 @@
       <concept id="1081256982272" name="jetbrains.mps.baseLanguage.structure.InstanceOfExpression" flags="nn" index="2ZW3vV">
         <child id="1081256993305" name="classType" index="2ZW6by" />
         <child id="1081256993304" name="leftExpression" index="2ZW6bz" />
+      </concept>
+      <concept id="1070533707846" name="jetbrains.mps.baseLanguage.structure.StaticFieldReference" flags="nn" index="10M0yZ">
+        <reference id="1144433057691" name="classifier" index="1PxDUh" />
       </concept>
       <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
       <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
@@ -119,6 +128,7 @@
       <concept id="1109283449304" name="jetbrains.mps.baseLanguage.structure.TypeVariableReference" flags="in" index="16syzq">
         <reference id="1109283546497" name="typeVariableDeclaration" index="16sUi3" />
       </concept>
+      <concept id="1092119917967" name="jetbrains.mps.baseLanguage.structure.MulExpression" flags="nn" index="17qRlL" />
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
@@ -172,6 +182,7 @@
       <concept id="1079359253375" name="jetbrains.mps.baseLanguage.structure.ParenthesizedExpression" flags="nn" index="1eOMI4">
         <child id="1079359253376" name="expression" index="1eOMHV" />
       </concept>
+      <concept id="1081506762703" name="jetbrains.mps.baseLanguage.structure.GreaterThanExpression" flags="nn" index="3eOSWO" />
       <concept id="1081506773034" name="jetbrains.mps.baseLanguage.structure.LessThanExpression" flags="nn" index="3eOVzh" />
       <concept id="1081516740877" name="jetbrains.mps.baseLanguage.structure.NotExpression" flags="nn" index="3fqX7Q">
         <child id="1081516765348" name="expression" index="3fr31v" />
@@ -226,6 +237,11 @@
         <child id="8276990574886367509" name="finallyClause" index="1zxBo6" />
         <child id="8276990574886367508" name="body" index="1zxBo7" />
       </concept>
+      <concept id="1163668896201" name="jetbrains.mps.baseLanguage.structure.TernaryOperatorExpression" flags="nn" index="3K4zz7">
+        <child id="1163668914799" name="condition" index="3K4Cdx" />
+        <child id="1163668922816" name="ifTrue" index="3K4E3e" />
+        <child id="1163668934364" name="ifFalse" index="3K4GZi" />
+      </concept>
       <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="nn" index="3SKdUt">
         <child id="8356039341262087992" name="line" index="1aUNEU" />
       </concept>
@@ -254,6 +270,9 @@
       <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
         <child id="1199569906740" name="parameter" index="1bW2Oz" />
         <child id="1199569916463" name="body" index="1bW5cS" />
+      </concept>
+      <concept id="1225797177491" name="jetbrains.mps.baseLanguage.closures.structure.InvokeFunctionOperation" flags="nn" index="1Bd96e">
+        <child id="1225797361612" name="parameter" index="1BdPVh" />
       </concept>
     </language>
     <language id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc">
@@ -323,10 +342,15 @@
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
         <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
       </concept>
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+      <concept id="4222318806802425298" name="jetbrains.mps.lang.core.structure.SuppressErrorsAnnotation" flags="ng" index="15s5l7">
+        <property id="8575328350543493365" name="message" index="huDt6" />
+        <property id="2423417345669755629" name="filter" index="1eyWvh" />
       </concept>
     </language>
     <language id="c7fb639f-be78-4307-89b0-b5959c3fa8c8" name="jetbrains.mps.lang.text">
@@ -343,6 +367,9 @@
       </concept>
       <concept id="540871147943773365" name="jetbrains.mps.baseLanguage.collections.structure.SingleArgumentSequenceOperation" flags="nn" index="25WWJ4">
         <child id="540871147943773366" name="argument" index="25WWJ7" />
+      </concept>
+      <concept id="1172650591544" name="jetbrains.mps.baseLanguage.collections.structure.SkipOperation" flags="nn" index="7r0gD">
+        <child id="1172658456740" name="elementsToSkip" index="7T0AP" />
       </concept>
       <concept id="1226511727824" name="jetbrains.mps.baseLanguage.collections.structure.SetType" flags="in" index="2hMVRd">
         <child id="1226511765987" name="elementType" index="2hN53Y" />
@@ -363,6 +390,7 @@
       <concept id="1153944233411" name="jetbrains.mps.baseLanguage.collections.structure.ForEachVariableReference" flags="nn" index="2GrUjf">
         <reference id="1153944258490" name="variable" index="2Gs0qQ" />
       </concept>
+      <concept id="1235566554328" name="jetbrains.mps.baseLanguage.collections.structure.AnyOperation" flags="nn" index="2HwmR7" />
       <concept id="1237721394592" name="jetbrains.mps.baseLanguage.collections.structure.AbstractContainerCreator" flags="nn" index="HWqM0">
         <child id="1237721435808" name="initValue" index="HW$Y0" />
         <child id="1237721435807" name="elementType" index="HW$YZ" />
@@ -370,6 +398,7 @@
       </concept>
       <concept id="1227008614712" name="jetbrains.mps.baseLanguage.collections.structure.LinkedListCreator" flags="nn" index="2Jqq0_" />
       <concept id="1227026082377" name="jetbrains.mps.baseLanguage.collections.structure.RemoveFirstElementOperation" flags="nn" index="2Kt2Hk" />
+      <concept id="1227026094155" name="jetbrains.mps.baseLanguage.collections.structure.RemoveLastElementOperation" flags="nn" index="2Kt5_m" />
       <concept id="1160600644654" name="jetbrains.mps.baseLanguage.collections.structure.ListCreatorWithInit" flags="nn" index="Tc6Ow" />
       <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="nn" index="TSZUe" />
       <concept id="1160666733551" name="jetbrains.mps.baseLanguage.collections.structure.AddAllElementsOperation" flags="nn" index="X8dFx" />
@@ -378,13 +407,20 @@
       <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="nn" index="34oBXx" />
       <concept id="1175845471038" name="jetbrains.mps.baseLanguage.collections.structure.ReverseOperation" flags="nn" index="35Qw8J" />
       <concept id="1167380149909" name="jetbrains.mps.baseLanguage.collections.structure.RemoveElementOperation" flags="nn" index="3dhRuq" />
+      <concept id="1165525191778" name="jetbrains.mps.baseLanguage.collections.structure.GetFirstOperation" flags="nn" index="1uHKPH" />
       <concept id="1240687580870" name="jetbrains.mps.baseLanguage.collections.structure.JoinOperation" flags="nn" index="3uJxvA">
         <child id="1240687658305" name="delimiter" index="3uJOhx" />
       </concept>
+      <concept id="1165530316231" name="jetbrains.mps.baseLanguage.collections.structure.IsEmptyOperation" flags="nn" index="1v1jN8" />
+      <concept id="1165595910856" name="jetbrains.mps.baseLanguage.collections.structure.GetLastOperation" flags="nn" index="1yVyf7" />
       <concept id="1225727723840" name="jetbrains.mps.baseLanguage.collections.structure.FindFirstOperation" flags="nn" index="1z4cxt" />
+      <concept id="1225730411176" name="jetbrains.mps.baseLanguage.collections.structure.FindLastOperation" flags="nn" index="1zesIP" />
       <concept id="1202128969694" name="jetbrains.mps.baseLanguage.collections.structure.SelectOperation" flags="nn" index="3$u5V9" />
       <concept id="1176501494711" name="jetbrains.mps.baseLanguage.collections.structure.IsNotEmptyOperation" flags="nn" index="3GX2aA" />
       <concept id="1172254888721" name="jetbrains.mps.baseLanguage.collections.structure.ContainsOperation" flags="nn" index="3JPx81" />
+      <concept id="1522217801069396578" name="jetbrains.mps.baseLanguage.collections.structure.FoldLeftOperation" flags="nn" index="1MD8d$">
+        <child id="1522217801069421796" name="seed" index="1MDeny" />
+      </concept>
       <concept id="5686963296372573083" name="jetbrains.mps.baseLanguage.collections.structure.AbstractContainerType" flags="in" index="3O5elB">
         <child id="5686963296372573084" name="elementType" index="3O5elw" />
       </concept>
@@ -393,6 +429,7 @@
   </registry>
   <node concept="312cEu" id="2tyo97nOHBG">
     <property role="TrG5h" value="IdentityHelperUtil" />
+    <property role="3GE5qa" value="identification" />
     <node concept="2YIFZL" id="2tyo97nOHJW" role="jymVt">
       <property role="TrG5h" value="wrap" />
       <property role="od$2w" value="false" />
@@ -428,6 +465,7 @@
   </node>
   <node concept="312cEu" id="6UjzKD01FHy">
     <property role="TrG5h" value="SNodeIdentityWrapperT" />
+    <property role="3GE5qa" value="identification" />
     <node concept="2tJIrI" id="6UjzKD01FIe" role="jymVt" />
     <node concept="3clFbW" id="6UjzKD01FIw" role="jymVt">
       <node concept="3cqZAl" id="6UjzKD01FIy" role="3clF45" />
@@ -450,7 +488,7 @@
     <node concept="2tJIrI" id="6UjzKD01FIi" role="jymVt" />
     <node concept="3clFb_" id="2tyo97nODD7" role="jymVt">
       <property role="1EzhhJ" value="false" />
-      <property role="TrG5h" value="unwarp" />
+      <property role="TrG5h" value="unwrap" />
       <property role="od$2w" value="false" />
       <property role="DiZV1" value="false" />
       <node concept="3clFbS" id="2tyo97nODDa" role="3clF47">
@@ -492,6 +530,7 @@
   </node>
   <node concept="312cEu" id="3JMPeKaHTsG">
     <property role="TrG5h" value="ModelComparatorMismatch" />
+    <property role="3GE5qa" value="comparison" />
     <node concept="3clFbW" id="3JMPeKaHTsH" role="jymVt">
       <node concept="37vLTG" id="3JMPeKaHTsI" role="3clF46">
         <property role="TrG5h" value="expected" />
@@ -743,6 +782,7 @@
   </node>
   <node concept="312cEu" id="3JMPeKaHTeD">
     <property role="TrG5h" value="ModelComparator" />
+    <property role="3GE5qa" value="comparison" />
     <node concept="3clFbW" id="3JMPeKaHTeE" role="jymVt">
       <node concept="3cqZAl" id="3JMPeKaHTeF" role="3clF45" />
       <node concept="3Tm1VV" id="3JMPeKaHTeG" role="1B3o_S" />
@@ -2851,6 +2891,7 @@
   </node>
   <node concept="312cEu" id="6UjzKD00nXB">
     <property role="TrG5h" value="SNodeIdentityWrapper" />
+    <property role="3GE5qa" value="identification" />
     <node concept="312cEg" id="6UjzKD00$qK" role="jymVt">
       <property role="34CwA1" value="false" />
       <property role="eg7rD" value="false" />
@@ -2860,7 +2901,7 @@
       <node concept="z59LJ" id="6UjzKD01wlg" role="lGtFl">
         <node concept="TZ5HA" id="6UjzKD01wlh" role="TZ5H$">
           <node concept="1dT_AC" id="6UjzKD01wli" role="1dT_Ay">
-            <property role="1dT_AB" value="This Class is used to preserve node identity across model boundaries. This is usefull in generator scenarios where" />
+            <property role="1dT_AB" value="This class is used to preserve node identity across model boundaries. This is useful in generator scenarios where" />
           </node>
         </node>
         <node concept="TZ5HA" id="6UjzKD01wWm" role="TZ5H$">
@@ -3115,6 +3156,7 @@
   </node>
   <node concept="312cEu" id="4biM00Jg0oQ">
     <property role="TrG5h" value="ApplicationHelper" />
+    <property role="3GE5qa" value="application" />
     <node concept="2tJIrI" id="4biM00Jg0Nc" role="jymVt" />
     <node concept="2YIFZL" id="4biM00Jg0NW" role="jymVt">
       <property role="TrG5h" value="runWithProgressAsync" />
@@ -3577,6 +3619,7 @@
   </node>
   <node concept="312cEu" id="9jWrhFizRs">
     <property role="TrG5h" value="LazyInit" />
+    <property role="3GE5qa" value="memoization" />
     <node concept="2tJIrI" id="9jWrhFmbfw" role="jymVt" />
     <node concept="2YIFZL" id="9jWrhFiKyu" role="jymVt">
       <property role="TrG5h" value="lazy" />
@@ -3772,6 +3815,7 @@
   </node>
   <node concept="312cEu" id="9jWrhFiXtZ">
     <property role="TrG5h" value="LazyInitWithCheck" />
+    <property role="3GE5qa" value="memoization" />
     <node concept="2tJIrI" id="9jWrhFmoFy" role="jymVt" />
     <node concept="2YIFZL" id="9jWrhFiXuJ" role="jymVt">
       <property role="TrG5h" value="lazy" />
@@ -4200,6 +4244,7 @@
   <node concept="312cEu" id="5Hb7SE23e8T">
     <property role="TrG5h" value="Traversal" />
     <property role="1sVAO0" value="true" />
+    <property role="3GE5qa" value="traversal" />
     <node concept="2tJIrI" id="5Hb7SE23JsJ" role="jymVt" />
     <node concept="2YIFZL" id="5Hb7SE2mUul" role="jymVt">
       <property role="TrG5h" value="doBreadthFirst" />
@@ -5239,6 +5284,1893 @@
         <property role="TUZQ4" value="template parameter defining which type of objects is traversed" />
         <node concept="zr_56" id="5Hb7SE31DQk" role="zr_5Q">
           <ref role="zr_51" node="5Hb7SE23Jsr" resolve="T" />
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="312cEu" id="65ATjZHjTwL">
+    <property role="TrG5h" value="ImmutablePath" />
+    <property role="1sVAO0" value="true" />
+    <property role="3GE5qa" value="instantiation" />
+    <node concept="3Tm1VV" id="65ATjZHjTwM" role="1B3o_S" />
+    <node concept="16euLQ" id="65ATjZHjU$1" role="16eVyc">
+      <property role="TrG5h" value="S" />
+    </node>
+    <node concept="312cEg" id="5LihCoMhIxN" role="jymVt">
+      <property role="TrG5h" value="segments" />
+      <node concept="3Tm6S6" id="5LihCoMhIp$" role="1B3o_S" />
+      <node concept="_YKpA" id="5LihCoMhIwh" role="1tU5fm">
+        <node concept="16syzq" id="65ATjZHljfS" role="_ZDj9">
+          <ref role="16sUi3" node="65ATjZHjU$1" resolve="T" />
+        </node>
+      </node>
+      <node concept="2ShNRf" id="5LihCoMhIQm" role="33vP2m">
+        <node concept="Tc6Ow" id="5LihCoMhZb3" role="2ShVmc">
+          <node concept="16syzq" id="65ATjZHljpT" role="HW$YZ">
+            <ref role="16sUi3" node="65ATjZHjU$1" resolve="T" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="65ATjZHljbM" role="jymVt" />
+    <node concept="3clFbW" id="65ATjZHltzI" role="jymVt">
+      <node concept="3cqZAl" id="65ATjZHltzK" role="3clF45" />
+      <node concept="3Tm1VV" id="65ATjZHltzL" role="1B3o_S" />
+      <node concept="3clFbS" id="65ATjZHltzM" role="3clF47" />
+    </node>
+    <node concept="2tJIrI" id="65ATjZHltI7" role="jymVt" />
+    <node concept="3clFbW" id="65ATjZHljwS" role="jymVt">
+      <node concept="37vLTG" id="65ATjZHljxr" role="3clF46">
+        <property role="TrG5h" value="segments" />
+        <node concept="A3Dl8" id="65ATjZHljBx" role="1tU5fm">
+          <node concept="16syzq" id="65ATjZHljE$" role="A3Ik2">
+            <ref role="16sUi3" node="65ATjZHjU$1" resolve="T" />
+          </node>
+        </node>
+      </node>
+      <node concept="3cqZAl" id="65ATjZHljwU" role="3clF45" />
+      <node concept="3Tm1VV" id="65ATjZHljwV" role="1B3o_S" />
+      <node concept="3clFbS" id="65ATjZHljwW" role="3clF47">
+        <node concept="3clFbF" id="65ATjZHljYE" role="3cqZAp">
+          <node concept="2OqwBi" id="65ATjZHllNK" role="3clFbG">
+            <node concept="2OqwBi" id="65ATjZHlk9X" role="2Oq$k0">
+              <node concept="Xjq3P" id="65ATjZHljYD" role="2Oq$k0" />
+              <node concept="2OwXpG" id="65ATjZHlkrv" role="2OqNvi">
+                <ref role="2Oxat5" node="5LihCoMhIxN" resolve="segments" />
+              </node>
+            </node>
+            <node concept="X8dFx" id="65ATjZHlnfU" role="2OqNvi">
+              <node concept="37vLTw" id="65ATjZHlnSf" role="25WWJ7">
+                <ref role="3cqZAo" node="65ATjZHljxr" resolve="segments" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="65ATjZHx9KI" role="jymVt" />
+    <node concept="3clFb_" id="65ATjZH$y4K" role="jymVt">
+      <property role="TrG5h" value="copy" />
+      <property role="1EzhhJ" value="true" />
+      <node concept="3clFbS" id="65ATjZH$y4M" role="3clF47" />
+      <node concept="3Tmbuc" id="65ATjZH$y4N" role="1B3o_S" />
+      <node concept="3uibUv" id="65ATjZHP8bI" role="3clF45">
+        <ref role="3uigEE" node="65ATjZHjTwL" resolve="ImmutablePath" />
+        <node concept="16syzq" id="65ATjZHPaJg" role="11_B2D">
+          <ref role="16sUi3" node="65ATjZHjU$1" resolve="S" />
+        </node>
+      </node>
+      <node concept="P$JXv" id="1dyouTTKxJN" role="lGtFl">
+        <node concept="TZ5HA" id="1dyouTTKxJO" role="TZ5H$">
+          <node concept="1dT_AC" id="1dyouTTKxJP" role="1dT_Ay">
+            <property role="1dT_AB" value="This is a factory method which has to create a specific object where all data" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="1dyouTTKz2k" role="TZ5H$">
+          <node concept="1dT_AC" id="1dyouTTKz2l" role="1dT_Ay">
+            <property role="1dT_AB" value="except the segments is a deep copy from the &quot;this&quot; object." />
+          </node>
+        </node>
+        <node concept="x79VA" id="1dyouTTKxJQ" role="3nqlJM">
+          <property role="x79VB" value="the deep copy" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="3u1rFxdD$fV" role="jymVt" />
+    <node concept="3clFb_" id="65ATjZHxexA" role="jymVt">
+      <property role="TrG5h" value="lastSegment" />
+      <node concept="3clFbS" id="65ATjZHxexD" role="3clF47">
+        <node concept="3clFbJ" id="65ATjZHxSgc" role="3cqZAp">
+          <node concept="3clFbS" id="65ATjZHxSge" role="3clFbx">
+            <node concept="3cpWs6" id="65ATjZHxYvP" role="3cqZAp">
+              <node concept="2YIFZM" id="65ATjZHy0UQ" role="3cqZAk">
+                <ref role="37wK5l" to="33ny:~Optional.empty()" resolve="empty" />
+                <ref role="1Pybhc" to="33ny:~Optional" resolve="Optional" />
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="65ATjZHxV2c" role="3clFbw">
+            <node concept="37vLTw" id="65ATjZHxThD" role="2Oq$k0">
+              <ref role="3cqZAo" node="5LihCoMhIxN" resolve="segments" />
+            </node>
+            <node concept="1v1jN8" id="65ATjZHxXL1" role="2OqNvi" />
+          </node>
+          <node concept="9aQIb" id="65ATjZHy1mW" role="9aQIa">
+            <node concept="3clFbS" id="65ATjZHy1mX" role="9aQI4">
+              <node concept="3cpWs6" id="65ATjZHy295" role="3cqZAp">
+                <node concept="2YIFZM" id="65ATjZHy44g" role="3cqZAk">
+                  <ref role="37wK5l" to="33ny:~Optional.of(java.lang.Object)" resolve="of" />
+                  <ref role="1Pybhc" to="33ny:~Optional" resolve="Optional" />
+                  <node concept="2OqwBi" id="65ATjZHy7KQ" role="37wK5m">
+                    <node concept="37vLTw" id="65ATjZHy56k" role="2Oq$k0">
+                      <ref role="3cqZAo" node="5LihCoMhIxN" resolve="segments" />
+                    </node>
+                    <node concept="1yVyf7" id="65ATjZHy9LJ" role="2OqNvi" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="65ATjZHxb0y" role="1B3o_S" />
+      <node concept="3uibUv" id="65ATjZHxGs2" role="3clF45">
+        <ref role="3uigEE" to="33ny:~Optional" resolve="Optional" />
+        <node concept="16syzq" id="65ATjZHxJRb" role="11_B2D">
+          <ref role="16sUi3" node="65ATjZHjU$1" resolve="T" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="65ATjZHlnZA" role="jymVt" />
+    <node concept="3clFb_" id="5PQUSslgGet" role="jymVt">
+      <property role="TrG5h" value="segmentsSize" />
+      <node concept="3clFbS" id="5PQUSslgGew" role="3clF47">
+        <node concept="3clFbF" id="5PQUSslgHf3" role="3cqZAp">
+          <node concept="2OqwBi" id="5PQUSslgJdZ" role="3clFbG">
+            <node concept="37vLTw" id="5PQUSslgHf2" role="2Oq$k0">
+              <ref role="3cqZAo" node="5LihCoMhIxN" resolve="segments" />
+            </node>
+            <node concept="34oBXx" id="4pJ152Ve7HW" role="2OqNvi" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="5PQUSslgFdo" role="1B3o_S" />
+      <node concept="10Oyi0" id="4pJ152VdULD" role="3clF45" />
+    </node>
+    <node concept="2tJIrI" id="3u1rFxdFzt_" role="jymVt" />
+    <node concept="3clFb_" id="3u1rFxdFBU5" role="jymVt">
+      <property role="TrG5h" value="segments" />
+      <node concept="3clFbS" id="3u1rFxdFBU8" role="3clF47">
+        <node concept="3clFbF" id="3u1rFxdFHmc" role="3cqZAp">
+          <node concept="37vLTw" id="3u1rFxdFN3l" role="3clFbG">
+            <ref role="3cqZAo" node="5LihCoMhIxN" resolve="segments" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="3u1rFxdF_A9" role="1B3o_S" />
+      <node concept="A3Dl8" id="3u1rFxdFACP" role="3clF45">
+        <node concept="16syzq" id="3u1rFxdFBKK" role="A3Ik2">
+          <ref role="16sUi3" node="65ATjZHjU$1" resolve="T" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="65ATjZHp26x" role="jymVt" />
+    <node concept="3clFb_" id="65ATjZHpG8B" role="jymVt">
+      <property role="TrG5h" value="segmentsReverse" />
+      <node concept="3clFbS" id="65ATjZHpG8E" role="3clF47">
+        <node concept="3clFbF" id="3u1rFxdFOA4" role="3cqZAp">
+          <node concept="2OqwBi" id="65ATjZHpNbX" role="3clFbG">
+            <node concept="2OqwBi" id="65ATjZHpL9W" role="2Oq$k0">
+              <node concept="Xjq3P" id="65ATjZHpL9X" role="2Oq$k0" />
+              <node concept="2OwXpG" id="65ATjZHpL9Y" role="2OqNvi">
+                <ref role="2Oxat5" node="5LihCoMhIxN" resolve="segments" />
+              </node>
+            </node>
+            <node concept="35Qw8J" id="65ATjZHpOQ9" role="2OqNvi" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="65ATjZHpFTK" role="1B3o_S" />
+      <node concept="A3Dl8" id="3u1rFxdFSaA" role="3clF45">
+        <node concept="16syzq" id="3u1rFxdFSaC" role="A3Ik2">
+          <ref role="16sUi3" node="65ATjZHjU$1" resolve="T" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="3u1rFxdFV6x" role="jymVt" />
+    <node concept="3clFb_" id="3kD7lY4E2G4" role="jymVt">
+      <property role="TrG5h" value="segmentsAsList" />
+      <node concept="3Tm1VV" id="3kD7lY4E2G7" role="1B3o_S" />
+      <node concept="3clFbS" id="3kD7lY4E2G8" role="3clF47">
+        <node concept="3clFbF" id="3kD7lY4EkWd" role="3cqZAp">
+          <node concept="2YIFZM" id="3kD7lY4MHPd" role="3clFbG">
+            <ref role="37wK5l" to="33ny:~Collections.unmodifiableList(java.util.List)" resolve="unmodifiableList" />
+            <ref role="1Pybhc" to="33ny:~Collections" resolve="Collections" />
+            <node concept="2OqwBi" id="3kD7lY4MHPe" role="37wK5m">
+              <node concept="Xjq3P" id="3kD7lY4MHPf" role="2Oq$k0" />
+              <node concept="2OwXpG" id="3kD7lY4MHPg" role="2OqNvi">
+                <ref role="2Oxat5" node="5LihCoMhIxN" resolve="segments" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="_YKpA" id="3kD7lY4MU4s" role="3clF45">
+        <node concept="16syzq" id="65ATjZHp1yB" role="_ZDj9">
+          <ref role="16sUi3" node="65ATjZHjU$1" resolve="T" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="65ATjZHR4ML" role="jymVt" />
+    <node concept="3clFb_" id="5LihCoMiiPS" role="jymVt">
+      <property role="TrG5h" value="append" />
+      <node concept="3clFbS" id="5LihCoMiiPV" role="3clF47">
+        <node concept="3cpWs8" id="5LihCoMikgI" role="3cqZAp">
+          <node concept="3cpWsn" id="5LihCoMikgJ" role="3cpWs9">
+            <property role="TrG5h" value="result" />
+            <node concept="1rXfSq" id="65ATjZHHYgs" role="33vP2m">
+              <ref role="37wK5l" node="65ATjZHHdB4" resolve="cloneObject" />
+            </node>
+            <node concept="3uibUv" id="65ATjZHO9tt" role="1tU5fm">
+              <ref role="3uigEE" node="65ATjZHjTwL" resolve="Path" />
+              <node concept="16syzq" id="65ATjZHObyI" role="11_B2D">
+                <ref role="16sUi3" node="65ATjZHjU$1" resolve="T" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="5LihCoMivDJ" role="3cqZAp">
+          <node concept="2OqwBi" id="5LihCoMiyPE" role="3clFbG">
+            <node concept="2OqwBi" id="5LihCoMiwrd" role="2Oq$k0">
+              <node concept="37vLTw" id="5LihCoMivDH" role="2Oq$k0">
+                <ref role="3cqZAo" node="5LihCoMikgJ" resolve="result" />
+              </node>
+              <node concept="2OwXpG" id="65ATjZHD35t" role="2OqNvi">
+                <ref role="2Oxat5" node="5LihCoMhIxN" resolve="segments" />
+              </node>
+            </node>
+            <node concept="TSZUe" id="5LihCoMi$1J" role="2OqNvi">
+              <node concept="37vLTw" id="5LihCoMiB2u" role="25WWJ7">
+                <ref role="3cqZAo" node="5LihCoMijoX" resolve="segment" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="5LihCoMiCuD" role="3cqZAp">
+          <node concept="37vLTw" id="5LihCoMiCuB" role="3clFbG">
+            <ref role="3cqZAo" node="5LihCoMikgJ" resolve="result" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="5LihCoMii_H" role="1B3o_S" />
+      <node concept="37vLTG" id="5LihCoMijoX" role="3clF46">
+        <property role="TrG5h" value="additionalSegment" />
+        <node concept="16syzq" id="65ATjZHAR3p" role="1tU5fm">
+          <ref role="16sUi3" node="65ATjZHjU$1" resolve="T" />
+        </node>
+      </node>
+      <node concept="3uibUv" id="65ATjZHPcTc" role="3clF45">
+        <ref role="3uigEE" node="65ATjZHjTwL" resolve="Path" />
+        <node concept="16syzq" id="65ATjZHPgd4" role="11_B2D">
+          <ref role="16sUi3" node="65ATjZHjU$1" resolve="T" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="65ATjZHE$Lb" role="jymVt" />
+    <node concept="3clFb_" id="5zD5ovm$jwh" role="jymVt">
+      <property role="TrG5h" value="append" />
+      <node concept="3clFbS" id="5zD5ovm$jwi" role="3clF47">
+        <node concept="3cpWs8" id="5zD5ovm$jwj" role="3cqZAp">
+          <node concept="3cpWsn" id="5zD5ovm$jwk" role="3cpWs9">
+            <property role="TrG5h" value="result" />
+            <node concept="3uibUv" id="5zD5ovm$jwl" role="1tU5fm">
+              <ref role="3uigEE" node="65ATjZHjTwL" resolve="Path" />
+              <node concept="16syzq" id="65ATjZHEZW8" role="11_B2D">
+                <ref role="16sUi3" node="65ATjZHjU$1" resolve="T" />
+              </node>
+            </node>
+            <node concept="1rXfSq" id="65ATjZHHPJP" role="33vP2m">
+              <ref role="37wK5l" node="65ATjZHHdB4" resolve="cloneObject" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="5zD5ovm$jw$" role="3cqZAp">
+          <node concept="2OqwBi" id="5zD5ovm$jw_" role="3clFbG">
+            <node concept="2OqwBi" id="5zD5ovm$jwA" role="2Oq$k0">
+              <node concept="37vLTw" id="5zD5ovm$jwB" role="2Oq$k0">
+                <ref role="3cqZAo" node="5zD5ovm$jwk" resolve="result" />
+              </node>
+              <node concept="2OwXpG" id="5zD5ovm$jwC" role="2OqNvi">
+                <ref role="2Oxat5" node="5LihCoMhIxN" resolve="segments" />
+              </node>
+            </node>
+            <node concept="X8dFx" id="5zD5ovm$TUC" role="2OqNvi">
+              <node concept="37vLTw" id="5zD5ovm$TUE" role="25WWJ7">
+                <ref role="3cqZAo" node="5zD5ovm$jwJ" resolve="segments" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="1ZWkc2tVYs8" role="3cqZAp">
+          <node concept="37vLTw" id="1ZWkc2tVYsa" role="3cqZAk">
+            <ref role="3cqZAo" node="5zD5ovm$jwk" resolve="result" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="5zD5ovm$jwH" role="1B3o_S" />
+      <node concept="37vLTG" id="5zD5ovm$jwJ" role="3clF46">
+        <property role="TrG5h" value="additionalSegments" />
+        <node concept="A3Dl8" id="1dyouTTnw79" role="1tU5fm">
+          <node concept="16syzq" id="1dyouTTnw7b" role="A3Ik2">
+            <ref role="16sUi3" node="65ATjZHjU$1" resolve="S" />
+          </node>
+        </node>
+      </node>
+      <node concept="3uibUv" id="65ATjZHEIN_" role="3clF45">
+        <ref role="3uigEE" node="65ATjZHjTwL" resolve="Path" />
+        <node concept="16syzq" id="65ATjZHEINA" role="11_B2D">
+          <ref role="16sUi3" node="65ATjZHjU$1" resolve="T" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="65ATjZHEBoF" role="jymVt" />
+    <node concept="3clFb_" id="65ATjZHGrFq" role="jymVt">
+      <property role="TrG5h" value="concat" />
+      <node concept="3clFbS" id="65ATjZHGrFr" role="3clF47">
+        <node concept="3cpWs8" id="65ATjZHGrFs" role="3cqZAp">
+          <node concept="3cpWsn" id="65ATjZHGrFt" role="3cpWs9">
+            <property role="TrG5h" value="result" />
+            <node concept="1rXfSq" id="65ATjZHHHLo" role="33vP2m">
+              <ref role="37wK5l" node="65ATjZHHdB4" resolve="cloneObject" />
+            </node>
+            <node concept="3uibUv" id="65ATjZHGDhP" role="1tU5fm">
+              <ref role="3uigEE" node="65ATjZHjTwL" resolve="Path" />
+              <node concept="16syzq" id="65ATjZHGDhQ" role="11_B2D">
+                <ref role="16sUi3" node="65ATjZHjU$1" resolve="T" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="65ATjZHGrFH" role="3cqZAp">
+          <node concept="2OqwBi" id="65ATjZHGrFI" role="3clFbG">
+            <node concept="2OqwBi" id="65ATjZHGrFJ" role="2Oq$k0">
+              <node concept="37vLTw" id="65ATjZHGrFK" role="2Oq$k0">
+                <ref role="3cqZAo" node="65ATjZHGrFt" resolve="result" />
+              </node>
+              <node concept="2OwXpG" id="65ATjZHGrFL" role="2OqNvi">
+                <ref role="2Oxat5" node="5LihCoMhIxN" resolve="segments" />
+              </node>
+            </node>
+            <node concept="X8dFx" id="65ATjZHGrFM" role="2OqNvi">
+              <node concept="2OqwBi" id="65ATjZHGrFN" role="25WWJ7">
+                <node concept="37vLTw" id="65ATjZHGrFO" role="2Oq$k0">
+                  <ref role="3cqZAo" node="65ATjZHGrFT" resolve="second" />
+                </node>
+                <node concept="2OwXpG" id="65ATjZHGrFP" role="2OqNvi">
+                  <ref role="2Oxat5" node="5LihCoMhIxN" resolve="segments" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="65ATjZHGrFQ" role="3cqZAp">
+          <node concept="37vLTw" id="65ATjZHGrFR" role="3clFbG">
+            <ref role="3cqZAo" node="65ATjZHGrFt" resolve="result" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="65ATjZHGrFS" role="1B3o_S" />
+      <node concept="37vLTG" id="65ATjZHGrFT" role="3clF46">
+        <property role="TrG5h" value="second" />
+        <node concept="3uibUv" id="65ATjZHGA0P" role="1tU5fm">
+          <ref role="3uigEE" node="65ATjZHjTwL" resolve="Path" />
+          <node concept="16syzq" id="65ATjZHGA0Q" role="11_B2D">
+            <ref role="16sUi3" node="65ATjZHjU$1" resolve="T" />
+          </node>
+        </node>
+      </node>
+      <node concept="3uibUv" id="65ATjZHGyUD" role="3clF45">
+        <ref role="3uigEE" node="65ATjZHjTwL" resolve="Path" />
+        <node concept="16syzq" id="65ATjZHGyUE" role="11_B2D">
+          <ref role="16sUi3" node="65ATjZHjU$1" resolve="T" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="3u1rFxek34E" role="jymVt" />
+    <node concept="3clFb_" id="3u1rFxekaQK" role="jymVt">
+      <property role="TrG5h" value="shorten" />
+      <node concept="3clFbS" id="3u1rFxekaQN" role="3clF47">
+        <node concept="3clFbJ" id="3u1rFxekhYi" role="3cqZAp">
+          <node concept="2OqwBi" id="3u1rFxeklvi" role="3clFbw">
+            <node concept="37vLTw" id="3u1rFxekjo1" role="2Oq$k0">
+              <ref role="3cqZAo" node="5LihCoMhIxN" resolve="segments" />
+            </node>
+            <node concept="1v1jN8" id="3u1rFxekoiN" role="2OqNvi" />
+          </node>
+          <node concept="3clFbS" id="3u1rFxekhYk" role="3clFbx">
+            <node concept="3cpWs6" id="3u1rFxekprB" role="3cqZAp">
+              <node concept="2YIFZM" id="3u1rFxeks8K" role="3cqZAk">
+                <ref role="37wK5l" to="33ny:~Optional.empty()" resolve="empty" />
+                <ref role="1Pybhc" to="33ny:~Optional" resolve="Optional" />
+              </node>
+            </node>
+          </node>
+          <node concept="9aQIb" id="3u1rFxeksVx" role="9aQIa">
+            <node concept="3clFbS" id="3u1rFxeksVy" role="9aQI4">
+              <node concept="3cpWs8" id="3u1rFxektGM" role="3cqZAp">
+                <node concept="3cpWsn" id="3u1rFxektGN" role="3cpWs9">
+                  <property role="TrG5h" value="result" />
+                  <node concept="1rXfSq" id="3u1rFxektGO" role="33vP2m">
+                    <ref role="37wK5l" node="65ATjZHHdB4" resolve="cloneObject" />
+                  </node>
+                  <node concept="3uibUv" id="3u1rFxektGP" role="1tU5fm">
+                    <ref role="3uigEE" node="65ATjZHjTwL" resolve="Path" />
+                    <node concept="16syzq" id="3u1rFxektGQ" role="11_B2D">
+                      <ref role="16sUi3" node="65ATjZHjU$1" resolve="T" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbF" id="3u1rFxektGR" role="3cqZAp">
+                <node concept="2OqwBi" id="3u1rFxektGS" role="3clFbG">
+                  <node concept="2OqwBi" id="3u1rFxektGT" role="2Oq$k0">
+                    <node concept="37vLTw" id="3u1rFxektGU" role="2Oq$k0">
+                      <ref role="3cqZAo" node="3u1rFxektGN" resolve="result" />
+                    </node>
+                    <node concept="2OwXpG" id="3u1rFxektGV" role="2OqNvi">
+                      <ref role="2Oxat5" node="5LihCoMhIxN" resolve="segments" />
+                    </node>
+                  </node>
+                  <node concept="2Kt5_m" id="3u1rFxek_pH" role="2OqNvi" />
+                </node>
+              </node>
+              <node concept="3cpWs6" id="3u1rFxekBnW" role="3cqZAp">
+                <node concept="2YIFZM" id="3u1rFxekDFE" role="3cqZAk">
+                  <ref role="37wK5l" to="33ny:~Optional.of(java.lang.Object)" resolve="of" />
+                  <ref role="1Pybhc" to="33ny:~Optional" resolve="Optional" />
+                  <node concept="37vLTw" id="3u1rFxekEV3" role="37wK5m">
+                    <ref role="3cqZAo" node="3u1rFxektGN" resolve="result" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="3u1rFxek7ON" role="1B3o_S" />
+      <node concept="3uibUv" id="3u1rFxeke0a" role="3clF45">
+        <ref role="3uigEE" to="33ny:~Optional" resolve="Optional" />
+        <node concept="3uibUv" id="3u1rFxekfXG" role="11_B2D">
+          <ref role="3uigEE" node="65ATjZHjTwL" resolve="ImmutablePath" />
+          <node concept="16syzq" id="3u1rFxekhb1" role="11_B2D">
+            <ref role="16sUi3" node="65ATjZHjU$1" resolve="S" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="3u1rFxekKnU" role="jymVt" />
+    <node concept="3clFb_" id="65ATjZHHdB4" role="jymVt">
+      <property role="TrG5h" value="cloneObject" />
+      <node concept="3clFbS" id="65ATjZHHdB7" role="3clF47">
+        <node concept="3cpWs8" id="65ATjZHHkP6" role="3cqZAp">
+          <node concept="3cpWsn" id="65ATjZHHkP7" role="3cpWs9">
+            <property role="TrG5h" value="result" />
+            <node concept="1rXfSq" id="65ATjZHHkP8" role="33vP2m">
+              <ref role="37wK5l" node="65ATjZH$y4K" resolve="create" />
+            </node>
+            <node concept="3uibUv" id="65ATjZHPqqU" role="1tU5fm">
+              <ref role="3uigEE" node="65ATjZHjTwL" resolve="Path" />
+              <node concept="16syzq" id="65ATjZHPqqV" role="11_B2D">
+                <ref role="16sUi3" node="65ATjZHjU$1" resolve="T" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="65ATjZHHkPb" role="3cqZAp">
+          <node concept="2OqwBi" id="65ATjZHHkPc" role="3clFbG">
+            <node concept="2OqwBi" id="65ATjZHHkPd" role="2Oq$k0">
+              <node concept="37vLTw" id="65ATjZHHkPe" role="2Oq$k0">
+                <ref role="3cqZAo" node="65ATjZHHkP7" resolve="result" />
+              </node>
+              <node concept="2OwXpG" id="65ATjZHHkPf" role="2OqNvi">
+                <ref role="2Oxat5" node="5LihCoMhIxN" resolve="segments" />
+              </node>
+            </node>
+            <node concept="X8dFx" id="65ATjZHHkPg" role="2OqNvi">
+              <node concept="2OqwBi" id="65ATjZHHkPh" role="25WWJ7">
+                <node concept="Xjq3P" id="65ATjZHHkPi" role="2Oq$k0" />
+                <node concept="2OwXpG" id="65ATjZHHkPj" role="2OqNvi">
+                  <ref role="2Oxat5" node="5LihCoMhIxN" resolve="segments" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="65ATjZHHwbM" role="3cqZAp">
+          <node concept="37vLTw" id="65ATjZHHwbK" role="3clFbG">
+            <ref role="3cqZAo" node="65ATjZHHkP7" resolve="result" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tmbuc" id="3u1rFxep7aA" role="1B3o_S" />
+      <node concept="3uibUv" id="65ATjZHPl5U" role="3clF45">
+        <ref role="3uigEE" node="65ATjZHjTwL" resolve="Path" />
+        <node concept="16syzq" id="65ATjZHPobK" role="11_B2D">
+          <ref role="16sUi3" node="65ATjZHjU$1" resolve="T" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="65ATjZHCniu" role="jymVt" />
+    <node concept="3clFb_" id="1ys6gNH1HKs" role="jymVt">
+      <property role="TrG5h" value="hashCode" />
+      <node concept="3Tm1VV" id="1ys6gNH1HKt" role="1B3o_S" />
+      <node concept="10Oyi0" id="1ys6gNH1HKw" role="3clF45" />
+      <node concept="3clFbS" id="1ys6gNH1HKx" role="3clF47">
+        <node concept="3clFbF" id="65ATjZHrwA6" role="3cqZAp">
+          <node concept="2OqwBi" id="65ATjZHrysV" role="3clFbG">
+            <node concept="37vLTw" id="65ATjZHrwA4" role="2Oq$k0">
+              <ref role="3cqZAo" node="5LihCoMhIxN" resolve="segments" />
+            </node>
+            <node concept="1MD8d$" id="65ATjZHrB4G" role="2OqNvi">
+              <node concept="1bVj0M" id="65ATjZHrB4I" role="23t8la">
+                <node concept="3clFbS" id="65ATjZHrB4J" role="1bW5cS">
+                  <node concept="3clFbF" id="65ATjZHrDpF" role="3cqZAp">
+                    <node concept="3cpWs3" id="65ATjZHrDpH" role="3clFbG">
+                      <node concept="2OqwBi" id="65ATjZHrDpI" role="3uHU7w">
+                        <node concept="37vLTw" id="65ATjZHrJcP" role="2Oq$k0">
+                          <ref role="3cqZAo" node="65ATjZHrB4M" resolve="it" />
+                        </node>
+                        <node concept="liA8E" id="65ATjZHrDpK" role="2OqNvi">
+                          <ref role="37wK5l" to="wyt6:~Object.hashCode()" resolve="hashCode" />
+                        </node>
+                      </node>
+                      <node concept="17qRlL" id="65ATjZHrDpL" role="3uHU7B">
+                        <node concept="3cmrfG" id="65ATjZHrDpM" role="3uHU7B">
+                          <property role="3cmrfH" value="31" />
+                        </node>
+                        <node concept="37vLTw" id="65ATjZHrDpN" role="3uHU7w">
+                          <ref role="3cqZAo" node="65ATjZHrB4K" resolve="s" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="gl6BB" id="65ATjZHrB4K" role="1bW2Oz">
+                  <property role="TrG5h" value="s" />
+                  <node concept="2jxLKc" id="65ATjZHrB4L" role="1tU5fm" />
+                </node>
+                <node concept="gl6BB" id="65ATjZHrB4M" role="1bW2Oz">
+                  <property role="TrG5h" value="it" />
+                  <node concept="2jxLKc" id="65ATjZHrB4N" role="1tU5fm" />
+                </node>
+              </node>
+              <node concept="3cmrfG" id="65ATjZHrCAV" role="1MDeny">
+                <property role="3cmrfH" value="7" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="1ys6gNH1HKy" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="1ys6gNH1O66" role="jymVt" />
+    <node concept="3clFb_" id="1ys6gNH1HK_" role="jymVt">
+      <property role="TrG5h" value="equals" />
+      <node concept="3Tm1VV" id="1ys6gNH1HKA" role="1B3o_S" />
+      <node concept="10P_77" id="1ys6gNH1HKC" role="3clF45" />
+      <node concept="37vLTG" id="1ys6gNH1HKD" role="3clF46">
+        <property role="TrG5h" value="obj" />
+        <node concept="3uibUv" id="1ys6gNH1HKE" role="1tU5fm">
+          <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="1ys6gNH1HKF" role="3clF47">
+        <node concept="3clFbJ" id="1ys6gNH1PBo" role="3cqZAp">
+          <node concept="3clFbS" id="1ys6gNH1PBp" role="3clFbx">
+            <node concept="3cpWs6" id="1ys6gNH1PBq" role="3cqZAp">
+              <node concept="3clFbT" id="1ys6gNH1PBr" role="3cqZAk">
+                <property role="3clFbU" value="true" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbC" id="1ys6gNH1PBs" role="3clFbw">
+            <node concept="Xjq3P" id="1ys6gNH1PBt" role="3uHU7w" />
+            <node concept="37vLTw" id="1ys6gNH1PBu" role="3uHU7B">
+              <ref role="3cqZAo" node="1ys6gNH1HKD" resolve="obj" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="1ys6gNH1PBv" role="3cqZAp">
+          <node concept="3clFbS" id="1ys6gNH1PBw" role="3clFbx">
+            <node concept="3cpWs6" id="1ys6gNH1PBx" role="3cqZAp">
+              <node concept="3clFbT" id="1ys6gNH1PBy" role="3cqZAk" />
+            </node>
+          </node>
+          <node concept="3fqX7Q" id="1ys6gNH1PBz" role="3clFbw">
+            <node concept="2ZW3vV" id="1ys6gNH1PB$" role="3fr31v">
+              <node concept="37vLTw" id="1ys6gNH1PBA" role="2ZW6bz">
+                <ref role="3cqZAo" node="1ys6gNH1HKD" resolve="obj" />
+              </node>
+              <node concept="3uibUv" id="65ATjZHr2pW" role="2ZW6by">
+                <ref role="3uigEE" node="65ATjZHjTwL" resolve="Path" />
+              </node>
+            </node>
+          </node>
+          <node concept="15s5l7" id="65ATjZHru$G" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;" />
+            <property role="huDt6" value="all typesystem messages" />
+          </node>
+        </node>
+        <node concept="3cpWs8" id="1ys6gNH1W8v" role="3cqZAp">
+          <node concept="3cpWsn" id="1ys6gNH1W8w" role="3cpWs9">
+            <property role="TrG5h" value="other" />
+            <node concept="3uibUv" id="1ys6gNH1W8x" role="1tU5fm">
+              <ref role="3uigEE" node="65ATjZHjTwL" resolve="Path" />
+              <node concept="16syzq" id="65ATjZHrlDo" role="11_B2D">
+                <ref role="16sUi3" node="65ATjZHjU$1" resolve="T" />
+              </node>
+            </node>
+            <node concept="0kSF2" id="65ATjZHr5Pc" role="33vP2m">
+              <node concept="3uibUv" id="65ATjZHr5Pf" role="0kSFW">
+                <ref role="3uigEE" node="65ATjZHjTwL" resolve="Path" />
+                <node concept="16syzq" id="65ATjZHrjxM" role="11_B2D">
+                  <ref role="16sUi3" node="65ATjZHjU$1" resolve="T" />
+                </node>
+              </node>
+              <node concept="37vLTw" id="65ATjZHr5jU" role="0kSFX">
+                <ref role="3cqZAo" node="1ys6gNH1HKD" resolve="obj" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="1ys6gNH3TjG" role="3cqZAp" />
+        <node concept="3SKdUt" id="1ys6gNH3I2I" role="3cqZAp">
+          <node concept="1PaTwC" id="1ys6gNH3I2J" role="1aUNEU">
+            <node concept="3oM_SD" id="1ys6gNH3Kle" role="1PaTwD">
+              <property role="3oM_SC" value="compare" />
+            </node>
+            <node concept="3oM_SD" id="1ys6gNH3Klg" role="1PaTwD">
+              <property role="3oM_SC" value="segment" />
+            </node>
+            <node concept="3oM_SD" id="1ys6gNH3Klj" role="1PaTwD">
+              <property role="3oM_SC" value="list" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="1ys6gNH3EE3" role="3cqZAp">
+          <node concept="17R0WA" id="55NPLvSFT95" role="3clFbG">
+            <node concept="2OqwBi" id="55NPLvSG5lh" role="3uHU7w">
+              <node concept="37vLTw" id="55NPLvSFYYe" role="2Oq$k0">
+                <ref role="3cqZAo" node="1ys6gNH1W8w" resolve="other" />
+              </node>
+              <node concept="2OwXpG" id="55NPLvSGc8T" role="2OqNvi">
+                <ref role="2Oxat5" node="5LihCoMhIxN" resolve="segments" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="55NPLvSFuP_" role="3uHU7B">
+              <node concept="Xjq3P" id="55NPLvSFowX" role="2Oq$k0" />
+              <node concept="2OwXpG" id="55NPLvSF_EJ" role="2OqNvi">
+                <ref role="2Oxat5" node="5LihCoMhIxN" resolve="segments" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="1ys6gNH1HKG" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="65ATjZHlnZB" role="jymVt" />
+    <node concept="3UR2Jj" id="1dyouTTKrPq" role="lGtFl">
+      <node concept="TZ5HA" id="1dyouTTKrPr" role="TZ5H$">
+        <node concept="1dT_AC" id="1dyouTTKrPs" role="1dT_Ay">
+          <property role="1dT_AB" value="A class representing a sequence of segments comprising a &quot;path&quot;." />
+        </node>
+      </node>
+      <node concept="TZ5HA" id="1dyouTTKtBM" role="TZ5H$">
+        <node concept="1dT_AC" id="1dyouTTKtBN" role="1dT_Ay">
+          <property role="1dT_AB" value="" />
+        </node>
+      </node>
+      <node concept="TZ5HA" id="1dyouTTKur5" role="TZ5H$">
+        <node concept="1dT_AC" id="1dyouTTKur6" role="1dT_Ay">
+          <property role="1dT_AB" value="The implementation is immutable, i.e. the path objects are never changed." />
+        </node>
+      </node>
+      <node concept="TUZQ0" id="1dyouTTKrPt" role="3nqlJM">
+        <property role="TUZQ4" value="the type of the path's segments" />
+        <node concept="zr_56" id="1dyouTTKrPv" role="zr_5Q">
+          <ref role="zr_51" node="65ATjZHjU$1" resolve="S" />
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="312cEu" id="65ATjZHjU$h">
+    <property role="TrG5h" value="InstancePath" />
+    <property role="1sVAO0" value="true" />
+    <property role="3GE5qa" value="instantiation" />
+    <node concept="3Tm1VV" id="65ATjZHjU$i" role="1B3o_S" />
+    <node concept="16euLQ" id="65ATjZHlpYF" role="16eVyc">
+      <property role="TrG5h" value="D" />
+    </node>
+    <node concept="16euLQ" id="65ATjZHjU$J" role="16eVyc">
+      <property role="TrG5h" value="S" />
+    </node>
+    <node concept="3uibUv" id="65ATjZHk76V" role="1zkMxy">
+      <ref role="3uigEE" node="65ATjZHjTwL" resolve="Path" />
+      <node concept="16syzq" id="65ATjZHk78w" role="11_B2D">
+        <ref role="16sUi3" node="65ATjZHjU$J" resolve="T" />
+      </node>
+    </node>
+    <node concept="312cEg" id="65ATjZHlp_8" role="jymVt">
+      <property role="TrG5h" value="root" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm6S6" id="65ATjZHloP8" role="1B3o_S" />
+      <node concept="16syzq" id="65ATjZHlpBL" role="1tU5fm">
+        <ref role="16sUi3" node="65ATjZHlpYF" resolve="R" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="65ATjZHlpCi" role="jymVt" />
+    <node concept="3clFbW" id="65ATjZHltXU" role="jymVt">
+      <node concept="37vLTG" id="65ATjZHlu15" role="3clF46">
+        <property role="TrG5h" value="root" />
+        <node concept="16syzq" id="65ATjZHlu4$" role="1tU5fm">
+          <ref role="16sUi3" node="65ATjZHlpYF" resolve="R" />
+        </node>
+      </node>
+      <node concept="3cqZAl" id="65ATjZHltXW" role="3clF45" />
+      <node concept="3Tm1VV" id="65ATjZHltXX" role="1B3o_S" />
+      <node concept="3clFbS" id="65ATjZHltXY" role="3clF47">
+        <node concept="3clFbF" id="65ATjZHlup6" role="3cqZAp">
+          <node concept="37vLTI" id="65ATjZHlvlG" role="3clFbG">
+            <node concept="37vLTw" id="65ATjZHlvy1" role="37vLTx">
+              <ref role="3cqZAo" node="65ATjZHlu15" resolve="root" />
+            </node>
+            <node concept="2OqwBi" id="65ATjZHluGH" role="37vLTJ">
+              <node concept="Xjq3P" id="65ATjZHlup5" role="2Oq$k0" />
+              <node concept="2OwXpG" id="65ATjZHlvat" role="2OqNvi">
+                <ref role="2Oxat5" node="65ATjZHlp_8" resolve="root" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="65ATjZHlB8h" role="jymVt" />
+    <node concept="3clFbW" id="65ATjZHlpIu" role="jymVt">
+      <node concept="3cqZAl" id="65ATjZHlpIw" role="3clF45" />
+      <node concept="3Tm1VV" id="65ATjZHlpIx" role="1B3o_S" />
+      <node concept="3clFbS" id="65ATjZHlpIy" role="3clF47">
+        <node concept="XkiVB" id="65ATjZHlqsd" role="3cqZAp">
+          <ref role="37wK5l" node="65ATjZHljwS" resolve="Path" />
+          <node concept="37vLTw" id="65ATjZHlqVR" role="37wK5m">
+            <ref role="3cqZAo" node="65ATjZHlpNM" resolve="segments" />
+          </node>
+        </node>
+        <node concept="3clFbF" id="65ATjZHlxCY" role="3cqZAp">
+          <node concept="37vLTI" id="65ATjZHlyEH" role="3clFbG">
+            <node concept="37vLTw" id="65ATjZHlB5m" role="37vLTx">
+              <ref role="3cqZAo" node="65ATjZHlpMB" resolve="root" />
+            </node>
+            <node concept="2OqwBi" id="65ATjZHlxX6" role="37vLTJ">
+              <node concept="Xjq3P" id="65ATjZHlxCW" role="2Oq$k0" />
+              <node concept="2OwXpG" id="65ATjZHlyrn" role="2OqNvi">
+                <ref role="2Oxat5" node="65ATjZHlp_8" resolve="root" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="65ATjZHlpMB" role="3clF46">
+        <property role="TrG5h" value="root" />
+        <node concept="16syzq" id="65ATjZHlpMA" role="1tU5fm">
+          <ref role="16sUi3" node="65ATjZHlpYF" resolve="R" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="65ATjZHlpNM" role="3clF46">
+        <property role="TrG5h" value="segments" />
+        <node concept="A3Dl8" id="65ATjZHlpTr" role="1tU5fm">
+          <node concept="16syzq" id="65ATjZHlpXE" role="A3Ik2">
+            <ref role="16sUi3" node="65ATjZHjU$J" resolve="T" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="65ATjZHlsyo" role="jymVt" />
+    <node concept="3clFb_" id="3u1rFxdQl6C" role="jymVt">
+      <property role="1EzhhJ" value="true" />
+      <property role="TrG5h" value="getDefinition" />
+      <node concept="37vLTG" id="3u1rFxdQn31" role="3clF46">
+        <property role="TrG5h" value="segment" />
+        <node concept="16syzq" id="3u1rFxdQruO" role="1tU5fm">
+          <ref role="16sUi3" node="65ATjZHjU$J" resolve="S" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="3u1rFxdQl6F" role="3clF47" />
+      <node concept="3Tmbuc" id="3u1rFxdVj6g" role="1B3o_S" />
+      <node concept="3uibUv" id="1dyouTTeVUO" role="3clF45">
+        <ref role="3uigEE" to="33ny:~Optional" resolve="Optional" />
+        <node concept="16syzq" id="1dyouTTeX2o" role="11_B2D">
+          <ref role="16sUi3" node="65ATjZHlpYF" resolve="D" />
+        </node>
+      </node>
+      <node concept="P$JXv" id="1dyouTTLC4y" role="lGtFl">
+        <node concept="TZ5HA" id="1dyouTTLC4z" role="TZ5H$">
+          <node concept="1dT_AC" id="1dyouTTLC4$" role="1dT_Ay">
+            <property role="1dT_AB" value="Provide the definition object for some segment." />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="1dyouTTLKtL" role="TZ5H$">
+          <node concept="1dT_AC" id="1dyouTTLKtM" role="1dT_Ay">
+            <property role="1dT_AB" value="" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="1dyouTTLLcx" role="TZ5H$">
+          <node concept="1dT_AC" id="1dyouTTLLcy" role="1dT_Ay">
+            <property role="1dT_AB" value="Note that this method does not require that the segment is actually part of the path." />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="1dyouTTLNXz" role="TZ5H$">
+          <node concept="1dT_AC" id="1dyouTTLNX$" role="1dT_Ay">
+            <property role="1dT_AB" value="Instead, the method is computing its result independent from the path-object &quot;this&quot;." />
+          </node>
+        </node>
+        <node concept="TUZQ0" id="1dyouTTLC4_" role="3nqlJM">
+          <property role="TUZQ4" value="some segment" />
+          <node concept="zr_55" id="1dyouTTLC4B" role="zr_5Q">
+            <ref role="zr_51" node="3u1rFxdQn31" resolve="segment" />
+          </node>
+        </node>
+        <node concept="x79VA" id="1dyouTTLC4C" role="3nqlJM">
+          <property role="x79VB" value="the corresponding definition object (or empty)" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="3u1rFxdU7Rz" role="jymVt" />
+    <node concept="3clFb_" id="65ATjZHvqwK" role="jymVt">
+      <property role="1EzhhJ" value="true" />
+      <property role="TrG5h" value="getRootPresentation" />
+      <node concept="3clFbS" id="65ATjZHvqwN" role="3clF47" />
+      <node concept="3Tmbuc" id="3u1rFxdVqtl" role="1B3o_S" />
+      <node concept="17QB3L" id="65ATjZHvpWV" role="3clF45" />
+    </node>
+    <node concept="2tJIrI" id="65ATjZH$jSv" role="jymVt" />
+    <node concept="3clFb_" id="65ATjZHmLvj" role="jymVt">
+      <property role="TrG5h" value="root" />
+      <node concept="3clFbS" id="65ATjZHmLvm" role="3clF47">
+        <node concept="3clFbF" id="65ATjZHmNcA" role="3cqZAp">
+          <node concept="2OqwBi" id="65ATjZHmNX1" role="3clFbG">
+            <node concept="Xjq3P" id="65ATjZHmNc_" role="2Oq$k0" />
+            <node concept="2OwXpG" id="65ATjZHmOyh" role="2OqNvi">
+              <ref role="2Oxat5" node="65ATjZHlp_8" resolve="root" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="65ATjZHmFwz" role="1B3o_S" />
+      <node concept="16syzq" id="65ATjZHmKZn" role="3clF45">
+        <ref role="16sUi3" node="65ATjZHlpYF" resolve="R" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="3u1rFxdRc9O" role="jymVt" />
+    <node concept="3clFb_" id="5LihCoMi1n7" role="jymVt">
+      <property role="TrG5h" value="getLeaf" />
+      <node concept="3clFbS" id="5LihCoMi1na" role="3clF47">
+        <node concept="3cpWs8" id="3u1rFxdRHx5" role="3cqZAp">
+          <node concept="3cpWsn" id="3u1rFxdRHx6" role="3cpWs9">
+            <property role="TrG5h" value="found" />
+            <node concept="16syzq" id="3u1rFxdRFTz" role="1tU5fm">
+              <ref role="16sUi3" node="65ATjZHjU$J" resolve="T" />
+            </node>
+            <node concept="2OqwBi" id="3u1rFxdRHx7" role="33vP2m">
+              <node concept="1rXfSq" id="3u1rFxdRHx8" role="2Oq$k0">
+                <ref role="37wK5l" node="3u1rFxdFBU5" resolve="segments" />
+              </node>
+              <node concept="1zesIP" id="3u1rFxdRHx9" role="2OqNvi">
+                <node concept="1bVj0M" id="3u1rFxdRHxa" role="23t8la">
+                  <node concept="3clFbS" id="3u1rFxdRHxb" role="1bW5cS">
+                    <node concept="3clFbF" id="3u1rFxdRHxc" role="3cqZAp">
+                      <node concept="2OqwBi" id="1dyouTTgfhU" role="3clFbG">
+                        <node concept="1rXfSq" id="3u1rFxdRHxf" role="2Oq$k0">
+                          <ref role="37wK5l" node="3u1rFxdQl6C" resolve="getTarget" />
+                          <node concept="37vLTw" id="3u1rFxdRHxg" role="37wK5m">
+                            <ref role="3cqZAo" node="3u1rFxdRHxh" resolve="it" />
+                          </node>
+                        </node>
+                        <node concept="liA8E" id="1dyouTTggFS" role="2OqNvi">
+                          <ref role="37wK5l" to="33ny:~Optional.isPresent()" resolve="isPresent" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="gl6BB" id="3u1rFxdRHxh" role="1bW2Oz">
+                    <property role="TrG5h" value="it" />
+                    <node concept="2jxLKc" id="3u1rFxdRHxi" role="1tU5fm" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="1dyouTTfkxR" role="3cqZAp">
+          <node concept="3clFbS" id="1dyouTTfkxT" role="3clFbx">
+            <node concept="3cpWs6" id="3u1rFxdSkSi" role="3cqZAp">
+              <node concept="1rXfSq" id="3u1rFxdSrqh" role="3cqZAk">
+                <ref role="37wK5l" node="65ATjZHmLvj" resolve="root" />
+              </node>
+            </node>
+          </node>
+          <node concept="17R0WA" id="1dyouTTfp_l" role="3clFbw">
+            <node concept="10Nm6u" id="1dyouTTfvi_" role="3uHU7w" />
+            <node concept="37vLTw" id="1dyouTTfmcz" role="3uHU7B">
+              <ref role="3cqZAo" node="3u1rFxdRHx6" resolve="found" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="1dyouTTf_Fb" role="3cqZAp">
+          <node concept="2OqwBi" id="1dyouTTfN4P" role="3clFbG">
+            <node concept="1rXfSq" id="1dyouTTf_F9" role="2Oq$k0">
+              <ref role="37wK5l" node="3u1rFxdQl6C" resolve="getTarget" />
+              <node concept="37vLTw" id="1dyouTTfF6t" role="37wK5m">
+                <ref role="3cqZAo" node="3u1rFxdRHx6" resolve="found" />
+              </node>
+            </node>
+            <node concept="liA8E" id="1dyouTTgjKg" role="2OqNvi">
+              <ref role="37wK5l" to="33ny:~Optional.get()" resolve="get" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="5LihCoMi1f3" role="1B3o_S" />
+      <node concept="16syzq" id="3u1rFxdRyrj" role="3clF45">
+        <ref role="16sUi3" node="65ATjZHlpYF" resolve="R" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="1dyouTTgm6I" role="jymVt" />
+    <node concept="3clFb_" id="1dyouTTgvA2" role="jymVt">
+      <property role="TrG5h" value="hasDefinition" />
+      <node concept="3clFbS" id="1dyouTTgvA5" role="3clF47">
+        <node concept="3clFbF" id="1dyouTTgzd9" role="3cqZAp">
+          <node concept="2OqwBi" id="1dyouTThcb2" role="3clFbG">
+            <node concept="2OqwBi" id="1dyouTTgGLZ" role="2Oq$k0">
+              <node concept="1rXfSq" id="1dyouTTgzd8" role="2Oq$k0">
+                <ref role="37wK5l" node="3u1rFxdQl6C" resolve="getDefinition" />
+                <node concept="37vLTw" id="1dyouTTgFuB" role="37wK5m">
+                  <ref role="3cqZAo" node="1dyouTTgCGK" resolve="segment" />
+                </node>
+              </node>
+              <node concept="liA8E" id="1dyouTTgIqA" role="2OqNvi">
+                <ref role="37wK5l" to="33ny:~Optional.map(java.util.function.Function)" resolve="map" />
+                <node concept="1bVj0M" id="1dyouTTgJEl" role="37wK5m">
+                  <node concept="gl6BB" id="1dyouTTgJEC" role="1bW2Oz">
+                    <property role="TrG5h" value="d" />
+                    <node concept="2jxLKc" id="1dyouTTgJED" role="1tU5fm" />
+                  </node>
+                  <node concept="3clFbS" id="1dyouTTgJF9" role="1bW5cS">
+                    <node concept="3clFbF" id="1dyouTTgRsU" role="3cqZAp">
+                      <node concept="17R0WA" id="1dyouTTh2Zm" role="3clFbG">
+                        <node concept="37vLTw" id="1dyouTTh5eA" role="3uHU7w">
+                          <ref role="3cqZAo" node="1dyouTTgx9D" resolve="definition" />
+                        </node>
+                        <node concept="37vLTw" id="1dyouTTgRsT" role="3uHU7B">
+                          <ref role="3cqZAo" node="1dyouTTgJEC" resolve="d" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="liA8E" id="1dyouTTheYX" role="2OqNvi">
+              <ref role="37wK5l" to="33ny:~Optional.orElse(java.lang.Object)" resolve="orElse" />
+              <node concept="3clFbT" id="1dyouTThgFo" role="37wK5m" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="1dyouTTgtzA" role="1B3o_S" />
+      <node concept="10P_77" id="1dyouTTgvaY" role="3clF45" />
+      <node concept="37vLTG" id="1dyouTTgCGK" role="3clF46">
+        <property role="TrG5h" value="segment" />
+        <node concept="16syzq" id="1dyouTTgDRB" role="1tU5fm">
+          <ref role="16sUi3" node="65ATjZHjU$J" resolve="S" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="1dyouTTgx9D" role="3clF46">
+        <property role="TrG5h" value="definition" />
+        <node concept="16syzq" id="1dyouTTgx9C" role="1tU5fm">
+          <ref role="16sUi3" node="65ATjZHlpYF" resolve="D" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="55NPLvSE7KC" role="jymVt" />
+    <node concept="3clFb_" id="5LihCoMiagY" role="jymVt">
+      <property role="TrG5h" value="visits" />
+      <node concept="3clFbS" id="5LihCoMiah1" role="3clF47">
+        <node concept="3clFbF" id="5LihCoMibbz" role="3cqZAp">
+          <node concept="22lmx$" id="5LihCoMicUm" role="3clFbG">
+            <node concept="2OqwBi" id="5LihCoMierU" role="3uHU7w">
+              <node concept="1rXfSq" id="65ATjZHzSA2" role="2Oq$k0">
+                <ref role="37wK5l" node="3u1rFxdFBU5" resolve="segments" />
+              </node>
+              <node concept="2HwmR7" id="5LihCoMif7J" role="2OqNvi">
+                <node concept="1bVj0M" id="5LihCoMif7L" role="23t8la">
+                  <node concept="3clFbS" id="5LihCoMif7M" role="1bW5cS">
+                    <node concept="3clFbF" id="5LihCoMifGI" role="3cqZAp">
+                      <node concept="1rXfSq" id="1dyouTThrtZ" role="3clFbG">
+                        <ref role="37wK5l" node="1dyouTTgvA2" resolve="hasTarget" />
+                        <node concept="37vLTw" id="1dyouTThu9L" role="37wK5m">
+                          <ref role="3cqZAo" node="2r1kIC$yAxz" resolve="it" />
+                        </node>
+                        <node concept="37vLTw" id="1dyouTThw9T" role="37wK5m">
+                          <ref role="3cqZAo" node="5LihCoMiaJ7" resolve="definition" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="gl6BB" id="2r1kIC$yAxz" role="1bW2Oz">
+                    <property role="TrG5h" value="it" />
+                    <node concept="2jxLKc" id="2r1kIC$yAx$" role="1tU5fm" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="17R0WA" id="5LihCoMibTh" role="3uHU7B">
+              <node concept="37vLTw" id="5LihCoMibby" role="3uHU7B">
+                <ref role="3cqZAo" node="5LihCoMiaJ7" resolve="ivaa" />
+              </node>
+              <node concept="1rXfSq" id="65ATjZHzKNb" role="3uHU7w">
+                <ref role="37wK5l" node="65ATjZHmLvj" resolve="root" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="5LihCoMi9WB" role="1B3o_S" />
+      <node concept="10P_77" id="5LihCoMiagP" role="3clF45" />
+      <node concept="37vLTG" id="5LihCoMiaJ7" role="3clF46">
+        <property role="TrG5h" value="definition" />
+        <node concept="16syzq" id="3u1rFxdSykp" role="1tU5fm">
+          <ref role="16sUi3" node="65ATjZHlpYF" resolve="R" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="3u1rFxelbMg" role="jymVt" />
+    <node concept="3clFb_" id="3u1rFxeqM8T" role="jymVt">
+      <property role="TrG5h" value="concatSafe" />
+      <node concept="37vLTG" id="3u1rFxeqPBN" role="3clF46">
+        <property role="TrG5h" value="subPath" />
+        <node concept="3uibUv" id="3u1rFxeqUxD" role="1tU5fm">
+          <ref role="3uigEE" node="65ATjZHjU$h" resolve="InstancePath" />
+          <node concept="16syzq" id="3u1rFxeqWo$" role="11_B2D">
+            <ref role="16sUi3" node="65ATjZHlpYF" resolve="D" />
+          </node>
+          <node concept="16syzq" id="3u1rFxer2lm" role="11_B2D">
+            <ref role="16sUi3" node="65ATjZHjU$J" resolve="S" />
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbS" id="3u1rFxeqM8W" role="3clF47">
+        <node concept="3SKdUt" id="1ZHv_j8jcLB" role="3cqZAp">
+          <node concept="1PaTwC" id="59FNqAPCJ9G" role="1aUNEU">
+            <node concept="3oM_SD" id="59FNqAPCJ9H" role="1PaTwD">
+              <property role="3oM_SC" value="sanity" />
+            </node>
+            <node concept="3oM_SD" id="3u1rFxeqws9" role="1PaTwD">
+              <property role="3oM_SC" value="check:" />
+            </node>
+            <node concept="3oM_SD" id="3u1rFxeqwAF" role="1PaTwD">
+              <property role="3oM_SC" value="root" />
+            </node>
+            <node concept="3oM_SD" id="59FNqAPCJ9I" role="1PaTwD">
+              <property role="3oM_SC" value="of" />
+            </node>
+            <node concept="3oM_SD" id="59FNqAPCJ9J" role="1PaTwD">
+              <property role="3oM_SC" value="subPath" />
+            </node>
+            <node concept="3oM_SD" id="59FNqAPCJ9K" role="1PaTwD">
+              <property role="3oM_SC" value="must" />
+            </node>
+            <node concept="3oM_SD" id="59FNqAPCJ9L" role="1PaTwD">
+              <property role="3oM_SC" value="match" />
+            </node>
+            <node concept="3oM_SD" id="59FNqAPCJ9M" role="1PaTwD">
+              <property role="3oM_SC" value="leaf" />
+            </node>
+            <node concept="3oM_SD" id="59FNqAPCJ9N" role="1PaTwD">
+              <property role="3oM_SC" value="instance" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="1ZHv_j8jcOJ" role="3cqZAp">
+          <node concept="3clFbS" id="1ZHv_j8jcOL" role="3clFbx">
+            <node concept="3cpWs6" id="1ZHv_j8jlRG" role="3cqZAp">
+              <node concept="2YIFZM" id="3u1rFxerqrt" role="3cqZAk">
+                <ref role="37wK5l" to="33ny:~Optional.empty()" resolve="empty" />
+                <ref role="1Pybhc" to="33ny:~Optional" resolve="Optional" />
+              </node>
+            </node>
+          </node>
+          <node concept="17QLQc" id="3u1rFxeq2fD" role="3clFbw">
+            <node concept="2OqwBi" id="1ZHv_j8jcUi" role="3uHU7B">
+              <node concept="37vLTw" id="1ZHv_j8jcQR" role="2Oq$k0">
+                <ref role="3cqZAo" node="3u1rFxeqPBN" resolve="subPath" />
+              </node>
+              <node concept="liA8E" id="3u1rFxem$Q5" role="2OqNvi">
+                <ref role="37wK5l" node="65ATjZHmLvj" resolve="root" />
+              </node>
+            </node>
+            <node concept="1rXfSq" id="3u1rFxeqdea" role="3uHU7w">
+              <ref role="37wK5l" node="5LihCoMi1n7" resolve="getLeaf" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="1ZHv_j8jn24" role="3cqZAp" />
+        <node concept="3SKdUt" id="3u1rFxes5t7" role="3cqZAp">
+          <node concept="1PaTwC" id="3u1rFxes5t8" role="1aUNEU">
+            <node concept="3oM_SD" id="3u1rFxes5t9" role="1PaTwD">
+              <property role="3oM_SC" value="do" />
+            </node>
+            <node concept="3oM_SD" id="3u1rFxes6J1" role="1PaTwD">
+              <property role="3oM_SC" value="actual" />
+            </node>
+            <node concept="3oM_SD" id="3u1rFxes6J3" role="1PaTwD">
+              <property role="3oM_SC" value="concatenation" />
+            </node>
+            <node concept="3oM_SD" id="3u1rFxes7e4" role="1PaTwD">
+              <property role="3oM_SC" value="of" />
+            </node>
+            <node concept="3oM_SD" id="3u1rFxes7e5" role="1PaTwD">
+              <property role="3oM_SC" value="segments," />
+            </node>
+            <node concept="3oM_SD" id="3u1rFxes7yA" role="1PaTwD">
+              <property role="3oM_SC" value="will" />
+            </node>
+            <node concept="3oM_SD" id="3u1rFxes7H7" role="1PaTwD">
+              <property role="3oM_SC" value="result" />
+            </node>
+            <node concept="3oM_SD" id="3u1rFxes7RC" role="1PaTwD">
+              <property role="3oM_SC" value="in" />
+            </node>
+            <node concept="3oM_SD" id="3u1rFxes81D" role="1PaTwD">
+              <property role="3oM_SC" value="an" />
+            </node>
+            <node concept="3oM_SD" id="3u1rFxes81U" role="1PaTwD">
+              <property role="3oM_SC" value="InstancePath" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="3u1rFxervBv" role="3cqZAp">
+          <node concept="2YIFZM" id="3u1rFxerxdw" role="3clFbG">
+            <ref role="37wK5l" to="33ny:~Optional.of(java.lang.Object)" resolve="of" />
+            <ref role="1Pybhc" to="33ny:~Optional" resolve="Optional" />
+            <node concept="0kSF2" id="3u1rFxerKaA" role="37wK5m">
+              <node concept="3uibUv" id="3u1rFxerKaC" role="0kSFW">
+                <ref role="3uigEE" node="65ATjZHjU$h" resolve="InstancePath" />
+                <node concept="16syzq" id="3u1rFxerV38" role="11_B2D">
+                  <ref role="16sUi3" node="65ATjZHlpYF" resolve="D" />
+                </node>
+                <node concept="16syzq" id="3u1rFxerSMU" role="11_B2D">
+                  <ref role="16sUi3" node="65ATjZHjU$J" resolve="S" />
+                </node>
+              </node>
+              <node concept="1rXfSq" id="3u1rFxerAV$" role="0kSFX">
+                <ref role="37wK5l" node="65ATjZHGrFq" resolve="concat" />
+                <node concept="37vLTw" id="3u1rFxerDGn" role="37wK5m">
+                  <ref role="3cqZAo" node="3u1rFxeqPBN" resolve="subPath" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="3u1rFxeqCw_" role="1B3o_S" />
+      <node concept="3uibUv" id="3u1rFxergzN" role="3clF45">
+        <ref role="3uigEE" to="33ny:~Optional" resolve="Optional" />
+        <node concept="3uibUv" id="3u1rFxeqEZm" role="11_B2D">
+          <ref role="3uigEE" node="65ATjZHjU$h" resolve="InstancePath" />
+          <node concept="16syzq" id="3u1rFxeqGj2" role="11_B2D">
+            <ref role="16sUi3" node="65ATjZHlpYF" resolve="D" />
+          </node>
+          <node concept="16syzq" id="3u1rFxeqHlH" role="11_B2D">
+            <ref role="16sUi3" node="65ATjZHjU$J" resolve="S" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="1dyouTTC2R9" role="jymVt" />
+    <node concept="3clFb_" id="1dyouTTGx2b" role="jymVt">
+      <property role="TrG5h" value="toExpression" />
+      <node concept="3clFbS" id="1dyouTTGx2c" role="3clF47">
+        <node concept="3cpWs8" id="1dyouTTGx2k" role="3cqZAp">
+          <node concept="3cpWsn" id="1dyouTTGx2l" role="3cpWs9">
+            <property role="TrG5h" value="start" />
+            <node concept="16syzq" id="1dyouTTGx2m" role="1tU5fm">
+              <ref role="16sUi3" node="1dyouTTGx34" resolve="E" />
+            </node>
+            <node concept="2OqwBi" id="1dyouTTGx2n" role="33vP2m">
+              <node concept="37vLTw" id="1dyouTTGx2o" role="2Oq$k0">
+                <ref role="3cqZAo" node="1dyouTTGx2U" resolve="startBuilder" />
+              </node>
+              <node concept="1Bd96e" id="1dyouTTGx2p" role="2OqNvi">
+                <node concept="37vLTw" id="1dyouTTGx2q" role="1BdPVh">
+                  <ref role="3cqZAo" node="65ATjZHlp_8" resolve="root" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="1dyouTTSFzP" role="3cqZAp">
+          <node concept="3clFbS" id="1dyouTTSFzR" role="3clFbx">
+            <node concept="3cpWs8" id="1dyouTTGx2u" role="3cqZAp">
+              <node concept="3cpWsn" id="1dyouTTGx2v" role="3cpWs9">
+                <property role="TrG5h" value="result" />
+                <node concept="16syzq" id="1dyouTTGx2w" role="1tU5fm">
+                  <ref role="16sUi3" node="1dyouTTGx34" resolve="E" />
+                </node>
+                <node concept="2OqwBi" id="1dyouTTGx2x" role="33vP2m">
+                  <node concept="1rXfSq" id="1dyouTTGx2z" role="2Oq$k0">
+                    <ref role="37wK5l" node="3u1rFxdFBU5" resolve="segments" />
+                  </node>
+                  <node concept="1MD8d$" id="1dyouTTGx2A" role="2OqNvi">
+                    <node concept="1bVj0M" id="1dyouTTGx2B" role="23t8la">
+                      <node concept="3clFbS" id="1dyouTTGx2C" role="1bW5cS">
+                        <node concept="3clFbJ" id="1dyouTU0BxH" role="3cqZAp">
+                          <node concept="3clFbS" id="1dyouTU0BxJ" role="3clFbx">
+                            <node concept="3cpWs6" id="1dyouTU0S45" role="3cqZAp">
+                              <node concept="10Nm6u" id="1dyouTU0UR9" role="3cqZAk" />
+                            </node>
+                          </node>
+                          <node concept="17R0WA" id="1dyouTU0Lf$" role="3clFbw">
+                            <node concept="10Nm6u" id="1dyouTU0OUd" role="3uHU7w" />
+                            <node concept="37vLTw" id="1dyouTU0IyN" role="3uHU7B">
+                              <ref role="3cqZAo" node="1dyouTTGx2J" resolve="e" />
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3clFbF" id="1dyouTU0ZKD" role="3cqZAp">
+                          <node concept="2OqwBi" id="1dyouTTGx2E" role="3clFbG">
+                            <node concept="37vLTw" id="1dyouTTGx2F" role="2Oq$k0">
+                              <ref role="3cqZAo" node="1dyouTTGx2Z" resolve="segmentBuilder" />
+                            </node>
+                            <node concept="1Bd96e" id="1dyouTTGx2G" role="2OqNvi">
+                              <node concept="37vLTw" id="1dyouTTGx2H" role="1BdPVh">
+                                <ref role="3cqZAo" node="1dyouTTGx2J" resolve="e" />
+                              </node>
+                              <node concept="37vLTw" id="1dyouTTGx2I" role="1BdPVh">
+                                <ref role="3cqZAo" node="1dyouTTGx2L" resolve="it" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="gl6BB" id="1dyouTTGx2J" role="1bW2Oz">
+                        <property role="TrG5h" value="e" />
+                        <node concept="2jxLKc" id="1dyouTTGx2K" role="1tU5fm" />
+                      </node>
+                      <node concept="gl6BB" id="1dyouTTGx2L" role="1bW2Oz">
+                        <property role="TrG5h" value="it" />
+                        <node concept="2jxLKc" id="1dyouTTGx2M" role="1tU5fm" />
+                      </node>
+                    </node>
+                    <node concept="37vLTw" id="1dyouTTGx2N" role="1MDeny">
+                      <ref role="3cqZAo" node="1dyouTTGx2l" resolve="start" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs6" id="1dyouTTT9V8" role="3cqZAp">
+              <node concept="2YIFZM" id="1dyouTTUieW" role="3cqZAk">
+                <ref role="37wK5l" to="33ny:~Optional.ofNullable(java.lang.Object)" resolve="ofNullable" />
+                <ref role="1Pybhc" to="33ny:~Optional" resolve="Optional" />
+                <node concept="37vLTw" id="1dyouTTUieX" role="37wK5m">
+                  <ref role="3cqZAo" node="1dyouTTGx2v" resolve="result" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3y3z36" id="1dyouTTSKfA" role="3clFbw">
+            <node concept="10Nm6u" id="1dyouTTSN8c" role="3uHU7w" />
+            <node concept="37vLTw" id="1dyouTTSIIz" role="3uHU7B">
+              <ref role="3cqZAo" node="1dyouTTGx2l" resolve="start" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="1dyouTTT48n" role="3cqZAp">
+          <node concept="2YIFZM" id="1dyouTTT6JT" role="3clFbG">
+            <ref role="37wK5l" to="33ny:~Optional.empty()" resolve="empty" />
+            <ref role="1Pybhc" to="33ny:~Optional" resolve="Optional" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="1dyouTTGx2R" role="1B3o_S" />
+      <node concept="3uibUv" id="1dyouTTGx2S" role="3clF45">
+        <ref role="3uigEE" to="33ny:~Optional" resolve="Optional" />
+        <node concept="16syzq" id="1dyouTTGx2T" role="11_B2D">
+          <ref role="16sUi3" node="1dyouTTGx34" resolve="E" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="1dyouTTGx2U" role="3clF46">
+        <property role="TrG5h" value="startBuilder" />
+        <node concept="1ajhzC" id="1dyouTTGx2V" role="1tU5fm">
+          <node concept="16syzq" id="1dyouTTGx2W" role="1ajl9A">
+            <ref role="16sUi3" node="1dyouTTGx34" resolve="E" />
+          </node>
+          <node concept="16syzq" id="1dyouTTGx2X" role="1ajw0F">
+            <ref role="16sUi3" node="65ATjZHlpYF" resolve="D" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="1dyouTTGx2Z" role="3clF46">
+        <property role="TrG5h" value="segmentBuilder" />
+        <node concept="1ajhzC" id="1dyouTTGx30" role="1tU5fm">
+          <node concept="16syzq" id="1dyouTTGx31" role="1ajw0F">
+            <ref role="16sUi3" node="1dyouTTGx34" resolve="E" />
+          </node>
+          <node concept="16syzq" id="1dyouTTGx32" role="1ajw0F">
+            <ref role="16sUi3" node="65ATjZHjU$J" resolve="S" />
+          </node>
+          <node concept="16syzq" id="1dyouTTGx33" role="1ajl9A">
+            <ref role="16sUi3" node="1dyouTTGx34" resolve="E" />
+          </node>
+        </node>
+      </node>
+      <node concept="16euLQ" id="1dyouTTGx34" role="16eVyc">
+        <property role="TrG5h" value="E" />
+      </node>
+      <node concept="P$JXv" id="1dyouTTGQiG" role="lGtFl">
+        <node concept="TZ5HA" id="1dyouTTGQiH" role="TZ5H$">
+          <node concept="1dT_AC" id="1dyouTTGQiI" role="1dT_Ay">
+            <property role="1dT_AB" value="Create expression from instance path." />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="1dyouTTHlb0" role="TZ5H$">
+          <node concept="1dT_AC" id="1dyouTTHlb1" role="1dT_Ay">
+            <property role="1dT_AB" value="" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="1dyouTTHtjv" role="TZ5H$">
+          <node concept="1dT_AC" id="1dyouTTHtjw" role="1dT_Ay">
+            <property role="1dT_AB" value="This version is used if the first part of the expression can be build just from the root definition." />
+          </node>
+        </node>
+        <node concept="TUZQ0" id="1dyouTTGQiJ" role="3nqlJM">
+          <property role="TUZQ4" value="lambda to build the first expression part from the root definition" />
+          <node concept="zr_55" id="1dyouTTGQiL" role="zr_5Q">
+            <ref role="zr_51" node="1dyouTTGx2U" resolve="startBuilder" />
+          </node>
+        </node>
+        <node concept="TUZQ0" id="1dyouTTGQiM" role="3nqlJM">
+          <property role="TUZQ4" value="lambda to enhance the expression by the next segment" />
+          <node concept="zr_55" id="1dyouTTGQiO" role="zr_5Q">
+            <ref role="zr_51" node="1dyouTTGx2Z" resolve="segmentBuilder" />
+          </node>
+        </node>
+        <node concept="TUZQ0" id="1dyouTTGQiP" role="3nqlJM">
+          <property role="TUZQ4" value="the expression type (e.g., node&lt;Expression&gt;)" />
+          <node concept="zr_56" id="1dyouTTGQiR" role="zr_5Q">
+            <ref role="zr_51" node="1dyouTTGx34" resolve="E" />
+          </node>
+        </node>
+        <node concept="x79VA" id="1dyouTTGQiS" role="3nqlJM">
+          <property role="x79VB" value="the resulting expression" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="1dyouTTGx2a" role="jymVt" />
+    <node concept="3clFb_" id="1dyouTTC9_u" role="jymVt">
+      <property role="TrG5h" value="toExpression" />
+      <node concept="3clFbS" id="1dyouTTC9_x" role="3clF47">
+        <node concept="3clFbJ" id="1dyouTTRv$t" role="3cqZAp">
+          <node concept="3clFbS" id="1dyouTTRv$v" role="3clFbx">
+            <node concept="3cpWs8" id="1dyouTTCIlb" role="3cqZAp">
+              <node concept="3cpWsn" id="1dyouTTCIle" role="3cpWs9">
+                <property role="TrG5h" value="start" />
+                <node concept="16syzq" id="1dyouTTCIl9" role="1tU5fm">
+                  <ref role="16sUi3" node="1dyouTTCkmJ" resolve="E" />
+                </node>
+                <node concept="2OqwBi" id="1dyouTTCSw3" role="33vP2m">
+                  <node concept="37vLTw" id="1dyouTTCQFb" role="2Oq$k0">
+                    <ref role="3cqZAo" node="1dyouTTCbrF" resolve="startBuilder" />
+                  </node>
+                  <node concept="1Bd96e" id="1dyouTTCUoZ" role="2OqNvi">
+                    <node concept="37vLTw" id="1dyouTTCXG2" role="1BdPVh">
+                      <ref role="3cqZAo" node="65ATjZHlp_8" resolve="root" />
+                    </node>
+                    <node concept="2OqwBi" id="1dyouTTD7PJ" role="1BdPVh">
+                      <node concept="1rXfSq" id="1dyouTTD5L2" role="2Oq$k0">
+                        <ref role="37wK5l" node="3u1rFxdFBU5" resolve="segments" />
+                      </node>
+                      <node concept="1uHKPH" id="1dyouTTDaxz" role="2OqNvi" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbJ" id="1dyouTTRN7R" role="3cqZAp">
+              <node concept="3clFbS" id="1dyouTTRN7T" role="3clFbx">
+                <node concept="3cpWs8" id="1dyouTTEern" role="3cqZAp">
+                  <node concept="3cpWsn" id="1dyouTTEero" role="3cpWs9">
+                    <property role="TrG5h" value="result" />
+                    <node concept="16syzq" id="1dyouTTEdfM" role="1tU5fm">
+                      <ref role="16sUi3" node="1dyouTTCkmJ" resolve="E" />
+                    </node>
+                    <node concept="2OqwBi" id="1dyouTTEerp" role="33vP2m">
+                      <node concept="2OqwBi" id="1dyouTTEerq" role="2Oq$k0">
+                        <node concept="1rXfSq" id="1dyouTTEerr" role="2Oq$k0">
+                          <ref role="37wK5l" node="3u1rFxdFBU5" resolve="segments" />
+                        </node>
+                        <node concept="7r0gD" id="1dyouTTEers" role="2OqNvi">
+                          <node concept="3cmrfG" id="1dyouTTEert" role="7T0AP">
+                            <property role="3cmrfH" value="1" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="1MD8d$" id="1dyouTTEeru" role="2OqNvi">
+                        <node concept="1bVj0M" id="1dyouTTEerv" role="23t8la">
+                          <node concept="3clFbS" id="1dyouTTEerw" role="1bW5cS">
+                            <node concept="3clFbJ" id="1dyouTU19lT" role="3cqZAp">
+                              <node concept="3clFbS" id="1dyouTU19lV" role="3clFbx">
+                                <node concept="3cpWs6" id="1dyouTU1jLt" role="3cqZAp">
+                                  <node concept="10Nm6u" id="1dyouTU1mAw" role="3cqZAk" />
+                                </node>
+                              </node>
+                              <node concept="17R0WA" id="1dyouTU1dG3" role="3clFbw">
+                                <node concept="10Nm6u" id="1dyouTU1gBE" role="3uHU7w" />
+                                <node concept="37vLTw" id="1dyouTU1c1Q" role="3uHU7B">
+                                  <ref role="3cqZAo" node="1dyouTTEerB" resolve="e" />
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="3clFbF" id="1dyouTU1vMQ" role="3cqZAp">
+                              <node concept="2OqwBi" id="1dyouTTUni$" role="3clFbG">
+                                <node concept="37vLTw" id="1dyouTTUni_" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="1dyouTTDlrJ" resolve="segmentBuilder" />
+                                </node>
+                                <node concept="1Bd96e" id="1dyouTTUniA" role="2OqNvi">
+                                  <node concept="37vLTw" id="1dyouTTUniB" role="1BdPVh">
+                                    <ref role="3cqZAo" node="1dyouTTEerB" resolve="e" />
+                                  </node>
+                                  <node concept="37vLTw" id="1dyouTTUniC" role="1BdPVh">
+                                    <ref role="3cqZAo" node="1dyouTTEerD" resolve="it" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="gl6BB" id="1dyouTTEerB" role="1bW2Oz">
+                            <property role="TrG5h" value="e" />
+                            <node concept="2jxLKc" id="1dyouTTEerC" role="1tU5fm" />
+                          </node>
+                          <node concept="gl6BB" id="1dyouTTEerD" role="1bW2Oz">
+                            <property role="TrG5h" value="it" />
+                            <node concept="2jxLKc" id="1dyouTTEerE" role="1tU5fm" />
+                          </node>
+                        </node>
+                        <node concept="37vLTw" id="1dyouTTEerF" role="1MDeny">
+                          <ref role="3cqZAo" node="1dyouTTCIle" resolve="start" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3cpWs6" id="1dyouTTSqpD" role="3cqZAp">
+                  <node concept="2YIFZM" id="1dyouTTUpSZ" role="3cqZAk">
+                    <ref role="37wK5l" to="33ny:~Optional.ofNullable(java.lang.Object)" resolve="ofNullable" />
+                    <ref role="1Pybhc" to="33ny:~Optional" resolve="Optional" />
+                    <node concept="37vLTw" id="1dyouTTUpT0" role="37wK5m">
+                      <ref role="3cqZAo" node="1dyouTTEero" resolve="result" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3y3z36" id="1dyouTTRRdd" role="3clFbw">
+                <node concept="10Nm6u" id="1dyouTTRU7R" role="3uHU7w" />
+                <node concept="37vLTw" id="1dyouTTRPFD" role="3uHU7B">
+                  <ref role="3cqZAo" node="1dyouTTCIle" resolve="start" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3eOSWO" id="1dyouTTRG79" role="3clFbw">
+            <node concept="3cmrfG" id="1dyouTTRGeC" role="3uHU7w">
+              <property role="3cmrfH" value="0" />
+            </node>
+            <node concept="1rXfSq" id="1dyouTTRy_T" role="3uHU7B">
+              <ref role="37wK5l" node="5PQUSslgGet" resolve="segmentsSize" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="1dyouTTSbDe" role="3cqZAp">
+          <node concept="2YIFZM" id="1dyouTTSd0T" role="3clFbG">
+            <ref role="37wK5l" to="33ny:~Optional.empty()" resolve="empty" />
+            <ref role="1Pybhc" to="33ny:~Optional" resolve="Optional" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="1dyouTTC6jK" role="1B3o_S" />
+      <node concept="3uibUv" id="1dyouTTC8an" role="3clF45">
+        <ref role="3uigEE" to="33ny:~Optional" resolve="Optional" />
+        <node concept="16syzq" id="1dyouTTCOJC" role="11_B2D">
+          <ref role="16sUi3" node="1dyouTTCkmJ" resolve="E" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="1dyouTTCbrF" role="3clF46">
+        <property role="TrG5h" value="startBuilder" />
+        <node concept="1ajhzC" id="1dyouTTCbrD" role="1tU5fm">
+          <node concept="16syzq" id="1dyouTTClMp" role="1ajl9A">
+            <ref role="16sUi3" node="1dyouTTCkmJ" resolve="E" />
+          </node>
+          <node concept="16syzq" id="1dyouTTCcSg" role="1ajw0F">
+            <ref role="16sUi3" node="65ATjZHlpYF" resolve="D" />
+          </node>
+          <node concept="16syzq" id="1dyouTTChtf" role="1ajw0F">
+            <ref role="16sUi3" node="65ATjZHjU$J" resolve="S" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="1dyouTTDlrJ" role="3clF46">
+        <property role="TrG5h" value="segmentBuilder" />
+        <node concept="1ajhzC" id="1dyouTTDn57" role="1tU5fm">
+          <node concept="16syzq" id="1dyouTTDoLu" role="1ajw0F">
+            <ref role="16sUi3" node="1dyouTTCkmJ" resolve="E" />
+          </node>
+          <node concept="16syzq" id="1dyouTTDpG9" role="1ajw0F">
+            <ref role="16sUi3" node="65ATjZHjU$J" resolve="S" />
+          </node>
+          <node concept="16syzq" id="1dyouTTDqHK" role="1ajl9A">
+            <ref role="16sUi3" node="1dyouTTCkmJ" resolve="E" />
+          </node>
+        </node>
+      </node>
+      <node concept="16euLQ" id="1dyouTTCkmJ" role="16eVyc">
+        <property role="TrG5h" value="E" />
+      </node>
+      <node concept="P$JXv" id="1dyouTTJGd4" role="lGtFl">
+        <node concept="TZ5HA" id="1dyouTTJVJs" role="TZ5H$">
+          <node concept="1dT_AC" id="1dyouTTJVJt" role="1dT_Ay">
+            <property role="1dT_AB" value="Create expression from instance path." />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="1dyouTTK6oE" role="TZ5H$">
+          <node concept="1dT_AC" id="1dyouTTK6oF" role="1dT_Ay">
+            <property role="1dT_AB" value="" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="1dyouTTJGd5" role="TZ5H$">
+          <node concept="1dT_AC" id="1dyouTTJGd6" role="1dT_Ay">
+            <property role="1dT_AB" value="This version is used if the first part of the expression is built from the root definition and the first segment." />
+          </node>
+        </node>
+        <node concept="TUZQ0" id="1dyouTTJIOH" role="3nqlJM">
+          <property role="TUZQ4" value="lambda to build the first expression part from the root definition and the first segment" />
+          <node concept="zr_55" id="1dyouTTJIOI" role="zr_5Q">
+            <ref role="zr_51" node="1dyouTTCbrF" resolve="startBuilder" />
+          </node>
+        </node>
+        <node concept="TUZQ0" id="1dyouTTJIOJ" role="3nqlJM">
+          <property role="TUZQ4" value="lambda to enhance the expression by the next segment (except the first)" />
+          <node concept="zr_55" id="1dyouTTJIOK" role="zr_5Q">
+            <ref role="zr_51" node="1dyouTTDlrJ" resolve="segmentBuilder" />
+          </node>
+        </node>
+        <node concept="TUZQ0" id="1dyouTTJIOL" role="3nqlJM">
+          <property role="TUZQ4" value="the expression type (e.g., node&lt;Expression&gt;)" />
+          <node concept="zr_56" id="1dyouTTJIOM" role="zr_5Q">
+            <ref role="zr_51" node="1dyouTTCkmJ" resolve="E" />
+          </node>
+        </node>
+        <node concept="x79VA" id="1dyouTTJION" role="3nqlJM">
+          <property role="x79VB" value="the resulting expression" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="3u1rFxeqxQX" role="jymVt" />
+    <node concept="3clFb_" id="65ATjZHrWLj" role="jymVt">
+      <property role="TrG5h" value="hashCode" />
+      <node concept="3Tm1VV" id="65ATjZHrWLk" role="1B3o_S" />
+      <node concept="10Oyi0" id="65ATjZHrWLl" role="3clF45" />
+      <node concept="3clFbS" id="65ATjZHrWLm" role="3clF47">
+        <node concept="3cpWs8" id="6Kqv3dgEuY6" role="3cqZAp">
+          <node concept="3cpWsn" id="6Kqv3dgEuY9" role="3cpWs9">
+            <property role="TrG5h" value="hash" />
+            <node concept="10Oyi0" id="6Kqv3dgEuY4" role="1tU5fm" />
+            <node concept="3K4zz7" id="6Kqv3dgEAER" role="33vP2m">
+              <node concept="3y3z36" id="6Kqv3dgEP0E" role="3K4Cdx">
+                <node concept="10Nm6u" id="6Kqv3dgERnI" role="3uHU7w" />
+                <node concept="2OqwBi" id="6Kqv3dgEEPW" role="3uHU7B">
+                  <node concept="Xjq3P" id="6Kqv3dgED9X" role="2Oq$k0" />
+                  <node concept="2OwXpG" id="6Kqv3dgEGCH" role="2OqNvi">
+                    <ref role="2Oxat5" node="65ATjZHlp_8" resolve="root" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3cmrfG" id="6Kqv3dgEZ5i" role="3K4GZi">
+                <property role="3cmrfH" value="7" />
+              </node>
+              <node concept="2OqwBi" id="1ys6gNH4WjN" role="3K4E3e">
+                <node concept="liA8E" id="1ys6gNH4X_I" role="2OqNvi">
+                  <ref role="37wK5l" to="wyt6:~Object.hashCode()" resolve="hashCode" />
+                </node>
+                <node concept="2OqwBi" id="1ys6gNH4OW4" role="2Oq$k0">
+                  <node concept="Xjq3P" id="1ys6gNH4Nbt" role="2Oq$k0" />
+                  <node concept="2OwXpG" id="1ys6gNH4QUj" role="2OqNvi">
+                    <ref role="2Oxat5" node="65ATjZHlp_8" resolve="root" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="65ATjZHs2vG" role="3cqZAp">
+          <node concept="37vLTI" id="65ATjZHs8nv" role="3clFbG">
+            <node concept="3cpWs3" id="65ATjZHskfH" role="37vLTx">
+              <node concept="17qRlL" id="65ATjZHscUp" role="3uHU7B">
+                <node concept="3cmrfG" id="65ATjZHs8z8" role="3uHU7B">
+                  <property role="3cmrfH" value="31" />
+                </node>
+                <node concept="37vLTw" id="65ATjZHseuj" role="3uHU7w">
+                  <ref role="3cqZAo" node="6Kqv3dgEuY9" resolve="hash" />
+                </node>
+              </node>
+              <node concept="3nyPlj" id="65ATjZHsnW0" role="3uHU7w">
+                <ref role="37wK5l" node="1ys6gNH1HKs" resolve="hashCode" />
+              </node>
+            </node>
+            <node concept="37vLTw" id="65ATjZHs2vE" role="37vLTJ">
+              <ref role="3cqZAo" node="6Kqv3dgEuY9" resolve="hash" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="1ys6gNH5x6u" role="3cqZAp">
+          <node concept="37vLTw" id="1ys6gNH5x6n" role="3clFbG">
+            <ref role="3cqZAo" node="6Kqv3dgEuY9" resolve="hash" />
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="65ATjZHrWLn" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="65ATjZHrWLo" role="jymVt" />
+    <node concept="3clFb_" id="65ATjZHrWLp" role="jymVt">
+      <property role="TrG5h" value="equals" />
+      <node concept="3Tm1VV" id="65ATjZHrWLq" role="1B3o_S" />
+      <node concept="10P_77" id="65ATjZHrWLr" role="3clF45" />
+      <node concept="37vLTG" id="65ATjZHrWLs" role="3clF46">
+        <property role="TrG5h" value="obj" />
+        <node concept="3uibUv" id="65ATjZHrWLt" role="1tU5fm">
+          <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="65ATjZHrWLu" role="3clF47">
+        <node concept="3clFbJ" id="65ATjZHrWLv" role="3cqZAp">
+          <node concept="3clFbS" id="65ATjZHrWLw" role="3clFbx">
+            <node concept="3cpWs6" id="65ATjZHrWLx" role="3cqZAp">
+              <node concept="3clFbT" id="65ATjZHrWLy" role="3cqZAk">
+                <property role="3clFbU" value="true" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbC" id="65ATjZHrWLz" role="3clFbw">
+            <node concept="Xjq3P" id="65ATjZHrWL$" role="3uHU7w" />
+            <node concept="37vLTw" id="65ATjZHrWL_" role="3uHU7B">
+              <ref role="3cqZAo" node="65ATjZHrWLs" resolve="obj" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="65ATjZHrWLA" role="3cqZAp">
+          <node concept="3clFbS" id="65ATjZHrWLB" role="3clFbx">
+            <node concept="3cpWs6" id="65ATjZHrWLC" role="3cqZAp">
+              <node concept="3clFbT" id="65ATjZHrWLD" role="3cqZAk" />
+            </node>
+          </node>
+          <node concept="3fqX7Q" id="65ATjZHrWLE" role="3clFbw">
+            <node concept="2ZW3vV" id="65ATjZHrWLF" role="3fr31v">
+              <node concept="3uibUv" id="1ys6gNH1PB_" role="2ZW6by">
+                <ref role="3uigEE" node="65ATjZHjU$h" resolve="RootPath" />
+              </node>
+              <node concept="37vLTw" id="65ATjZHrWLG" role="2ZW6bz">
+                <ref role="3cqZAo" node="65ATjZHrWLs" resolve="obj" />
+              </node>
+            </node>
+          </node>
+          <node concept="15s5l7" id="65ATjZHIo3w" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;" />
+            <property role="huDt6" value="all typesystem messages" />
+          </node>
+        </node>
+        <node concept="3cpWs8" id="65ATjZHrWLH" role="3cqZAp">
+          <node concept="3cpWsn" id="65ATjZHrWLI" role="3cpWs9">
+            <property role="TrG5h" value="other" />
+            <node concept="3uibUv" id="65ATjZHrWLJ" role="1tU5fm">
+              <ref role="3uigEE" node="65ATjZHjU$h" resolve="RootPath" />
+              <node concept="16syzq" id="65ATjZHsNXH" role="11_B2D">
+                <ref role="16sUi3" node="65ATjZHlpYF" resolve="R" />
+              </node>
+              <node concept="16syzq" id="65ATjZHsUm6" role="11_B2D">
+                <ref role="16sUi3" node="65ATjZHjU$J" resolve="T" />
+              </node>
+            </node>
+            <node concept="0kSF2" id="65ATjZHsA8h" role="33vP2m">
+              <node concept="3uibUv" id="65ATjZHsA8k" role="0kSFW">
+                <ref role="3uigEE" node="65ATjZHjU$h" resolve="RootPath" />
+                <node concept="16syzq" id="65ATjZHsJTo" role="11_B2D">
+                  <ref role="16sUi3" node="65ATjZHlpYF" resolve="R" />
+                </node>
+                <node concept="16syzq" id="65ATjZHsLdu" role="11_B2D">
+                  <ref role="16sUi3" node="65ATjZHjU$J" resolve="T" />
+                </node>
+              </node>
+              <node concept="37vLTw" id="65ATjZHs_jt" role="0kSFX">
+                <ref role="3cqZAo" node="65ATjZHrWLs" resolve="obj" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="65ATjZHsVEk" role="3cqZAp" />
+        <node concept="3SKdUt" id="1ys6gNH3Old" role="3cqZAp">
+          <node concept="1PaTwC" id="1ys6gNH3Ole" role="1aUNEU">
+            <node concept="3oM_SD" id="1ys6gNH3UmR" role="1PaTwD">
+              <property role="3oM_SC" value="compare" />
+            </node>
+            <node concept="3oM_SD" id="1ys6gNH3Omw" role="1PaTwD">
+              <property role="3oM_SC" value="root" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="1ys6gNH3Unh" role="3cqZAp">
+          <node concept="3clFbS" id="1ys6gNH3Unj" role="3clFbx">
+            <node concept="3cpWs6" id="1ys6gNH4ixx" role="3cqZAp">
+              <node concept="3clFbT" id="1ys6gNH4ixP" role="3cqZAk" />
+            </node>
+          </node>
+          <node concept="17QLQc" id="1ys6gNH4aD_" role="3clFbw">
+            <node concept="2OqwBi" id="1ys6gNH4eHw" role="3uHU7w">
+              <node concept="37vLTw" id="1ys6gNH4dbP" role="2Oq$k0">
+                <ref role="3cqZAo" node="65ATjZHrWLI" resolve="other" />
+              </node>
+              <node concept="2OwXpG" id="1ys6gNH4gUF" role="2OqNvi">
+                <ref role="2Oxat5" node="65ATjZHlp_8" resolve="root" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="1ys6gNH3XGX" role="3uHU7B">
+              <node concept="Xjq3P" id="1ys6gNH3WeM" role="2Oq$k0" />
+              <node concept="2OwXpG" id="1ys6gNH3YTW" role="2OqNvi">
+                <ref role="2Oxat5" node="65ATjZHlp_8" resolve="root" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="65ATjZHrWLK" role="3cqZAp" />
+        <node concept="3SKdUt" id="65ATjZHrWLL" role="3cqZAp">
+          <node concept="1PaTwC" id="65ATjZHrWLM" role="1aUNEU">
+            <node concept="3oM_SD" id="65ATjZHrWLN" role="1PaTwD">
+              <property role="3oM_SC" value="compare" />
+            </node>
+            <node concept="3oM_SD" id="65ATjZHrWLO" role="1PaTwD">
+              <property role="3oM_SC" value="segment" />
+            </node>
+            <node concept="3oM_SD" id="65ATjZHrWLP" role="1PaTwD">
+              <property role="3oM_SC" value="list" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="65ATjZHrWLQ" role="3cqZAp">
+          <node concept="3nyPlj" id="65ATjZHt09X" role="3clFbG">
+            <ref role="37wK5l" node="1ys6gNH1HK_" resolve="equals" />
+            <node concept="37vLTw" id="65ATjZHt2Y8" role="37wK5m">
+              <ref role="3cqZAo" node="65ATjZHrWLs" resolve="obj" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="65ATjZHrWLY" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="65ATjZHuzJJ" role="jymVt" />
+    <node concept="3clFb_" id="6oXs4_P_MZH" role="jymVt">
+      <property role="TrG5h" value="toString" />
+      <node concept="3Tm1VV" id="6oXs4_P_MZI" role="1B3o_S" />
+      <node concept="17QB3L" id="6oXs4_PBnZ5" role="3clF45" />
+      <node concept="3clFbS" id="6oXs4_P_MZL" role="3clF47">
+        <node concept="3clFbF" id="6oXs4_P_UXh" role="3cqZAp">
+          <node concept="2OqwBi" id="6oXs4_PAdpD" role="3clFbG">
+            <property role="hSjvv" value="true" />
+            <node concept="2OqwBi" id="6oXs4_PATaf" role="2Oq$k0">
+              <property role="hSjvv" value="true" />
+              <node concept="2OqwBi" id="6oXs4_PAuXe" role="2Oq$k0">
+                <property role="hSjvv" value="true" />
+                <node concept="2ShNRf" id="6oXs4_P_UXf" role="2Oq$k0">
+                  <node concept="1pGfFk" id="6oXs4_PA7rq" role="2ShVmc">
+                    <ref role="37wK5l" to="qt06:~ToStringBuilder.&lt;init&gt;(java.lang.Object,org.apache.commons.lang3.builder.ToStringStyle)" resolve="ToStringBuilder" />
+                    <node concept="Xjq3P" id="6oXs4_PAahK" role="37wK5m" />
+                    <node concept="10M0yZ" id="6oXs4_PAryo" role="37wK5m">
+                      <ref role="3cqZAo" to="qt06:~ToStringStyle.MULTI_LINE_STYLE" resolve="MULTI_LINE_STYLE" />
+                      <ref role="1PxDUh" to="qt06:~ToStringStyle" resolve="ToStringStyle" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="liA8E" id="6oXs4_PAy6m" role="2OqNvi">
+                  <ref role="37wK5l" to="qt06:~ToStringBuilder.append(java.lang.String,java.lang.Object)" resolve="append" />
+                  <node concept="Xl_RD" id="6oXs4_PA$6Y" role="37wK5m">
+                    <property role="Xl_RC" value="root" />
+                  </node>
+                  <node concept="1rXfSq" id="65ATjZHwfa4" role="37wK5m">
+                    <ref role="37wK5l" node="65ATjZHvqwK" resolve="getRootPresentation" />
+                  </node>
+                </node>
+              </node>
+              <node concept="liA8E" id="6oXs4_PAV8f" role="2OqNvi">
+                <ref role="37wK5l" to="qt06:~ToStringBuilder.append(java.lang.String,java.lang.Object)" resolve="append" />
+                <node concept="Xl_RD" id="6oXs4_PAYko" role="37wK5m">
+                  <property role="Xl_RC" value="segments" />
+                </node>
+                <node concept="1rXfSq" id="65ATjZHq8Vs" role="37wK5m">
+                  <ref role="37wK5l" node="3u1rFxdFBU5" resolve="segments" />
+                </node>
+              </node>
+            </node>
+            <node concept="liA8E" id="6oXs4_PAfUG" role="2OqNvi">
+              <ref role="37wK5l" to="qt06:~ToStringBuilder.toString()" resolve="toString" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="6oXs4_P_MZM" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="3UR2Jj" id="1dyouTTKIRS" role="lGtFl">
+      <node concept="TZ5HA" id="1dyouTTKIRT" role="TZ5H$">
+        <node concept="1dT_AC" id="1dyouTTKIRU" role="1dT_Ay">
+          <property role="1dT_AB" value="A class representing an instance path, i.e. a root and a sequence of segments." />
+        </node>
+      </node>
+      <node concept="TZ5HA" id="1dyouTTKRHU" role="TZ5H$">
+        <node concept="1dT_AC" id="1dyouTTKRHV" role="1dT_Ay">
+          <property role="1dT_AB" value="Each segment represents an instance of some definition object. The definition objects" />
+        </node>
+      </node>
+      <node concept="TZ5HA" id="1dyouTTL0UC" role="TZ5H$">
+        <node concept="1dT_AC" id="1dyouTTL0UD" role="1dT_Ay">
+          <property role="1dT_AB" value="and the root must have the same type D (the &quot;definition&quot; type)." />
+        </node>
+      </node>
+      <node concept="TZ5HA" id="1dyouTTL8Ow" role="TZ5H$">
+        <node concept="1dT_AC" id="1dyouTTL8Ox" role="1dT_Ay">
+          <property role="1dT_AB" value="" />
+        </node>
+      </node>
+      <node concept="TZ5HA" id="1dyouTTL8Oy" role="TZ5H$">
+        <node concept="1dT_AC" id="1dyouTTL8Oz" role="1dT_Ay">
+          <property role="1dT_AB" value="Example: The &quot;definition&quot; type is a &quot;Component&quot;, and the segment type is a &quot;ComponentInstance&quot;." />
+        </node>
+      </node>
+      <node concept="TZ5HA" id="1dyouTTLbHQ" role="TZ5H$">
+        <node concept="1dT_AC" id="1dyouTTLbHR" role="1dT_Ay">
+          <property role="1dT_AB" value="         Each Component has a list of sub-components, specified by ComponentInstance elements." />
+        </node>
+      </node>
+      <node concept="TZ5HA" id="1dyouTTLkjq" role="TZ5H$">
+        <node concept="1dT_AC" id="1dyouTTLkjr" role="1dT_Ay">
+          <property role="1dT_AB" value="         An InstancePath defines some nested sub-component, starting from a root component definition." />
+        </node>
+      </node>
+      <node concept="TUZQ0" id="1dyouTTKIRV" role="3nqlJM">
+        <property role="TUZQ4" value="the type of the root of the path (the &quot;definition&quot; type)" />
+        <node concept="zr_56" id="1dyouTTKIRX" role="zr_5Q">
+          <ref role="zr_51" node="65ATjZHlpYF" resolve="D" />
+        </node>
+      </node>
+      <node concept="TUZQ0" id="1dyouTTKIRY" role="3nqlJM">
+        <property role="TUZQ4" value="the type of the path's segments (the &quot;segment&quot; type)" />
+        <node concept="zr_56" id="1dyouTTKIS0" role="zr_5Q">
+          <ref role="zr_51" node="65ATjZHjU$J" resolve="S" />
         </node>
       </node>
     </node>

--- a/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.common/models/com/mbeddr/mpsutil/common/util.mps
+++ b/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.common/models/com/mbeddr/mpsutil/common/util.mps
@@ -5296,6 +5296,18 @@
     <node concept="16euLQ" id="65ATjZHjU$1" role="16eVyc">
       <property role="TrG5h" value="S" />
     </node>
+    <node concept="16euLQ" id="6USpnrapQRs" role="16eVyc">
+      <property role="TrG5h" value="T" />
+      <node concept="3uibUv" id="6USpnraqnVp" role="3ztrMU">
+        <ref role="3uigEE" node="65ATjZHjTwL" resolve="ImmutablePath" />
+        <node concept="16syzq" id="6USpnraqoN2" role="11_B2D">
+          <ref role="16sUi3" node="65ATjZHjU$1" resolve="S" />
+        </node>
+        <node concept="16syzq" id="6USpnraqoX7" role="11_B2D">
+          <ref role="16sUi3" node="6USpnrapQRs" resolve="T" />
+        </node>
+      </node>
+    </node>
     <node concept="312cEg" id="5LihCoMhIxN" role="jymVt">
       <property role="TrG5h" value="segments" />
       <node concept="3Tm6S6" id="5LihCoMhIp$" role="1B3o_S" />
@@ -5354,11 +5366,8 @@
       <property role="1EzhhJ" value="true" />
       <node concept="3clFbS" id="65ATjZH$y4M" role="3clF47" />
       <node concept="3Tmbuc" id="65ATjZH$y4N" role="1B3o_S" />
-      <node concept="3uibUv" id="65ATjZHP8bI" role="3clF45">
-        <ref role="3uigEE" node="65ATjZHjTwL" resolve="ImmutablePath" />
-        <node concept="16syzq" id="65ATjZHPaJg" role="11_B2D">
-          <ref role="16sUi3" node="65ATjZHjU$1" resolve="S" />
-        </node>
+      <node concept="16syzq" id="6USpnraqqXx" role="3clF45">
+        <ref role="16sUi3" node="6USpnrapQRs" resolve="T" />
       </node>
       <node concept="P$JXv" id="1dyouTTKxJN" role="lGtFl">
         <node concept="TZ5HA" id="1dyouTTKxJO" role="TZ5H$">
@@ -5456,7 +5465,7 @@
     </node>
     <node concept="2tJIrI" id="65ATjZHp26x" role="jymVt" />
     <node concept="3clFb_" id="65ATjZHpG8B" role="jymVt">
-      <property role="TrG5h" value="segmentsReverse" />
+      <property role="TrG5h" value="segmentsReversed" />
       <node concept="3clFbS" id="65ATjZHpG8E" role="3clF47">
         <node concept="3clFbF" id="3u1rFxdFOA4" role="3cqZAp">
           <node concept="2OqwBi" id="65ATjZHpNbX" role="3clFbG">
@@ -5511,19 +5520,19 @@
             <node concept="1rXfSq" id="65ATjZHHYgs" role="33vP2m">
               <ref role="37wK5l" node="65ATjZHHdB4" resolve="cloneObject" />
             </node>
-            <node concept="3uibUv" id="65ATjZHO9tt" role="1tU5fm">
-              <ref role="3uigEE" node="65ATjZHjTwL" resolve="Path" />
-              <node concept="16syzq" id="65ATjZHObyI" role="11_B2D">
-                <ref role="16sUi3" node="65ATjZHjU$1" resolve="T" />
-              </node>
+            <node concept="16syzq" id="6USpnraqtlh" role="1tU5fm">
+              <ref role="16sUi3" node="6USpnrapQRs" resolve="T" />
             </node>
           </node>
         </node>
         <node concept="3clFbF" id="5LihCoMivDJ" role="3cqZAp">
           <node concept="2OqwBi" id="5LihCoMiyPE" role="3clFbG">
             <node concept="2OqwBi" id="5LihCoMiwrd" role="2Oq$k0">
-              <node concept="37vLTw" id="5LihCoMivDH" role="2Oq$k0">
-                <ref role="3cqZAo" node="5LihCoMikgJ" resolve="result" />
+              <node concept="1rXfSq" id="6USpnratza3" role="2Oq$k0">
+                <ref role="37wK5l" node="6USpnratakR" resolve="upcast" />
+                <node concept="37vLTw" id="6USpnrat_0v" role="37wK5m">
+                  <ref role="3cqZAo" node="5LihCoMikgJ" resolve="result" />
+                </node>
               </node>
               <node concept="2OwXpG" id="65ATjZHD35t" role="2OqNvi">
                 <ref role="2Oxat5" node="5LihCoMhIxN" resolve="segments" />
@@ -5549,11 +5558,8 @@
           <ref role="16sUi3" node="65ATjZHjU$1" resolve="T" />
         </node>
       </node>
-      <node concept="3uibUv" id="65ATjZHPcTc" role="3clF45">
-        <ref role="3uigEE" node="65ATjZHjTwL" resolve="Path" />
-        <node concept="16syzq" id="65ATjZHPgd4" role="11_B2D">
-          <ref role="16sUi3" node="65ATjZHjU$1" resolve="T" />
-        </node>
+      <node concept="16syzq" id="6USpnraqsnq" role="3clF45">
+        <ref role="16sUi3" node="6USpnrapQRs" resolve="T" />
       </node>
     </node>
     <node concept="2tJIrI" id="65ATjZHE$Lb" role="jymVt" />
@@ -5563,11 +5569,8 @@
         <node concept="3cpWs8" id="5zD5ovm$jwj" role="3cqZAp">
           <node concept="3cpWsn" id="5zD5ovm$jwk" role="3cpWs9">
             <property role="TrG5h" value="result" />
-            <node concept="3uibUv" id="5zD5ovm$jwl" role="1tU5fm">
-              <ref role="3uigEE" node="65ATjZHjTwL" resolve="Path" />
-              <node concept="16syzq" id="65ATjZHEZW8" role="11_B2D">
-                <ref role="16sUi3" node="65ATjZHjU$1" resolve="T" />
-              </node>
+            <node concept="16syzq" id="6USpnraqvYK" role="1tU5fm">
+              <ref role="16sUi3" node="6USpnrapQRs" resolve="T" />
             </node>
             <node concept="1rXfSq" id="65ATjZHHPJP" role="33vP2m">
               <ref role="37wK5l" node="65ATjZHHdB4" resolve="cloneObject" />
@@ -5577,8 +5580,11 @@
         <node concept="3clFbF" id="5zD5ovm$jw$" role="3cqZAp">
           <node concept="2OqwBi" id="5zD5ovm$jw_" role="3clFbG">
             <node concept="2OqwBi" id="5zD5ovm$jwA" role="2Oq$k0">
-              <node concept="37vLTw" id="5zD5ovm$jwB" role="2Oq$k0">
-                <ref role="3cqZAo" node="5zD5ovm$jwk" resolve="result" />
+              <node concept="1rXfSq" id="6USpnratBFK" role="2Oq$k0">
+                <ref role="37wK5l" node="6USpnratakR" resolve="upcast" />
+                <node concept="37vLTw" id="6USpnratCXK" role="37wK5m">
+                  <ref role="3cqZAo" node="5zD5ovm$jwk" resolve="result" />
+                </node>
               </node>
               <node concept="2OwXpG" id="5zD5ovm$jwC" role="2OqNvi">
                 <ref role="2Oxat5" node="5LihCoMhIxN" resolve="segments" />
@@ -5606,11 +5612,8 @@
           </node>
         </node>
       </node>
-      <node concept="3uibUv" id="65ATjZHEIN_" role="3clF45">
-        <ref role="3uigEE" node="65ATjZHjTwL" resolve="Path" />
-        <node concept="16syzq" id="65ATjZHEINA" role="11_B2D">
-          <ref role="16sUi3" node="65ATjZHjU$1" resolve="T" />
-        </node>
+      <node concept="16syzq" id="6USpnraquvn" role="3clF45">
+        <ref role="16sUi3" node="6USpnrapQRs" resolve="T" />
       </node>
     </node>
     <node concept="2tJIrI" id="65ATjZHEBoF" role="jymVt" />
@@ -5623,22 +5626,22 @@
             <node concept="1rXfSq" id="65ATjZHHHLo" role="33vP2m">
               <ref role="37wK5l" node="65ATjZHHdB4" resolve="cloneObject" />
             </node>
-            <node concept="3uibUv" id="65ATjZHGDhP" role="1tU5fm">
-              <ref role="3uigEE" node="65ATjZHjTwL" resolve="Path" />
-              <node concept="16syzq" id="65ATjZHGDhQ" role="11_B2D">
-                <ref role="16sUi3" node="65ATjZHjU$1" resolve="T" />
-              </node>
+            <node concept="16syzq" id="6USpnraqEqF" role="1tU5fm">
+              <ref role="16sUi3" node="6USpnrapQRs" resolve="T" />
             </node>
           </node>
         </node>
         <node concept="3clFbF" id="65ATjZHGrFH" role="3cqZAp">
           <node concept="2OqwBi" id="65ATjZHGrFI" role="3clFbG">
             <node concept="2OqwBi" id="65ATjZHGrFJ" role="2Oq$k0">
-              <node concept="37vLTw" id="65ATjZHGrFK" role="2Oq$k0">
-                <ref role="3cqZAo" node="65ATjZHGrFt" resolve="result" />
-              </node>
               <node concept="2OwXpG" id="65ATjZHGrFL" role="2OqNvi">
                 <ref role="2Oxat5" node="5LihCoMhIxN" resolve="segments" />
+              </node>
+              <node concept="1rXfSq" id="6USpnratG5k" role="2Oq$k0">
+                <ref role="37wK5l" node="6USpnratakR" resolve="upcast" />
+                <node concept="37vLTw" id="6USpnratHqs" role="37wK5m">
+                  <ref role="3cqZAo" node="65ATjZHGrFt" resolve="result" />
+                </node>
               </node>
             </node>
             <node concept="X8dFx" id="65ATjZHGrFM" role="2OqNvi">
@@ -5662,18 +5665,18 @@
       <node concept="3Tm1VV" id="65ATjZHGrFS" role="1B3o_S" />
       <node concept="37vLTG" id="65ATjZHGrFT" role="3clF46">
         <property role="TrG5h" value="second" />
-        <node concept="3uibUv" id="65ATjZHGA0P" role="1tU5fm">
-          <ref role="3uigEE" node="65ATjZHjTwL" resolve="Path" />
-          <node concept="16syzq" id="65ATjZHGA0Q" role="11_B2D">
-            <ref role="16sUi3" node="65ATjZHjU$1" resolve="T" />
+        <node concept="3uibUv" id="6USpnrart2J" role="1tU5fm">
+          <ref role="3uigEE" node="65ATjZHjTwL" resolve="ImmutablePath" />
+          <node concept="16syzq" id="6USpnrarvnE" role="11_B2D">
+            <ref role="16sUi3" node="65ATjZHjU$1" resolve="S" />
+          </node>
+          <node concept="16syzq" id="6USpnrarwcO" role="11_B2D">
+            <ref role="16sUi3" node="6USpnrapQRs" resolve="T" />
           </node>
         </node>
       </node>
-      <node concept="3uibUv" id="65ATjZHGyUD" role="3clF45">
-        <ref role="3uigEE" node="65ATjZHjTwL" resolve="Path" />
-        <node concept="16syzq" id="65ATjZHGyUE" role="11_B2D">
-          <ref role="16sUi3" node="65ATjZHjU$1" resolve="T" />
-        </node>
+      <node concept="16syzq" id="6USpnraqBV5" role="3clF45">
+        <ref role="16sUi3" node="6USpnrapQRs" resolve="T" />
       </node>
     </node>
     <node concept="2tJIrI" id="3u1rFxek34E" role="jymVt" />
@@ -5703,19 +5706,19 @@
                   <node concept="1rXfSq" id="3u1rFxektGO" role="33vP2m">
                     <ref role="37wK5l" node="65ATjZHHdB4" resolve="cloneObject" />
                   </node>
-                  <node concept="3uibUv" id="3u1rFxektGP" role="1tU5fm">
-                    <ref role="3uigEE" node="65ATjZHjTwL" resolve="Path" />
-                    <node concept="16syzq" id="3u1rFxektGQ" role="11_B2D">
-                      <ref role="16sUi3" node="65ATjZHjU$1" resolve="T" />
-                    </node>
+                  <node concept="16syzq" id="6USpnraq_28" role="1tU5fm">
+                    <ref role="16sUi3" node="6USpnrapQRs" resolve="T" />
                   </node>
                 </node>
               </node>
               <node concept="3clFbF" id="3u1rFxektGR" role="3cqZAp">
                 <node concept="2OqwBi" id="3u1rFxektGS" role="3clFbG">
                   <node concept="2OqwBi" id="3u1rFxektGT" role="2Oq$k0">
-                    <node concept="37vLTw" id="3u1rFxektGU" role="2Oq$k0">
-                      <ref role="3cqZAo" node="3u1rFxektGN" resolve="result" />
+                    <node concept="1rXfSq" id="6USpnratIG_" role="2Oq$k0">
+                      <ref role="37wK5l" node="6USpnratakR" resolve="upcast" />
+                      <node concept="37vLTw" id="6USpnratK1_" role="37wK5m">
+                        <ref role="3cqZAo" node="3u1rFxektGN" resolve="result" />
+                      </node>
                     </node>
                     <node concept="2OwXpG" id="3u1rFxektGV" role="2OqNvi">
                       <ref role="2Oxat5" node="5LihCoMhIxN" resolve="segments" />
@@ -5740,15 +5743,12 @@
       <node concept="3Tm1VV" id="3u1rFxek7ON" role="1B3o_S" />
       <node concept="3uibUv" id="3u1rFxeke0a" role="3clF45">
         <ref role="3uigEE" to="33ny:~Optional" resolve="Optional" />
-        <node concept="3uibUv" id="3u1rFxekfXG" role="11_B2D">
-          <ref role="3uigEE" node="65ATjZHjTwL" resolve="ImmutablePath" />
-          <node concept="16syzq" id="3u1rFxekhb1" role="11_B2D">
-            <ref role="16sUi3" node="65ATjZHjU$1" resolve="S" />
-          </node>
+        <node concept="16syzq" id="6USpnraq_VE" role="11_B2D">
+          <ref role="16sUi3" node="6USpnrapQRs" resolve="T" />
         </node>
       </node>
     </node>
-    <node concept="2tJIrI" id="3u1rFxekKnU" role="jymVt" />
+    <node concept="2tJIrI" id="6USpnrat57_" role="jymVt" />
     <node concept="3clFb_" id="65ATjZHHdB4" role="jymVt">
       <property role="TrG5h" value="cloneObject" />
       <node concept="3clFbS" id="65ATjZHHdB7" role="3clF47">
@@ -5756,24 +5756,24 @@
           <node concept="3cpWsn" id="65ATjZHHkP7" role="3cpWs9">
             <property role="TrG5h" value="result" />
             <node concept="1rXfSq" id="65ATjZHHkP8" role="33vP2m">
-              <ref role="37wK5l" node="65ATjZH$y4K" resolve="create" />
+              <ref role="37wK5l" node="65ATjZH$y4K" resolve="copy" />
             </node>
-            <node concept="3uibUv" id="65ATjZHPqqU" role="1tU5fm">
-              <ref role="3uigEE" node="65ATjZHjTwL" resolve="Path" />
-              <node concept="16syzq" id="65ATjZHPqqV" role="11_B2D">
-                <ref role="16sUi3" node="65ATjZHjU$1" resolve="T" />
-              </node>
+            <node concept="16syzq" id="6USpnraqz3M" role="1tU5fm">
+              <ref role="16sUi3" node="6USpnrapQRs" resolve="T" />
             </node>
           </node>
         </node>
         <node concept="3clFbF" id="65ATjZHHkPb" role="3cqZAp">
           <node concept="2OqwBi" id="65ATjZHHkPc" role="3clFbG">
             <node concept="2OqwBi" id="65ATjZHHkPd" role="2Oq$k0">
-              <node concept="37vLTw" id="65ATjZHHkPe" role="2Oq$k0">
-                <ref role="3cqZAo" node="65ATjZHHkP7" resolve="result" />
-              </node>
               <node concept="2OwXpG" id="65ATjZHHkPf" role="2OqNvi">
                 <ref role="2Oxat5" node="5LihCoMhIxN" resolve="segments" />
+              </node>
+              <node concept="1rXfSq" id="6USpnrauc2H" role="2Oq$k0">
+                <ref role="37wK5l" node="6USpnratakR" resolve="upcast" />
+                <node concept="37vLTw" id="6USpnraudqn" role="37wK5m">
+                  <ref role="3cqZAo" node="65ATjZHHkP7" resolve="result" />
+                </node>
               </node>
             </node>
             <node concept="X8dFx" id="65ATjZHHkPg" role="2OqNvi">
@@ -5793,14 +5793,56 @@
         </node>
       </node>
       <node concept="3Tmbuc" id="3u1rFxep7aA" role="1B3o_S" />
-      <node concept="3uibUv" id="65ATjZHPl5U" role="3clF45">
-        <ref role="3uigEE" node="65ATjZHjTwL" resolve="Path" />
-        <node concept="16syzq" id="65ATjZHPobK" role="11_B2D">
-          <ref role="16sUi3" node="65ATjZHjU$1" resolve="T" />
-        </node>
+      <node concept="16syzq" id="6USpnraqxl1" role="3clF45">
+        <ref role="16sUi3" node="6USpnrapQRs" resolve="T" />
       </node>
     </node>
     <node concept="2tJIrI" id="65ATjZHCniu" role="jymVt" />
+    <node concept="3clFb_" id="6USpnratakR" role="jymVt">
+      <property role="TrG5h" value="upcast" />
+      <node concept="3clFbS" id="6USpnratakU" role="3clF47">
+        <node concept="3clFbF" id="6USpnratrZ4" role="3cqZAp">
+          <node concept="0kSF2" id="6USpnratpgP" role="3clFbG">
+            <node concept="3uibUv" id="6USpnratpgS" role="0kSFW">
+              <ref role="3uigEE" node="65ATjZHjTwL" resolve="ImmutablePath" />
+              <node concept="16syzq" id="6USpnratpgT" role="11_B2D">
+                <ref role="16sUi3" node="65ATjZHjU$1" resolve="S" />
+              </node>
+              <node concept="16syzq" id="6USpnratpgU" role="11_B2D">
+                <ref role="16sUi3" node="6USpnrapQRs" resolve="T" />
+              </node>
+            </node>
+            <node concept="37vLTw" id="6USpnratnma" role="0kSFX">
+              <ref role="3cqZAo" node="6USpnratb$R" resolve="obj" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm6S6" id="6USpnrat7i_" role="1B3o_S" />
+      <node concept="3uibUv" id="6USpnratcDE" role="3clF45">
+        <ref role="3uigEE" node="65ATjZHjTwL" resolve="ImmutablePath" />
+        <node concept="16syzq" id="6USpnratfjO" role="11_B2D">
+          <ref role="16sUi3" node="65ATjZHjU$1" resolve="S" />
+        </node>
+        <node concept="16syzq" id="6USpnratg8w" role="11_B2D">
+          <ref role="16sUi3" node="6USpnrapQRs" resolve="T" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="6USpnratb$R" role="3clF46">
+        <property role="TrG5h" value="obj" />
+        <node concept="16syzq" id="6USpnratb$Q" role="1tU5fm">
+          <ref role="16sUi3" node="6USpnrapQRs" resolve="T" />
+        </node>
+      </node>
+      <node concept="P$JXv" id="6USpnratvnt" role="lGtFl">
+        <node concept="TZ5HA" id="6USpnratvnu" role="TZ5H$">
+          <node concept="1dT_AC" id="6USpnratvnv" role="1dT_Ay">
+            <property role="1dT_AB" value="This is needed to fix compile errors in the generated Java." />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="3u1rFxekKnU" role="jymVt" />
     <node concept="3clFb_" id="1ys6gNH1HKs" role="jymVt">
       <property role="TrG5h" value="hashCode" />
       <node concept="3Tm1VV" id="1ys6gNH1HKt" role="1B3o_S" />
@@ -5911,12 +5953,18 @@
               <node concept="16syzq" id="65ATjZHrlDo" role="11_B2D">
                 <ref role="16sUi3" node="65ATjZHjU$1" resolve="T" />
               </node>
+              <node concept="16syzq" id="6USpnraqFUE" role="11_B2D">
+                <ref role="16sUi3" node="6USpnrapQRs" resolve="T" />
+              </node>
             </node>
             <node concept="0kSF2" id="65ATjZHr5Pc" role="33vP2m">
               <node concept="3uibUv" id="65ATjZHr5Pf" role="0kSFW">
                 <ref role="3uigEE" node="65ATjZHjTwL" resolve="Path" />
                 <node concept="16syzq" id="65ATjZHrjxM" role="11_B2D">
                   <ref role="16sUi3" node="65ATjZHjU$1" resolve="T" />
+                </node>
+                <node concept="16syzq" id="6USpnraqHxX" role="11_B2D">
+                  <ref role="16sUi3" node="6USpnrapQRs" resolve="T" />
                 </node>
               </node>
               <node concept="37vLTw" id="65ATjZHr5jU" role="0kSFX">
@@ -5998,10 +6046,28 @@
     <node concept="16euLQ" id="65ATjZHjU$J" role="16eVyc">
       <property role="TrG5h" value="S" />
     </node>
+    <node concept="16euLQ" id="6USpnrapFVg" role="16eVyc">
+      <property role="TrG5h" value="T" />
+      <node concept="3uibUv" id="6USpnraqXkx" role="3ztrMU">
+        <ref role="3uigEE" node="65ATjZHjU$h" resolve="InstancePath" />
+        <node concept="16syzq" id="6USpnrar1eo" role="11_B2D">
+          <ref role="16sUi3" node="65ATjZHlpYF" resolve="D" />
+        </node>
+        <node concept="16syzq" id="6USpnrar2mG" role="11_B2D">
+          <ref role="16sUi3" node="65ATjZHjU$J" resolve="S" />
+        </node>
+        <node concept="16syzq" id="6USpnrar3wy" role="11_B2D">
+          <ref role="16sUi3" node="6USpnrapFVg" resolve="T" />
+        </node>
+      </node>
+    </node>
     <node concept="3uibUv" id="65ATjZHk76V" role="1zkMxy">
       <ref role="3uigEE" node="65ATjZHjTwL" resolve="Path" />
       <node concept="16syzq" id="65ATjZHk78w" role="11_B2D">
         <ref role="16sUi3" node="65ATjZHjU$J" resolve="T" />
+      </node>
+      <node concept="16syzq" id="6USpnraqePT" role="11_B2D">
+        <ref role="16sUi3" node="6USpnrapFVg" resolve="T" />
       </node>
     </node>
     <node concept="312cEg" id="65ATjZHlp_8" role="jymVt">
@@ -6350,6 +6416,9 @@
           <node concept="16syzq" id="3u1rFxer2lm" role="11_B2D">
             <ref role="16sUi3" node="65ATjZHjU$J" resolve="S" />
           </node>
+          <node concept="16syzq" id="6USpnrarhXb" role="11_B2D">
+            <ref role="16sUi3" node="6USpnrapFVg" resolve="T" />
+          </node>
         </node>
       </node>
       <node concept="3clFbS" id="3u1rFxeqM8W" role="3clF47">
@@ -6446,21 +6515,10 @@
           <node concept="2YIFZM" id="3u1rFxerxdw" role="3clFbG">
             <ref role="37wK5l" to="33ny:~Optional.of(java.lang.Object)" resolve="of" />
             <ref role="1Pybhc" to="33ny:~Optional" resolve="Optional" />
-            <node concept="0kSF2" id="3u1rFxerKaA" role="37wK5m">
-              <node concept="3uibUv" id="3u1rFxerKaC" role="0kSFW">
-                <ref role="3uigEE" node="65ATjZHjU$h" resolve="InstancePath" />
-                <node concept="16syzq" id="3u1rFxerV38" role="11_B2D">
-                  <ref role="16sUi3" node="65ATjZHlpYF" resolve="D" />
-                </node>
-                <node concept="16syzq" id="3u1rFxerSMU" role="11_B2D">
-                  <ref role="16sUi3" node="65ATjZHjU$J" resolve="S" />
-                </node>
-              </node>
-              <node concept="1rXfSq" id="3u1rFxerAV$" role="0kSFX">
-                <ref role="37wK5l" node="65ATjZHGrFq" resolve="concat" />
-                <node concept="37vLTw" id="3u1rFxerDGn" role="37wK5m">
-                  <ref role="3cqZAo" node="3u1rFxeqPBN" resolve="subPath" />
-                </node>
+            <node concept="1rXfSq" id="3u1rFxerAV$" role="37wK5m">
+              <ref role="37wK5l" node="65ATjZHGrFq" resolve="concat" />
+              <node concept="37vLTw" id="3u1rFxerDGn" role="37wK5m">
+                <ref role="3cqZAo" node="3u1rFxeqPBN" resolve="subPath" />
               </node>
             </node>
           </node>
@@ -6469,14 +6527,8 @@
       <node concept="3Tm1VV" id="3u1rFxeqCw_" role="1B3o_S" />
       <node concept="3uibUv" id="3u1rFxergzN" role="3clF45">
         <ref role="3uigEE" to="33ny:~Optional" resolve="Optional" />
-        <node concept="3uibUv" id="3u1rFxeqEZm" role="11_B2D">
-          <ref role="3uigEE" node="65ATjZHjU$h" resolve="InstancePath" />
-          <node concept="16syzq" id="3u1rFxeqGj2" role="11_B2D">
-            <ref role="16sUi3" node="65ATjZHlpYF" resolve="D" />
-          </node>
-          <node concept="16syzq" id="3u1rFxeqHlH" role="11_B2D">
-            <ref role="16sUi3" node="65ATjZHjU$J" resolve="S" />
-          </node>
+        <node concept="16syzq" id="6USpnrarckK" role="11_B2D">
+          <ref role="16sUi3" node="6USpnrapFVg" resolve="T" />
         </node>
       </node>
     </node>
@@ -6994,6 +7046,9 @@
               <node concept="16syzq" id="65ATjZHsUm6" role="11_B2D">
                 <ref role="16sUi3" node="65ATjZHjU$J" resolve="T" />
               </node>
+              <node concept="16syzq" id="6USpnrauMms" role="11_B2D">
+                <ref role="16sUi3" node="6USpnrapFVg" resolve="T" />
+              </node>
             </node>
             <node concept="0kSF2" id="65ATjZHsA8h" role="33vP2m">
               <node concept="3uibUv" id="65ATjZHsA8k" role="0kSFW">
@@ -7003,6 +7058,9 @@
                 </node>
                 <node concept="16syzq" id="65ATjZHsLdu" role="11_B2D">
                   <ref role="16sUi3" node="65ATjZHjU$J" resolve="T" />
+                </node>
+                <node concept="16syzq" id="6USpnrauV8r" role="11_B2D">
+                  <ref role="16sUi3" node="6USpnrapFVg" resolve="T" />
                 </node>
               </node>
               <node concept="37vLTw" id="65ATjZHs_jt" role="0kSFX">

--- a/code/languages/com.mbeddr.mpsutil/tests/test.com.mbeddr.mpsutil.common/models/test.com.mbeddr.mpsutil.common.util@tests.mps
+++ b/code/languages/com.mbeddr.mpsutil/tests/test.com.mbeddr.mpsutil.common/models/test.com.mbeddr.mpsutil.common.util@tests.mps
@@ -4358,6 +4358,24 @@
             <ref role="3cqZAo" node="1dyouTTmHto" resolve="p2a" />
           </node>
         </node>
+        <node concept="3vlDli" id="710iChRQlRY" role="3cqZAp">
+          <node concept="2OqwBi" id="710iChRQlRZ" role="3tpDZB">
+            <node concept="37vLTw" id="710iChRQlS0" role="2Oq$k0">
+              <ref role="3cqZAo" node="1dyouTTmHto" resolve="p2a" />
+            </node>
+            <node concept="liA8E" id="710iChRQlS1" role="2OqNvi">
+              <ref role="37wK5l" to="7wpd:65ATjZHrWLj" resolve="hashCode" />
+            </node>
+          </node>
+          <node concept="2OqwBi" id="710iChRQlS2" role="3tpDZA">
+            <node concept="37vLTw" id="710iChRQlS3" role="2Oq$k0">
+              <ref role="3cqZAo" node="1dyouTTmU5X" resolve="p2b" />
+            </node>
+            <node concept="liA8E" id="710iChRQlS4" role="2OqNvi">
+              <ref role="37wK5l" to="7wpd:65ATjZHrWLj" resolve="hashCode" />
+            </node>
+          </node>
+        </node>
       </node>
     </node>
     <node concept="1LZb2c" id="1dyouTTnfGR" role="1SL9yI">
@@ -4450,6 +4468,24 @@
           </node>
           <node concept="37vLTw" id="1dyouTTnfHm" role="3tpDZA">
             <ref role="3cqZAo" node="1dyouTTnfH4" resolve="p2a" />
+          </node>
+        </node>
+        <node concept="3vlDli" id="710iChRQ7As" role="3cqZAp">
+          <node concept="2OqwBi" id="710iChRQigP" role="3tpDZB">
+            <node concept="37vLTw" id="710iChRQg7R" role="2Oq$k0">
+              <ref role="3cqZAo" node="1dyouTTnfH4" resolve="p2a" />
+            </node>
+            <node concept="liA8E" id="710iChRQk7Q" role="2OqNvi">
+              <ref role="37wK5l" to="7wpd:65ATjZHrWLj" resolve="hashCode" />
+            </node>
+          </node>
+          <node concept="2OqwBi" id="710iChRQbDP" role="3tpDZA">
+            <node concept="37vLTw" id="710iChRQ9$n" role="2Oq$k0">
+              <ref role="3cqZAo" node="1dyouTTnfHb" resolve="p2b" />
+            </node>
+            <node concept="liA8E" id="710iChRQeBx" role="2OqNvi">
+              <ref role="37wK5l" to="7wpd:65ATjZHrWLj" resolve="hashCode" />
+            </node>
           </node>
         </node>
       </node>
@@ -4576,6 +4612,24 @@
             </node>
             <node concept="liA8E" id="1dyouTTpAiY" role="2OqNvi">
               <ref role="37wK5l" to="33ny:~Optional.get()" resolve="get" />
+            </node>
+          </node>
+        </node>
+        <node concept="3vlDli" id="710iChRPzcl" role="3cqZAp">
+          <node concept="2OqwBi" id="710iChRPBN6" role="3tpDZB">
+            <node concept="37vLTw" id="710iChRPBec" role="2Oq$k0">
+              <ref role="3cqZAo" node="1dyouTTpjG6" resolve="p3" />
+            </node>
+            <node concept="liA8E" id="710iChRPDoE" role="2OqNvi">
+              <ref role="37wK5l" to="7wpd:65ATjZHrWLj" resolve="hashCode" />
+            </node>
+          </node>
+          <node concept="2OqwBi" id="710iChRP$2$" role="3tpDZA">
+            <node concept="37vLTw" id="710iChRPzOs" role="2Oq$k0">
+              <ref role="3cqZAo" node="1dyouTTpezc" resolve="result" />
+            </node>
+            <node concept="liA8E" id="710iChRPAyc" role="2OqNvi">
+              <ref role="37wK5l" to="33ny:~Optional.hashCode()" resolve="hashCode" />
             </node>
           </node>
         </node>

--- a/code/languages/com.mbeddr.mpsutil/tests/test.com.mbeddr.mpsutil.common/models/test.com.mbeddr.mpsutil.common.util@tests.mps
+++ b/code/languages/com.mbeddr.mpsutil/tests/test.com.mbeddr.mpsutil.common/models/test.com.mbeddr.mpsutil.common.util@tests.mps
@@ -8,6 +8,9 @@
     <use id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures" version="0" />
     <use id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections" version="2" />
     <use id="515552c7-fcc0-4ab4-9789-2f3c49344e85" name="jetbrains.mps.baseLanguage.varVariable" version="0" />
+    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
+    <use id="3a13115c-633c-4c5c-bbcc-75c4219e9555" name="jetbrains.mps.lang.quotation" version="5" />
+    <use id="f47b95d4-5e73-4c04-9204-18076950153b" name="de.itemis.mps.compare" version="0" />
   </languages>
   <imports>
     <import index="7wpd" ref="c7a315e6-1d93-4186-85bc-2dfafd1ccc21/r:fb1c47d7-a72e-4e01-92dc-1e9f2ba4a118(com.mbeddr.mpsutil.common/com.mbeddr.mpsutil.common.util)" />
@@ -16,15 +19,35 @@
     <import index="gtp9" ref="r:007d0985-20e2-4d70-80f1-d0de1aff1076(com.mbeddr.mpsutil.common.graph)" />
     <import index="3o3z" ref="ecfb9949-7433-4db5-85de-0f84d172e4ce/java:com.google.common.collect(de.q60.mps.collections.libs/)" />
     <import index="qhup" ref="b0f8641f-bd77-4421-8425-30d9088a82f7/java:org.apache.commons.lang3.mutable(org.apache.commons/)" />
+    <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
+    <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
   </imports>
   <registry>
     <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
       <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
         <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
       </concept>
+      <concept id="1216913645126" name="jetbrains.mps.lang.test.structure.NodesTestCase" flags="lg" index="1lH9Xt">
+        <property id="2616911529524314943" name="accessMode" index="3DII0k" />
+        <child id="1216993439383" name="methods" index="1qtyYc" />
+        <child id="1217501822150" name="nodesToCheck" index="1SKRRt" />
+        <child id="1217501895093" name="testMethods" index="1SL9yI" />
+      </concept>
+      <concept id="1216989428737" name="jetbrains.mps.lang.test.structure.TestNode" flags="ng" index="1qefOq">
+        <child id="1216989461394" name="nodeToCheck" index="1qenE9" />
+      </concept>
+      <concept id="1210673684636" name="jetbrains.mps.lang.test.structure.TestNodeAnnotation" flags="ng" index="3xLA65" />
+      <concept id="1210674524691" name="jetbrains.mps.lang.test.structure.TestNodeReference" flags="nn" index="3xONca">
+        <reference id="1210674534086" name="declaration" index="3xOPvv" />
+      </concept>
+      <concept id="1225978065297" name="jetbrains.mps.lang.test.structure.SimpleNodeTest" flags="ng" index="1LZb2c" />
     </language>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1224071154655" name="jetbrains.mps.baseLanguage.structure.AsExpression" flags="nn" index="0kSF2">
+        <child id="1224071154657" name="classifierType" index="0kSFW" />
+        <child id="1224071154656" name="expression" index="0kSFX" />
+      </concept>
       <concept id="1219920932475" name="jetbrains.mps.baseLanguage.structure.VariableArityType" flags="in" index="8X2XB">
         <child id="1219921048460" name="componentType" index="8Xvag" />
       </concept>
@@ -32,6 +55,7 @@
         <child id="1068498886297" name="rValue" index="37vLTx" />
         <child id="1068498886295" name="lValue" index="37vLTJ" />
       </concept>
+      <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
       <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="nn" index="2tJIrI" />
       <concept id="1239714755177" name="jetbrains.mps.baseLanguage.structure.AbstractUnaryNumberOperation" flags="nn" index="2$Kvd9">
@@ -59,11 +83,21 @@
       <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
         <child id="1145553007750" name="creator" index="2ShVmc" />
       </concept>
+      <concept id="3870108946630849399" name="jetbrains.mps.baseLanguage.structure.StaticFieldReferenceOperation" flags="ng" index="SiP3y" />
+      <concept id="1070462154015" name="jetbrains.mps.baseLanguage.structure.StaticFieldDeclaration" flags="ig" index="Wx3nA" />
       <concept id="1070475354124" name="jetbrains.mps.baseLanguage.structure.ThisExpression" flags="nn" index="Xjq3P" />
+      <concept id="1070475587102" name="jetbrains.mps.baseLanguage.structure.SuperConstructorInvocation" flags="nn" index="XkiVB" />
+      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
+        <property id="1070475926801" name="value" index="Xl_RC" />
+      </concept>
       <concept id="1081236700938" name="jetbrains.mps.baseLanguage.structure.StaticMethodDeclaration" flags="ig" index="2YIFZL" />
       <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
         <reference id="1144433194310" name="classConcept" index="1Pybhc" />
       </concept>
+      <concept id="1070533707846" name="jetbrains.mps.baseLanguage.structure.StaticFieldReference" flags="nn" index="10M0yZ">
+        <reference id="1144433057691" name="classifier" index="1PxDUh" />
+      </concept>
+      <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
       <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
       <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
       <concept id="1070534934090" name="jetbrains.mps.baseLanguage.structure.CastExpression" flags="nn" index="10QFUN">
@@ -85,6 +119,7 @@
       </concept>
       <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
       <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
+      <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
       </concept>
@@ -99,12 +134,20 @@
         <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
       <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
+      <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
+        <child id="1068580123160" name="condition" index="3clFbw" />
+        <child id="1068580123161" name="ifTrue" index="3clFbx" />
+      </concept>
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
       </concept>
       <concept id="1068580123140" name="jetbrains.mps.baseLanguage.structure.ConstructorDeclaration" flags="ig" index="3clFbW" />
       <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
         <property id="1068580320021" name="value" index="3cmrfH" />
+      </concept>
+      <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
+      <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
+        <child id="1068581517676" name="expression" index="3cqZAk" />
       </concept>
       <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
         <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
@@ -120,6 +163,7 @@
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
         <child id="4972241301747169160" name="typeArgument" index="3PaCim" />
       </concept>
+      <concept id="1073063089578" name="jetbrains.mps.baseLanguage.structure.SuperMethodCall" flags="nn" index="3nyPlj" />
       <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk">
         <child id="1212687122400" name="typeParameter" index="1pMfVU" />
       </concept>
@@ -127,6 +171,7 @@
         <property id="521412098689998745" name="nonStatic" index="2bfB8j" />
         <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
       </concept>
+      <concept id="7812454656619025412" name="jetbrains.mps.baseLanguage.structure.LocalMethodCall" flags="nn" index="1rXfSq" />
       <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
         <reference id="1107535924139" name="classifier" index="3uigEE" />
         <child id="1109201940907" name="parameter" index="11_B2D" />
@@ -139,6 +184,9 @@
       <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ngI" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
       </concept>
+      <concept id="5497648299878491908" name="jetbrains.mps.baseLanguage.structure.BaseVariableReference" flags="nn" index="1M0zk4">
+        <reference id="5497648299878491909" name="baseVariableDeclaration" index="1M0zk5" />
+      </concept>
       <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="nn" index="3SKdUt">
         <child id="8356039341262087992" name="line" index="1aUNEU" />
       </concept>
@@ -147,14 +195,45 @@
       <concept id="1146644641414" name="jetbrains.mps.baseLanguage.structure.ProtectedVisibility" flags="nn" index="3Tmbuc" />
     </language>
     <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
+      <concept id="2524418899405758586" name="jetbrains.mps.baseLanguage.closures.structure.InferredClosureParameterDeclaration" flags="ig" index="gl6BB" />
       <concept id="1199542442495" name="jetbrains.mps.baseLanguage.closures.structure.FunctionType" flags="in" index="1ajhzC">
         <child id="1199542457201" name="resultType" index="1ajl9A" />
         <child id="1199542501692" name="parameterType" index="1ajw0F" />
       </concept>
       <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
+        <property id="890797661671409019" name="forceMultiLine" index="3yWfEV" />
         <child id="1199569906740" name="parameter" index="1bW2Oz" />
         <child id="1199569916463" name="body" index="1bW5cS" />
       </concept>
+    </language>
+    <language id="443f4c36-fcf5-4eb6-9500-8d06ed259e3e" name="jetbrains.mps.baseLanguage.classifiers">
+      <concept id="1205752633985" name="jetbrains.mps.baseLanguage.classifiers.structure.ThisClassifierExpression" flags="nn" index="2WthIp" />
+      <concept id="1205756064662" name="jetbrains.mps.baseLanguage.classifiers.structure.IMemberOperation" flags="ngI" index="2WEnae">
+        <reference id="1205756909548" name="member" index="2WH_rO" />
+      </concept>
+      <concept id="1205769003971" name="jetbrains.mps.baseLanguage.classifiers.structure.DefaultClassifierMethodDeclaration" flags="ng" index="2XrIbr" />
+      <concept id="1205769149993" name="jetbrains.mps.baseLanguage.classifiers.structure.DefaultClassifierMethodCallOperation" flags="nn" index="2XshWL">
+        <child id="1205770614681" name="actualArgument" index="2XxRq1" />
+      </concept>
+    </language>
+    <language id="3a13115c-633c-4c5c-bbcc-75c4219e9555" name="jetbrains.mps.lang.quotation">
+      <concept id="5455284157994012186" name="jetbrains.mps.lang.quotation.structure.NodeBuilderInitLink" flags="ng" index="2pIpSj">
+        <reference id="5455284157994012188" name="link" index="2pIpSl" />
+        <child id="1595412875168045827" name="initValue" index="28nt2d" />
+      </concept>
+      <concept id="5455284157993863837" name="jetbrains.mps.lang.quotation.structure.NodeBuilder" flags="nn" index="2pJPEk">
+        <child id="5455284157993863838" name="quotedNode" index="2pJPEn" />
+      </concept>
+      <concept id="5455284157993863840" name="jetbrains.mps.lang.quotation.structure.NodeBuilderNode" flags="nn" index="2pJPED">
+        <reference id="5455284157993910961" name="concept" index="2pJxaS" />
+        <child id="5455284157993911099" name="values" index="2pJxcM" />
+      </concept>
+      <concept id="8182547171709752110" name="jetbrains.mps.lang.quotation.structure.NodeBuilderExpression" flags="nn" index="36biLy">
+        <child id="8182547171709752112" name="expression" index="36biLW" />
+      </concept>
+    </language>
+    <language id="f47b95d4-5e73-4c04-9204-18076950153b" name="de.itemis.mps.compare">
+      <concept id="756135271275943220" name="de.itemis.mps.compare.structure.AssertNodeEquals" flags="ng" index="3GXo0L" />
     </language>
     <language id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest">
       <concept id="1171931690126" name="jetbrains.mps.baseLanguage.unitTest.structure.TestMethod" flags="ig" index="3s$Bmu">
@@ -179,6 +258,27 @@
         <child id="1171983854940" name="condition" index="3vFALc" />
       </concept>
     </language>
+    <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="8329979535468945057" name="jetbrains.mps.lang.smodel.structure.Node_PresentationOperation" flags="ng" index="2Iv5rx" />
+      <concept id="1883223317721008708" name="jetbrains.mps.lang.smodel.structure.IfInstanceOfStatement" flags="nn" index="Jncv_">
+        <reference id="1883223317721008712" name="nodeConcept" index="JncvD" />
+        <child id="1883223317721008709" name="body" index="Jncv$" />
+        <child id="1883223317721008711" name="variable" index="JncvA" />
+        <child id="1883223317721008710" name="nodeExpression" index="JncvB" />
+      </concept>
+      <concept id="1883223317721008713" name="jetbrains.mps.lang.smodel.structure.IfInstanceOfVariable" flags="ng" index="JncvC" />
+      <concept id="1883223317721107059" name="jetbrains.mps.lang.smodel.structure.IfInstanceOfVarReference" flags="nn" index="Jnkvi" />
+      <concept id="1171999116870" name="jetbrains.mps.lang.smodel.structure.Node_IsNullOperation" flags="nn" index="3w_OXm" />
+      <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
+        <reference id="1138405853777" name="concept" index="ehGHo" />
+      </concept>
+      <concept id="1138056022639" name="jetbrains.mps.lang.smodel.structure.SPropertyAccess" flags="nn" index="3TrcHB">
+        <reference id="1138056395725" name="property" index="3TsBF5" />
+      </concept>
+      <concept id="1138056143562" name="jetbrains.mps.lang.smodel.structure.SLinkAccess" flags="nn" index="3TrEf2">
+        <reference id="1138056516764" name="link" index="3Tt5mk" />
+      </concept>
+    </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
         <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
@@ -201,6 +301,9 @@
       </concept>
     </language>
     <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
+      <concept id="1204796164442" name="jetbrains.mps.baseLanguage.collections.structure.InternalSequenceOperation" flags="nn" index="23sCx2">
+        <child id="1204796294226" name="closure" index="23t8la" />
+      </concept>
       <concept id="540871147943773365" name="jetbrains.mps.baseLanguage.collections.structure.SingleArgumentSequenceOperation" flags="nn" index="25WWJ4">
         <child id="540871147943773366" name="argument" index="25WWJ7" />
       </concept>
@@ -218,17 +321,28 @@
       <concept id="1153944233411" name="jetbrains.mps.baseLanguage.collections.structure.ForEachVariableReference" flags="nn" index="2GrUjf">
         <reference id="1153944258490" name="variable" index="2Gs0qQ" />
       </concept>
+      <concept id="1235573135402" name="jetbrains.mps.baseLanguage.collections.structure.SingletonSequenceCreator" flags="nn" index="2HTt$P">
+        <child id="1235573187520" name="singletonValue" index="2HTEbv" />
+      </concept>
       <concept id="1237721394592" name="jetbrains.mps.baseLanguage.collections.structure.AbstractContainerCreator" flags="nn" index="HWqM0">
+        <child id="1237721435808" name="initValue" index="HW$Y0" />
         <child id="1237721435807" name="elementType" index="HW$YZ" />
       </concept>
       <concept id="1160600644654" name="jetbrains.mps.baseLanguage.collections.structure.ListCreatorWithInit" flags="nn" index="Tc6Ow" />
       <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="nn" index="TSZUe" />
+      <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="nn" index="34oBXx" />
       <concept id="1240325842691" name="jetbrains.mps.baseLanguage.collections.structure.AsSequenceOperation" flags="nn" index="39bAoz" />
+      <concept id="1165525191778" name="jetbrains.mps.baseLanguage.collections.structure.GetFirstOperation" flags="nn" index="1uHKPH" />
+      <concept id="1165530316231" name="jetbrains.mps.baseLanguage.collections.structure.IsEmptyOperation" flags="nn" index="1v1jN8" />
+      <concept id="1165595910856" name="jetbrains.mps.baseLanguage.collections.structure.GetLastOperation" flags="nn" index="1yVyf7" />
+      <concept id="1522217801069396578" name="jetbrains.mps.baseLanguage.collections.structure.FoldLeftOperation" flags="nn" index="1MD8d$">
+        <child id="1522217801069421796" name="seed" index="1MDeny" />
+      </concept>
     </language>
   </registry>
   <node concept="3s_ewN" id="9jWrhFjvu4">
     <property role="3s_ewP" value="LazyInit" />
-    <property role="3GE5qa" value="lazy" />
+    <property role="3GE5qa" value="memoization" />
     <node concept="3Tm1VV" id="9jWrhFjvu5" role="1B3o_S" />
     <node concept="3s_gsd" id="9jWrhFjvu6" role="3s_ewO">
       <node concept="3s$Bmu" id="9jWrhFjvuD" role="3s_gse">
@@ -484,7 +598,7 @@
   </node>
   <node concept="3s_ewN" id="9jWrhFl41j">
     <property role="3s_ewP" value="LazyInitWithCheck" />
-    <property role="3GE5qa" value="lazy" />
+    <property role="3GE5qa" value="memoization" />
     <node concept="3Tm1VV" id="9jWrhFl41k" role="1B3o_S" />
     <node concept="3s_gsd" id="9jWrhFl41l" role="3s_ewO">
       <node concept="3s$Bmu" id="9jWrhFl41m" role="3s_gse">
@@ -3433,6 +3547,2435 @@
             </node>
           </node>
           <node concept="3clFbH" id="5yIFZmd4bTE" role="3cqZAp" />
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="1lH9Xt" id="3u1rFxeDkWz">
+    <property role="3DII0k" value="2hh8MJdVwqX/command" />
+    <property role="3GE5qa" value="instantiation" />
+    <property role="TrG5h" value="NestedMemberPathTest" />
+    <node concept="2XrIbr" id="1dyouTTk_fj" role="1qtyYc">
+      <property role="TrG5h" value="checkCommon" />
+      <node concept="37vLTG" id="1dyouTTk_Dl" role="3clF46">
+        <property role="TrG5h" value="path" />
+        <node concept="3uibUv" id="1dyouTTk_DG" role="1tU5fm">
+          <ref role="3uigEE" node="3u1rFxeDiKa" resolve="NestedMemberPath" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="1dyouTTl_wm" role="3clF46">
+        <property role="TrG5h" value="expectedPathString" />
+        <node concept="17QB3L" id="1dyouTTl_XJ" role="1tU5fm" />
+      </node>
+      <node concept="3cqZAl" id="1dyouTTk_C3" role="3clF45" />
+      <node concept="3clFbS" id="1dyouTTk_fl" role="3clF47">
+        <node concept="3vlDli" id="1dyouTTlCqi" role="3cqZAp">
+          <node concept="37vLTw" id="1dyouTTlFdl" role="3tpDZB">
+            <ref role="3cqZAo" node="1dyouTTl_wm" resolve="expected" />
+          </node>
+          <node concept="2OqwBi" id="1dyouTTlD$j" role="3tpDZA">
+            <node concept="37vLTw" id="1dyouTTlCRB" role="2Oq$k0">
+              <ref role="3cqZAo" node="1dyouTTk_Dl" resolve="path" />
+            </node>
+            <node concept="liA8E" id="1dyouTTlENx" role="2OqNvi">
+              <ref role="37wK5l" node="1dyouTTlmKZ" resolve="asString" />
+            </node>
+          </node>
+        </node>
+        <node concept="3vlDli" id="1dyouTTk_P3" role="3cqZAp">
+          <node concept="3xONca" id="1dyouTTk_P4" role="3tpDZB">
+            <ref role="3xOPvv" node="1dyouTTikIF" resolve="defA" />
+          </node>
+          <node concept="2OqwBi" id="1dyouTTk_P5" role="3tpDZA">
+            <node concept="37vLTw" id="1dyouTTk_P6" role="2Oq$k0">
+              <ref role="3cqZAo" node="1dyouTTk_Dl" resolve="path" />
+            </node>
+            <node concept="liA8E" id="1dyouTTk_P7" role="2OqNvi">
+              <ref role="37wK5l" to="7wpd:65ATjZHmLvj" resolve="root" />
+            </node>
+          </node>
+        </node>
+        <node concept="3vwNmj" id="1dyouTTkA43" role="3cqZAp">
+          <node concept="3clFbC" id="1dyouTTkED7" role="3vwVQn">
+            <node concept="2OqwBi" id="1dyouTTkH2b" role="3uHU7w">
+              <node concept="37vLTw" id="1dyouTTkG07" role="2Oq$k0">
+                <ref role="3cqZAo" node="1dyouTTk_Dl" resolve="path" />
+              </node>
+              <node concept="liA8E" id="1dyouTTkHSY" role="2OqNvi">
+                <ref role="37wK5l" to="7wpd:5PQUSslgGet" resolve="segmentsSize" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="1dyouTTkBQu" role="3uHU7B">
+              <node concept="2OqwBi" id="1dyouTTkA_3" role="2Oq$k0">
+                <node concept="37vLTw" id="1dyouTTkA5E" role="2Oq$k0">
+                  <ref role="3cqZAo" node="1dyouTTk_Dl" resolve="path" />
+                </node>
+                <node concept="liA8E" id="1dyouTTkBpI" role="2OqNvi">
+                  <ref role="37wK5l" to="7wpd:3u1rFxdFBU5" resolve="segments" />
+                </node>
+              </node>
+              <node concept="34oBXx" id="1dyouTTkD0w" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+        <node concept="3vwNmj" id="1dyouTTkIcF" role="3cqZAp">
+          <node concept="3clFbC" id="1dyouTTkXOC" role="3vwVQn">
+            <node concept="2OqwBi" id="1dyouTTkYZO" role="3uHU7w">
+              <node concept="37vLTw" id="1dyouTTkY4c" role="2Oq$k0">
+                <ref role="3cqZAo" node="1dyouTTk_Dl" resolve="path" />
+              </node>
+              <node concept="liA8E" id="1dyouTTkZe$" role="2OqNvi">
+                <ref role="37wK5l" to="7wpd:5PQUSslgGet" resolve="segmentsSize" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="1dyouTTkOo3" role="3uHU7B">
+              <node concept="2OqwBi" id="1dyouTTkIjv" role="2Oq$k0">
+                <node concept="37vLTw" id="1dyouTTkIhL" role="2Oq$k0">
+                  <ref role="3cqZAo" node="1dyouTTk_Dl" resolve="path" />
+                </node>
+                <node concept="liA8E" id="1dyouTTkIw0" role="2OqNvi">
+                  <ref role="37wK5l" to="7wpd:3kD7lY4E2G4" resolve="segmentsAsList" />
+                </node>
+              </node>
+              <node concept="34oBXx" id="1dyouTTkXpQ" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+        <node concept="3vwNmj" id="1dyouTTkZCh" role="3cqZAp">
+          <node concept="3clFbC" id="1dyouTTl5WF" role="3vwVQn">
+            <node concept="2OqwBi" id="1dyouTTl7ct" role="3uHU7w">
+              <node concept="37vLTw" id="1dyouTTl6ey" role="2Oq$k0">
+                <ref role="3cqZAo" node="1dyouTTk_Dl" resolve="path" />
+              </node>
+              <node concept="liA8E" id="1dyouTTl8bH" role="2OqNvi">
+                <ref role="37wK5l" to="7wpd:5PQUSslgGet" resolve="segmentsSize" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="1dyouTTl34V" role="3uHU7B">
+              <node concept="2OqwBi" id="1dyouTTl1tZ" role="2Oq$k0">
+                <node concept="37vLTw" id="1dyouTTl0UP" role="2Oq$k0">
+                  <ref role="3cqZAo" node="1dyouTTk_Dl" resolve="path" />
+                </node>
+                <node concept="liA8E" id="1dyouTTl2o9" role="2OqNvi">
+                  <ref role="37wK5l" to="7wpd:65ATjZHpG8B" resolve="segmentsReverse" />
+                </node>
+              </node>
+              <node concept="34oBXx" id="1dyouTTl45u" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+        <node concept="3vwNmj" id="1dyouTTl8v1" role="3cqZAp">
+          <node concept="2OqwBi" id="1dyouTTl8v2" role="3vwVQn">
+            <node concept="37vLTw" id="1dyouTTl8v3" role="2Oq$k0">
+              <ref role="3cqZAo" node="1dyouTTk_Dl" resolve="path" />
+            </node>
+            <node concept="liA8E" id="1dyouTTl8v4" role="2OqNvi">
+              <ref role="37wK5l" to="7wpd:5LihCoMiagY" resolve="visits" />
+              <node concept="3xONca" id="1dyouTTl8v5" role="37wK5m">
+                <ref role="3xOPvv" node="1dyouTTikIF" resolve="defA" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="1dyouTTqlbE" role="3cqZAp" />
+        <node concept="3SKdUt" id="1dyouTTqF7q" role="3cqZAp">
+          <node concept="1PaTwC" id="1dyouTTqF7r" role="1aUNEU">
+            <node concept="3oM_SD" id="1dyouTTqFL_" role="1PaTwD">
+              <property role="3oM_SC" value="getDefinition/hasDefinition" />
+            </node>
+            <node concept="3oM_SD" id="1dyouTTqFLQ" role="1PaTwD">
+              <property role="3oM_SC" value="works" />
+            </node>
+            <node concept="3oM_SD" id="1dyouTTqFM8" role="1PaTwD">
+              <property role="3oM_SC" value="the" />
+            </node>
+            <node concept="3oM_SD" id="1dyouTTqFMp" role="1PaTwD">
+              <property role="3oM_SC" value="same" />
+            </node>
+            <node concept="3oM_SD" id="1dyouTTqFME" role="1PaTwD">
+              <property role="3oM_SC" value="independent" />
+            </node>
+            <node concept="3oM_SD" id="1dyouTTqFNb" role="1PaTwD">
+              <property role="3oM_SC" value="what" />
+            </node>
+            <node concept="3oM_SD" id="1dyouTTqFNs" role="1PaTwD">
+              <property role="3oM_SC" value="the" />
+            </node>
+            <node concept="3oM_SD" id="1dyouTTqFNH" role="1PaTwD">
+              <property role="3oM_SC" value="actual" />
+            </node>
+            <node concept="3oM_SD" id="1dyouTTqFOL" role="1PaTwD">
+              <property role="3oM_SC" value="path" />
+            </node>
+            <node concept="3oM_SD" id="1dyouTTqFOg" role="1PaTwD">
+              <property role="3oM_SC" value="is" />
+            </node>
+          </node>
+        </node>
+        <node concept="3vlDli" id="1dyouTTqf5h" role="3cqZAp">
+          <node concept="3xONca" id="1dyouTTq_D8" role="3tpDZB">
+            <ref role="3xOPvv" node="1dyouTTjrFE" resolve="defB" />
+          </node>
+          <node concept="2OqwBi" id="1dyouTTtVii" role="3tpDZA">
+            <node concept="2OqwBi" id="1dyouTTqgs9" role="2Oq$k0">
+              <node concept="37vLTw" id="1dyouTTqfED" role="2Oq$k0">
+                <ref role="3cqZAo" node="1dyouTTk_Dl" resolve="path" />
+              </node>
+              <node concept="liA8E" id="1dyouTTq$sU" role="2OqNvi">
+                <ref role="37wK5l" node="1dyouTTekeP" resolve="getDefinition" />
+                <node concept="3xONca" id="1dyouTTq_4g" role="37wK5m">
+                  <ref role="3xOPvv" node="1dyouTTiO3j" resolve="b2" />
+                </node>
+              </node>
+            </node>
+            <node concept="liA8E" id="1dyouTTtZ$8" role="2OqNvi">
+              <ref role="37wK5l" to="33ny:~Optional.get()" resolve="get" />
+            </node>
+          </node>
+        </node>
+        <node concept="3vwNmj" id="1dyouTTqmdC" role="3cqZAp">
+          <node concept="2OqwBi" id="1dyouTTqn_X" role="3vwVQn">
+            <node concept="37vLTw" id="1dyouTTqmOd" role="2Oq$k0">
+              <ref role="3cqZAo" node="1dyouTTk_Dl" resolve="path" />
+            </node>
+            <node concept="liA8E" id="1dyouTTqoKX" role="2OqNvi">
+              <ref role="37wK5l" to="7wpd:1dyouTTgvA2" resolve="hasDefinition" />
+              <node concept="3xONca" id="1dyouTTqpmS" role="37wK5m">
+                <ref role="3xOPvv" node="1dyouTTiO3j" resolve="b2" />
+              </node>
+              <node concept="3xONca" id="1dyouTTqqCC" role="37wK5m">
+                <ref role="3xOPvv" node="1dyouTTjrFE" resolve="defB" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3vwNmj" id="1dyouTTqrba" role="3cqZAp">
+          <node concept="2OqwBi" id="1dyouTTqrbb" role="3vwVQn">
+            <node concept="37vLTw" id="1dyouTTqrbc" role="2Oq$k0">
+              <ref role="3cqZAo" node="1dyouTTk_Dl" resolve="path" />
+            </node>
+            <node concept="liA8E" id="1dyouTTqrbd" role="2OqNvi">
+              <ref role="37wK5l" to="7wpd:1dyouTTgvA2" resolve="hasDefinition" />
+              <node concept="3xONca" id="1dyouTTqxiZ" role="37wK5m">
+                <ref role="3xOPvv" node="1dyouTTkiHP" resolve="c1" />
+              </node>
+              <node concept="3xONca" id="1dyouTTqyyw" role="37wK5m">
+                <ref role="3xOPvv" node="1dyouTTjrDn" resolve="defC" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="1dyouTTdWaJ" role="1SL9yI">
+      <property role="TrG5h" value="pathConstructor0" />
+      <node concept="3cqZAl" id="1dyouTTdWaK" role="3clF45" />
+      <node concept="3clFbS" id="1dyouTTdWaO" role="3clF47">
+        <node concept="3cpWs8" id="1dyouTTiliL" role="3cqZAp">
+          <node concept="3cpWsn" id="1dyouTTiliM" role="3cpWs9">
+            <property role="TrG5h" value="path" />
+            <node concept="3uibUv" id="1dyouTTikJu" role="1tU5fm">
+              <ref role="3uigEE" node="3u1rFxeDiKa" resolve="NestedMemberPath" />
+            </node>
+            <node concept="2ShNRf" id="1dyouTTiliN" role="33vP2m">
+              <node concept="1pGfFk" id="1dyouTTiliO" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" node="1dyouTTekMU" resolve="NestedMemberPath" />
+                <node concept="3xONca" id="1dyouTTiliP" role="37wK5m">
+                  <ref role="3xOPvv" node="1dyouTTikIF" resolve="root" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="1dyouTTl9qT" role="3cqZAp">
+          <node concept="2OqwBi" id="1dyouTTl9qN" role="3clFbG">
+            <node concept="2WthIp" id="1dyouTTl9qQ" role="2Oq$k0" />
+            <node concept="2XshWL" id="1dyouTTl9qS" role="2OqNvi">
+              <ref role="2WH_rO" node="1dyouTTk_fj" resolve="checkCommon" />
+              <node concept="37vLTw" id="1dyouTTl9Db" role="2XxRq1">
+                <ref role="3cqZAo" node="1dyouTTiliM" resolve="path" />
+              </node>
+              <node concept="Xl_RD" id="1dyouTTlK1u" role="2XxRq1">
+                <property role="Xl_RC" value="A" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3vlDli" id="1dyouTTj8iD" role="3cqZAp">
+          <node concept="3cmrfG" id="1dyouTTjdMd" role="3tpDZB">
+            <property role="3cmrfH" value="0" />
+          </node>
+          <node concept="2OqwBi" id="1dyouTTjbIm" role="3tpDZA">
+            <node concept="37vLTw" id="1dyouTTjb11" role="2Oq$k0">
+              <ref role="3cqZAo" node="1dyouTTiliM" resolve="p1" />
+            </node>
+            <node concept="liA8E" id="1dyouTTjcqi" role="2OqNvi">
+              <ref role="37wK5l" to="7wpd:5PQUSslgGet" resolve="segmentsSize" />
+            </node>
+          </node>
+        </node>
+        <node concept="3vwNmj" id="1dyouTTjlDA" role="3cqZAp">
+          <node concept="2OqwBi" id="1dyouTTjoQM" role="3vwVQn">
+            <node concept="2OqwBi" id="1dyouTTjmX3" role="2Oq$k0">
+              <node concept="37vLTw" id="1dyouTTjmeC" role="2Oq$k0">
+                <ref role="3cqZAo" node="1dyouTTiliM" resolve="p1" />
+              </node>
+              <node concept="liA8E" id="1dyouTTjob0" role="2OqNvi">
+                <ref role="37wK5l" to="7wpd:3u1rFxdFBU5" resolve="segments" />
+              </node>
+            </node>
+            <node concept="1v1jN8" id="1dyouTTjpKx" role="2OqNvi" />
+          </node>
+        </node>
+        <node concept="3vlDli" id="1dyouTTj_LU" role="3cqZAp">
+          <node concept="3xONca" id="1dyouTTjCgi" role="3tpDZB">
+            <ref role="3xOPvv" node="1dyouTTikIF" resolve="defA" />
+          </node>
+          <node concept="2OqwBi" id="1dyouTTjAYd" role="3tpDZA">
+            <node concept="37vLTw" id="1dyouTTjAbU" role="2Oq$k0">
+              <ref role="3cqZAo" node="1dyouTTiliM" resolve="p1" />
+            </node>
+            <node concept="liA8E" id="1dyouTTjBSS" role="2OqNvi">
+              <ref role="37wK5l" to="7wpd:5LihCoMi1n7" resolve="getLeaf" />
+            </node>
+          </node>
+        </node>
+        <node concept="3vFxKo" id="1dyouTTjwM6" role="3cqZAp">
+          <node concept="2OqwBi" id="1dyouTTjwM7" role="3vFALc">
+            <node concept="37vLTw" id="1dyouTTjwM8" role="2Oq$k0">
+              <ref role="3cqZAo" node="1dyouTTiliM" resolve="p1" />
+            </node>
+            <node concept="liA8E" id="1dyouTTjwM9" role="2OqNvi">
+              <ref role="37wK5l" to="7wpd:5LihCoMiagY" resolve="visits" />
+              <node concept="3xONca" id="1dyouTTjwMa" role="37wK5m">
+                <ref role="3xOPvv" node="1dyouTTjrFE" resolve="defB" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3vFxKo" id="1dyouTTjtRg" role="3cqZAp">
+          <node concept="2OqwBi" id="1dyouTTjuXY" role="3vFALc">
+            <node concept="37vLTw" id="1dyouTTjud0" role="2Oq$k0">
+              <ref role="3cqZAo" node="1dyouTTiliM" resolve="p1" />
+            </node>
+            <node concept="liA8E" id="1dyouTTjw2u" role="2OqNvi">
+              <ref role="37wK5l" to="7wpd:5LihCoMiagY" resolve="visits" />
+              <node concept="3xONca" id="1dyouTTjwnp" role="37wK5m">
+                <ref role="3xOPvv" node="1dyouTTjrDn" resolve="defC" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="1dyouTTjD33" role="1SL9yI">
+      <property role="TrG5h" value="pathConstructor1" />
+      <node concept="3cqZAl" id="1dyouTTjD34" role="3clF45" />
+      <node concept="3clFbS" id="1dyouTTjD35" role="3clF47">
+        <node concept="3cpWs8" id="1dyouTTjD36" role="3cqZAp">
+          <node concept="3cpWsn" id="1dyouTTjD37" role="3cpWs9">
+            <property role="TrG5h" value="path" />
+            <node concept="3uibUv" id="1dyouTTjD38" role="1tU5fm">
+              <ref role="3uigEE" node="3u1rFxeDiKa" resolve="NestedMemberPath" />
+            </node>
+            <node concept="2ShNRf" id="1dyouTTjD39" role="33vP2m">
+              <node concept="1pGfFk" id="1dyouTTjD3a" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" node="1dyouTTemtd" />
+                <node concept="3xONca" id="1dyouTTjD3b" role="37wK5m">
+                  <ref role="3xOPvv" node="1dyouTTikIF" resolve="defA" />
+                </node>
+                <node concept="2ShNRf" id="1dyouTTjGEl" role="37wK5m">
+                  <node concept="2HTt$P" id="1dyouTTjGEm" role="2ShVmc">
+                    <node concept="3xONca" id="1dyouTTjGEo" role="2HTEbv">
+                      <ref role="3xOPvv" node="1dyouTTiO3j" resolve="b2" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="1dyouTTlaxe" role="3cqZAp">
+          <node concept="2OqwBi" id="1dyouTTlax8" role="3clFbG">
+            <node concept="2WthIp" id="1dyouTTlaxb" role="2Oq$k0" />
+            <node concept="2XshWL" id="1dyouTTlaxd" role="2OqNvi">
+              <ref role="2WH_rO" node="1dyouTTk_fj" resolve="checkCommon" />
+              <node concept="37vLTw" id="1dyouTTlaxg" role="2XxRq1">
+                <ref role="3cqZAo" node="1dyouTTjD37" resolve="path" />
+              </node>
+              <node concept="Xl_RD" id="1dyouTTlKaW" role="2XxRq1">
+                <property role="Xl_RC" value="A/b2" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3vlDli" id="1dyouTTjD3h" role="3cqZAp">
+          <node concept="3cmrfG" id="1dyouTTjD3i" role="3tpDZB">
+            <property role="3cmrfH" value="1" />
+          </node>
+          <node concept="2OqwBi" id="1dyouTTjD3j" role="3tpDZA">
+            <node concept="37vLTw" id="1dyouTTjD3k" role="2Oq$k0">
+              <ref role="3cqZAo" node="1dyouTTjD37" resolve="p1" />
+            </node>
+            <node concept="liA8E" id="1dyouTTjD3l" role="2OqNvi">
+              <ref role="37wK5l" to="7wpd:5PQUSslgGet" resolve="segmentsSize" />
+            </node>
+          </node>
+        </node>
+        <node concept="3vlDli" id="1dyouTTjKUk" role="3cqZAp">
+          <node concept="3xONca" id="1dyouTTkdaf" role="3tpDZB">
+            <ref role="3xOPvv" node="1dyouTTiO3j" resolve="b2" />
+          </node>
+          <node concept="2OqwBi" id="1dyouTTkaQe" role="3tpDZA">
+            <node concept="2OqwBi" id="1dyouTTjMvN" role="2Oq$k0">
+              <node concept="37vLTw" id="1dyouTTjLER" role="2Oq$k0">
+                <ref role="3cqZAo" node="1dyouTTjD37" resolve="path" />
+              </node>
+              <node concept="liA8E" id="1dyouTTjNU1" role="2OqNvi">
+                <ref role="37wK5l" to="7wpd:3u1rFxdFBU5" resolve="segments" />
+              </node>
+            </node>
+            <node concept="1uHKPH" id="1dyouTTkd3m" role="2OqNvi" />
+          </node>
+        </node>
+        <node concept="3vlDli" id="1dyouTTjD3s" role="3cqZAp">
+          <node concept="3xONca" id="1dyouTTjD3t" role="3tpDZB">
+            <ref role="3xOPvv" node="1dyouTTjrFE" resolve="defB" />
+          </node>
+          <node concept="2OqwBi" id="1dyouTTjD3u" role="3tpDZA">
+            <node concept="37vLTw" id="1dyouTTjD3v" role="2Oq$k0">
+              <ref role="3cqZAo" node="1dyouTTjD37" resolve="p1" />
+            </node>
+            <node concept="liA8E" id="1dyouTTjD3w" role="2OqNvi">
+              <ref role="37wK5l" to="7wpd:5LihCoMi1n7" resolve="getLeaf" />
+            </node>
+          </node>
+        </node>
+        <node concept="3vwNmj" id="1dyouTTjS4v" role="3cqZAp">
+          <node concept="2OqwBi" id="1dyouTTjS4w" role="3vwVQn">
+            <node concept="37vLTw" id="1dyouTTjS4x" role="2Oq$k0">
+              <ref role="3cqZAo" node="1dyouTTjD37" resolve="path" />
+            </node>
+            <node concept="liA8E" id="1dyouTTjS4y" role="2OqNvi">
+              <ref role="37wK5l" to="7wpd:5LihCoMiagY" resolve="visits" />
+              <node concept="3xONca" id="1dyouTTjS4z" role="37wK5m">
+                <ref role="3xOPvv" node="1dyouTTjrFE" resolve="defB" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3vFxKo" id="1dyouTTjD3F" role="3cqZAp">
+          <node concept="2OqwBi" id="1dyouTTjD3G" role="3vFALc">
+            <node concept="37vLTw" id="1dyouTTjD3H" role="2Oq$k0">
+              <ref role="3cqZAo" node="1dyouTTjD37" resolve="p1" />
+            </node>
+            <node concept="liA8E" id="1dyouTTjD3I" role="2OqNvi">
+              <ref role="37wK5l" to="7wpd:5LihCoMiagY" resolve="visits" />
+              <node concept="3xONca" id="1dyouTTjD3J" role="37wK5m">
+                <ref role="3xOPvv" node="1dyouTTjrDn" resolve="defC" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="1dyouTTki6g" role="1SL9yI">
+      <property role="TrG5h" value="pathConstructor2" />
+      <node concept="3cqZAl" id="1dyouTTki6h" role="3clF45" />
+      <node concept="3clFbS" id="1dyouTTki6i" role="3clF47">
+        <node concept="3cpWs8" id="1dyouTTki6j" role="3cqZAp">
+          <node concept="3cpWsn" id="1dyouTTki6k" role="3cpWs9">
+            <property role="TrG5h" value="path" />
+            <node concept="3uibUv" id="1dyouTTki6l" role="1tU5fm">
+              <ref role="3uigEE" node="3u1rFxeDiKa" resolve="NestedMemberPath" />
+            </node>
+            <node concept="2ShNRf" id="1dyouTTki6m" role="33vP2m">
+              <node concept="1pGfFk" id="1dyouTTki6n" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" node="1dyouTTemtd" />
+                <node concept="3xONca" id="1dyouTTki6o" role="37wK5m">
+                  <ref role="3xOPvv" node="1dyouTTikIF" resolve="defA" />
+                </node>
+                <node concept="2ShNRf" id="1dyouTTklyp" role="37wK5m">
+                  <node concept="Tc6Ow" id="1dyouTTkmfC" role="2ShVmc">
+                    <node concept="3xONca" id="1dyouTTks_P" role="HW$Y0">
+                      <ref role="3xOPvv" node="1dyouTTiO3j" resolve="b2" />
+                    </node>
+                    <node concept="3xONca" id="1dyouTTksPx" role="HW$Y0">
+                      <ref role="3xOPvv" node="1dyouTTkiHP" resolve="c1" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="1dyouTTldjJ" role="3cqZAp">
+          <node concept="2OqwBi" id="1dyouTTldjD" role="3clFbG">
+            <node concept="2WthIp" id="1dyouTTldjG" role="2Oq$k0" />
+            <node concept="2XshWL" id="1dyouTTldjI" role="2OqNvi">
+              <ref role="2WH_rO" node="1dyouTTk_fj" resolve="checkCommon" />
+              <node concept="37vLTw" id="1dyouTTld$g" role="2XxRq1">
+                <ref role="3cqZAo" node="1dyouTTki6k" resolve="path" />
+              </node>
+              <node concept="Xl_RD" id="1dyouTTlK_c" role="2XxRq1">
+                <property role="Xl_RC" value="A/b2/c1" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3vlDli" id="1dyouTTki6y" role="3cqZAp">
+          <node concept="2OqwBi" id="1dyouTTki6$" role="3tpDZA">
+            <node concept="37vLTw" id="1dyouTTki6_" role="2Oq$k0">
+              <ref role="3cqZAo" node="1dyouTTki6k" resolve="path" />
+            </node>
+            <node concept="liA8E" id="1dyouTTki6A" role="2OqNvi">
+              <ref role="37wK5l" to="7wpd:5PQUSslgGet" resolve="segmentsSize" />
+            </node>
+          </node>
+          <node concept="3cmrfG" id="1dyouTTksXt" role="3tpDZB">
+            <property role="3cmrfH" value="2" />
+          </node>
+        </node>
+        <node concept="3vlDli" id="1dyouTTki6B" role="3cqZAp">
+          <node concept="3xONca" id="1dyouTTki6C" role="3tpDZB">
+            <ref role="3xOPvv" node="1dyouTTiO3j" resolve="b2" />
+          </node>
+          <node concept="2OqwBi" id="1dyouTTki6D" role="3tpDZA">
+            <node concept="2OqwBi" id="1dyouTTki6E" role="2Oq$k0">
+              <node concept="37vLTw" id="1dyouTTki6F" role="2Oq$k0">
+                <ref role="3cqZAo" node="1dyouTTki6k" resolve="path" />
+              </node>
+              <node concept="liA8E" id="1dyouTTki6G" role="2OqNvi">
+                <ref role="37wK5l" to="7wpd:3u1rFxdFBU5" resolve="segments" />
+              </node>
+            </node>
+            <node concept="1uHKPH" id="1dyouTTki6H" role="2OqNvi" />
+          </node>
+        </node>
+        <node concept="3vlDli" id="1dyouTTkt4n" role="3cqZAp">
+          <node concept="3xONca" id="1dyouTTkt4o" role="3tpDZB">
+            <ref role="3xOPvv" node="1dyouTTkiHP" resolve="c1" />
+          </node>
+          <node concept="2OqwBi" id="1dyouTTkt4p" role="3tpDZA">
+            <node concept="2OqwBi" id="1dyouTTkt4q" role="2Oq$k0">
+              <node concept="37vLTw" id="1dyouTTkt4r" role="2Oq$k0">
+                <ref role="3cqZAo" node="1dyouTTki6k" resolve="path" />
+              </node>
+              <node concept="liA8E" id="1dyouTTkt4s" role="2OqNvi">
+                <ref role="37wK5l" to="7wpd:3u1rFxdFBU5" resolve="segments" />
+              </node>
+            </node>
+            <node concept="1yVyf7" id="1dyouTTkuyR" role="2OqNvi" />
+          </node>
+        </node>
+        <node concept="3vlDli" id="1dyouTTki6I" role="3cqZAp">
+          <node concept="3xONca" id="1dyouTTki6J" role="3tpDZB">
+            <ref role="3xOPvv" node="1dyouTTjrDn" resolve="defC" />
+          </node>
+          <node concept="2OqwBi" id="1dyouTTki6K" role="3tpDZA">
+            <node concept="37vLTw" id="1dyouTTki6L" role="2Oq$k0">
+              <ref role="3cqZAo" node="1dyouTTki6k" resolve="path" />
+            </node>
+            <node concept="liA8E" id="1dyouTTki6M" role="2OqNvi">
+              <ref role="37wK5l" to="7wpd:5LihCoMi1n7" resolve="getLeaf" />
+            </node>
+          </node>
+        </node>
+        <node concept="3vwNmj" id="1dyouTTki6S" role="3cqZAp">
+          <node concept="2OqwBi" id="1dyouTTki6T" role="3vwVQn">
+            <node concept="37vLTw" id="1dyouTTki6U" role="2Oq$k0">
+              <ref role="3cqZAo" node="1dyouTTki6k" resolve="path" />
+            </node>
+            <node concept="liA8E" id="1dyouTTki6V" role="2OqNvi">
+              <ref role="37wK5l" to="7wpd:5LihCoMiagY" resolve="visits" />
+              <node concept="3xONca" id="1dyouTTki6W" role="37wK5m">
+                <ref role="3xOPvv" node="1dyouTTjrFE" resolve="defB" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3vwNmj" id="1dyouTTkuUz" role="3cqZAp">
+          <node concept="2OqwBi" id="1dyouTTkuU$" role="3vwVQn">
+            <node concept="37vLTw" id="1dyouTTkuU_" role="2Oq$k0">
+              <ref role="3cqZAo" node="1dyouTTki6k" resolve="path" />
+            </node>
+            <node concept="liA8E" id="1dyouTTkuUA" role="2OqNvi">
+              <ref role="37wK5l" to="7wpd:5LihCoMiagY" resolve="visits" />
+              <node concept="3xONca" id="1dyouTTkuUB" role="37wK5m">
+                <ref role="3xOPvv" node="1dyouTTjrDn" resolve="defC" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="1dyouTTm0CL" role="1SL9yI">
+      <property role="TrG5h" value="pathConstructor3" />
+      <node concept="3cqZAl" id="1dyouTTm0CM" role="3clF45" />
+      <node concept="3clFbS" id="1dyouTTm0CN" role="3clF47">
+        <node concept="3cpWs8" id="1dyouTTm0CO" role="3cqZAp">
+          <node concept="3cpWsn" id="1dyouTTm0CP" role="3cpWs9">
+            <property role="TrG5h" value="path" />
+            <node concept="3uibUv" id="1dyouTTm0CQ" role="1tU5fm">
+              <ref role="3uigEE" node="3u1rFxeDiKa" resolve="NestedMemberPath" />
+            </node>
+            <node concept="2ShNRf" id="1dyouTTm0CR" role="33vP2m">
+              <node concept="1pGfFk" id="1dyouTTm0CS" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" node="1dyouTTemtd" resolve="NestedMemberPath" />
+                <node concept="3xONca" id="1dyouTTm0CT" role="37wK5m">
+                  <ref role="3xOPvv" node="1dyouTTikIF" resolve="defA" />
+                </node>
+                <node concept="2ShNRf" id="1dyouTTm0CU" role="37wK5m">
+                  <node concept="Tc6Ow" id="1dyouTTm0CV" role="2ShVmc">
+                    <node concept="3xONca" id="1dyouTTm0CW" role="HW$Y0">
+                      <ref role="3xOPvv" node="1dyouTTiO3j" resolve="b2" />
+                    </node>
+                    <node concept="3xONca" id="1dyouTTm0CX" role="HW$Y0">
+                      <ref role="3xOPvv" node="1dyouTTkiHP" resolve="c1" />
+                    </node>
+                    <node concept="3xONca" id="1dyouTTm1St" role="HW$Y0">
+                      <ref role="3xOPvv" node="1dyouTTm1RY" resolve="i2" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="1dyouTTm0CY" role="3cqZAp">
+          <node concept="2OqwBi" id="1dyouTTm0CZ" role="3clFbG">
+            <node concept="2WthIp" id="1dyouTTm0D0" role="2Oq$k0" />
+            <node concept="2XshWL" id="1dyouTTm0D1" role="2OqNvi">
+              <ref role="2WH_rO" node="1dyouTTk_fj" resolve="checkCommon" />
+              <node concept="37vLTw" id="1dyouTTm0D2" role="2XxRq1">
+                <ref role="3cqZAo" node="1dyouTTm0CP" resolve="path" />
+              </node>
+              <node concept="Xl_RD" id="1dyouTTm0D3" role="2XxRq1">
+                <property role="Xl_RC" value="A/b2/c1/i2" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3vlDli" id="1dyouTTm0D4" role="3cqZAp">
+          <node concept="2OqwBi" id="1dyouTTm0D5" role="3tpDZA">
+            <node concept="37vLTw" id="1dyouTTm0D6" role="2Oq$k0">
+              <ref role="3cqZAo" node="1dyouTTm0CP" resolve="path" />
+            </node>
+            <node concept="liA8E" id="1dyouTTm0D7" role="2OqNvi">
+              <ref role="37wK5l" to="7wpd:5PQUSslgGet" resolve="segmentsSize" />
+            </node>
+          </node>
+          <node concept="3cmrfG" id="1dyouTTm0D8" role="3tpDZB">
+            <property role="3cmrfH" value="3" />
+          </node>
+        </node>
+        <node concept="3vlDli" id="1dyouTTm0D9" role="3cqZAp">
+          <node concept="3xONca" id="1dyouTTm0Da" role="3tpDZB">
+            <ref role="3xOPvv" node="1dyouTTiO3j" resolve="b2" />
+          </node>
+          <node concept="2OqwBi" id="1dyouTTm0Db" role="3tpDZA">
+            <node concept="2OqwBi" id="1dyouTTm0Dc" role="2Oq$k0">
+              <node concept="37vLTw" id="1dyouTTm0Dd" role="2Oq$k0">
+                <ref role="3cqZAo" node="1dyouTTm0CP" resolve="path" />
+              </node>
+              <node concept="liA8E" id="1dyouTTm0De" role="2OqNvi">
+                <ref role="37wK5l" to="7wpd:3u1rFxdFBU5" resolve="segments" />
+              </node>
+            </node>
+            <node concept="1uHKPH" id="1dyouTTm0Df" role="2OqNvi" />
+          </node>
+        </node>
+        <node concept="3vlDli" id="1dyouTTm0Dg" role="3cqZAp">
+          <node concept="2OqwBi" id="1dyouTTm0Di" role="3tpDZA">
+            <node concept="2OqwBi" id="1dyouTTm0Dj" role="2Oq$k0">
+              <node concept="37vLTw" id="1dyouTTm0Dk" role="2Oq$k0">
+                <ref role="3cqZAo" node="1dyouTTm0CP" resolve="path" />
+              </node>
+              <node concept="liA8E" id="1dyouTTm0Dl" role="2OqNvi">
+                <ref role="37wK5l" to="7wpd:3u1rFxdFBU5" resolve="segments" />
+              </node>
+            </node>
+            <node concept="1yVyf7" id="1dyouTTm0Dm" role="2OqNvi" />
+          </node>
+          <node concept="3xONca" id="1dyouTTm2rC" role="3tpDZB">
+            <ref role="3xOPvv" node="1dyouTTm1RY" resolve="i2" />
+          </node>
+        </node>
+        <node concept="3vlDli" id="1dyouTTm2yx" role="3cqZAp">
+          <node concept="2OqwBi" id="1dyouTTm2yz" role="3tpDZA">
+            <node concept="2OqwBi" id="1dyouTTm2y$" role="2Oq$k0">
+              <node concept="37vLTw" id="1dyouTTm2y_" role="2Oq$k0">
+                <ref role="3cqZAo" node="1dyouTTm0CP" resolve="path" />
+              </node>
+              <node concept="liA8E" id="1dyouTTm2yA" role="2OqNvi">
+                <ref role="37wK5l" to="7wpd:65ATjZHpG8B" resolve="segmentsReverse" />
+              </node>
+            </node>
+            <node concept="1uHKPH" id="1dyouTTm2yB" role="2OqNvi" />
+          </node>
+          <node concept="3xONca" id="1dyouTTm46g" role="3tpDZB">
+            <ref role="3xOPvv" node="1dyouTTm1RY" resolve="i2" />
+          </node>
+        </node>
+        <node concept="3vlDli" id="1dyouTTm0Dn" role="3cqZAp">
+          <node concept="Xl_RD" id="1dyouTTmmxT" role="3tpDZB">
+            <property role="Xl_RC" value="Integer" />
+          </node>
+          <node concept="2OqwBi" id="1dyouTTmjUD" role="3tpDZA">
+            <node concept="2OqwBi" id="1dyouTTm0Dp" role="2Oq$k0">
+              <node concept="37vLTw" id="1dyouTTm0Dq" role="2Oq$k0">
+                <ref role="3cqZAo" node="1dyouTTm0CP" resolve="path" />
+              </node>
+              <node concept="liA8E" id="1dyouTTm0Dr" role="2OqNvi">
+                <ref role="37wK5l" to="7wpd:5LihCoMi1n7" resolve="getLeaf" />
+              </node>
+            </node>
+            <node concept="3TrcHB" id="1dyouTTmm1R" role="2OqNvi">
+              <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+            </node>
+          </node>
+        </node>
+        <node concept="3vwNmj" id="1dyouTTm0Ds" role="3cqZAp">
+          <node concept="2OqwBi" id="1dyouTTm0Dt" role="3vwVQn">
+            <node concept="37vLTw" id="1dyouTTm0Du" role="2Oq$k0">
+              <ref role="3cqZAo" node="1dyouTTm0CP" resolve="path" />
+            </node>
+            <node concept="liA8E" id="1dyouTTm0Dv" role="2OqNvi">
+              <ref role="37wK5l" to="7wpd:5LihCoMiagY" resolve="visits" />
+              <node concept="3xONca" id="1dyouTTm0Dw" role="37wK5m">
+                <ref role="3xOPvv" node="1dyouTTjrFE" resolve="defB" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3vwNmj" id="1dyouTTm0Dx" role="3cqZAp">
+          <node concept="2OqwBi" id="1dyouTTm0Dy" role="3vwVQn">
+            <node concept="37vLTw" id="1dyouTTm0Dz" role="2Oq$k0">
+              <ref role="3cqZAo" node="1dyouTTm0CP" resolve="path" />
+            </node>
+            <node concept="liA8E" id="1dyouTTm0D$" role="2OqNvi">
+              <ref role="37wK5l" to="7wpd:5LihCoMiagY" resolve="visits" />
+              <node concept="3xONca" id="1dyouTTm0D_" role="37wK5m">
+                <ref role="3xOPvv" node="1dyouTTjrDn" resolve="defC" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="1dyouTTmB$7" role="1SL9yI">
+      <property role="TrG5h" value="appendSingleSegment" />
+      <node concept="3cqZAl" id="1dyouTTmB$8" role="3clF45" />
+      <node concept="3clFbS" id="1dyouTTmB$c" role="3clF47">
+        <node concept="3cpWs8" id="1dyouTTmEBv" role="3cqZAp">
+          <node concept="3cpWsn" id="1dyouTTmEBw" role="3cpWs9">
+            <property role="TrG5h" value="p1" />
+            <node concept="3uibUv" id="1dyouTTmEBx" role="1tU5fm">
+              <ref role="3uigEE" node="3u1rFxeDiKa" resolve="NestedMemberPath" />
+            </node>
+            <node concept="2ShNRf" id="1dyouTTmEBy" role="33vP2m">
+              <node concept="1pGfFk" id="1dyouTTmEBz" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" node="1dyouTTemtd" />
+                <node concept="3xONca" id="1dyouTTmEB$" role="37wK5m">
+                  <ref role="3xOPvv" node="1dyouTTikIF" resolve="defA" />
+                </node>
+                <node concept="2ShNRf" id="1dyouTTmEB_" role="37wK5m">
+                  <node concept="Tc6Ow" id="1dyouTTmEBA" role="2ShVmc">
+                    <node concept="3xONca" id="1dyouTTmEBB" role="HW$Y0">
+                      <ref role="3xOPvv" node="1dyouTTiO3j" resolve="b2" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="1dyouTTmHtn" role="3cqZAp">
+          <node concept="3cpWsn" id="1dyouTTmHto" role="3cpWs9">
+            <property role="TrG5h" value="p2a" />
+            <node concept="3uibUv" id="1dyouTTmSGs" role="1tU5fm">
+              <ref role="3uigEE" node="3u1rFxeDiKa" resolve="NestedMemberPath" />
+            </node>
+            <node concept="2OqwBi" id="1dyouTTmHtp" role="33vP2m">
+              <node concept="37vLTw" id="1dyouTTmHtq" role="2Oq$k0">
+                <ref role="3cqZAo" node="1dyouTTmEBw" resolve="p1" />
+              </node>
+              <node concept="liA8E" id="1dyouTTmHtr" role="2OqNvi">
+                <ref role="37wK5l" node="1dyouTTmJNs" resolve="append" />
+                <node concept="3xONca" id="1dyouTTmHts" role="37wK5m">
+                  <ref role="3xOPvv" node="1dyouTTkiHP" resolve="c1" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="1dyouTTmU5W" role="3cqZAp">
+          <node concept="3cpWsn" id="1dyouTTmU5X" role="3cpWs9">
+            <property role="TrG5h" value="p2b" />
+            <node concept="3uibUv" id="1dyouTTmU5Y" role="1tU5fm">
+              <ref role="3uigEE" node="3u1rFxeDiKa" resolve="NestedMemberPath" />
+            </node>
+            <node concept="2ShNRf" id="1dyouTTmU5Z" role="33vP2m">
+              <node concept="1pGfFk" id="1dyouTTmU60" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" node="1dyouTTemtd" />
+                <node concept="3xONca" id="1dyouTTmU61" role="37wK5m">
+                  <ref role="3xOPvv" node="1dyouTTikIF" resolve="defA" />
+                </node>
+                <node concept="2ShNRf" id="1dyouTTmU62" role="37wK5m">
+                  <node concept="Tc6Ow" id="1dyouTTmU63" role="2ShVmc">
+                    <node concept="3xONca" id="1dyouTTmU64" role="HW$Y0">
+                      <ref role="3xOPvv" node="1dyouTTiO3j" resolve="b2" />
+                    </node>
+                    <node concept="3xONca" id="1dyouTTmUDE" role="HW$Y0">
+                      <ref role="3xOPvv" node="1dyouTTkiHP" resolve="c1" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3vlDli" id="1dyouTTmVfh" role="3cqZAp">
+          <node concept="37vLTw" id="1dyouTTmViP" role="3tpDZB">
+            <ref role="3cqZAo" node="1dyouTTmU5X" resolve="p2b" />
+          </node>
+          <node concept="37vLTw" id="1dyouTTmVho" role="3tpDZA">
+            <ref role="3cqZAo" node="1dyouTTmHto" resolve="p2a" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="1dyouTTnfGR" role="1SL9yI">
+      <property role="TrG5h" value="appendSegments" />
+      <node concept="3cqZAl" id="1dyouTTnfGS" role="3clF45" />
+      <node concept="3clFbS" id="1dyouTTnfGT" role="3clF47">
+        <node concept="3cpWs8" id="1dyouTTnfGU" role="3cqZAp">
+          <node concept="3cpWsn" id="1dyouTTnfGV" role="3cpWs9">
+            <property role="TrG5h" value="p1" />
+            <node concept="3uibUv" id="1dyouTTnfGW" role="1tU5fm">
+              <ref role="3uigEE" node="3u1rFxeDiKa" resolve="NestedMemberPath" />
+            </node>
+            <node concept="2ShNRf" id="1dyouTTnfGX" role="33vP2m">
+              <node concept="1pGfFk" id="1dyouTTnfGY" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" node="1dyouTTemtd" resolve="NestedMemberPath" />
+                <node concept="3xONca" id="1dyouTTnfGZ" role="37wK5m">
+                  <ref role="3xOPvv" node="1dyouTTikIF" resolve="defA" />
+                </node>
+                <node concept="2ShNRf" id="1dyouTTnfH0" role="37wK5m">
+                  <node concept="Tc6Ow" id="1dyouTTnfH1" role="2ShVmc">
+                    <node concept="3xONca" id="1dyouTTnfH2" role="HW$Y0">
+                      <ref role="3xOPvv" node="1dyouTTiO3j" resolve="b2" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="1dyouTTnfH3" role="3cqZAp">
+          <node concept="3cpWsn" id="1dyouTTnfH4" role="3cpWs9">
+            <property role="TrG5h" value="p2a" />
+            <node concept="3uibUv" id="1dyouTTnfH5" role="1tU5fm">
+              <ref role="3uigEE" node="3u1rFxeDiKa" resolve="NestedMemberPath" />
+            </node>
+            <node concept="2OqwBi" id="1dyouTTnfH6" role="33vP2m">
+              <node concept="37vLTw" id="1dyouTTnfH7" role="2Oq$k0">
+                <ref role="3cqZAo" node="1dyouTTnfGV" resolve="p1" />
+              </node>
+              <node concept="liA8E" id="1dyouTTnfH8" role="2OqNvi">
+                <ref role="37wK5l" node="1dyouTTnitF" resolve="append" />
+                <node concept="2ShNRf" id="1dyouTTo4Xv" role="37wK5m">
+                  <node concept="Tc6Ow" id="1dyouTTo4Xw" role="2ShVmc">
+                    <node concept="3xONca" id="1dyouTToiUj" role="HW$Y0">
+                      <ref role="3xOPvv" node="1dyouTTkiHP" resolve="c1" />
+                    </node>
+                    <node concept="3xONca" id="1dyouTToj6f" role="HW$Y0">
+                      <ref role="3xOPvv" node="1dyouTTm1RY" resolve="i2" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="1dyouTTnfHa" role="3cqZAp">
+          <node concept="3cpWsn" id="1dyouTTnfHb" role="3cpWs9">
+            <property role="TrG5h" value="p2b" />
+            <node concept="3uibUv" id="1dyouTTnfHc" role="1tU5fm">
+              <ref role="3uigEE" node="3u1rFxeDiKa" resolve="NestedMemberPath" />
+            </node>
+            <node concept="2ShNRf" id="1dyouTTnfHd" role="33vP2m">
+              <node concept="1pGfFk" id="1dyouTTnfHe" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" node="1dyouTTemtd" resolve="NestedMemberPath" />
+                <node concept="3xONca" id="1dyouTTnfHf" role="37wK5m">
+                  <ref role="3xOPvv" node="1dyouTTikIF" resolve="defA" />
+                </node>
+                <node concept="2ShNRf" id="1dyouTTnfHg" role="37wK5m">
+                  <node concept="Tc6Ow" id="1dyouTTnfHh" role="2ShVmc">
+                    <node concept="3xONca" id="1dyouTTnfHi" role="HW$Y0">
+                      <ref role="3xOPvv" node="1dyouTTiO3j" resolve="b2" />
+                    </node>
+                    <node concept="3xONca" id="1dyouTTnfHj" role="HW$Y0">
+                      <ref role="3xOPvv" node="1dyouTTkiHP" resolve="c1" />
+                    </node>
+                    <node concept="3xONca" id="1dyouTTojeC" role="HW$Y0">
+                      <ref role="3xOPvv" node="1dyouTTm1RY" resolve="i2" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3vlDli" id="1dyouTTnfHk" role="3cqZAp">
+          <node concept="37vLTw" id="1dyouTTnfHl" role="3tpDZB">
+            <ref role="3cqZAo" node="1dyouTTnfHb" resolve="p2b" />
+          </node>
+          <node concept="37vLTw" id="1dyouTTnfHm" role="3tpDZA">
+            <ref role="3cqZAo" node="1dyouTTnfH4" resolve="p2a" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="1dyouTTo_8o" role="1SL9yI">
+      <property role="TrG5h" value="concatPathsCorrect" />
+      <node concept="3cqZAl" id="1dyouTTo_8p" role="3clF45" />
+      <node concept="3clFbS" id="1dyouTTo_8t" role="3clF47">
+        <node concept="3cpWs8" id="1dyouTTo_TZ" role="3cqZAp">
+          <node concept="3cpWsn" id="1dyouTTo_U0" role="3cpWs9">
+            <property role="TrG5h" value="p1" />
+            <node concept="3uibUv" id="1dyouTTo_U1" role="1tU5fm">
+              <ref role="3uigEE" node="3u1rFxeDiKa" resolve="NestedMemberPath" />
+            </node>
+            <node concept="2ShNRf" id="1dyouTTo_U2" role="33vP2m">
+              <node concept="1pGfFk" id="1dyouTTo_U3" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" node="1dyouTTemtd" />
+                <node concept="3xONca" id="1dyouTTo_U4" role="37wK5m">
+                  <ref role="3xOPvv" node="1dyouTTikIF" resolve="defA" />
+                </node>
+                <node concept="2ShNRf" id="1dyouTTo_U5" role="37wK5m">
+                  <node concept="Tc6Ow" id="1dyouTTo_U6" role="2ShVmc">
+                    <node concept="3xONca" id="1dyouTTo_U7" role="HW$Y0">
+                      <ref role="3xOPvv" node="1dyouTTiO3j" resolve="b2" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="1dyouTToAh0" role="3cqZAp">
+          <node concept="3cpWsn" id="1dyouTToAh1" role="3cpWs9">
+            <property role="TrG5h" value="p2" />
+            <node concept="3uibUv" id="1dyouTToAh2" role="1tU5fm">
+              <ref role="3uigEE" node="3u1rFxeDiKa" resolve="NestedMemberPath" />
+            </node>
+            <node concept="2ShNRf" id="1dyouTToAh3" role="33vP2m">
+              <node concept="1pGfFk" id="1dyouTToAh4" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" node="1dyouTTemtd" resolve="NestedMemberPath" />
+                <node concept="3xONca" id="1dyouTToAh5" role="37wK5m">
+                  <ref role="3xOPvv" node="1dyouTTjrFE" resolve="defB" />
+                </node>
+                <node concept="2ShNRf" id="1dyouTToAh6" role="37wK5m">
+                  <node concept="Tc6Ow" id="1dyouTToAh7" role="2ShVmc">
+                    <node concept="3xONca" id="1dyouTToAh8" role="HW$Y0">
+                      <ref role="3xOPvv" node="1dyouTTkiHP" resolve="c1" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="1dyouTTpezb" role="3cqZAp">
+          <node concept="3cpWsn" id="1dyouTTpezc" role="3cpWs9">
+            <property role="TrG5h" value="result" />
+            <node concept="3uibUv" id="1dyouTTpdYn" role="1tU5fm">
+              <ref role="3uigEE" to="33ny:~Optional" resolve="Optional" />
+              <node concept="3uibUv" id="1dyouTTpdYq" role="11_B2D">
+                <ref role="3uigEE" node="3u1rFxeDiKa" resolve="NestedMemberPath" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="1dyouTTpezd" role="33vP2m">
+              <node concept="37vLTw" id="1dyouTTpeze" role="2Oq$k0">
+                <ref role="3cqZAo" node="1dyouTTo_U0" resolve="p1" />
+              </node>
+              <node concept="liA8E" id="1dyouTTpezf" role="2OqNvi">
+                <ref role="37wK5l" node="1dyouTToJ5m" resolve="concatSafe" />
+                <node concept="37vLTw" id="1dyouTTpezg" role="37wK5m">
+                  <ref role="3cqZAo" node="1dyouTToAh1" resolve="p2" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3vwNmj" id="1dyouTTpiM6" role="3cqZAp">
+          <node concept="2OqwBi" id="1dyouTTpiWM" role="3vwVQn">
+            <node concept="37vLTw" id="1dyouTTpiOX" role="2Oq$k0">
+              <ref role="3cqZAo" node="1dyouTTpezc" resolve="result" />
+            </node>
+            <node concept="liA8E" id="1dyouTTpjtu" role="2OqNvi">
+              <ref role="37wK5l" to="33ny:~Optional.isPresent()" resolve="isPresent" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="1dyouTTpjB4" role="3cqZAp" />
+        <node concept="3cpWs8" id="1dyouTTpjG5" role="3cqZAp">
+          <node concept="3cpWsn" id="1dyouTTpjG6" role="3cpWs9">
+            <property role="TrG5h" value="p3" />
+            <node concept="3uibUv" id="1dyouTTpjG7" role="1tU5fm">
+              <ref role="3uigEE" node="3u1rFxeDiKa" resolve="NestedMemberPath" />
+            </node>
+            <node concept="2ShNRf" id="1dyouTTpjG8" role="33vP2m">
+              <node concept="1pGfFk" id="1dyouTTpjG9" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" node="1dyouTTemtd" />
+                <node concept="3xONca" id="1dyouTTpjGa" role="37wK5m">
+                  <ref role="3xOPvv" node="1dyouTTikIF" resolve="defA" />
+                </node>
+                <node concept="2ShNRf" id="1dyouTTpjGb" role="37wK5m">
+                  <node concept="Tc6Ow" id="1dyouTTpjGc" role="2ShVmc">
+                    <node concept="3xONca" id="1dyouTTpjGd" role="HW$Y0">
+                      <ref role="3xOPvv" node="1dyouTTiO3j" resolve="b2" />
+                    </node>
+                    <node concept="3xONca" id="1dyouTTplTe" role="HW$Y0">
+                      <ref role="3xOPvv" node="1dyouTTkiHP" resolve="c1" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3vlDli" id="1dyouTTpm4Y" role="3cqZAp">
+          <node concept="37vLTw" id="1dyouTTpmdv" role="3tpDZB">
+            <ref role="3cqZAo" node="1dyouTTpjG6" resolve="p3" />
+          </node>
+          <node concept="2OqwBi" id="1dyouTTp_wM" role="3tpDZA">
+            <node concept="37vLTw" id="1dyouTTpma4" role="2Oq$k0">
+              <ref role="3cqZAo" node="1dyouTTpezc" resolve="result" />
+            </node>
+            <node concept="liA8E" id="1dyouTTpAiY" role="2OqNvi">
+              <ref role="37wK5l" to="33ny:~Optional.get()" resolve="get" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="1dyouTTpM0L" role="1SL9yI">
+      <property role="TrG5h" value="concatPathsWrong" />
+      <node concept="3cqZAl" id="1dyouTTpM0M" role="3clF45" />
+      <node concept="3clFbS" id="1dyouTTpM0N" role="3clF47">
+        <node concept="3cpWs8" id="1dyouTTpM0O" role="3cqZAp">
+          <node concept="3cpWsn" id="1dyouTTpM0P" role="3cpWs9">
+            <property role="TrG5h" value="p1" />
+            <node concept="3uibUv" id="1dyouTTpM0Q" role="1tU5fm">
+              <ref role="3uigEE" node="3u1rFxeDiKa" resolve="NestedMemberPath" />
+            </node>
+            <node concept="2ShNRf" id="1dyouTTpM0R" role="33vP2m">
+              <node concept="1pGfFk" id="1dyouTTpM0S" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" node="1dyouTTemtd" resolve="NestedMemberPath" />
+                <node concept="3xONca" id="1dyouTTpM0T" role="37wK5m">
+                  <ref role="3xOPvv" node="1dyouTTikIF" resolve="defA" />
+                </node>
+                <node concept="2ShNRf" id="1dyouTTpM0U" role="37wK5m">
+                  <node concept="Tc6Ow" id="1dyouTTpM0V" role="2ShVmc">
+                    <node concept="3xONca" id="1dyouTTpM0W" role="HW$Y0">
+                      <ref role="3xOPvv" node="1dyouTTiO3j" resolve="b2" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="1dyouTTpM0X" role="3cqZAp">
+          <node concept="3cpWsn" id="1dyouTTpM0Y" role="3cpWs9">
+            <property role="TrG5h" value="p2" />
+            <node concept="3uibUv" id="1dyouTTpM0Z" role="1tU5fm">
+              <ref role="3uigEE" node="3u1rFxeDiKa" resolve="NestedMemberPath" />
+            </node>
+            <node concept="2ShNRf" id="1dyouTTpM10" role="33vP2m">
+              <node concept="1pGfFk" id="1dyouTTpM11" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" node="1dyouTTemtd" resolve="NestedMemberPath" />
+                <node concept="3xONca" id="1dyouTTpM12" role="37wK5m">
+                  <ref role="3xOPvv" node="1dyouTTjrDn" resolve="defC" />
+                </node>
+                <node concept="2ShNRf" id="1dyouTTpM13" role="37wK5m">
+                  <node concept="Tc6Ow" id="1dyouTTpM14" role="2ShVmc">
+                    <node concept="3xONca" id="1dyouTTpXHX" role="HW$Y0">
+                      <ref role="3xOPvv" node="1dyouTTm1RY" resolve="i2" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="1dyouTTpM16" role="3cqZAp">
+          <node concept="3cpWsn" id="1dyouTTpM17" role="3cpWs9">
+            <property role="TrG5h" value="result" />
+            <node concept="3uibUv" id="1dyouTTpM18" role="1tU5fm">
+              <ref role="3uigEE" to="33ny:~Optional" resolve="Optional" />
+              <node concept="3uibUv" id="1dyouTTpM19" role="11_B2D">
+                <ref role="3uigEE" node="3u1rFxeDiKa" resolve="NestedMemberPath" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="1dyouTTpM1a" role="33vP2m">
+              <node concept="37vLTw" id="1dyouTTpM1b" role="2Oq$k0">
+                <ref role="3cqZAo" node="1dyouTTpM0P" resolve="p1" />
+              </node>
+              <node concept="liA8E" id="1dyouTTpM1c" role="2OqNvi">
+                <ref role="37wK5l" node="1dyouTToJ5m" resolve="concatSafe" />
+                <node concept="37vLTw" id="1dyouTTpM1d" role="37wK5m">
+                  <ref role="3cqZAo" node="1dyouTTpM0Y" resolve="p2" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3vwNmj" id="1dyouTTpM1e" role="3cqZAp">
+          <node concept="2OqwBi" id="1dyouTTpM1f" role="3vwVQn">
+            <node concept="37vLTw" id="1dyouTTpM1g" role="2Oq$k0">
+              <ref role="3cqZAo" node="1dyouTTpM17" resolve="result" />
+            </node>
+            <node concept="liA8E" id="1dyouTTpYq8" role="2OqNvi">
+              <ref role="37wK5l" to="33ny:~Optional.isEmpty()" resolve="isEmpty" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="3u1rFxeDm0R" role="1SKRRt">
+      <node concept="312cEu" id="3u1rFxeDm0P" role="1qenE9">
+        <property role="TrG5h" value="A" />
+        <node concept="3Tm1VV" id="3u1rFxeDm0Q" role="1B3o_S" />
+        <node concept="312cEg" id="1dyouTTdVNL" role="jymVt">
+          <property role="TrG5h" value="b1" />
+          <node concept="3Tm1VV" id="1dyouTTdVMW" role="1B3o_S" />
+          <node concept="3uibUv" id="1dyouTTdVNu" role="1tU5fm">
+            <ref role="3uigEE" node="1dyouTTdIM3" resolve="B" />
+          </node>
+        </node>
+        <node concept="312cEg" id="1dyouTTdVQr" role="jymVt">
+          <property role="TrG5h" value="b2" />
+          <node concept="3Tm1VV" id="1dyouTTdVPn" role="1B3o_S" />
+          <node concept="3uibUv" id="1dyouTTdVPV" role="1tU5fm">
+            <ref role="3uigEE" node="1dyouTTdIM3" resolve="B" />
+          </node>
+          <node concept="3xLA65" id="1dyouTTiO3j" role="lGtFl">
+            <property role="TrG5h" value="b2" />
+          </node>
+        </node>
+        <node concept="3xLA65" id="1dyouTTikIF" role="lGtFl">
+          <property role="TrG5h" value="defA" />
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="1dyouTTdIM2" role="1SKRRt">
+      <node concept="312cEu" id="1dyouTTdIM3" role="1qenE9">
+        <property role="TrG5h" value="B" />
+        <node concept="3Tm1VV" id="1dyouTTdIM4" role="1B3o_S" />
+        <node concept="312cEg" id="1dyouTTdVTD" role="jymVt">
+          <property role="TrG5h" value="c1" />
+          <node concept="3Tm1VV" id="1dyouTTdVSi" role="1B3o_S" />
+          <node concept="3uibUv" id="1dyouTTdVT5" role="1tU5fm">
+            <ref role="3uigEE" node="1dyouTTdIMf" resolve="C" />
+          </node>
+          <node concept="3xLA65" id="1dyouTTkiHP" role="lGtFl">
+            <property role="TrG5h" value="c1" />
+          </node>
+        </node>
+        <node concept="312cEg" id="1dyouTTdVWV" role="jymVt">
+          <property role="TrG5h" value="c2" />
+          <node concept="3Tm1VV" id="1dyouTTdVVL" role="1B3o_S" />
+          <node concept="3uibUv" id="1dyouTTdVWA" role="1tU5fm">
+            <ref role="3uigEE" node="1dyouTTdIMf" resolve="C" />
+          </node>
+        </node>
+        <node concept="312cEg" id="1dyouTTdW0E" role="jymVt">
+          <property role="TrG5h" value="c3" />
+          <node concept="3Tm1VV" id="1dyouTTdVZ7" role="1B3o_S" />
+          <node concept="3uibUv" id="1dyouTTdVZY" role="1tU5fm">
+            <ref role="3uigEE" node="1dyouTTdIMf" resolve="C" />
+          </node>
+        </node>
+        <node concept="3xLA65" id="1dyouTTjrFE" role="lGtFl">
+          <property role="TrG5h" value="defB" />
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="1dyouTTdIMe" role="1SKRRt">
+      <node concept="312cEu" id="1dyouTTdIMf" role="1qenE9">
+        <property role="TrG5h" value="C" />
+        <node concept="3Tm1VV" id="1dyouTTdIMg" role="1B3o_S" />
+        <node concept="312cEg" id="1dyouTTdW5u" role="jymVt">
+          <property role="TrG5h" value="i1" />
+          <node concept="3Tm1VV" id="1dyouTTdW3x" role="1B3o_S" />
+          <node concept="3uibUv" id="1dyouTTdWl7" role="1tU5fm">
+            <ref role="3uigEE" to="wyt6:~Integer" resolve="Integer" />
+          </node>
+        </node>
+        <node concept="312cEg" id="1dyouTTdW9C" role="jymVt">
+          <property role="TrG5h" value="i2" />
+          <node concept="3Tm1VV" id="1dyouTTdW7_" role="1B3o_S" />
+          <node concept="3uibUv" id="1dyouTTdWm_" role="1tU5fm">
+            <ref role="3uigEE" to="wyt6:~Integer" resolve="Integer" />
+          </node>
+          <node concept="3xLA65" id="1dyouTTm1RY" role="lGtFl">
+            <property role="TrG5h" value="i2" />
+          </node>
+        </node>
+        <node concept="3xLA65" id="1dyouTTjrDn" role="lGtFl">
+          <property role="TrG5h" value="defC" />
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="312cEu" id="3u1rFxeDiKa">
+    <property role="3GE5qa" value="instantiation" />
+    <property role="TrG5h" value="NestedMemberPath" />
+    <node concept="2tJIrI" id="1dyouTTekz5" role="jymVt" />
+    <node concept="3clFbW" id="1dyouTTekMU" role="jymVt">
+      <node concept="3cqZAl" id="1dyouTTekMW" role="3clF45" />
+      <node concept="3Tm1VV" id="1dyouTTekMX" role="1B3o_S" />
+      <node concept="3clFbS" id="1dyouTTekMY" role="3clF47">
+        <node concept="XkiVB" id="1dyouTTelAV" role="3cqZAp">
+          <ref role="37wK5l" to="7wpd:65ATjZHltXU" resolve="InstancePath" />
+          <node concept="37vLTw" id="1dyouTTelVI" role="37wK5m">
+            <ref role="3cqZAo" node="1dyouTTekVP" resolve="root" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="1dyouTTekVP" role="3clF46">
+        <property role="TrG5h" value="root" />
+        <node concept="3Tqbb2" id="1dyouTTekVO" role="1tU5fm">
+          <ref role="ehGHo" to="tpee:g7pOWCK" resolve="Classifier" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="1dyouTTemaW" role="jymVt" />
+    <node concept="3clFbW" id="1dyouTTemtd" role="jymVt">
+      <node concept="37vLTG" id="1dyouTTemAf" role="3clF46">
+        <property role="TrG5h" value="root" />
+        <node concept="3Tqbb2" id="1dyouTTemAg" role="1tU5fm">
+          <ref role="ehGHo" to="tpee:g7pOWCK" resolve="Classifier" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="1dyouTTemIk" role="3clF46">
+        <property role="TrG5h" value="segments" />
+        <node concept="A3Dl8" id="1dyouTTemRi" role="1tU5fm">
+          <node concept="3Tqbb2" id="1dyouTTemSt" role="A3Ik2">
+            <ref role="ehGHo" to="tpee:fz3uBXI" resolve="VariableDeclaration" />
+          </node>
+        </node>
+      </node>
+      <node concept="3cqZAl" id="1dyouTTemtf" role="3clF45" />
+      <node concept="3Tm1VV" id="1dyouTTemtg" role="1B3o_S" />
+      <node concept="3clFbS" id="1dyouTTemth" role="3clF47">
+        <node concept="XkiVB" id="1dyouTTenel" role="3cqZAp">
+          <ref role="37wK5l" to="7wpd:65ATjZHlpIu" />
+          <node concept="37vLTw" id="1dyouTTenvu" role="37wK5m">
+            <ref role="3cqZAo" node="1dyouTTemAf" resolve="root" />
+          </node>
+          <node concept="37vLTw" id="1dyouTTeodB" role="37wK5m">
+            <ref role="3cqZAo" node="1dyouTTemIk" resolve="segments" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="1dyouTTeo_U" role="jymVt" />
+    <node concept="3Tm1VV" id="3u1rFxeDiKb" role="1B3o_S" />
+    <node concept="3uibUv" id="3u1rFxeDjjc" role="1zkMxy">
+      <ref role="3uigEE" to="7wpd:65ATjZHjU$h" resolve="InstancePath" />
+      <node concept="3Tqbb2" id="1dyouTTek2o" role="11_B2D">
+        <ref role="ehGHo" to="tpee:g7pOWCK" resolve="Classifier" />
+      </node>
+      <node concept="3Tqbb2" id="1dyouTTek8F" role="11_B2D">
+        <ref role="ehGHo" to="tpee:fz3uBXI" resolve="VariableDeclaration" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="1dyouTTekf7" role="jymVt">
+      <property role="TrG5h" value="copy" />
+      <node concept="3Tmbuc" id="1dyouTTekf9" role="1B3o_S" />
+      <node concept="3uibUv" id="1dyouTTepZF" role="3clF45">
+        <ref role="3uigEE" node="3u1rFxeDiKa" resolve="NestedMemberPath" />
+      </node>
+      <node concept="3clFbS" id="1dyouTTekfg" role="3clF47">
+        <node concept="3clFbF" id="1dyouTTekfj" role="3cqZAp">
+          <node concept="2ShNRf" id="1dyouTTeqkc" role="3clFbG">
+            <node concept="1pGfFk" id="1dyouTTerWm" role="2ShVmc">
+              <property role="373rjd" value="true" />
+              <ref role="37wK5l" node="1dyouTTekMU" resolve="NestedMemberPath" />
+              <node concept="1rXfSq" id="1dyouTTesdK" role="37wK5m">
+                <ref role="37wK5l" to="7wpd:65ATjZHmLvj" resolve="root" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="1dyouTTekfh" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="1dyouTTepD_" role="jymVt" />
+    <node concept="3clFb_" id="1dyouTTekeP" role="jymVt">
+      <property role="TrG5h" value="getDefinition" />
+      <node concept="37vLTG" id="1dyouTTekeQ" role="3clF46">
+        <property role="TrG5h" value="segment" />
+        <node concept="3Tqbb2" id="1dyouTTekeV" role="1tU5fm">
+          <ref role="ehGHo" to="tpee:fz3uBXI" resolve="VariableDeclaration" />
+        </node>
+      </node>
+      <node concept="3Tmbuc" id="1dyouTTekeT" role="1B3o_S" />
+      <node concept="3uibUv" id="1dyouTTeYWJ" role="3clF45">
+        <ref role="3uigEE" to="33ny:~Optional" resolve="Optional" />
+        <node concept="3Tqbb2" id="1dyouTTekeW" role="11_B2D">
+          <ref role="ehGHo" to="tpee:g7pOWCK" resolve="Classifier" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="1dyouTTekeX" role="3clF47">
+        <node concept="Jncv_" id="1dyouTTeAOL" role="3cqZAp">
+          <ref role="JncvD" to="tpee:g7uibYu" resolve="ClassifierType" />
+          <node concept="2OqwBi" id="1dyouTTeBgJ" role="JncvB">
+            <node concept="37vLTw" id="1dyouTTeBdW" role="2Oq$k0">
+              <ref role="3cqZAo" node="1dyouTTekeQ" resolve="segment" />
+            </node>
+            <node concept="3TrEf2" id="1dyouTTeBv5" role="2OqNvi">
+              <ref role="3Tt5mk" to="tpee:4VkOLwjf83e" resolve="type" />
+            </node>
+          </node>
+          <node concept="3clFbS" id="1dyouTTeAOP" role="Jncv$">
+            <node concept="3cpWs6" id="1dyouTTeC_6" role="3cqZAp">
+              <node concept="2YIFZM" id="1dyouTTf031" role="3cqZAk">
+                <ref role="37wK5l" to="33ny:~Optional.of(java.lang.Object)" resolve="of" />
+                <ref role="1Pybhc" to="33ny:~Optional" resolve="Optional" />
+                <node concept="2OqwBi" id="1dyouTTf0E0" role="37wK5m">
+                  <node concept="Jnkvi" id="1dyouTTf0ke" role="2Oq$k0">
+                    <ref role="1M0zk5" node="1dyouTTeAOR" resolve="ct" />
+                  </node>
+                  <node concept="3TrEf2" id="1dyouTTf1hZ" role="2OqNvi">
+                    <ref role="3Tt5mk" to="tpee:g7uigIF" resolve="classifier" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="JncvC" id="1dyouTTeAOR" role="JncvA">
+            <property role="TrG5h" value="ct" />
+            <node concept="2jxLKc" id="1dyouTTeAOS" role="1tU5fm" />
+          </node>
+        </node>
+        <node concept="3clFbF" id="1dyouTTf20Z" role="3cqZAp">
+          <node concept="2YIFZM" id="1dyouTTf2oV" role="3clFbG">
+            <ref role="37wK5l" to="33ny:~Optional.empty()" resolve="empty" />
+            <ref role="1Pybhc" to="33ny:~Optional" resolve="Optional" />
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="1dyouTTekeY" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="1dyouTTeoKC" role="jymVt" />
+    <node concept="3clFb_" id="1dyouTTekeZ" role="jymVt">
+      <property role="TrG5h" value="getRootPresentation" />
+      <node concept="3Tmbuc" id="1dyouTTekf1" role="1B3o_S" />
+      <node concept="17QB3L" id="1dyouTTekf2" role="3clF45" />
+      <node concept="3clFbS" id="1dyouTTekf3" role="3clF47">
+        <node concept="3clFbF" id="1dyouTTekf6" role="3cqZAp">
+          <node concept="2OqwBi" id="1dyouTTf3nL" role="3clFbG">
+            <node concept="1rXfSq" id="1dyouTTf2Jc" role="2Oq$k0">
+              <ref role="37wK5l" to="7wpd:65ATjZHmLvj" resolve="root" />
+            </node>
+            <node concept="2Iv5rx" id="1dyouTTf4pL" role="2OqNvi" />
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="1dyouTTekf4" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="1dyouTTlm1j" role="jymVt" />
+    <node concept="3clFb_" id="1dyouTTlmKZ" role="jymVt">
+      <property role="TrG5h" value="asString" />
+      <node concept="3clFbS" id="1dyouTTlmL2" role="3clF47">
+        <node concept="3clFbF" id="1dyouTTln7l" role="3cqZAp">
+          <node concept="2OqwBi" id="1dyouTTlo0q" role="3clFbG">
+            <node concept="1rXfSq" id="1dyouTTln7k" role="2Oq$k0">
+              <ref role="37wK5l" to="7wpd:3u1rFxdFBU5" resolve="segments" />
+            </node>
+            <node concept="1MD8d$" id="1dyouTTlp8g" role="2OqNvi">
+              <node concept="1bVj0M" id="1dyouTTlp8i" role="23t8la">
+                <node concept="3clFbS" id="1dyouTTlp8j" role="1bW5cS">
+                  <node concept="3clFbF" id="1dyouTTlt1Y" role="3cqZAp">
+                    <node concept="3cpWs3" id="1dyouTTlwLy" role="3clFbG">
+                      <node concept="2OqwBi" id="1dyouTTlxu3" role="3uHU7w">
+                        <node concept="37vLTw" id="1dyouTTlwNl" role="2Oq$k0">
+                          <ref role="3cqZAo" node="1dyouTTlp8m" resolve="it" />
+                        </node>
+                        <node concept="3TrcHB" id="1dyouTTlz6S" role="2OqNvi">
+                          <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                        </node>
+                      </node>
+                      <node concept="3cpWs3" id="1dyouTTlumM" role="3uHU7B">
+                        <node concept="37vLTw" id="1dyouTTlt1X" role="3uHU7B">
+                          <ref role="3cqZAo" node="1dyouTTlp8k" resolve="s" />
+                        </node>
+                        <node concept="Xl_RD" id="1dyouTTluo_" role="3uHU7w">
+                          <property role="Xl_RC" value="/" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="gl6BB" id="1dyouTTlp8k" role="1bW2Oz">
+                  <property role="TrG5h" value="s" />
+                  <node concept="2jxLKc" id="1dyouTTlp8l" role="1tU5fm" />
+                </node>
+                <node concept="gl6BB" id="1dyouTTlp8m" role="1bW2Oz">
+                  <property role="TrG5h" value="it" />
+                  <node concept="2jxLKc" id="1dyouTTlp8n" role="1tU5fm" />
+                </node>
+              </node>
+              <node concept="2OqwBi" id="1dyouTTlrov" role="1MDeny">
+                <node concept="1rXfSq" id="1dyouTTlqD6" role="2Oq$k0">
+                  <ref role="37wK5l" to="7wpd:65ATjZHmLvj" resolve="root" />
+                </node>
+                <node concept="3TrcHB" id="1dyouTTls$R" role="2OqNvi">
+                  <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="1dyouTTlmkt" role="1B3o_S" />
+      <node concept="17QB3L" id="1dyouTTlmBC" role="3clF45" />
+    </node>
+    <node concept="2tJIrI" id="1dyouTTmIMJ" role="jymVt" />
+    <node concept="3clFb_" id="1dyouTTmJNs" role="jymVt">
+      <property role="TrG5h" value="append" />
+      <node concept="37vLTG" id="1dyouTTmKd7" role="3clF46">
+        <property role="TrG5h" value="segment" />
+        <node concept="3Tqbb2" id="1dyouTTmKd8" role="1tU5fm">
+          <ref role="ehGHo" to="tpee:fz3uBXI" resolve="VariableDeclaration" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="1dyouTTmJNv" role="3clF47">
+        <node concept="3clFbF" id="1dyouTTmKKS" role="3cqZAp">
+          <node concept="0kSF2" id="1dyouTTmMPW" role="3clFbG">
+            <node concept="3uibUv" id="1dyouTTmMPY" role="0kSFW">
+              <ref role="3uigEE" node="3u1rFxeDiKa" resolve="NestedMemberPath" />
+            </node>
+            <node concept="3nyPlj" id="1dyouTTmKKR" role="0kSFX">
+              <ref role="37wK5l" to="7wpd:5LihCoMiiPS" resolve="append" />
+              <node concept="37vLTw" id="1dyouTTmLRY" role="37wK5m">
+                <ref role="3cqZAo" node="1dyouTTmKd7" resolve="segment" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="1dyouTTmJcL" role="1B3o_S" />
+      <node concept="3uibUv" id="1dyouTTmJAu" role="3clF45">
+        <ref role="3uigEE" node="3u1rFxeDiKa" resolve="NestedMemberPath" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="1dyouTTnj3c" role="jymVt" />
+    <node concept="3clFb_" id="1dyouTTnitF" role="jymVt">
+      <property role="TrG5h" value="append" />
+      <node concept="37vLTG" id="1dyouTTnitG" role="3clF46">
+        <property role="TrG5h" value="segments" />
+        <node concept="A3Dl8" id="1dyouTTnk8r" role="1tU5fm">
+          <node concept="3Tqbb2" id="1dyouTTnk8s" role="A3Ik2">
+            <ref role="ehGHo" to="tpee:fz3uBXI" resolve="VariableDeclaration" />
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbS" id="1dyouTTnitI" role="3clF47">
+        <node concept="3clFbF" id="1dyouTTnitJ" role="3cqZAp">
+          <node concept="0kSF2" id="1dyouTTnitK" role="3clFbG">
+            <node concept="3uibUv" id="1dyouTTnitL" role="0kSFW">
+              <ref role="3uigEE" node="3u1rFxeDiKa" resolve="NestedMemberPath" />
+            </node>
+            <node concept="3nyPlj" id="1dyouTTnitM" role="0kSFX">
+              <ref role="37wK5l" to="7wpd:5zD5ovm$jwh" resolve="append" />
+              <node concept="37vLTw" id="1dyouTTnitN" role="37wK5m">
+                <ref role="3cqZAo" node="1dyouTTnitG" resolve="segments" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="1dyouTTnitO" role="1B3o_S" />
+      <node concept="3uibUv" id="1dyouTTnitP" role="3clF45">
+        <ref role="3uigEE" node="3u1rFxeDiKa" resolve="NestedMemberPath" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="1dyouTToG9f" role="jymVt" />
+    <node concept="3clFb_" id="1dyouTToJ5m" role="jymVt">
+      <property role="TrG5h" value="concatSafe" />
+      <node concept="3clFbS" id="1dyouTToJ5p" role="3clF47">
+        <node concept="3clFbF" id="1dyouTToKM3" role="3cqZAp">
+          <node concept="2OqwBi" id="1dyouTToXY6" role="3clFbG">
+            <node concept="3nyPlj" id="1dyouTToKM2" role="2Oq$k0">
+              <ref role="37wK5l" to="7wpd:3u1rFxeqM8T" resolve="concatSafe" />
+              <node concept="37vLTw" id="1dyouTToM5I" role="37wK5m">
+                <ref role="3cqZAo" node="1dyouTToJGn" resolve="other" />
+              </node>
+            </node>
+            <node concept="liA8E" id="1dyouTToZcL" role="2OqNvi">
+              <ref role="37wK5l" to="33ny:~Optional.map(java.util.function.Function)" resolve="map" />
+              <node concept="1bVj0M" id="1dyouTToZW2" role="37wK5m">
+                <node concept="gl6BB" id="1dyouTToZWl" role="1bW2Oz">
+                  <property role="TrG5h" value="p" />
+                  <node concept="2jxLKc" id="1dyouTToZWm" role="1tU5fm" />
+                </node>
+                <node concept="3clFbS" id="1dyouTToZWN" role="1bW5cS">
+                  <node concept="3clFbF" id="1dyouTTp1CM" role="3cqZAp">
+                    <node concept="0kSF2" id="1dyouTTp3$G" role="3clFbG">
+                      <node concept="3uibUv" id="1dyouTTp3$I" role="0kSFW">
+                        <ref role="3uigEE" node="3u1rFxeDiKa" resolve="NestedMemberPath" />
+                      </node>
+                      <node concept="37vLTw" id="1dyouTTp1CL" role="0kSFX">
+                        <ref role="3cqZAo" node="1dyouTToZWl" resolve="p" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="1dyouTToHi_" role="1B3o_S" />
+      <node concept="3uibUv" id="1dyouTToIJJ" role="3clF45">
+        <ref role="3uigEE" to="33ny:~Optional" resolve="Optional" />
+        <node concept="3uibUv" id="1dyouTTp9kp" role="11_B2D">
+          <ref role="3uigEE" node="3u1rFxeDiKa" resolve="NestedMemberPath" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="1dyouTToJGn" role="3clF46">
+        <property role="TrG5h" value="other" />
+        <node concept="3uibUv" id="1dyouTToJGm" role="1tU5fm">
+          <ref role="3uigEE" node="3u1rFxeDiKa" resolve="NestedMemberPath" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="1dyouTTEWDK" role="jymVt" />
+    <node concept="3clFb_" id="1dyouTTF559" role="jymVt">
+      <property role="TrG5h" value="toExpression" />
+      <node concept="3clFbS" id="1dyouTTF55c" role="3clF47">
+        <node concept="3clFbF" id="1dyouTTF6M4" role="3cqZAp">
+          <node concept="3nyPlj" id="1dyouTTF6M3" role="3clFbG">
+            <ref role="37wK5l" to="7wpd:1dyouTTC9_u" resolve="toExpression" />
+            <node concept="1bVj0M" id="1dyouTTF9oA" role="37wK5m">
+              <property role="3yWfEV" value="true" />
+              <node concept="gl6BB" id="1dyouTTF9oK" role="1bW2Oz">
+                <property role="TrG5h" value="d" />
+                <node concept="2jxLKc" id="1dyouTTF9oL" role="1tU5fm" />
+              </node>
+              <node concept="gl6BB" id="1dyouTTF9pI" role="1bW2Oz">
+                <property role="TrG5h" value="seg0" />
+                <node concept="2jxLKc" id="1dyouTTF9pJ" role="1tU5fm" />
+              </node>
+              <node concept="3clFbS" id="1dyouTTF9pK" role="1bW5cS">
+                <node concept="Jncv_" id="1dyouTTQ6J9" role="3cqZAp">
+                  <ref role="JncvD" to="tpee:f$Wx3kv" resolve="StaticFieldDeclaration" />
+                  <node concept="37vLTw" id="1dyouTTQ8eZ" role="JncvB">
+                    <ref role="3cqZAo" node="1dyouTTF9pI" resolve="s" />
+                  </node>
+                  <node concept="3clFbS" id="1dyouTTQ6Jd" role="Jncv$">
+                    <node concept="3cpWs6" id="1dyouTTQhHI" role="3cqZAp">
+                      <node concept="2pJPEk" id="1dyouTTFaU9" role="3cqZAk">
+                        <node concept="2pJPED" id="1dyouTTFaUa" role="2pJPEn">
+                          <ref role="2pJxaS" to="tpee:f_0M0x6" resolve="StaticFieldReference" />
+                          <node concept="2pIpSj" id="1dyouTTFaUb" role="2pJxcM">
+                            <ref role="2pIpSl" to="tpee:gDPxDYr" />
+                            <node concept="36biLy" id="1dyouTTFaUc" role="28nt2d">
+                              <node concept="37vLTw" id="1dyouTTFe_E" role="36biLW">
+                                <ref role="3cqZAo" node="1dyouTTF9oK" resolve="d" />
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="2pIpSj" id="1dyouTTFaUe" role="2pJxcM">
+                            <ref role="2pIpSl" to="tpee:f_2Pw7K" />
+                            <node concept="36biLy" id="1dyouTTFaUf" role="28nt2d">
+                              <node concept="Jnkvi" id="1dyouTTV69t" role="36biLW">
+                                <ref role="1M0zk5" node="1dyouTTQ6Jf" resolve="sfd0" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="JncvC" id="1dyouTTQ6Jf" role="JncvA">
+                    <property role="TrG5h" value="sfd0" />
+                    <node concept="2jxLKc" id="1dyouTTQ6Jg" role="1tU5fm" />
+                  </node>
+                </node>
+                <node concept="3clFbF" id="1dyouTTQlZU" role="3cqZAp">
+                  <node concept="10Nm6u" id="1dyouTTQlZS" role="3clFbG" />
+                </node>
+              </node>
+            </node>
+            <node concept="1bVj0M" id="1dyouTTFolc" role="37wK5m">
+              <node concept="gl6BB" id="1dyouTTFoln" role="1bW2Oz">
+                <property role="TrG5h" value="prefix" />
+                <node concept="2jxLKc" id="1dyouTTFolo" role="1tU5fm" />
+              </node>
+              <node concept="gl6BB" id="1dyouTTPfI_" role="1bW2Oz">
+                <property role="TrG5h" value="seg" />
+                <node concept="2jxLKc" id="1dyouTTPfIA" role="1tU5fm" />
+              </node>
+              <node concept="3clFbS" id="1dyouTTFomn" role="1bW5cS">
+                <node concept="3cpWs8" id="1dyouTTY5Cr" role="3cqZAp">
+                  <node concept="3cpWsn" id="1dyouTTY5Cs" role="3cpWs9">
+                    <property role="TrG5h" value="sre" />
+                    <node concept="3Tqbb2" id="1dyouTTY4tg" role="1tU5fm">
+                      <ref role="ehGHo" to="tpee:hqOqG0K" resolve="IOperation" />
+                    </node>
+                    <node concept="1rXfSq" id="1dyouTTY5Ct" role="33vP2m">
+                      <ref role="37wK5l" node="1dyouTTNb00" resolve="makeSegmentRefExpr" />
+                      <node concept="37vLTw" id="1dyouTTY5Cu" role="37wK5m">
+                        <ref role="3cqZAo" node="1dyouTTPfI_" resolve="seg" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbJ" id="1dyouTTYO6J" role="3cqZAp">
+                  <node concept="3clFbS" id="1dyouTTYO6L" role="3clFbx">
+                    <node concept="3cpWs6" id="1dyouTTYW94" role="3cqZAp">
+                      <node concept="10Nm6u" id="1dyouTTZ0MB" role="3cqZAk" />
+                    </node>
+                  </node>
+                  <node concept="2OqwBi" id="1dyouTTYSfJ" role="3clFbw">
+                    <node concept="37vLTw" id="1dyouTTYPEJ" role="2Oq$k0">
+                      <ref role="3cqZAo" node="1dyouTTY5Cs" resolve="sre" />
+                    </node>
+                    <node concept="3w_OXm" id="1dyouTTYUmB" role="2OqNvi" />
+                  </node>
+                </node>
+                <node concept="3clFbF" id="1dyouTTZ83U" role="3cqZAp">
+                  <node concept="2pJPEk" id="1dyouTTNkfX" role="3clFbG">
+                    <node concept="2pJPED" id="1dyouTTNkfY" role="2pJPEn">
+                      <ref role="2pJxaS" to="tpee:hqOqwz4" resolve="DotExpression" />
+                      <node concept="2pIpSj" id="1dyouTTNkfZ" role="2pJxcM">
+                        <ref role="2pIpSl" to="tpee:hqOq$gm" />
+                        <node concept="36biLy" id="1dyouTTNkg0" role="28nt2d">
+                          <node concept="37vLTw" id="1dyouTTNkg1" role="36biLW">
+                            <ref role="3cqZAo" node="1dyouTTFoln" resolve="prefix" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="2pIpSj" id="1dyouTTXlJH" role="2pJxcM">
+                        <ref role="2pIpSl" to="tpee:hqOqNr4" />
+                        <node concept="36biLy" id="1dyouTTXUoz" role="28nt2d">
+                          <node concept="37vLTw" id="1dyouTTYF3u" role="36biLW">
+                            <ref role="3cqZAo" node="1dyouTTY5Cs" resolve="sre" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="1dyouTTEZs$" role="1B3o_S" />
+      <node concept="3uibUv" id="1dyouTTF0Sa" role="3clF45">
+        <ref role="3uigEE" to="33ny:~Optional" resolve="Optional" />
+        <node concept="3Tqbb2" id="1dyouTTF1C3" role="11_B2D">
+          <ref role="ehGHo" to="tpee:fz3vP1J" resolve="Expression" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="1dyouTTN5zU" role="jymVt" />
+    <node concept="2YIFZL" id="1dyouTTNb00" role="jymVt">
+      <property role="TrG5h" value="makeSegmentRefExpr" />
+      <node concept="37vLTG" id="1dyouTTNgsE" role="3clF46">
+        <property role="TrG5h" value="seg" />
+        <node concept="3Tqbb2" id="1dyouTTNhmK" role="1tU5fm">
+          <ref role="ehGHo" to="tpee:fz3uBXI" resolve="VariableDeclaration" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="1dyouTTNb03" role="3clF47">
+        <node concept="Jncv_" id="1dyouTTXHgy" role="3cqZAp">
+          <ref role="JncvD" to="tpee:fz12cDC" resolve="FieldDeclaration" />
+          <node concept="37vLTw" id="1dyouTTXHgz" role="JncvB">
+            <ref role="3cqZAo" node="1dyouTTNgsE" resolve="seg" />
+          </node>
+          <node concept="3clFbS" id="1dyouTTXHg$" role="Jncv$">
+            <node concept="3cpWs6" id="1dyouTTXHg_" role="3cqZAp">
+              <node concept="2pJPEk" id="1dyouTTXHgA" role="3cqZAk">
+                <node concept="2pJPED" id="1dyouTTXHgB" role="2pJPEn">
+                  <ref role="2pJxaS" to="tpee:hqOwXtU" resolve="FieldReferenceOperation" />
+                  <node concept="2pIpSj" id="1dyouTTXHgC" role="2pJxcM">
+                    <ref role="2pIpSl" to="tpee:hqOxapj" resolve="fieldDeclaration" />
+                    <node concept="36biLy" id="1dyouTTXHgD" role="28nt2d">
+                      <node concept="Jnkvi" id="1dyouTTXHgE" role="36biLW">
+                        <ref role="1M0zk5" node="1dyouTTXHgF" resolve="fd" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="JncvC" id="1dyouTTXHgF" role="JncvA">
+            <property role="TrG5h" value="fd" />
+            <node concept="2jxLKc" id="1dyouTTXHgG" role="1tU5fm" />
+          </node>
+        </node>
+        <node concept="Jncv_" id="1dyouTTXwLA" role="3cqZAp">
+          <ref role="JncvD" to="tpee:f$Wx3kv" resolve="StaticFieldDeclaration" />
+          <node concept="37vLTw" id="1dyouTTXxO4" role="JncvB">
+            <ref role="3cqZAo" node="1dyouTTNgsE" resolve="seg" />
+          </node>
+          <node concept="3clFbS" id="1dyouTTXwLE" role="Jncv$">
+            <node concept="3cpWs6" id="1dyouTTXB_X" role="3cqZAp">
+              <node concept="2pJPEk" id="1dyouTTXDqX" role="3cqZAk">
+                <node concept="2pJPED" id="1dyouTTXDqZ" role="2pJPEn">
+                  <ref role="2pJxaS" to="tpee:3mPoTkdZzdR" resolve="StaticFieldReferenceOperation" />
+                  <node concept="2pIpSj" id="1dyouTTXG78" role="2pJxcM">
+                    <ref role="2pIpSl" to="tpee:3mPoTkdZzrB" resolve="staticFieldDeclaration" />
+                    <node concept="36biLy" id="1dyouTTXGW1" role="28nt2d">
+                      <node concept="Jnkvi" id="1dyouTTXHc1" role="36biLW">
+                        <ref role="1M0zk5" node="1dyouTTXwLG" resolve="sfd" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="JncvC" id="1dyouTTXwLG" role="JncvA">
+            <property role="TrG5h" value="sfd" />
+            <node concept="2jxLKc" id="1dyouTTXwLH" role="1tU5fm" />
+          </node>
+        </node>
+        <node concept="3clFbF" id="1dyouTTNztq" role="3cqZAp">
+          <node concept="10Nm6u" id="1dyouTTNzto" role="3clFbG" />
+        </node>
+      </node>
+      <node concept="3Tm6S6" id="1dyouTTN8_W" role="1B3o_S" />
+      <node concept="3Tqbb2" id="1dyouTTNc$S" role="3clF45">
+        <ref role="ehGHo" to="tpee:hqOqG0K" resolve="IOperation" />
+      </node>
+    </node>
+  </node>
+  <node concept="1lH9Xt" id="1dyouTTriDH">
+    <property role="3DII0k" value="2hh8MJdVwqX/command" />
+    <property role="3GE5qa" value="instantiation" />
+    <property role="TrG5h" value="PathToExpressionTest" />
+    <node concept="1LZb2c" id="1dyouTTriHc" role="1SL9yI">
+      <property role="TrG5h" value="convertToExpression0" />
+      <node concept="3cqZAl" id="1dyouTTriHd" role="3clF45" />
+      <node concept="3clFbS" id="1dyouTTriHe" role="3clF47">
+        <node concept="3cpWs8" id="1dyouTTriHf" role="3cqZAp">
+          <node concept="3cpWsn" id="1dyouTTriHg" role="3cpWs9">
+            <property role="TrG5h" value="path" />
+            <node concept="3uibUv" id="1dyouTTriHh" role="1tU5fm">
+              <ref role="3uigEE" node="3u1rFxeDiKa" resolve="NestedMemberPath" />
+            </node>
+            <node concept="2ShNRf" id="1dyouTTriHi" role="33vP2m">
+              <node concept="1pGfFk" id="1dyouTTriHj" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" node="1dyouTTekMU" />
+                <node concept="3xONca" id="1dyouTTriHk" role="37wK5m">
+                  <ref role="3xOPvv" node="1dyouTTriKF" resolve="defA" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3vlDli" id="1dyouTTriHw" role="3cqZAp">
+          <node concept="2OqwBi" id="1dyouTTriHx" role="3tpDZA">
+            <node concept="37vLTw" id="1dyouTTriHy" role="2Oq$k0">
+              <ref role="3cqZAo" node="1dyouTTriHg" resolve="path" />
+            </node>
+            <node concept="liA8E" id="1dyouTTriHz" role="2OqNvi">
+              <ref role="37wK5l" to="7wpd:5PQUSslgGet" resolve="segmentsSize" />
+            </node>
+          </node>
+          <node concept="3cmrfG" id="1dyouTTB_2k" role="3tpDZB">
+            <property role="3cmrfH" value="0" />
+          </node>
+        </node>
+        <node concept="3clFbH" id="1dyouTT_V5a" role="3cqZAp" />
+        <node concept="3cpWs8" id="1dyouTT_WJP" role="3cqZAp">
+          <node concept="3cpWsn" id="1dyouTT_WJQ" role="3cpWs9">
+            <property role="TrG5h" value="result" />
+            <node concept="3uibUv" id="1dyouTT_WDS" role="1tU5fm">
+              <ref role="3uigEE" to="33ny:~Optional" resolve="Optional" />
+              <node concept="3Tqbb2" id="1dyouTT_WDV" role="11_B2D">
+                <ref role="ehGHo" to="tpee:fz3vP1J" resolve="Expression" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="1dyouTT_WJR" role="33vP2m">
+              <node concept="37vLTw" id="1dyouTT_WJS" role="2Oq$k0">
+                <ref role="3cqZAo" node="1dyouTTriHg" resolve="path" />
+              </node>
+              <node concept="liA8E" id="1dyouTT_WJT" role="2OqNvi">
+                <ref role="37wK5l" node="1dyouTTF559" resolve="toExpression2" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3vwNmj" id="1dyouTT_Xaz" role="3cqZAp">
+          <node concept="2OqwBi" id="1dyouTT_Xtg" role="3vwVQn">
+            <node concept="37vLTw" id="1dyouTT_Xkb" role="2Oq$k0">
+              <ref role="3cqZAo" node="1dyouTT_WJQ" resolve="result" />
+            </node>
+            <node concept="liA8E" id="1dyouTT_Y1s" role="2OqNvi">
+              <ref role="37wK5l" to="33ny:~Optional.isEmpty()" resolve="isEmpty" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="1dyouTTBzyW" role="1SL9yI">
+      <property role="TrG5h" value="convertToExpression1" />
+      <node concept="3cqZAl" id="1dyouTTBzyX" role="3clF45" />
+      <node concept="3clFbS" id="1dyouTTBzyY" role="3clF47">
+        <node concept="3cpWs8" id="1dyouTTBzyZ" role="3cqZAp">
+          <node concept="3cpWsn" id="1dyouTTBzz0" role="3cpWs9">
+            <property role="TrG5h" value="path" />
+            <node concept="3uibUv" id="1dyouTTBzz1" role="1tU5fm">
+              <ref role="3uigEE" node="3u1rFxeDiKa" resolve="NestedMemberPath" />
+            </node>
+            <node concept="2ShNRf" id="1dyouTTBzz2" role="33vP2m">
+              <node concept="1pGfFk" id="1dyouTTBzz3" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" node="1dyouTTemtd" resolve="NestedMemberPath" />
+                <node concept="3xONca" id="1dyouTTBzz4" role="37wK5m">
+                  <ref role="3xOPvv" node="1dyouTTriKF" resolve="root" />
+                </node>
+                <node concept="2ShNRf" id="1dyouTTBzz5" role="37wK5m">
+                  <node concept="Tc6Ow" id="1dyouTTBzz6" role="2ShVmc">
+                    <node concept="3xONca" id="1dyouTTBzz7" role="HW$Y0">
+                      <ref role="3xOPvv" node="1dyouTTtdog" resolve="b1" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3vlDli" id="1dyouTTBzz8" role="3cqZAp">
+          <node concept="2OqwBi" id="1dyouTTBzz9" role="3tpDZA">
+            <node concept="37vLTw" id="1dyouTTBzza" role="2Oq$k0">
+              <ref role="3cqZAo" node="1dyouTTBzz0" resolve="path" />
+            </node>
+            <node concept="liA8E" id="1dyouTTBzzb" role="2OqNvi">
+              <ref role="37wK5l" to="7wpd:5PQUSslgGet" resolve="segmentsSize" />
+            </node>
+          </node>
+          <node concept="3cmrfG" id="1dyouTTBzzc" role="3tpDZB">
+            <property role="3cmrfH" value="1" />
+          </node>
+        </node>
+        <node concept="3clFbH" id="1dyouTTBzzd" role="3cqZAp" />
+        <node concept="3cpWs8" id="1dyouTTBzze" role="3cqZAp">
+          <node concept="3cpWsn" id="1dyouTTBzzf" role="3cpWs9">
+            <property role="TrG5h" value="result" />
+            <node concept="3uibUv" id="1dyouTTBzzg" role="1tU5fm">
+              <ref role="3uigEE" to="33ny:~Optional" resolve="Optional" />
+              <node concept="3Tqbb2" id="1dyouTTBzzh" role="11_B2D">
+                <ref role="ehGHo" to="tpee:fz3vP1J" resolve="Expression" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="1dyouTTBzzi" role="33vP2m">
+              <node concept="37vLTw" id="1dyouTTBzzj" role="2Oq$k0">
+                <ref role="3cqZAo" node="1dyouTTBzz0" resolve="path" />
+              </node>
+              <node concept="liA8E" id="1dyouTTBzzk" role="2OqNvi">
+                <ref role="37wK5l" node="1dyouTTF559" resolve="toExpression2" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3vwNmj" id="1dyouTTBzzl" role="3cqZAp">
+          <node concept="2OqwBi" id="1dyouTTBzzm" role="3vwVQn">
+            <node concept="37vLTw" id="1dyouTTBzzn" role="2Oq$k0">
+              <ref role="3cqZAo" node="1dyouTTBzzf" resolve="result" />
+            </node>
+            <node concept="liA8E" id="1dyouTTBzzo" role="2OqNvi">
+              <ref role="37wK5l" to="33ny:~Optional.isPresent()" resolve="isPresent" />
+            </node>
+          </node>
+        </node>
+        <node concept="3GXo0L" id="1dyouTTBzzp" role="3cqZAp">
+          <node concept="3xONca" id="1dyouTTBzzq" role="3tpDZB">
+            <ref role="3xOPvv" node="1dyouTTzvnB" resolve="expected1" />
+          </node>
+          <node concept="2OqwBi" id="1dyouTTBzzr" role="3tpDZA">
+            <node concept="37vLTw" id="1dyouTTBzzs" role="2Oq$k0">
+              <ref role="3cqZAo" node="1dyouTTBzzf" resolve="result" />
+            </node>
+            <node concept="liA8E" id="1dyouTTBzzt" role="2OqNvi">
+              <ref role="37wK5l" to="33ny:~Optional.get()" resolve="get" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="1dyouTTB9gy" role="1SL9yI">
+      <property role="TrG5h" value="convertToExpression2a" />
+      <node concept="3cqZAl" id="1dyouTTB9gz" role="3clF45" />
+      <node concept="3clFbS" id="1dyouTTB9g$" role="3clF47">
+        <node concept="3cpWs8" id="1dyouTTB9g_" role="3cqZAp">
+          <node concept="3cpWsn" id="1dyouTTB9gA" role="3cpWs9">
+            <property role="TrG5h" value="path" />
+            <node concept="3uibUv" id="1dyouTTB9gB" role="1tU5fm">
+              <ref role="3uigEE" node="3u1rFxeDiKa" resolve="NestedMemberPath" />
+            </node>
+            <node concept="2ShNRf" id="1dyouTTB9gC" role="33vP2m">
+              <node concept="1pGfFk" id="1dyouTTB9gD" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" node="1dyouTTemtd" resolve="NestedMemberPath" />
+                <node concept="3xONca" id="1dyouTTB9gE" role="37wK5m">
+                  <ref role="3xOPvv" node="1dyouTTriKF" resolve="root" />
+                </node>
+                <node concept="2ShNRf" id="1dyouTTB9gF" role="37wK5m">
+                  <node concept="Tc6Ow" id="1dyouTTB9gG" role="2ShVmc">
+                    <node concept="3xONca" id="1dyouTTB9gH" role="HW$Y0">
+                      <ref role="3xOPvv" node="1dyouTTtdog" resolve="b1" />
+                    </node>
+                    <node concept="3xONca" id="1dyouTTB9gI" role="HW$Y0">
+                      <ref role="3xOPvv" node="1dyouTTtd_m" resolve="c2" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3vlDli" id="1dyouTTB9gK" role="3cqZAp">
+          <node concept="2OqwBi" id="1dyouTTB9gL" role="3tpDZA">
+            <node concept="37vLTw" id="1dyouTTB9gM" role="2Oq$k0">
+              <ref role="3cqZAo" node="1dyouTTB9gA" resolve="path" />
+            </node>
+            <node concept="liA8E" id="1dyouTTB9gN" role="2OqNvi">
+              <ref role="37wK5l" to="7wpd:5PQUSslgGet" resolve="segmentsSize" />
+            </node>
+          </node>
+          <node concept="3cmrfG" id="1dyouTTB9gO" role="3tpDZB">
+            <property role="3cmrfH" value="2" />
+          </node>
+        </node>
+        <node concept="3clFbH" id="1dyouTTB9gP" role="3cqZAp" />
+        <node concept="3cpWs8" id="1dyouTTB9gQ" role="3cqZAp">
+          <node concept="3cpWsn" id="1dyouTTB9gR" role="3cpWs9">
+            <property role="TrG5h" value="result" />
+            <node concept="3uibUv" id="1dyouTTB9gS" role="1tU5fm">
+              <ref role="3uigEE" to="33ny:~Optional" resolve="Optional" />
+              <node concept="3Tqbb2" id="1dyouTTB9gT" role="11_B2D">
+                <ref role="ehGHo" to="tpee:fz3vP1J" resolve="Expression" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="1dyouTTB9gU" role="33vP2m">
+              <node concept="37vLTw" id="1dyouTTB9gV" role="2Oq$k0">
+                <ref role="3cqZAo" node="1dyouTTB9gA" resolve="path" />
+              </node>
+              <node concept="liA8E" id="1dyouTTB9gW" role="2OqNvi">
+                <ref role="37wK5l" node="1dyouTTF559" resolve="toExpression2" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3vwNmj" id="1dyouTTB9gX" role="3cqZAp">
+          <node concept="2OqwBi" id="1dyouTTB9gY" role="3vwVQn">
+            <node concept="37vLTw" id="1dyouTTB9gZ" role="2Oq$k0">
+              <ref role="3cqZAo" node="1dyouTTB9gR" resolve="result" />
+            </node>
+            <node concept="liA8E" id="1dyouTTB9h0" role="2OqNvi">
+              <ref role="37wK5l" to="33ny:~Optional.isPresent()" resolve="isPresent" />
+            </node>
+          </node>
+        </node>
+        <node concept="3GXo0L" id="1dyouTTB9h1" role="3cqZAp">
+          <node concept="3xONca" id="1dyouTTB9h2" role="3tpDZB">
+            <ref role="3xOPvv" node="1dyouTTzvIr" resolve="expected2" />
+          </node>
+          <node concept="2OqwBi" id="1dyouTTB9h3" role="3tpDZA">
+            <node concept="37vLTw" id="1dyouTTB9h4" role="2Oq$k0">
+              <ref role="3cqZAo" node="1dyouTTB9gR" resolve="result" />
+            </node>
+            <node concept="liA8E" id="1dyouTTB9h5" role="2OqNvi">
+              <ref role="37wK5l" to="33ny:~Optional.get()" resolve="get" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="1dyouTTWN_N" role="1SL9yI">
+      <property role="TrG5h" value="convertToExpression2b" />
+      <node concept="3cqZAl" id="1dyouTTWN_O" role="3clF45" />
+      <node concept="3clFbS" id="1dyouTTWN_P" role="3clF47">
+        <node concept="3cpWs8" id="1dyouTTWN_Q" role="3cqZAp">
+          <node concept="3cpWsn" id="1dyouTTWN_R" role="3cpWs9">
+            <property role="TrG5h" value="path" />
+            <node concept="3uibUv" id="1dyouTTWN_S" role="1tU5fm">
+              <ref role="3uigEE" node="3u1rFxeDiKa" resolve="NestedMemberPath" />
+            </node>
+            <node concept="2ShNRf" id="1dyouTTWN_T" role="33vP2m">
+              <node concept="1pGfFk" id="1dyouTTWN_U" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" node="1dyouTTemtd" resolve="NestedMemberPath" />
+                <node concept="3xONca" id="1dyouTTWN_V" role="37wK5m">
+                  <ref role="3xOPvv" node="1dyouTTriKF" resolve="root" />
+                </node>
+                <node concept="2ShNRf" id="1dyouTTWN_W" role="37wK5m">
+                  <node concept="Tc6Ow" id="1dyouTTWN_X" role="2ShVmc">
+                    <node concept="3xONca" id="1dyouTTWN_Y" role="HW$Y0">
+                      <ref role="3xOPvv" node="1dyouTTtdog" resolve="bStatic" />
+                    </node>
+                    <node concept="3xONca" id="1dyouTTWN_Z" role="HW$Y0">
+                      <ref role="3xOPvv" node="1dyouTTVtyk" resolve="cNonStatic" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3vlDli" id="1dyouTTWNA0" role="3cqZAp">
+          <node concept="2OqwBi" id="1dyouTTWNA1" role="3tpDZA">
+            <node concept="37vLTw" id="1dyouTTWNA2" role="2Oq$k0">
+              <ref role="3cqZAo" node="1dyouTTWN_R" resolve="path" />
+            </node>
+            <node concept="liA8E" id="1dyouTTWNA3" role="2OqNvi">
+              <ref role="37wK5l" to="7wpd:5PQUSslgGet" resolve="segmentsSize" />
+            </node>
+          </node>
+          <node concept="3cmrfG" id="1dyouTTWNA4" role="3tpDZB">
+            <property role="3cmrfH" value="2" />
+          </node>
+        </node>
+        <node concept="3clFbH" id="1dyouTTWNA5" role="3cqZAp" />
+        <node concept="3cpWs8" id="1dyouTTWNA6" role="3cqZAp">
+          <node concept="3cpWsn" id="1dyouTTWNA7" role="3cpWs9">
+            <property role="TrG5h" value="result" />
+            <node concept="3uibUv" id="1dyouTTWNA8" role="1tU5fm">
+              <ref role="3uigEE" to="33ny:~Optional" resolve="Optional" />
+              <node concept="3Tqbb2" id="1dyouTTWNA9" role="11_B2D">
+                <ref role="ehGHo" to="tpee:fz3vP1J" resolve="Expression" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="1dyouTTWNAa" role="33vP2m">
+              <node concept="37vLTw" id="1dyouTTWNAb" role="2Oq$k0">
+                <ref role="3cqZAo" node="1dyouTTWN_R" resolve="path" />
+              </node>
+              <node concept="liA8E" id="1dyouTTWNAc" role="2OqNvi">
+                <ref role="37wK5l" node="1dyouTTF559" resolve="toExpression" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3vwNmj" id="1dyouTTWNAd" role="3cqZAp">
+          <node concept="2OqwBi" id="1dyouTTWNAe" role="3vwVQn">
+            <node concept="37vLTw" id="1dyouTTWNAf" role="2Oq$k0">
+              <ref role="3cqZAo" node="1dyouTTWNA7" resolve="result" />
+            </node>
+            <node concept="liA8E" id="1dyouTTWNAg" role="2OqNvi">
+              <ref role="37wK5l" to="33ny:~Optional.isPresent()" resolve="isPresent" />
+            </node>
+          </node>
+        </node>
+        <node concept="3GXo0L" id="1dyouTTWNAh" role="3cqZAp">
+          <node concept="3xONca" id="1dyouTTWNAi" role="3tpDZB">
+            <ref role="3xOPvv" node="1dyouTTWIYh" resolve="expected2b" />
+          </node>
+          <node concept="2OqwBi" id="1dyouTTWNAj" role="3tpDZA">
+            <node concept="37vLTw" id="1dyouTTWNAk" role="2Oq$k0">
+              <ref role="3cqZAo" node="1dyouTTWNA7" resolve="result" />
+            </node>
+            <node concept="liA8E" id="1dyouTTWNAl" role="2OqNvi">
+              <ref role="37wK5l" to="33ny:~Optional.get()" resolve="get" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="1dyouTTB9Ho" role="1SL9yI">
+      <property role="TrG5h" value="convertToExpression3" />
+      <node concept="3cqZAl" id="1dyouTTB9Hp" role="3clF45" />
+      <node concept="3clFbS" id="1dyouTTB9Hq" role="3clF47">
+        <node concept="3cpWs8" id="1dyouTTB9Hr" role="3cqZAp">
+          <node concept="3cpWsn" id="1dyouTTB9Hs" role="3cpWs9">
+            <property role="TrG5h" value="path" />
+            <node concept="3uibUv" id="1dyouTTB9Ht" role="1tU5fm">
+              <ref role="3uigEE" node="3u1rFxeDiKa" resolve="NestedMemberPath" />
+            </node>
+            <node concept="2ShNRf" id="1dyouTTB9Hu" role="33vP2m">
+              <node concept="1pGfFk" id="1dyouTTB9Hv" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" node="1dyouTTemtd" resolve="NestedMemberPath" />
+                <node concept="3xONca" id="1dyouTTB9Hw" role="37wK5m">
+                  <ref role="3xOPvv" node="1dyouTTriKF" resolve="root" />
+                </node>
+                <node concept="2ShNRf" id="1dyouTTB9Hx" role="37wK5m">
+                  <node concept="Tc6Ow" id="1dyouTTB9Hy" role="2ShVmc">
+                    <node concept="3xONca" id="1dyouTTB9Hz" role="HW$Y0">
+                      <ref role="3xOPvv" node="1dyouTTtdog" resolve="b1" />
+                    </node>
+                    <node concept="3xONca" id="1dyouTTB9H$" role="HW$Y0">
+                      <ref role="3xOPvv" node="1dyouTTVtyk" resolve="cNonStatic" />
+                    </node>
+                    <node concept="3xONca" id="1dyouTTB9H_" role="HW$Y0">
+                      <ref role="3xOPvv" node="1dyouTTtdGB" resolve="i1" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3vlDli" id="1dyouTTB9HA" role="3cqZAp">
+          <node concept="2OqwBi" id="1dyouTTB9HB" role="3tpDZA">
+            <node concept="37vLTw" id="1dyouTTB9HC" role="2Oq$k0">
+              <ref role="3cqZAo" node="1dyouTTB9Hs" resolve="path" />
+            </node>
+            <node concept="liA8E" id="1dyouTTB9HD" role="2OqNvi">
+              <ref role="37wK5l" to="7wpd:5PQUSslgGet" resolve="segmentsSize" />
+            </node>
+          </node>
+          <node concept="3cmrfG" id="1dyouTTB9HE" role="3tpDZB">
+            <property role="3cmrfH" value="3" />
+          </node>
+        </node>
+        <node concept="3clFbH" id="1dyouTTB9HF" role="3cqZAp" />
+        <node concept="3cpWs8" id="1dyouTTB9HG" role="3cqZAp">
+          <node concept="3cpWsn" id="1dyouTTB9HH" role="3cpWs9">
+            <property role="TrG5h" value="result" />
+            <node concept="3uibUv" id="1dyouTTB9HI" role="1tU5fm">
+              <ref role="3uigEE" to="33ny:~Optional" resolve="Optional" />
+              <node concept="3Tqbb2" id="1dyouTTB9HJ" role="11_B2D">
+                <ref role="ehGHo" to="tpee:fz3vP1J" resolve="Expression" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="1dyouTTB9HK" role="33vP2m">
+              <node concept="37vLTw" id="1dyouTTB9HL" role="2Oq$k0">
+                <ref role="3cqZAo" node="1dyouTTB9Hs" resolve="path" />
+              </node>
+              <node concept="liA8E" id="1dyouTTB9HM" role="2OqNvi">
+                <ref role="37wK5l" node="1dyouTTF559" resolve="toExpression2" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3vwNmj" id="1dyouTTB9HN" role="3cqZAp">
+          <node concept="2OqwBi" id="1dyouTTB9HO" role="3vwVQn">
+            <node concept="37vLTw" id="1dyouTTB9HP" role="2Oq$k0">
+              <ref role="3cqZAo" node="1dyouTTB9HH" resolve="result" />
+            </node>
+            <node concept="liA8E" id="1dyouTTB9HQ" role="2OqNvi">
+              <ref role="37wK5l" to="33ny:~Optional.isPresent()" resolve="isPresent" />
+            </node>
+          </node>
+        </node>
+        <node concept="3GXo0L" id="1dyouTTB9HR" role="3cqZAp">
+          <node concept="3xONca" id="1dyouTTB9HS" role="3tpDZB">
+            <ref role="3xOPvv" node="1dyouTTzs$F" resolve="expected3" />
+          </node>
+          <node concept="2OqwBi" id="1dyouTTB9HT" role="3tpDZA">
+            <node concept="37vLTw" id="1dyouTTB9HU" role="2Oq$k0">
+              <ref role="3cqZAo" node="1dyouTTB9HH" resolve="result" />
+            </node>
+            <node concept="liA8E" id="1dyouTTB9HV" role="2OqNvi">
+              <ref role="37wK5l" to="33ny:~Optional.get()" resolve="get" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="1dyouTTVuXu" role="1SL9yI">
+      <property role="TrG5h" value="catchErrorDuringConversion" />
+      <node concept="3cqZAl" id="1dyouTTVuXv" role="3clF45" />
+      <node concept="3clFbS" id="1dyouTTVuXz" role="3clF47">
+        <node concept="3SKdUt" id="1dyouTTZydK" role="3cqZAp">
+          <node concept="1PaTwC" id="1dyouTTZydL" role="1aUNEU">
+            <node concept="3oM_SD" id="1dyouTTZydM" role="1PaTwD">
+              <property role="3oM_SC" value="it" />
+            </node>
+            <node concept="3oM_SD" id="1dyouTTZyma" role="1PaTwD">
+              <property role="3oM_SC" value="is" />
+            </node>
+            <node concept="3oM_SD" id="1dyouTTZymc" role="1PaTwD">
+              <property role="3oM_SC" value="not" />
+            </node>
+            <node concept="3oM_SD" id="1dyouTTZymd" role="1PaTwD">
+              <property role="3oM_SC" value="possible" />
+            </node>
+            <node concept="3oM_SD" id="1dyouTTZyoy" role="1PaTwD">
+              <property role="3oM_SC" value="to" />
+            </node>
+            <node concept="3oM_SD" id="1dyouTTZyqR" role="1PaTwD">
+              <property role="3oM_SC" value="construct" />
+            </node>
+            <node concept="3oM_SD" id="1dyouTTZytc" role="1PaTwD">
+              <property role="3oM_SC" value="an" />
+            </node>
+            <node concept="3oM_SD" id="1dyouTTZytH" role="1PaTwD">
+              <property role="3oM_SC" value="expression" />
+            </node>
+            <node concept="3oM_SD" id="1dyouTTZyw2" role="1PaTwD">
+              <property role="3oM_SC" value="where" />
+            </node>
+            <node concept="3oM_SD" id="1dyouTTZyyn" role="1PaTwD">
+              <property role="3oM_SC" value="a" />
+            </node>
+            <node concept="3oM_SD" id="1dyouTTZyDA" role="1PaTwD">
+              <property role="3oM_SC" value="non-static" />
+            </node>
+            <node concept="3oM_SD" id="1dyouTTZyMT" role="1PaTwD">
+              <property role="3oM_SC" value="member" />
+            </node>
+            <node concept="3oM_SD" id="1dyouTTZyRi" role="1PaTwD">
+              <property role="3oM_SC" value="is" />
+            </node>
+            <node concept="3oM_SD" id="1dyouTTZyRN" role="1PaTwD">
+              <property role="3oM_SC" value="referenced" />
+            </node>
+            <node concept="3oM_SD" id="1dyouTTZyWs" role="1PaTwD">
+              <property role="3oM_SC" value="without" />
+            </node>
+            <node concept="3oM_SD" id="1dyouTTZz3r" role="1PaTwD">
+              <property role="3oM_SC" value="&quot;this&quot;" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="1dyouTTVwaU" role="3cqZAp">
+          <node concept="3cpWsn" id="1dyouTTVwaV" role="3cpWs9">
+            <property role="TrG5h" value="path" />
+            <node concept="3uibUv" id="1dyouTTVwaW" role="1tU5fm">
+              <ref role="3uigEE" node="3u1rFxeDiKa" resolve="NestedMemberPath" />
+            </node>
+            <node concept="2ShNRf" id="1dyouTTVwaX" role="33vP2m">
+              <node concept="1pGfFk" id="1dyouTTVwaY" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" node="1dyouTTemtd" />
+                <node concept="3xONca" id="1dyouTTVwaZ" role="37wK5m">
+                  <ref role="3xOPvv" node="1dyouTTriKF" resolve="root" />
+                </node>
+                <node concept="2ShNRf" id="1dyouTTVwb0" role="37wK5m">
+                  <node concept="Tc6Ow" id="1dyouTTVwb1" role="2ShVmc">
+                    <node concept="3xONca" id="1dyouTTVwb2" role="HW$Y0">
+                      <ref role="3xOPvv" node="1dyouTTW8S2" resolve="bNonStatic" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="1dyouTTVyzr" role="3cqZAp">
+          <node concept="3cpWsn" id="1dyouTTVyzs" role="3cpWs9">
+            <property role="TrG5h" value="result" />
+            <node concept="3uibUv" id="1dyouTTVyzt" role="1tU5fm">
+              <ref role="3uigEE" to="33ny:~Optional" resolve="Optional" />
+              <node concept="3Tqbb2" id="1dyouTTVyzu" role="11_B2D">
+                <ref role="ehGHo" to="tpee:fz3vP1J" resolve="Expression" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="1dyouTTVyzv" role="33vP2m">
+              <node concept="37vLTw" id="1dyouTTVyzw" role="2Oq$k0">
+                <ref role="3cqZAo" node="1dyouTTVwaV" resolve="path" />
+              </node>
+              <node concept="liA8E" id="1dyouTTVyzx" role="2OqNvi">
+                <ref role="37wK5l" node="1dyouTTF559" resolve="toExpression2" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3vwNmj" id="1dyouTTVyzy" role="3cqZAp">
+          <node concept="2OqwBi" id="1dyouTTVyzz" role="3vwVQn">
+            <node concept="37vLTw" id="1dyouTTVyz$" role="2Oq$k0">
+              <ref role="3cqZAo" node="1dyouTTVyzs" resolve="result" />
+            </node>
+            <node concept="liA8E" id="1dyouTTVyz_" role="2OqNvi">
+              <ref role="37wK5l" to="33ny:~Optional.isEmpty()" resolve="isEmpty" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="1dyouTTriKx" role="1SKRRt">
+      <node concept="312cEu" id="1dyouTTriKy" role="1qenE9">
+        <property role="TrG5h" value="AX" />
+        <node concept="3Tm1VV" id="1dyouTTriKz" role="1B3o_S" />
+        <node concept="Wx3nA" id="1dyouTTt0TB" role="jymVt">
+          <property role="TrG5h" value="bStatic" />
+          <node concept="3uibUv" id="1dyouTTriKA" role="1tU5fm">
+            <ref role="3uigEE" node="1dyouTTriKZ" resolve="B" />
+          </node>
+          <node concept="3Tm1VV" id="1dyouTTriK_" role="1B3o_S" />
+          <node concept="3xLA65" id="1dyouTTtdog" role="lGtFl">
+            <property role="TrG5h" value="bStatic" />
+          </node>
+        </node>
+        <node concept="312cEg" id="1dyouTTW5ER" role="jymVt">
+          <property role="TrG5h" value="bNonStatic" />
+          <node concept="3Tm1VV" id="1dyouTTW4Gx" role="1B3o_S" />
+          <node concept="3uibUv" id="1dyouTTW5Aa" role="1tU5fm">
+            <ref role="3uigEE" node="1dyouTTriKZ" resolve="BX" />
+          </node>
+          <node concept="3xLA65" id="1dyouTTW8S2" role="lGtFl">
+            <property role="TrG5h" value="bNonStatic" />
+          </node>
+        </node>
+        <node concept="2tJIrI" id="1dyouTTtcn6" role="jymVt" />
+        <node concept="3clFb_" id="1dyouTTzrSi" role="jymVt">
+          <property role="TrG5h" value="p1" />
+          <node concept="3clFbS" id="1dyouTTzrSj" role="3clF47">
+            <node concept="3cpWs6" id="1dyouTTzrSk" role="3cqZAp">
+              <node concept="10M0yZ" id="1dyouTTzrSn" role="3cqZAk">
+                <ref role="3cqZAo" node="1dyouTTt0TB" resolve="b1" />
+                <ref role="1PxDUh" node="1dyouTTriKy" resolve="AX" />
+                <node concept="3xLA65" id="1dyouTTzvnB" role="lGtFl">
+                  <property role="TrG5h" value="expected1" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3Tm1VV" id="1dyouTTzrSr" role="1B3o_S" />
+          <node concept="3uibUv" id="1dyouTTzwhs" role="3clF45">
+            <ref role="3uigEE" node="1dyouTTriKZ" resolve="BX" />
+          </node>
+        </node>
+        <node concept="3clFb_" id="1dyouTTzstx" role="jymVt">
+          <property role="TrG5h" value="p2a" />
+          <node concept="3clFbS" id="1dyouTTzsty" role="3clF47">
+            <node concept="3cpWs6" id="1dyouTTzstz" role="3cqZAp">
+              <node concept="2OqwBi" id="1dyouTTzst_" role="3cqZAk">
+                <node concept="10M0yZ" id="1dyouTTzstA" role="2Oq$k0">
+                  <ref role="3cqZAo" node="1dyouTTt0TB" resolve="b1" />
+                  <ref role="1PxDUh" node="1dyouTTriKy" resolve="AX" />
+                </node>
+                <node concept="SiP3y" id="1dyouTTWFs$" role="2OqNvi">
+                  <ref role="3cqZAo" node="1dyouTTt1VK" resolve="cStatic" />
+                </node>
+                <node concept="3xLA65" id="1dyouTTzvIr" role="lGtFl">
+                  <property role="TrG5h" value="expected2a" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3Tm1VV" id="1dyouTTzstE" role="1B3o_S" />
+          <node concept="3uibUv" id="1dyouTTzw_Z" role="3clF45">
+            <ref role="3uigEE" node="1dyouTTriLd" resolve="CX" />
+          </node>
+        </node>
+        <node concept="3clFb_" id="1dyouTTWIYb" role="jymVt">
+          <property role="TrG5h" value="p2b" />
+          <node concept="3clFbS" id="1dyouTTWIYc" role="3clF47">
+            <node concept="3cpWs6" id="1dyouTTWIYd" role="3cqZAp">
+              <node concept="2OqwBi" id="1dyouTTWIYe" role="3cqZAk">
+                <node concept="10M0yZ" id="1dyouTTWIYf" role="2Oq$k0">
+                  <ref role="3cqZAo" node="1dyouTTt0TB" resolve="bStatic" />
+                  <ref role="1PxDUh" node="1dyouTTriKy" resolve="AX" />
+                </node>
+                <node concept="2OwXpG" id="1dyouTTWMM2" role="2OqNvi">
+                  <ref role="2Oxat5" node="1dyouTTVtye" resolve="cNonStatic" />
+                </node>
+                <node concept="3xLA65" id="1dyouTTWIYh" role="lGtFl">
+                  <property role="TrG5h" value="expected2b" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3Tm1VV" id="1dyouTTWIYi" role="1B3o_S" />
+          <node concept="3uibUv" id="1dyouTTWIYj" role="3clF45">
+            <ref role="3uigEE" node="1dyouTTriLd" resolve="CX" />
+          </node>
+        </node>
+        <node concept="3clFb_" id="1dyouTTzs$z" role="jymVt">
+          <property role="TrG5h" value="p3" />
+          <node concept="3clFbS" id="1dyouTTzs$$" role="3clF47">
+            <node concept="3cpWs6" id="1dyouTTzs$_" role="3cqZAp">
+              <node concept="2OqwBi" id="1dyouTTzs$A" role="3cqZAk">
+                <node concept="2OqwBi" id="1dyouTTzs$B" role="2Oq$k0">
+                  <node concept="10M0yZ" id="1dyouTTzs$C" role="2Oq$k0">
+                    <ref role="3cqZAo" node="1dyouTTt0TB" resolve="b1" />
+                    <ref role="1PxDUh" node="1dyouTTriKy" resolve="AX" />
+                  </node>
+                  <node concept="2OwXpG" id="1dyouTTWIeg" role="2OqNvi">
+                    <ref role="2Oxat5" node="1dyouTTVtye" resolve="cNonStatic" />
+                  </node>
+                </node>
+                <node concept="SiP3y" id="1dyouTTzs$E" role="2OqNvi">
+                  <ref role="3cqZAo" node="1dyouTTt2pV" resolve="i1" />
+                </node>
+                <node concept="3xLA65" id="1dyouTTzs$F" role="lGtFl">
+                  <property role="TrG5h" value="expected3" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3Tm1VV" id="1dyouTTzs$G" role="1B3o_S" />
+          <node concept="10Oyi0" id="1dyouTTzs$H" role="3clF45" />
+        </node>
+        <node concept="3xLA65" id="1dyouTTriKF" role="lGtFl">
+          <property role="TrG5h" value="root" />
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="1dyouTTriKY" role="1SKRRt">
+      <node concept="312cEu" id="1dyouTTriKZ" role="1qenE9">
+        <property role="TrG5h" value="BX" />
+        <node concept="3Tm1VV" id="1dyouTTriL0" role="1B3o_S" />
+        <node concept="Wx3nA" id="1dyouTTt1VK" role="jymVt">
+          <property role="TrG5h" value="cStatic" />
+          <node concept="3uibUv" id="1dyouTTriL7" role="1tU5fm">
+            <ref role="3uigEE" node="1dyouTTriLd" resolve="C" />
+          </node>
+          <node concept="3Tm1VV" id="1dyouTTriL6" role="1B3o_S" />
+          <node concept="3xLA65" id="1dyouTTtd_m" role="lGtFl">
+            <property role="TrG5h" value="cStatic" />
+          </node>
+        </node>
+        <node concept="312cEg" id="1dyouTTVtye" role="jymVt">
+          <property role="TrG5h" value="cNonStatic" />
+          <node concept="3uibUv" id="1dyouTTVtyi" role="1tU5fm">
+            <ref role="3uigEE" node="1dyouTTriLd" resolve="CX" />
+          </node>
+          <node concept="3Tm1VV" id="1dyouTTVtyh" role="1B3o_S" />
+          <node concept="3xLA65" id="1dyouTTVtyk" role="lGtFl">
+            <property role="TrG5h" value="cNonStatic" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="1dyouTTriLc" role="1SKRRt">
+      <node concept="312cEu" id="1dyouTTriLd" role="1qenE9">
+        <property role="TrG5h" value="CX" />
+        <node concept="3Tm1VV" id="1dyouTTriLe" role="1B3o_S" />
+        <node concept="Wx3nA" id="1dyouTTt2pV" role="jymVt">
+          <property role="TrG5h" value="i1" />
+          <node concept="3uibUv" id="1dyouTTriLk" role="1tU5fm">
+            <ref role="3uigEE" to="wyt6:~Integer" resolve="Integer" />
+          </node>
+          <node concept="3Tm1VV" id="1dyouTTriLj" role="1B3o_S" />
+          <node concept="3xLA65" id="1dyouTTtdGB" role="lGtFl">
+            <property role="TrG5h" value="i1" />
+          </node>
         </node>
       </node>
     </node>

--- a/code/languages/com.mbeddr.mpsutil/tests/test.com.mbeddr.mpsutil.common/models/test.com.mbeddr.mpsutil.common.util@tests.mps
+++ b/code/languages/com.mbeddr.mpsutil/tests/test.com.mbeddr.mpsutil.common/models/test.com.mbeddr.mpsutil.common.util@tests.mps
@@ -4792,6 +4792,25 @@
         </node>
       </node>
     </node>
+    <node concept="2tJIrI" id="6USpnrazy_y" role="jymVt" />
+    <node concept="3clFbW" id="6USpnrazAHn" role="jymVt">
+      <node concept="3cqZAl" id="6USpnrazAHp" role="3clF45" />
+      <node concept="3Tm1VV" id="6USpnrazAHq" role="1B3o_S" />
+      <node concept="3clFbS" id="6USpnrazAHr" role="3clF47">
+        <node concept="XkiVB" id="6USpnrazD2H" role="3cqZAp">
+          <ref role="37wK5l" to="7wpd:6USpnrawOgS" resolve="InstancePath" />
+          <node concept="37vLTw" id="6USpnrazE7s" role="37wK5m">
+            <ref role="3cqZAo" node="6USpnrazBHQ" resolve="orig" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="6USpnrazBHQ" role="3clF46">
+        <property role="TrG5h" value="orig" />
+        <node concept="3uibUv" id="6USpnrazBHP" role="1tU5fm">
+          <ref role="3uigEE" node="3u1rFxeDiKa" resolve="NestedMemberPath" />
+        </node>
+      </node>
+    </node>
     <node concept="2tJIrI" id="1dyouTTeo_U" role="jymVt" />
     <node concept="3Tm1VV" id="3u1rFxeDiKb" role="1B3o_S" />
     <node concept="3uibUv" id="3u1rFxeDjjc" role="1zkMxy">
@@ -4807,7 +4826,7 @@
       </node>
     </node>
     <node concept="3clFb_" id="1dyouTTekf7" role="jymVt">
-      <property role="TrG5h" value="copy" />
+      <property role="TrG5h" value="cloneObject" />
       <node concept="3Tmbuc" id="1dyouTTekf9" role="1B3o_S" />
       <node concept="3uibUv" id="1dyouTTepZF" role="3clF45">
         <ref role="3uigEE" node="3u1rFxeDiKa" resolve="NestedMemberPath" />
@@ -4817,10 +4836,8 @@
           <node concept="2ShNRf" id="1dyouTTeqkc" role="3clFbG">
             <node concept="1pGfFk" id="1dyouTTerWm" role="2ShVmc">
               <property role="373rjd" value="true" />
-              <ref role="37wK5l" node="1dyouTTekMU" resolve="NestedMemberPath" />
-              <node concept="1rXfSq" id="1dyouTTesdK" role="37wK5m">
-                <ref role="37wK5l" to="7wpd:65ATjZHmLvj" resolve="root" />
-              </node>
+              <ref role="37wK5l" node="6USpnrazAHn" />
+              <node concept="Xjq3P" id="6USpnrazHQW" role="37wK5m" />
             </node>
           </node>
         </node>

--- a/code/languages/com.mbeddr.mpsutil/tests/test.com.mbeddr.mpsutil.common/models/test.com.mbeddr.mpsutil.common.util@tests.mps
+++ b/code/languages/com.mbeddr.mpsutil/tests/test.com.mbeddr.mpsutil.common/models/test.com.mbeddr.mpsutil.common.util@tests.mps
@@ -44,10 +44,6 @@
       <concept id="1225978065297" name="jetbrains.mps.lang.test.structure.SimpleNodeTest" flags="ng" index="1LZb2c" />
     </language>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
-      <concept id="1224071154655" name="jetbrains.mps.baseLanguage.structure.AsExpression" flags="nn" index="0kSF2">
-        <child id="1224071154657" name="classifierType" index="0kSFW" />
-        <child id="1224071154656" name="expression" index="0kSFX" />
-      </concept>
       <concept id="1219920932475" name="jetbrains.mps.baseLanguage.structure.VariableArityType" flags="in" index="8X2XB">
         <child id="1219921048460" name="componentType" index="8Xvag" />
       </concept>
@@ -4306,7 +4302,7 @@
                 <ref role="3cqZAo" node="1dyouTTmEBw" resolve="p1" />
               </node>
               <node concept="liA8E" id="1dyouTTmHtr" role="2OqNvi">
-                <ref role="37wK5l" node="1dyouTTmJNs" resolve="append" />
+                <ref role="37wK5l" to="7wpd:5LihCoMiiPS" resolve="append" />
                 <node concept="3xONca" id="1dyouTTmHts" role="37wK5m">
                   <ref role="3xOPvv" node="1dyouTTkiHP" resolve="c1" />
                 </node>
@@ -4390,7 +4386,7 @@
                 <ref role="3cqZAo" node="1dyouTTnfGV" resolve="p1" />
               </node>
               <node concept="liA8E" id="1dyouTTnfH8" role="2OqNvi">
-                <ref role="37wK5l" node="1dyouTTnitF" resolve="append" />
+                <ref role="37wK5l" to="7wpd:5zD5ovm$jwh" resolve="append" />
                 <node concept="2ShNRf" id="1dyouTTo4Xv" role="37wK5m">
                   <node concept="Tc6Ow" id="1dyouTTo4Xw" role="2ShVmc">
                     <node concept="3xONca" id="1dyouTToiUj" role="HW$Y0">
@@ -4511,7 +4507,7 @@
                 <ref role="3cqZAo" node="1dyouTTo_U0" resolve="p1" />
               </node>
               <node concept="liA8E" id="1dyouTTpezf" role="2OqNvi">
-                <ref role="37wK5l" node="1dyouTToJ5m" resolve="concatSafe" />
+                <ref role="37wK5l" to="7wpd:3u1rFxeqM8T" resolve="concatSafe" />
                 <node concept="37vLTw" id="1dyouTTpezg" role="37wK5m">
                   <ref role="3cqZAo" node="1dyouTToAh1" resolve="p2" />
                 </node>
@@ -4638,7 +4634,7 @@
                 <ref role="3cqZAo" node="1dyouTTpM0P" resolve="p1" />
               </node>
               <node concept="liA8E" id="1dyouTTpM1c" role="2OqNvi">
-                <ref role="37wK5l" node="1dyouTToJ5m" resolve="concatSafe" />
+                <ref role="37wK5l" to="7wpd:3u1rFxeqM8T" resolve="concatSafe" />
                 <node concept="37vLTw" id="1dyouTTpM1d" role="37wK5m">
                   <ref role="3cqZAo" node="1dyouTTpM0Y" resolve="p2" />
                 </node>
@@ -4806,6 +4802,9 @@
       <node concept="3Tqbb2" id="1dyouTTek8F" role="11_B2D">
         <ref role="ehGHo" to="tpee:fz3uBXI" resolve="VariableDeclaration" />
       </node>
+      <node concept="3uibUv" id="6USpnrashEu" role="11_B2D">
+        <ref role="3uigEE" node="3u1rFxeDiKa" resolve="NestedMemberPath" />
+      </node>
     </node>
     <node concept="3clFb_" id="1dyouTTekf7" role="jymVt">
       <property role="TrG5h" value="copy" />
@@ -4964,116 +4963,6 @@
       </node>
       <node concept="3Tm1VV" id="1dyouTTlmkt" role="1B3o_S" />
       <node concept="17QB3L" id="1dyouTTlmBC" role="3clF45" />
-    </node>
-    <node concept="2tJIrI" id="1dyouTTmIMJ" role="jymVt" />
-    <node concept="3clFb_" id="1dyouTTmJNs" role="jymVt">
-      <property role="TrG5h" value="append" />
-      <node concept="37vLTG" id="1dyouTTmKd7" role="3clF46">
-        <property role="TrG5h" value="segment" />
-        <node concept="3Tqbb2" id="1dyouTTmKd8" role="1tU5fm">
-          <ref role="ehGHo" to="tpee:fz3uBXI" resolve="VariableDeclaration" />
-        </node>
-      </node>
-      <node concept="3clFbS" id="1dyouTTmJNv" role="3clF47">
-        <node concept="3clFbF" id="1dyouTTmKKS" role="3cqZAp">
-          <node concept="0kSF2" id="1dyouTTmMPW" role="3clFbG">
-            <node concept="3uibUv" id="1dyouTTmMPY" role="0kSFW">
-              <ref role="3uigEE" node="3u1rFxeDiKa" resolve="NestedMemberPath" />
-            </node>
-            <node concept="3nyPlj" id="1dyouTTmKKR" role="0kSFX">
-              <ref role="37wK5l" to="7wpd:5LihCoMiiPS" resolve="append" />
-              <node concept="37vLTw" id="1dyouTTmLRY" role="37wK5m">
-                <ref role="3cqZAo" node="1dyouTTmKd7" resolve="segment" />
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="1dyouTTmJcL" role="1B3o_S" />
-      <node concept="3uibUv" id="1dyouTTmJAu" role="3clF45">
-        <ref role="3uigEE" node="3u1rFxeDiKa" resolve="NestedMemberPath" />
-      </node>
-    </node>
-    <node concept="2tJIrI" id="1dyouTTnj3c" role="jymVt" />
-    <node concept="3clFb_" id="1dyouTTnitF" role="jymVt">
-      <property role="TrG5h" value="append" />
-      <node concept="37vLTG" id="1dyouTTnitG" role="3clF46">
-        <property role="TrG5h" value="segments" />
-        <node concept="A3Dl8" id="1dyouTTnk8r" role="1tU5fm">
-          <node concept="3Tqbb2" id="1dyouTTnk8s" role="A3Ik2">
-            <ref role="ehGHo" to="tpee:fz3uBXI" resolve="VariableDeclaration" />
-          </node>
-        </node>
-      </node>
-      <node concept="3clFbS" id="1dyouTTnitI" role="3clF47">
-        <node concept="3clFbF" id="1dyouTTnitJ" role="3cqZAp">
-          <node concept="0kSF2" id="1dyouTTnitK" role="3clFbG">
-            <node concept="3uibUv" id="1dyouTTnitL" role="0kSFW">
-              <ref role="3uigEE" node="3u1rFxeDiKa" resolve="NestedMemberPath" />
-            </node>
-            <node concept="3nyPlj" id="1dyouTTnitM" role="0kSFX">
-              <ref role="37wK5l" to="7wpd:5zD5ovm$jwh" resolve="append" />
-              <node concept="37vLTw" id="1dyouTTnitN" role="37wK5m">
-                <ref role="3cqZAo" node="1dyouTTnitG" resolve="segments" />
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="1dyouTTnitO" role="1B3o_S" />
-      <node concept="3uibUv" id="1dyouTTnitP" role="3clF45">
-        <ref role="3uigEE" node="3u1rFxeDiKa" resolve="NestedMemberPath" />
-      </node>
-    </node>
-    <node concept="2tJIrI" id="1dyouTToG9f" role="jymVt" />
-    <node concept="3clFb_" id="1dyouTToJ5m" role="jymVt">
-      <property role="TrG5h" value="concatSafe" />
-      <node concept="3clFbS" id="1dyouTToJ5p" role="3clF47">
-        <node concept="3clFbF" id="1dyouTToKM3" role="3cqZAp">
-          <node concept="2OqwBi" id="1dyouTToXY6" role="3clFbG">
-            <node concept="3nyPlj" id="1dyouTToKM2" role="2Oq$k0">
-              <ref role="37wK5l" to="7wpd:3u1rFxeqM8T" resolve="concatSafe" />
-              <node concept="37vLTw" id="1dyouTToM5I" role="37wK5m">
-                <ref role="3cqZAo" node="1dyouTToJGn" resolve="other" />
-              </node>
-            </node>
-            <node concept="liA8E" id="1dyouTToZcL" role="2OqNvi">
-              <ref role="37wK5l" to="33ny:~Optional.map(java.util.function.Function)" resolve="map" />
-              <node concept="1bVj0M" id="1dyouTToZW2" role="37wK5m">
-                <node concept="gl6BB" id="1dyouTToZWl" role="1bW2Oz">
-                  <property role="TrG5h" value="p" />
-                  <node concept="2jxLKc" id="1dyouTToZWm" role="1tU5fm" />
-                </node>
-                <node concept="3clFbS" id="1dyouTToZWN" role="1bW5cS">
-                  <node concept="3clFbF" id="1dyouTTp1CM" role="3cqZAp">
-                    <node concept="0kSF2" id="1dyouTTp3$G" role="3clFbG">
-                      <node concept="3uibUv" id="1dyouTTp3$I" role="0kSFW">
-                        <ref role="3uigEE" node="3u1rFxeDiKa" resolve="NestedMemberPath" />
-                      </node>
-                      <node concept="37vLTw" id="1dyouTTp1CL" role="0kSFX">
-                        <ref role="3cqZAo" node="1dyouTToZWl" resolve="p" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="1dyouTToHi_" role="1B3o_S" />
-      <node concept="3uibUv" id="1dyouTToIJJ" role="3clF45">
-        <ref role="3uigEE" to="33ny:~Optional" resolve="Optional" />
-        <node concept="3uibUv" id="1dyouTTp9kp" role="11_B2D">
-          <ref role="3uigEE" node="3u1rFxeDiKa" resolve="NestedMemberPath" />
-        </node>
-      </node>
-      <node concept="37vLTG" id="1dyouTToJGn" role="3clF46">
-        <property role="TrG5h" value="other" />
-        <node concept="3uibUv" id="1dyouTToJGm" role="1tU5fm">
-          <ref role="3uigEE" node="3u1rFxeDiKa" resolve="NestedMemberPath" />
-        </node>
-      </node>
     </node>
     <node concept="2tJIrI" id="1dyouTTEWDK" role="jymVt" />
     <node concept="3clFb_" id="1dyouTTF559" role="jymVt">

--- a/code/languages/com.mbeddr.mpsutil/tests/test.com.mbeddr.mpsutil.common/models/test.com.mbeddr.mpsutil.common.util@tests.mps
+++ b/code/languages/com.mbeddr.mpsutil/tests/test.com.mbeddr.mpsutil.common/models/test.com.mbeddr.mpsutil.common.util@tests.mps
@@ -11,6 +11,7 @@
     <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
     <use id="3a13115c-633c-4c5c-bbcc-75c4219e9555" name="jetbrains.mps.lang.quotation" version="5" />
     <use id="f47b95d4-5e73-4c04-9204-18076950153b" name="de.itemis.mps.compare" version="0" />
+    <use id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc" version="2" />
   </languages>
   <imports>
     <import index="7wpd" ref="c7a315e6-1d93-4186-85bc-2dfafd1ccc21/r:fb1c47d7-a72e-4e01-92dc-1e9f2ba4a118(com.mbeddr.mpsutil.common/com.mbeddr.mpsutil.common.util)" />
@@ -201,6 +202,18 @@
         <child id="1199569906740" name="parameter" index="1bW2Oz" />
         <child id="1199569916463" name="body" index="1bW5cS" />
       </concept>
+    </language>
+    <language id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc">
+      <concept id="5349172909345501395" name="jetbrains.mps.baseLanguage.javadoc.structure.BaseDocComment" flags="ng" index="P$AiS">
+        <child id="8465538089690331502" name="body" index="TZ5H$" />
+      </concept>
+      <concept id="8465538089690331500" name="jetbrains.mps.baseLanguage.javadoc.structure.CommentLine" flags="ng" index="TZ5HA">
+        <child id="8970989240999019149" name="part" index="1dT_Ay" />
+      </concept>
+      <concept id="8970989240999019143" name="jetbrains.mps.baseLanguage.javadoc.structure.TextCommentLinePart" flags="ng" index="1dT_AC">
+        <property id="8970989240999019144" name="text" index="1dT_AB" />
+      </concept>
+      <concept id="2068944020170241612" name="jetbrains.mps.baseLanguage.javadoc.structure.ClassifierDocComment" flags="ng" index="3UR2Jj" />
     </language>
     <language id="443f4c36-fcf5-4eb6-9500-8d06ed259e3e" name="jetbrains.mps.baseLanguage.classifiers">
       <concept id="1205752633985" name="jetbrains.mps.baseLanguage.classifiers.structure.ThisClassifierExpression" flags="nn" index="2WthIp" />
@@ -4795,7 +4808,7 @@
     <node concept="2tJIrI" id="6USpnrazy_y" role="jymVt" />
     <node concept="3clFbW" id="6USpnrazAHn" role="jymVt">
       <node concept="3cqZAl" id="6USpnrazAHp" role="3clF45" />
-      <node concept="3Tm1VV" id="6USpnrazAHq" role="1B3o_S" />
+      <node concept="3Tm6S6" id="6USpnrb3VBk" role="1B3o_S" />
       <node concept="3clFbS" id="6USpnrazAHr" role="3clF47">
         <node concept="XkiVB" id="6USpnrazD2H" role="3cqZAp">
           <ref role="37wK5l" to="7wpd:6USpnrawOgS" resolve="InstancePath" />
@@ -5183,6 +5196,38 @@
       <node concept="3Tm6S6" id="1dyouTTN8_W" role="1B3o_S" />
       <node concept="3Tqbb2" id="1dyouTTNc$S" role="3clF45">
         <ref role="ehGHo" to="tpee:hqOqG0K" resolve="IOperation" />
+      </node>
+    </node>
+    <node concept="3UR2Jj" id="710iChROKTk" role="lGtFl">
+      <node concept="TZ5HA" id="710iChROKTl" role="TZ5H$">
+        <node concept="1dT_AC" id="710iChROKTm" role="1dT_Ay">
+          <property role="1dT_AB" value="Represent a nested base-language class member by an &quot;InstancePath&quot;." />
+        </node>
+      </node>
+      <node concept="TZ5HA" id="710iChROQRp" role="TZ5H$">
+        <node concept="1dT_AC" id="710iChROQRq" role="1dT_Ay">
+          <property role="1dT_AB" value="" />
+        </node>
+      </node>
+      <node concept="TZ5HA" id="710iChROTpz" role="TZ5H$">
+        <node concept="1dT_AC" id="710iChROTp$" role="1dT_Ay">
+          <property role="1dT_AB" value="This is just an example how to use the InstancePath abstract class." />
+        </node>
+      </node>
+      <node concept="TZ5HA" id="710iChRP4Pz" role="TZ5H$">
+        <node concept="1dT_AC" id="710iChRP4P$" role="1dT_Ay">
+          <property role="1dT_AB" value="" />
+        </node>
+      </node>
+      <node concept="TZ5HA" id="710iChRP757" role="TZ5H$">
+        <node concept="1dT_AC" id="710iChRP758" role="1dT_Ay">
+          <property role="1dT_AB" value="It could be helpful to implement some base-language code analyser. But as this is a theoretical option only, " />
+        </node>
+      </node>
+      <node concept="TZ5HA" id="710iChRP9K7" role="TZ5H$">
+        <node concept="1dT_AC" id="710iChRP9K8" role="1dT_Ay">
+          <property role="1dT_AB" value="we keep the class here in the test solution until someone actually wants to use it. " />
+        </node>
       </node>
     </node>
   </node>

--- a/code/languages/com.mbeddr.mpsutil/tests/test.com.mbeddr.mpsutil.common/test.com.mbeddr.mpsutil.common.msd
+++ b/code/languages/com.mbeddr.mpsutil/tests/test.com.mbeddr.mpsutil.common/test.com.mbeddr.mpsutil.common.msd
@@ -25,6 +25,7 @@
     <language slang="l:443f4c36-fcf5-4eb6-9500-8d06ed259e3e:jetbrains.mps.baseLanguage.classifiers" version="0" />
     <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
     <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="2" />
+    <language slang="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" version="2" />
     <language slang="l:f61473f9-130f-42f6-b98d-6c438812c2f6:jetbrains.mps.baseLanguage.unitTest" version="1" />
     <language slang="l:515552c7-fcc0-4ab4-9789-2f3c49344e85:jetbrains.mps.baseLanguage.varVariable" version="0" />
     <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />

--- a/code/languages/com.mbeddr.mpsutil/tests/test.com.mbeddr.mpsutil.common/test.com.mbeddr.mpsutil.common.msd
+++ b/code/languages/com.mbeddr.mpsutil/tests/test.com.mbeddr.mpsutil.common/test.com.mbeddr.mpsutil.common.msd
@@ -17,8 +17,10 @@
     <dependency reexport="false">822a7acd-f487-45f5-bbb9-1ce595a1705f(com.mbeddr.mpsutil.ecore.stubs)</dependency>
     <dependency reexport="false">ecfb9949-7433-4db5-85de-0f84d172e4ce(de.q60.mps.collections.libs)</dependency>
     <dependency reexport="false">b0f8641f-bd77-4421-8425-30d9088a82f7(org.apache.commons)</dependency>
+    <dependency reexport="false">f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)</dependency>
   </dependencies>
   <languageVersions>
+    <language slang="l:f47b95d4-5e73-4c04-9204-18076950153b:de.itemis.mps.compare" version="0" />
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
     <language slang="l:443f4c36-fcf5-4eb6-9500-8d06ed259e3e:jetbrains.mps.baseLanguage.classifiers" version="0" />
     <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
@@ -26,6 +28,9 @@
     <language slang="l:f61473f9-130f-42f6-b98d-6c438812c2f6:jetbrains.mps.baseLanguage.unitTest" version="1" />
     <language slang="l:515552c7-fcc0-4ab4-9789-2f3c49344e85:jetbrains.mps.baseLanguage.varVariable" version="0" />
     <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
+    <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
+    <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="5" />
+    <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="19" />
     <language slang="l:8585453e-6bfb-4d80-98de-b16074f1d86c:jetbrains.mps.lang.test" version="6" />
     <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
   </languageVersions>
@@ -37,6 +42,11 @@
     <module reference="c7a315e6-1d93-4186-85bc-2dfafd1ccc21(com.mbeddr.mpsutil.common)" version="0" />
     <module reference="822a7acd-f487-45f5-bbb9-1ce595a1705f(com.mbeddr.mpsutil.ecore.stubs)" version="0" />
     <module reference="ecfb9949-7433-4db5-85de-0f84d172e4ce(de.q60.mps.collections.libs)" version="0" />
+    <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
+    <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
+    <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
+    <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
+    <module reference="9ded098b-ad6a-4657-bfd9-48636cfe8bc3(jetbrains.mps.lang.traceable)" version="0" />
     <module reference="b0f8641f-bd77-4421-8425-30d9088a82f7(org.apache.commons)" version="0" />
     <module reference="fceddec6-7184-49a0-9009-0da4dbdc8b95(test.com.mbeddr.mpsutil.common)" version="0" />
   </dependencyVersions>


### PR DESCRIPTION
This solves #2911, see description of the functionality there.

The PR comes with an example application class (for base language), and provides a couple of tests. We intend to use the new helper classes for at least two applications in IETS3-Core (e.g., ArtifactPath), and possibly in some customer applications.