### PR TITLE
Fix test.ts.ext.components.embedded to work with 2025.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 
 //MPS version
 ext.mpsMajor = "2025.1"
-ext.mpsBuild = "2025.1-RC1"
+ext.mpsBuild = "2025.1"
 
 //MPS-extensions version
 ext.mpsExtensionsVersion = "2025.1.3226.9d3d593"

--- a/code/languages/com.mbeddr.build/solutions/com.mbeddr.ext.build/models/com/mbeddr/ext/build.mps
+++ b/code/languages/com.mbeddr.build/solutions/com.mbeddr.ext.build/models/com/mbeddr/ext/build.mps
@@ -21,7 +21,9 @@
       <concept id="4560297596904469362" name="jetbrains.mps.build.mps.tests.structure.BuildMps_TestModule" flags="nn" index="22LTRM">
         <reference id="4560297596904469363" name="module" index="22LTRN" />
       </concept>
-      <concept id="6593674873639474400" name="jetbrains.mps.build.mps.tests.structure.BuildMps_TestModules_Options" flags="ng" index="24cAiW" />
+      <concept id="6593674873639474400" name="jetbrains.mps.build.mps.tests.structure.BuildMps_TestModules_Options" flags="ng" index="24cAiW">
+        <child id="7978162869575635130" name="projectPath" index="1RZ71A" />
+      </concept>
       <concept id="4005526075820600484" name="jetbrains.mps.build.mps.tests.structure.BuildModuleTestsPlugin" flags="ng" index="1gjT0q" />
     </language>
     <language id="798100da-4f0a-421a-b991-71f8c50ce5d2" name="jetbrains.mps.build">
@@ -1183,7 +1185,6 @@
         <property role="3LESm3" value="65b00399-c5df-4987-baee-fe04224907ff" />
         <property role="TrG5h" value="test.ts.ext.components" />
         <property role="aoJFB" value="eYcmk9QOlj/sources_and_tests" />
-        <property role="3vZFNd" value="3kCd1ud3JDD/compile_ext" />
         <node concept="1SiIV0" id="3YIXnYN2g6K" role="3bR37C">
           <node concept="3bR9La" id="3YIXnYN2g6L" role="1SiIV1">
             <ref role="3bR37D" to="p6ld:7tgCHAyOtFQ" resolve="com.mbeddr.ext.compositecomponents" />
@@ -1259,13 +1260,7 @@
         <property role="BnDLt" value="true" />
         <property role="3LESm3" value="cc872c37-5126-4cea-bcc0-b45897eba581" />
         <property role="TrG5h" value="test.ts.ext.components.embedded" />
-        <property role="aoJFB" value="eYcmk9QOli/sources" />
-        <property role="3vZFNd" value="3kCd1ud3JDD/compile_ext" />
-        <node concept="1SiIV0" id="3F9kUGaP0yE" role="3bR37C">
-          <node concept="3bR9La" id="3F9kUGaP0yF" role="1SiIV1">
-            <ref role="3bR37D" to="p6ld:7eF9rfAuAO0" resolve="com.mbeddr.ext.components" />
-          </node>
-        </node>
+        <property role="aoJFB" value="eYcmk9QOlj/sources_and_tests" />
         <node concept="398BVA" id="3F9kUGaP0yK" role="3LF7KH">
           <ref role="398BVh" node="7Vt15sLW_nb" resolve="mbeddr.ext" />
           <node concept="2Ry0Ak" id="3F9kUGaP0yL" role="iGT6I">
@@ -1287,8 +1282,8 @@
               <ref role="398BVh" node="7Vt15sLW_nb" resolve="mbeddr.ext" />
               <node concept="2Ry0Ak" id="3F9kUGaP0yS" role="iGT6I">
                 <property role="2Ry0Am" value="tests" />
-                <node concept="2Ry0Ak" id="3F9kUGaP0yT" role="2Ry0An">
-                  <property role="2Ry0Am" value="test.ts.ext.components" />
+                <node concept="2Ry0Ak" id="5ZZlSojjwIq" role="2Ry0An">
+                  <property role="2Ry0Am" value="test.ts.ext.components.embedded" />
                 </node>
               </node>
             </node>
@@ -1327,7 +1322,6 @@
         <property role="TrG5h" value="test.ext.components.nodes_tracing" />
         <property role="3LESm3" value="3296cd37-5e43-4ad5-8880-d0471ef48d5d" />
         <property role="aoJFB" value="eYcmk9QOlj/sources_and_tests" />
-        <property role="3vZFNd" value="3kCd1ud3JDD/compile_ext" />
         <node concept="398BVA" id="7IMscoYPuuB" role="3LF7KH">
           <ref role="398BVh" node="7Vt15sLW_nb" resolve="mbeddr.ext" />
           <node concept="2Ry0Ak" id="7IMscoYPuuC" role="iGT6I">
@@ -1394,7 +1388,6 @@
         <property role="TrG5h" value="test.ts.ext.units" />
         <property role="3LESm3" value="3e91b33c-9c18-4307-9388-e5d6e8b6ef30" />
         <property role="aoJFB" value="eYcmk9QOlj/sources_and_tests" />
-        <property role="3vZFNd" value="3kCd1ud3JDD/compile_ext" />
         <node concept="398BVA" id="1VMOGozl6KZ" role="3LF7KH">
           <ref role="398BVh" node="7Vt15sLW_nb" resolve="mbeddr.ext" />
           <node concept="2Ry0Ak" id="1VMOGozl6Pe" role="iGT6I">
@@ -1461,7 +1454,6 @@
         <property role="TrG5h" value="test.ts.ext.concurrency" />
         <property role="3LESm3" value="1150a9b6-68b1-44b7-a7e5-cba98fe879c1" />
         <property role="aoJFB" value="eYcmk9QOlj/sources_and_tests" />
-        <property role="3vZFNd" value="3kCd1ud3JDD/compile_ext" />
         <node concept="1SiIV0" id="6qOUCDpKTrb" role="3bR37C">
           <node concept="3bR9La" id="6qOUCDpKTrc" role="1SiIV1">
             <ref role="3bR37D" to="p6ld:73JrkgyB$b9" resolve="com.mbeddr.ext.concurrency" />
@@ -1523,7 +1515,6 @@
         <property role="TrG5h" value="test.editor.ext" />
         <property role="3LESm3" value="578ac46a-d23e-4d41-919e-312fa2683e3f" />
         <property role="aoJFB" value="eYcmk9QOlj/sources_and_tests" />
-        <property role="3vZFNd" value="3kCd1ud3JDD/compile_ext" />
         <node concept="398BVA" id="5$jJV5ebzIf" role="3LF7KH">
           <ref role="398BVh" node="7Vt15sLW_nb" resolve="mbeddr.ext" />
           <node concept="2Ry0Ak" id="5$jJV5ebzM6" role="iGT6I">
@@ -1603,7 +1594,6 @@
         <property role="TrG5h" value="test.ex.ext.statemachine" />
         <property role="3LESm3" value="3ef85fa6-42d3-4b91-b2be-19b37203ff69" />
         <property role="aoJFB" value="eYcmk9QOlj/sources_and_tests" />
-        <property role="3vZFNd" value="3kCd1ud3JDD/compile_ext" />
         <node concept="398BVA" id="73rNuZmLa1Z" role="3LF7KH">
           <ref role="398BVh" node="7Vt15sLW_nb" resolve="mbeddr.ext" />
           <node concept="2Ry0Ak" id="73rNuZmLa20" role="iGT6I">
@@ -1657,7 +1647,6 @@
         <property role="TrG5h" value="test.ext.statemachine.nodes_tracing" />
         <property role="3LESm3" value="ee6f777b-4776-4dc5-8ab5-cff0050a11eb" />
         <property role="aoJFB" value="eYcmk9QOlj/sources_and_tests" />
-        <property role="3vZFNd" value="3kCd1ud3JDD/compile_ext" />
         <node concept="398BVA" id="pq_X7YaYwR" role="3LF7KH">
           <ref role="398BVh" node="7Vt15sLW_nb" resolve="mbeddr.ext" />
           <node concept="2Ry0Ak" id="pq_X7YaYAv" role="iGT6I">
@@ -1724,7 +1713,6 @@
         <property role="TrG5h" value="test.ext.math.nodes_tracing" />
         <property role="3LESm3" value="307598f2-bbfa-4d05-8e98-221d003ce000" />
         <property role="aoJFB" value="eYcmk9QOlj/sources_and_tests" />
-        <property role="3vZFNd" value="3kCd1ud3JDD/compile_ext" />
         <node concept="398BVA" id="5X2Sm8lVI_P" role="3LF7KH">
           <ref role="398BVh" node="7Vt15sLW_nb" resolve="mbeddr.ext" />
           <node concept="2Ry0Ak" id="5X2Sm8lVI_Q" role="iGT6I">
@@ -1813,7 +1801,11 @@
       <node concept="22LTRM" id="7IMscoYPv3M" role="22LTRK">
         <ref role="22LTRN" node="7IMscoYPuqC" resolve="test.ext.components.nodes_tracing" />
       </node>
-      <node concept="24cAiW" id="76N1O$Kj6vH" role="24cAkG" />
+      <node concept="24cAiW" id="76N1O$Kj6vH" role="24cAkG">
+        <node concept="398BVA" id="5ZZlSojjgGQ" role="1RZ71A">
+          <ref role="398BVh" node="7Vt15sLW_nb" resolve="mbeddr.ext" />
+        </node>
+      </node>
     </node>
   </node>
 </model>

--- a/code/languages/com.mbeddr.ext/tests/test.ts.ext.components.embedded/models/main@tests.mps
+++ b/code/languages/com.mbeddr.ext/tests/test.ts.ext.components.embedded/models/main@tests.mps
@@ -3,10 +3,10 @@
   <persistence version="9" />
   <languages>
     <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="6" />
-    <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="1" />
     <use id="028899e1-bfee-4db6-b470-ed0f9ee5f662" name="com.mbeddr.ext.components.embedded" version="0" />
     <use id="783af01f-87a7-412c-be99-293a162652b5" name="com.mbeddr.core.embedded" version="1" />
     <use id="54f2a59b-97bb-4c09-af92-928ebf9c5966" name="com.mbeddr.ext.compositecomponents" version="0" />
+    <use id="0d04a6cc-773e-4069-b9b0-11884b2ff1c8" name="com.mbeddr.ext.units" version="1" />
     <devkit ref="24565007-e59f-42fc-ac10-da3836deec1c(com.mbeddr.components)" />
   </languages>
   <imports>
@@ -26,9 +26,6 @@
         <reference id="8333855927540250453" name="declaration" index="39XzEq" />
       </concept>
       <concept id="4531408400484511853" name="jetbrains.mps.lang.test.structure.ReportErrorStatementReference" flags="ng" index="2PYRI3" />
-      <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
-        <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
-      </concept>
       <concept id="1216913645126" name="jetbrains.mps.lang.test.structure.NodesTestCase" flags="lg" index="1lH9Xt">
         <property id="2616911529524314943" name="accessMode" index="3DII0k" />
         <child id="1217501822150" name="nodesToCheck" index="1SKRRt" />
@@ -36,6 +33,9 @@
       <concept id="1216989428737" name="jetbrains.mps.lang.test.structure.TestNode" flags="ng" index="1qefOq">
         <child id="1216989461394" name="nodeToCheck" index="1qenE9" />
       </concept>
+    </language>
+    <language id="0d04a6cc-773e-4069-b9b0-11884b2ff1c8" name="com.mbeddr.ext.units">
+      <concept id="5348704582971040037" name="com.mbeddr.ext.units.structure.UnitConfigItem" flags="ng" index="2eh4Hv" />
     </language>
     <language id="028899e1-bfee-4db6-b470-ed0f9ee5f662" name="com.mbeddr.ext.components.embedded">
       <concept id="1265662339477539521" name="com.mbeddr.ext.components.embedded.structure.InterruptExitHandler" flags="ng" index="RHCfK">
@@ -82,6 +82,7 @@
         <property id="8774011376396215812" name="linker" index="18_EFo" />
         <property id="3963667026125442601" name="gdb" index="3r8Kw1" />
         <property id="3963667026125442676" name="make" index="3r8Kxs" />
+        <property id="1691534949151697076" name="linkerOptions" index="3I8uaA" />
       </concept>
       <concept id="5323740605968447019" name="com.mbeddr.core.buildconfig.structure.Platform" flags="ng" index="2AWWZO">
         <property id="5952395988556102274" name="supportsSharedLibraries" index="uKT8v" />
@@ -97,8 +98,17 @@
     </language>
     <language id="bd640b8f-4be4-42b6-8dc0-2c94d1ddf606" name="com.mbeddr.ext.components.gen_nomw">
       <concept id="2103658896110278831" name="com.mbeddr.ext.components.gen_nomw.structure.NoMwComponentsGenStrategy" flags="ng" index="3i3YCL">
+        <property id="7883182368027992003" name="removeUnusedRequiredPorts" index="2$yeXr" />
+        <property id="1553713790141527405" name="wireStatically" index="35zhco" />
         <property id="4768833643347725006" name="generateContracts" index="3Ewwow" />
+        <reference id="1553713790141527407" name="instanceConfig" index="35zhcq" />
       </concept>
+    </language>
+    <language id="2693fc71-9b0e-4b05-ab13-f57227d675f2" name="com.mbeddr.core.util">
+      <concept id="4459718605982051949" name="com.mbeddr.core.util.structure.ReportingConfiguration" flags="ng" index="2Q9Fgs">
+        <child id="4459718605982051999" name="strategy" index="2Q9FjI" />
+      </concept>
+      <concept id="4459718605982051980" name="com.mbeddr.core.util.structure.PrintfReportingStrategy" flags="ng" index="2Q9FjX" />
     </language>
     <language id="d4280a54-f6df-4383-aa41-d1b2bffa7eb1" name="com.mbeddr.core.base">
       <concept id="4459718605982007337" name="com.mbeddr.core.base.structure.IConfigurationContainer" flags="ngI" index="2Q9xDo">
@@ -130,9 +140,13 @@
       <concept id="8934095934011938595" name="com.mbeddr.core.modules.structure.EmptyModuleContent" flags="ng" index="2NXPZ9" />
       <concept id="7892328519581704407" name="com.mbeddr.core.modules.structure.Argument" flags="ng" index="19RgSI" />
     </language>
+    <language id="06d68b77-b699-4918-83b8-857e63787800" name="com.mbeddr.core.unittest">
+      <concept id="8610007178384196427" name="com.mbeddr.core.unittest.structure.UnitTestConfigItem" flags="ng" index="12mU2y" />
+    </language>
     <language id="54f2a59b-97bb-4c09-af92-928ebf9c5966" name="com.mbeddr.ext.compositecomponents">
       <concept id="7780999115923947731" name="com.mbeddr.ext.compositecomponents.structure.CompositeComponentInstanceConfig" flags="ng" index="5JiAF" />
       <concept id="7780999115923829680" name="com.mbeddr.ext.compositecomponents.structure.CompositeComponent" flags="ng" index="5JLF8" />
+      <concept id="7540109328385923714" name="com.mbeddr.ext.compositecomponents.structure.CompositeComponentsConfigItem" flags="ng" index="1eFCfY" />
     </language>
     <language id="783af01f-87a7-412c-be99-293a162652b5" name="com.mbeddr.core.embedded">
       <concept id="9172009453269286222" name="com.mbeddr.core.embedded.structure.DefaultInterruptKind" flags="ng" index="3_UBHe" />
@@ -140,6 +154,10 @@
         <child id="9172009453269286214" name="kind" index="3_UBH6" />
       </concept>
       <concept id="1017957699896642358" name="com.mbeddr.core.embedded.structure.InterruptDeclaration" flags="ng" index="1O_wwk" />
+      <concept id="6847490852669234129" name="com.mbeddr.core.embedded.structure.RegisterConfigurationItem" flags="ng" index="3V4jtR">
+        <child id="6847490852670616471" name="kind" index="3Vb1WL" />
+      </concept>
+      <concept id="6847490852670653132" name="com.mbeddr.core.embedded.structure.EmulatedRegisterKind" flags="ng" index="3VbeTE" />
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
@@ -853,9 +871,6 @@
       </node>
     </node>
   </node>
-  <node concept="2XOHcx" id="45k_U8HjFeP">
-    <property role="2XOHcw" value="${mbeddr.github.core.home}/code/languages/com.mbeddr.ext/" />
-  </node>
   <node concept="1lH9Xt" id="3F9kUGaOQp8">
     <property role="TrG5h" value="InterruptChecksInBuildConfiguration" />
     <property role="3DII0k" value="2hh8MJdVwqX/command" />
@@ -1067,6 +1082,39 @@
         </node>
       </node>
     </node>
+  </node>
+  <node concept="2v9HqL" id="1nTCJdUh_C_">
+    <node concept="2AWWZL" id="1nTCJdUh_Ej" role="2AWWZH">
+      <property role="2AWWZJ" value="gcc" />
+      <property role="3r8Kw1" value="gdb" />
+      <property role="3r8Kxs" value="make" />
+      <property role="2AWWZI" value="-std=c99" />
+      <property role="1FkSt$" value="-g" />
+      <property role="3I8uaA" value="" />
+      <property role="UXd52" value="g++" />
+      <property role="UXd4T" value="-std=c++11" />
+      <property role="18_EFo" value="gcc" />
+    </node>
+    <node concept="2Q9Fgs" id="1nTCJdUh_El" role="2Q9xDr">
+      <node concept="2Q9FjX" id="1nTCJdUh_Em" role="2Q9FjI" />
+    </node>
+    <node concept="3i2$bm" id="1nTCJdUh_Et" role="2Q9xDr">
+      <node concept="3i3YCL" id="1nTCJdUh_E_" role="3i30U9">
+        <property role="3Ewwow" value="true" />
+        <property role="35zhco" value="true" />
+        <property role="2$yeXr" value="true" />
+        <ref role="35zhcq" to="yrk4:3F9kUGaOOYS" resolve="FlatDummyInstances1" />
+      </node>
+    </node>
+    <node concept="2eh4Hv" id="1nTCJdUn2Te" role="2Q9xDr" />
+    <node concept="1eFCfY" id="1nTCJdUn5s9" role="2Q9xDr" />
+    <node concept="3V4jtR" id="1nTCJdUn7YM" role="2Q9xDr">
+      <node concept="3VbeTE" id="1nTCJdUn7Z6" role="3Vb1WL" />
+    </node>
+    <node concept="3_UEaq" id="1nTCJdUng6j" role="2Q9xDr">
+      <node concept="3_UBHe" id="1nTCJdUng6F" role="3_UBH6" />
+    </node>
+    <node concept="12mU2y" id="5B69dDbeJFx" role="2Q9xDr" />
   </node>
 </model>
 

--- a/code/languages/com.mbeddr.ext/tests/test.ts.ext.components.embedded/tests.ts.ext.components.embedded.msd
+++ b/code/languages/com.mbeddr.ext/tests/test.ts.ext.components.embedded/tests.ts.ext.components.embedded.msd
@@ -12,7 +12,6 @@
     <facet type="tests" />
   </facets>
   <dependencies>
-    <dependency reexport="false">97d24244-51db-4e2e-97fc-7bd73b1f5f40(com.mbeddr.ext.components)</dependency>
     <dependency reexport="false">028899e1-bfee-4db6-b470-ed0f9ee5f662(com.mbeddr.ext.components.embedded)</dependency>
   </dependencies>
   <languageVersions>
@@ -37,6 +36,7 @@
     <language slang="l:36a565f1-3fa0-42d6-baac-f87e209c9789:com.mbeddr.ext.components.mock" version="0" />
     <language slang="l:41911c23-eb23-4ee6-872f-bc7f7ebce290:com.mbeddr.ext.components.test" version="0" />
     <language slang="l:54f2a59b-97bb-4c09-af92-928ebf9c5966:com.mbeddr.ext.compositecomponents" version="0" />
+    <language slang="l:0d04a6cc-773e-4069-b9b0-11884b2ff1c8:com.mbeddr.ext.units" version="1" />
     <language slang="l:63e0e566-5131-447e-90e3-12ea330e1a00:com.mbeddr.mpsutil.blutil" version="3" />
     <language slang="l:d3a0fd26-445a-466c-900e-10444ddfed52:com.mbeddr.mpsutil.filepicker" version="0" />
     <language slang="l:1c897ba5-9d43-4035-ac7f-0306495743ac:com.mbeddr.mpsutil.interpreter.test" version="0" />


### PR DESCRIPTION
Add a build configuration to ensure that test classes are not dropped.