### PR TITLE
Plugin mpsutil.jung depends on "full" MPS (aka workbench)

### DIFF
--- a/code/languages/com.mbeddr.platform.build/solutions/com.mbeddr.platform/models/com/mbeddr/platform/build.mps
+++ b/code/languages/com.mbeddr.platform.build/solutions/com.mbeddr.platform/models/com/mbeddr/platform/build.mps
@@ -496,7 +496,7 @@
         <ref role="m$f5T" node="3quoVcnKz3m" resolve="group.jung" />
       </node>
       <node concept="m$_yC" id="64SK4bcI_br" role="m$_yJ">
-        <ref role="m$_y1" to="ffeo:4k71ibbKLe8" resolve="jetbrains.mps.core" />
+        <ref role="m$_y1" to="ffeo:4k71ibbLe59" resolve="com.intellij.modules.mps" />
       </node>
       <node concept="2iUeEo" id="7yAshxDtoql" role="2iVFfd">
         <property role="2iUeEt" value="mbeddr" />


### PR DESCRIPTION
MPS is now strict about missing plugin dependencis (MPS-38286) 
pluginSolution requires j.m.ide.editor which comes from "workbench" plugin.