### PR TITLE
Upgrade plantuml to 1.2025.2

### DIFF
--- a/subprojects/com.mbeddr/platform/build.gradle
+++ b/subprojects/com.mbeddr/platform/build.gradle
@@ -59,7 +59,7 @@ def bundledDeps = [
             exclude module: 'stax-api'
         }),
         new BundledDep('jfreechart', ['org.jfree:jfreechart:1.5.5'], 'com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.jfreechart.runtime', {}),
-        new BundledDep('plantuml', ['net.sourceforge.plantuml:plantuml:8059'], 'com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.plantuml/solutions/pluginSolution'),
+        new BundledDep('plantuml', ['net.sourceforge.plantuml:plantuml:1.2025.2'], 'com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.plantuml/solutions/pluginSolution'),
         new BundledDep('opencsv', ['au.com.bytecode:opencsv:2.4'], 'com.mbeddr.mpsutil/solutions/com.opencsv'),
         new BundledDep('mockito', ['org.mockito:mockito-core:5.17.0'], 'com.mbeddr.mpsutil/solutions/org.mockito', {}),
         new BundledDep('ecore', ['org.eclipse.emf:org.eclipse.emf.ecore.xcore:1.32.0'], 'com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.ecore.stubs', {


### PR DESCRIPTION
8059 is an old version, update to this version will be blocked by #2950.