### PR TITLE
renovate: do not upgrade PlantUML to old versions

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -52,6 +52,11 @@
       "matchPackageNames": ["com.jetbrains.jdk:*"],
       "matchBaseBranches": ["!/^master$/"],
       "enabled": false
+    },
+
+    {
+      "matchPackageNames" : ["net.sourceforge.plantuml:plantuml"],
+      "allowedVersions": "< 2000"
     }
   ]
 }


### PR DESCRIPTION
The version of PlantUML to use will be changed in the 2024.1 branch and cascaded to master, but Renovate configuration has to be applied to master.

PlantUML versioning scheme changed from versions like 8059 to versions like 2017.x and then again to 1.2017.x, and we want only these 1.x.y versions.