### PR TITLE
mpsutil.actionsfilter: initialize the action manager before working with it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is _loosely_ based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). The project does _not_ follow
 Semantic Versioning and the changes are simply documented in reverse chronological order, grouped by calendar month.
 
+# May 2025
+
+## com.mbeddr.mpsutil.actionsfilter
+
+- An exception (!app.isDispatchThread()) was fixed that was related to the initialization of the actionsfilter language.
+
 # April 2025
 
 ## com.mbeddr.doc

--- a/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.actionsfilter.runtime/models/com/mbeddr/mpsutil/actionsfilter/runtime.mps
+++ b/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.actionsfilter.runtime/models/com/mbeddr/mpsutil/actionsfilter/runtime.mps
@@ -12833,6 +12833,28 @@
             </node>
           </node>
         </node>
+        <node concept="3cpWs8" id="7xgxWxJ7qDJ" role="3cqZAp">
+          <node concept="3cpWsn" id="7xgxWxJ7qDK" role="3cpWs9">
+            <property role="TrG5h" value="instance" />
+            <node concept="3uibUv" id="7xgxWxJ7qko" role="1tU5fm">
+              <ref role="3uigEE" to="qkt:~ActionManager" resolve="ActionManager" />
+            </node>
+            <node concept="2YIFZM" id="7xgxWxJ8AKo" role="33vP2m">
+              <ref role="37wK5l" to="qkt:~ActionManager.getInstance()" resolve="getInstance" />
+              <ref role="1Pybhc" to="qkt:~ActionManager" resolve="ActionManager" />
+            </node>
+          </node>
+        </node>
+        <node concept="RRSsy" id="7xgxWxJ7rQi" role="3cqZAp">
+          <node concept="3cpWs3" id="7xgxWxJ7uLY" role="RRSoy">
+            <node concept="37vLTw" id="7xgxWxJ7vQM" role="3uHU7w">
+              <ref role="3cqZAo" node="7xgxWxJ7qDK" resolve="instance" />
+            </node>
+            <node concept="Xl_RD" id="7xgxWxJ7rQk" role="3uHU7B">
+              <property role="Xl_RC" value="Action manager initialized:" />
+            </node>
+          </node>
+        </node>
         <node concept="3clFbF" id="24qwin8x0Ns" role="3cqZAp">
           <node concept="2YIFZM" id="24qwin8x0Rd" role="3clFbG">
             <ref role="37wK5l" to="dxuu:~SwingUtilities.invokeLater(java.lang.Runnable)" resolve="invokeLater" />


### PR DESCRIPTION
If we do not do this outside of the EDT thread, the class will complain because it can't be initialized on this thread when we need it for the ActionsApplicationComponent.
Another similar issue in MPS: https://youtrack.jetbrains.com/issue/MPS-33812/Assertion-failed
This exception is very unlikely to happen anyway because MPS probably also needs to initialize this class somewhere.

https://github.com/mbeddr/mbeddr.core/issues/2340 is not reproducible (happens very rarely) for me but should be fixed by that.