### PR TITLE
mbeddr.doc: make IDs robust over several generations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Semantic Versioning and the changes are simply documented in reverse chronologic
 
 # May 2025
 
+## com.mbeddr.doc
+- Use original nodeID for stable ID (SID) generation instead of transient nodeID
+
 ## com.mbeddr.mpsutil.actionsfilter
 
 - An exception (!app.isDispatchThread()) was fixed that was related to the initialization of the actionsfilter language.

--- a/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc.gen_latex/generator/template/com/mbeddr/doc/gen_latex/generator/template/main@generator.mps
+++ b/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc.gen_latex/generator/template/com/mbeddr/doc/gen_latex/generator/template/main@generator.mps
@@ -25,6 +25,7 @@
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" />
     <import index="48kf" ref="r:5f41c82d-84d1-4fb1-a1cf-6697d2365854(com.mbeddr.mpsutil.filepicker.behavior)" />
+    <import index="znf5" ref="r:07597124-beb3-41b7-beb1-a882af3ded40(com.mbeddr.doc.plugin)" />
   </imports>
   <registry>
     <language id="13744753-c81f-424a-9c1b-cf8943bf4e86" name="jetbrains.mps.lang.sharedConcepts">
@@ -220,6 +221,9 @@
       </concept>
     </language>
     <language id="d7706f63-9be2-479c-a3da-ae92af1e64d5" name="jetbrains.mps.lang.generator.generationContext">
+      <concept id="1229477454423" name="jetbrains.mps.lang.generator.generationContext.structure.GenerationContextOp_GetOriginalCopiedInputByOutput" flags="nn" index="12$id9">
+        <child id="1229477520175" name="outputNode" index="12$y8L" />
+      </concept>
       <concept id="1216860049635" name="jetbrains.mps.lang.generator.generationContext.structure.TemplateFunctionParameter_generationContext" flags="nn" index="1iwH7S" />
       <concept id="1217026863835" name="jetbrains.mps.lang.generator.generationContext.structure.GenerationContextOp_GetOriginalInputModel" flags="nn" index="1st3f0" />
     </language>
@@ -1813,11 +1817,15 @@
                   <property role="P4ACc" value="f8f68d92-c6d2-44b3-8d63-c00ade75ec86/4457500422381364540/4457500422381364541" />
                   <node concept="3zFVjK" id="3RseghIc$Gx" role="3zH0cK">
                     <node concept="3clFbS" id="3RseghIc$Gy" role="2VODD2">
-                      <node concept="3clFbF" id="3RseghIc$Gz" role="3cqZAp">
-                        <node concept="2OqwBi" id="3RseghIc$G$" role="3clFbG">
-                          <node concept="30H73N" id="3RseghIc$GA" role="2Oq$k0" />
-                          <node concept="2qgKlT" id="6jiGbW_JG4W" role="2OqNvi">
-                            <ref role="37wK5l" to="4gky:6jiGbW_aIil" resolve="stableId" />
+                      <node concept="3clFbF" id="4XyruUDCSu7" role="3cqZAp">
+                        <node concept="2YIFZM" id="4XyruUDCSw4" role="3clFbG">
+                          <ref role="37wK5l" to="znf5:52iEUv_OK3m" resolve="getOriginalStableId" />
+                          <ref role="1Pybhc" to="znf5:4XyruUDBFl$" resolve="DocGeneratorHelper" />
+                          <node concept="2OqwBi" id="3x8tM34lh5m" role="37wK5m">
+                            <node concept="1iwH7S" id="3x8tM34lgEW" role="2Oq$k0" />
+                            <node concept="12$id9" id="3x8tM34lhw7" role="2OqNvi">
+                              <node concept="30H73N" id="3x8tM34lhx3" role="12$y8L" />
+                            </node>
                           </node>
                         </node>
                       </node>
@@ -2214,12 +2222,16 @@
                   <property role="P4ACc" value="f8f68d92-c6d2-44b3-8d63-c00ade75ec86/4457500422381364540/4457500422381364541" />
                   <node concept="3zFVjK" id="3DAECxG6qZ2" role="3zH0cK">
                     <node concept="3clFbS" id="3DAECxG6qZ3" role="2VODD2">
-                      <node concept="3clFbF" id="3DAECxG6qZ4" role="3cqZAp">
-                        <node concept="2OqwBi" id="3DAECxG6qZ5" role="3clFbG">
-                          <node concept="2qgKlT" id="6jiGbW_GeII" role="2OqNvi">
-                            <ref role="37wK5l" to="4gky:6jiGbW_aIil" resolve="stableId" />
+                      <node concept="3clFbF" id="4XyruUDD3vA" role="3cqZAp">
+                        <node concept="2YIFZM" id="4XyruUDD3vB" role="3clFbG">
+                          <ref role="37wK5l" to="znf5:52iEUv_OK3m" resolve="getOriginalStableId" />
+                          <ref role="1Pybhc" to="znf5:4XyruUDBFl$" resolve="DocGeneratorHelper" />
+                          <node concept="2OqwBi" id="3x8tM34ljkT" role="37wK5m">
+                            <node concept="1iwH7S" id="3x8tM34ljkU" role="2Oq$k0" />
+                            <node concept="12$id9" id="3x8tM34ljkV" role="2OqNvi">
+                              <node concept="30H73N" id="3x8tM34ljkW" role="12$y8L" />
+                            </node>
                           </node>
-                          <node concept="30H73N" id="3DAECxG6qZ7" role="2Oq$k0" />
                         </node>
                       </node>
                     </node>
@@ -2463,12 +2475,16 @@
                       <property role="P4ACc" value="f8f68d92-c6d2-44b3-8d63-c00ade75ec86/4457500422381364540/4457500422381364541" />
                       <node concept="3zFVjK" id="4vQSg$Ar7kk" role="3zH0cK">
                         <node concept="3clFbS" id="4vQSg$Ar7kl" role="2VODD2">
-                          <node concept="3clFbF" id="4vQSg$Ar7km" role="3cqZAp">
-                            <node concept="2OqwBi" id="6jiGbW_JP4$" role="3clFbG">
-                              <node concept="2qgKlT" id="6jiGbW_JP4_" role="2OqNvi">
-                                <ref role="37wK5l" to="4gky:6jiGbW_aIil" resolve="stableId" />
+                          <node concept="3clFbF" id="4XyruUDD58s" role="3cqZAp">
+                            <node concept="2YIFZM" id="4XyruUDD58t" role="3clFbG">
+                              <ref role="37wK5l" to="znf5:52iEUv_OK3m" resolve="getOriginalStableId" />
+                              <ref role="1Pybhc" to="znf5:4XyruUDBFl$" resolve="DocGeneratorHelper" />
+                              <node concept="2OqwBi" id="3x8tM34ljmY" role="37wK5m">
+                                <node concept="1iwH7S" id="3x8tM34ljmZ" role="2Oq$k0" />
+                                <node concept="12$id9" id="3x8tM34ljn0" role="2OqNvi">
+                                  <node concept="30H73N" id="3x8tM34ljn1" role="12$y8L" />
+                                </node>
                               </node>
-                              <node concept="30H73N" id="6jiGbW_JP4A" role="2Oq$k0" />
                             </node>
                           </node>
                         </node>
@@ -2630,11 +2646,15 @@
                   <property role="P4ACc" value="f8f68d92-c6d2-44b3-8d63-c00ade75ec86/4457500422381364540/4457500422381364541" />
                   <node concept="3zFVjK" id="6jiGbW$Iwda" role="3zH0cK">
                     <node concept="3clFbS" id="6jiGbW$Iwdb" role="2VODD2">
-                      <node concept="3clFbF" id="6jiGbW$Iwdc" role="3cqZAp">
-                        <node concept="2OqwBi" id="6jiGbW$Iwdd" role="3clFbG">
-                          <node concept="30H73N" id="6jiGbW$Iwdf" role="2Oq$k0" />
-                          <node concept="2qgKlT" id="6jiGbW_GfZL" role="2OqNvi">
-                            <ref role="37wK5l" to="4gky:6jiGbW_aIil" resolve="stableId" />
+                      <node concept="3clFbF" id="4XyruUDD63o" role="3cqZAp">
+                        <node concept="2YIFZM" id="4XyruUDD63p" role="3clFbG">
+                          <ref role="37wK5l" to="znf5:52iEUv_OK3m" resolve="getOriginalStableId" />
+                          <ref role="1Pybhc" to="znf5:4XyruUDBFl$" resolve="DocGeneratorHelper" />
+                          <node concept="2OqwBi" id="3x8tM34ljp0" role="37wK5m">
+                            <node concept="1iwH7S" id="3x8tM34ljp1" role="2Oq$k0" />
+                            <node concept="12$id9" id="3x8tM34ljp2" role="2OqNvi">
+                              <node concept="30H73N" id="3x8tM34ljp3" role="12$y8L" />
+                            </node>
                           </node>
                         </node>
                       </node>
@@ -2889,11 +2909,15 @@
                   <property role="P4ACc" value="f8f68d92-c6d2-44b3-8d63-c00ade75ec86/4457500422381364540/4457500422381364541" />
                   <node concept="3zFVjK" id="519ky_SjBN$" role="3zH0cK">
                     <node concept="3clFbS" id="519ky_SjBN_" role="2VODD2">
-                      <node concept="3clFbF" id="519ky_SjBNA" role="3cqZAp">
-                        <node concept="2OqwBi" id="519ky_SjBNB" role="3clFbG">
-                          <node concept="30H73N" id="519ky_SjBND" role="2Oq$k0" />
-                          <node concept="2qgKlT" id="6jiGbW_JPNW" role="2OqNvi">
-                            <ref role="37wK5l" to="4gky:6jiGbW_aIil" resolve="stableId" />
+                      <node concept="3clFbF" id="4XyruUDD8JM" role="3cqZAp">
+                        <node concept="2YIFZM" id="4XyruUDD8JN" role="3clFbG">
+                          <ref role="37wK5l" to="znf5:52iEUv_OK3m" resolve="getOriginalStableId" />
+                          <ref role="1Pybhc" to="znf5:4XyruUDBFl$" resolve="DocGeneratorHelper" />
+                          <node concept="2OqwBi" id="3x8tM34ll0u" role="37wK5m">
+                            <node concept="1iwH7S" id="3x8tM34ll0v" role="2Oq$k0" />
+                            <node concept="12$id9" id="3x8tM34ll0w" role="2OqNvi">
+                              <node concept="30H73N" id="3x8tM34ll0x" role="12$y8L" />
+                            </node>
                           </node>
                         </node>
                       </node>
@@ -3334,16 +3358,20 @@
                 <property role="P4ACc" value="f8f68d92-c6d2-44b3-8d63-c00ade75ec86/4457500422381364540/4457500422381364541" />
                 <node concept="3zFVjK" id="3RseghIc$J6" role="3zH0cK">
                   <node concept="3clFbS" id="3RseghIc$J7" role="2VODD2">
-                    <node concept="3clFbF" id="3RseghIc$J8" role="3cqZAp">
-                      <node concept="2OqwBi" id="3RseghIc$J9" role="3clFbG">
-                        <node concept="2OqwBi" id="3RseghIc$Ja" role="2Oq$k0">
-                          <node concept="30H73N" id="3RseghIc$Jb" role="2Oq$k0" />
-                          <node concept="3TrEf2" id="3RseghIc$Jc" role="2OqNvi">
-                            <ref role="3Tt5mk" to="2c95:5yxqZJwzrde" resolve="image" />
+                    <node concept="3clFbF" id="4XyruUDDddd" role="3cqZAp">
+                      <node concept="2YIFZM" id="4XyruUDDdde" role="3clFbG">
+                        <ref role="37wK5l" to="znf5:52iEUv_OK3m" resolve="getOriginalStableId" />
+                        <ref role="1Pybhc" to="znf5:4XyruUDBFl$" resolve="DocGeneratorHelper" />
+                        <node concept="2OqwBi" id="3x8tM34lnfP" role="37wK5m">
+                          <node concept="1iwH7S" id="3x8tM34lnfQ" role="2Oq$k0" />
+                          <node concept="12$id9" id="3x8tM34lnfR" role="2OqNvi">
+                            <node concept="2OqwBi" id="3x8tM34lnHj" role="12$y8L">
+                              <node concept="30H73N" id="3x8tM34lnfS" role="2Oq$k0" />
+                              <node concept="3TrEf2" id="3x8tM34lomB" role="2OqNvi">
+                                <ref role="3Tt5mk" to="2c95:5yxqZJwzrde" resolve="image" />
+                              </node>
+                            </node>
                           </node>
-                        </node>
-                        <node concept="2qgKlT" id="6jiGbW_JQzP" role="2OqNvi">
-                          <ref role="37wK5l" to="4gky:6jiGbW_aIil" resolve="stableId" />
                         </node>
                       </node>
                     </node>
@@ -3397,16 +3425,20 @@
                 <property role="P4ACc" value="f8f68d92-c6d2-44b3-8d63-c00ade75ec86/4457500422381364540/4457500422381364541" />
                 <node concept="3zFVjK" id="3RseghIc$I4" role="3zH0cK">
                   <node concept="3clFbS" id="3RseghIc$I5" role="2VODD2">
-                    <node concept="3clFbF" id="3RseghIc$I6" role="3cqZAp">
-                      <node concept="2OqwBi" id="6jiGbW_JQOA" role="3clFbG">
-                        <node concept="2OqwBi" id="6jiGbW_JQOB" role="2Oq$k0">
-                          <node concept="30H73N" id="6jiGbW_JQOC" role="2Oq$k0" />
-                          <node concept="3TrEf2" id="6jiGbW_JQOD" role="2OqNvi">
-                            <ref role="3Tt5mk" to="2c95:2TZO3DbvhAJ" resolve="target" />
+                    <node concept="3clFbF" id="4XyruUDDhPN" role="3cqZAp">
+                      <node concept="2YIFZM" id="4XyruUDDhPO" role="3clFbG">
+                        <ref role="37wK5l" to="znf5:52iEUv_OK3m" resolve="getOriginalStableId" />
+                        <ref role="1Pybhc" to="znf5:4XyruUDBFl$" resolve="DocGeneratorHelper" />
+                        <node concept="2OqwBi" id="3x8tM34lqlV" role="37wK5m">
+                          <node concept="1iwH7S" id="3x8tM34lqlW" role="2Oq$k0" />
+                          <node concept="12$id9" id="3x8tM34lqlX" role="2OqNvi">
+                            <node concept="2OqwBi" id="3x8tM34lqMs" role="12$y8L">
+                              <node concept="30H73N" id="3x8tM34lqlY" role="2Oq$k0" />
+                              <node concept="3TrEf2" id="3x8tM34lrcV" role="2OqNvi">
+                                <ref role="3Tt5mk" to="2c95:2TZO3DbvhAJ" resolve="target" />
+                              </node>
+                            </node>
                           </node>
-                        </node>
-                        <node concept="2qgKlT" id="6jiGbW_JQOE" role="2OqNvi">
-                          <ref role="37wK5l" to="4gky:6jiGbW_aIil" resolve="stableId" />
                         </node>
                       </node>
                     </node>

--- a/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc.gen_markdown/generator/templates/com.mbeddr.doc.gen_markdown.generator.templates@generator.mps
+++ b/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc.gen_markdown/generator/templates/com.mbeddr.doc.gen_markdown.generator.templates@generator.mps
@@ -13,6 +13,7 @@
     <import index="2c95" ref="r:5f7188a9-e7b4-4a2e-bef9-38d2cf379fdc(com.mbeddr.doc.structure)" />
     <import index="z8wv" ref="r:bde2bd5f-4391-4804-803d-13d421a91250(com.mbeddr.doc.gen_markdown.plugin)" />
     <import index="iyyx" ref="r:9f4ef5d6-785f-4a6d-b4d4-e364a57b5856(com.mbeddr.doc.markdown.structure)" />
+    <import index="znf5" ref="r:07597124-beb3-41b7-beb1-a882af3ded40(com.mbeddr.doc.plugin)" />
     <import index="4gky" ref="r:e1dfab1d-c7a7-43e7-9f26-028afd483e82(com.mbeddr.doc.behavior)" implicit="true" />
     <import index="vs0r" ref="r:f7764ca4-8c75-4049-922b-08516400a727(com.mbeddr.core.base.structure)" implicit="true" />
     <import index="87nw" ref="r:ca2ab6bb-f6e7-4c0f-a88c-b78b9b31fff3(de.slisson.mps.richtext.structure)" implicit="true" />
@@ -372,11 +373,15 @@
                       <property role="P4ACc" value="479c7a8c-02f9-43b5-9139-d910cb22f298/6666499814681541919/6666499814681541920" />
                       <node concept="3zFVjK" id="xxE$BM_6Hi" role="3zH0cK">
                         <node concept="3clFbS" id="xxE$BM_6Hj" role="2VODD2">
-                          <node concept="3clFbF" id="xxE$BM_6LV" role="3cqZAp">
-                            <node concept="2OqwBi" id="xxE$BM_76z" role="3clFbG">
-                              <node concept="30H73N" id="xxE$BM_6LU" role="2Oq$k0" />
-                              <node concept="2qgKlT" id="xxE$BM_7z3" role="2OqNvi">
-                                <ref role="37wK5l" to="4gky:6jiGbW_aIil" resolve="stableId" />
+                          <node concept="3clFbF" id="4XyruUDDJd0" role="3cqZAp">
+                            <node concept="2YIFZM" id="3x8tM34lFYY" role="3clFbG">
+                              <ref role="37wK5l" to="znf5:52iEUv_OK3m" resolve="getOriginalStableId" />
+                              <ref role="1Pybhc" to="znf5:4XyruUDBFl$" resolve="DocGeneratorHelper" />
+                              <node concept="2OqwBi" id="3x8tM34lFYZ" role="37wK5m">
+                                <node concept="1iwH7S" id="3x8tM34lFZ0" role="2Oq$k0" />
+                                <node concept="12$id9" id="3x8tM34lFZ1" role="2OqNvi">
+                                  <node concept="30H73N" id="3x8tM34lFZ2" role="12$y8L" />
+                                </node>
                               </node>
                             </node>
                           </node>
@@ -546,11 +551,15 @@
                       <property role="P4ACc" value="479c7a8c-02f9-43b5-9139-d910cb22f298/6666499814681541919/6666499814681541920" />
                       <node concept="3zFVjK" id="xxE$BM_7K3" role="3zH0cK">
                         <node concept="3clFbS" id="xxE$BM_7K4" role="2VODD2">
-                          <node concept="3clFbF" id="xxE$BM_7K5" role="3cqZAp">
-                            <node concept="2OqwBi" id="xxE$BM_7K6" role="3clFbG">
-                              <node concept="30H73N" id="xxE$BM_7K7" role="2Oq$k0" />
-                              <node concept="2qgKlT" id="xxE$BM_7K8" role="2OqNvi">
-                                <ref role="37wK5l" to="4gky:6jiGbW_aIil" resolve="stableId" />
+                          <node concept="3clFbF" id="4XyruUDDKSn" role="3cqZAp">
+                            <node concept="2YIFZM" id="3x8tM34lGsF" role="3clFbG">
+                              <ref role="37wK5l" to="znf5:52iEUv_OK3m" resolve="getOriginalStableId" />
+                              <ref role="1Pybhc" to="znf5:4XyruUDBFl$" resolve="DocGeneratorHelper" />
+                              <node concept="2OqwBi" id="3x8tM34lGsG" role="37wK5m">
+                                <node concept="1iwH7S" id="3x8tM34lGsH" role="2Oq$k0" />
+                                <node concept="12$id9" id="3x8tM34lGsI" role="2OqNvi">
+                                  <node concept="30H73N" id="3x8tM34lGsJ" role="12$y8L" />
+                                </node>
                               </node>
                             </node>
                           </node>
@@ -720,11 +729,15 @@
                       <property role="P4ACc" value="479c7a8c-02f9-43b5-9139-d910cb22f298/6666499814681541919/6666499814681541920" />
                       <node concept="3zFVjK" id="xxE$BM_7Yo" role="3zH0cK">
                         <node concept="3clFbS" id="xxE$BM_7Yp" role="2VODD2">
-                          <node concept="3clFbF" id="xxE$BM_7Yq" role="3cqZAp">
-                            <node concept="2OqwBi" id="xxE$BM_7Yr" role="3clFbG">
-                              <node concept="30H73N" id="xxE$BM_7Ys" role="2Oq$k0" />
-                              <node concept="2qgKlT" id="xxE$BM_7Yt" role="2OqNvi">
-                                <ref role="37wK5l" to="4gky:6jiGbW_aIil" resolve="stableId" />
+                          <node concept="3clFbF" id="4XyruUDDS3s" role="3cqZAp">
+                            <node concept="2YIFZM" id="3x8tM34lGK$" role="3clFbG">
+                              <ref role="37wK5l" to="znf5:52iEUv_OK3m" resolve="getOriginalStableId" />
+                              <ref role="1Pybhc" to="znf5:4XyruUDBFl$" resolve="DocGeneratorHelper" />
+                              <node concept="2OqwBi" id="3x8tM34lGK_" role="37wK5m">
+                                <node concept="1iwH7S" id="3x8tM34lGKA" role="2Oq$k0" />
+                                <node concept="12$id9" id="3x8tM34lGKB" role="2OqNvi">
+                                  <node concept="30H73N" id="3x8tM34lGKC" role="12$y8L" />
+                                </node>
                               </node>
                             </node>
                           </node>
@@ -894,11 +907,15 @@
                       <property role="P4ACc" value="479c7a8c-02f9-43b5-9139-d910cb22f298/6666499814681541919/6666499814681541920" />
                       <node concept="3zFVjK" id="4zO5iT9sXNP" role="3zH0cK">
                         <node concept="3clFbS" id="4zO5iT9sXNQ" role="2VODD2">
-                          <node concept="3clFbF" id="4zO5iT9sXNR" role="3cqZAp">
-                            <node concept="2OqwBi" id="4zO5iT9sXNS" role="3clFbG">
-                              <node concept="30H73N" id="4zO5iT9sXNT" role="2Oq$k0" />
-                              <node concept="2qgKlT" id="4zO5iT9sXNU" role="2OqNvi">
-                                <ref role="37wK5l" to="4gky:6jiGbW_aIil" resolve="stableId" />
+                          <node concept="3clFbF" id="4XyruUDDSQI" role="3cqZAp">
+                            <node concept="2YIFZM" id="3x8tM34lGOK" role="3clFbG">
+                              <ref role="37wK5l" to="znf5:52iEUv_OK3m" resolve="getOriginalStableId" />
+                              <ref role="1Pybhc" to="znf5:4XyruUDBFl$" resolve="DocGeneratorHelper" />
+                              <node concept="2OqwBi" id="3x8tM34lGOL" role="37wK5m">
+                                <node concept="1iwH7S" id="3x8tM34lGOM" role="2Oq$k0" />
+                                <node concept="12$id9" id="3x8tM34lGON" role="2OqNvi">
+                                  <node concept="30H73N" id="3x8tM34lGOO" role="12$y8L" />
+                                </node>
                               </node>
                             </node>
                           </node>
@@ -1068,11 +1085,15 @@
                       <property role="P4ACc" value="479c7a8c-02f9-43b5-9139-d910cb22f298/6666499814681541919/6666499814681541920" />
                       <node concept="3zFVjK" id="4zO5iT9sYEs" role="3zH0cK">
                         <node concept="3clFbS" id="4zO5iT9sYEt" role="2VODD2">
-                          <node concept="3clFbF" id="4zO5iT9sYEu" role="3cqZAp">
-                            <node concept="2OqwBi" id="4zO5iT9sYEv" role="3clFbG">
-                              <node concept="30H73N" id="4zO5iT9sYEw" role="2Oq$k0" />
-                              <node concept="2qgKlT" id="4zO5iT9sYEx" role="2OqNvi">
-                                <ref role="37wK5l" to="4gky:6jiGbW_aIil" resolve="stableId" />
+                          <node concept="3clFbF" id="4XyruUDDTE8" role="3cqZAp">
+                            <node concept="2YIFZM" id="3x8tM34lGSW" role="3clFbG">
+                              <ref role="37wK5l" to="znf5:52iEUv_OK3m" resolve="getOriginalStableId" />
+                              <ref role="1Pybhc" to="znf5:4XyruUDBFl$" resolve="DocGeneratorHelper" />
+                              <node concept="2OqwBi" id="3x8tM34lGSX" role="37wK5m">
+                                <node concept="1iwH7S" id="3x8tM34lGSY" role="2Oq$k0" />
+                                <node concept="12$id9" id="3x8tM34lGSZ" role="2OqNvi">
+                                  <node concept="30H73N" id="3x8tM34lGT0" role="12$y8L" />
+                                </node>
                               </node>
                             </node>
                           </node>
@@ -1242,11 +1263,15 @@
                       <property role="P4ACc" value="479c7a8c-02f9-43b5-9139-d910cb22f298/6666499814681541919/6666499814681541920" />
                       <node concept="3zFVjK" id="4zO5iT9treK" role="3zH0cK">
                         <node concept="3clFbS" id="4zO5iT9treL" role="2VODD2">
-                          <node concept="3clFbF" id="4zO5iT9treM" role="3cqZAp">
-                            <node concept="2OqwBi" id="4zO5iT9treN" role="3clFbG">
-                              <node concept="30H73N" id="4zO5iT9treO" role="2Oq$k0" />
-                              <node concept="2qgKlT" id="4zO5iT9treP" role="2OqNvi">
-                                <ref role="37wK5l" to="4gky:6jiGbW_aIil" resolve="stableId" />
+                          <node concept="3clFbF" id="4XyruUDDUtE" role="3cqZAp">
+                            <node concept="2YIFZM" id="3x8tM34lH21" role="3clFbG">
+                              <ref role="37wK5l" to="znf5:52iEUv_OK3m" resolve="getOriginalStableId" />
+                              <ref role="1Pybhc" to="znf5:4XyruUDBFl$" resolve="DocGeneratorHelper" />
+                              <node concept="2OqwBi" id="3x8tM34lH22" role="37wK5m">
+                                <node concept="1iwH7S" id="3x8tM34lH23" role="2Oq$k0" />
+                                <node concept="12$id9" id="3x8tM34lH24" role="2OqNvi">
+                                  <node concept="30H73N" id="3x8tM34lH25" role="12$y8L" />
+                                </node>
                               </node>
                             </node>
                           </node>
@@ -1833,11 +1858,15 @@
                     <property role="P4ACc" value="479c7a8c-02f9-43b5-9139-d910cb22f298/6666499814681541919/6666499814681541920" />
                     <node concept="3zFVjK" id="xxE$BM$Lb5" role="3zH0cK">
                       <node concept="3clFbS" id="xxE$BM$Lb6" role="2VODD2">
-                        <node concept="3clFbF" id="xxE$BM$Lg4" role="3cqZAp">
-                          <node concept="2OqwBi" id="xxE$BM$L$S" role="3clFbG">
-                            <node concept="30H73N" id="xxE$BM$Lg3" role="2Oq$k0" />
-                            <node concept="2qgKlT" id="xxE$BM$M67" role="2OqNvi">
-                              <ref role="37wK5l" to="4gky:6jiGbW_aIil" resolve="stableId" />
+                        <node concept="3clFbF" id="4XyruUDCSu7" role="3cqZAp">
+                          <node concept="2YIFZM" id="4XyruUDCSw4" role="3clFbG">
+                            <ref role="37wK5l" to="znf5:52iEUv_OK3m" resolve="getOriginalStableId" />
+                            <ref role="1Pybhc" to="znf5:4XyruUDBFl$" resolve="DocGeneratorHelper" />
+                            <node concept="2OqwBi" id="3x8tM34lh5m" role="37wK5m">
+                              <node concept="1iwH7S" id="3x8tM34lgEW" role="2Oq$k0" />
+                              <node concept="12$id9" id="3x8tM34lhw7" role="2OqNvi">
+                                <node concept="30H73N" id="3x8tM34lhx3" role="12$y8L" />
+                              </node>
                             </node>
                           </node>
                         </node>
@@ -1916,21 +1945,25 @@
             <property role="P4ACc" value="22a8c356-ae1a-4079-96b0-d5e7c21ae7c4/839091667655539422/839091667655539425" />
             <node concept="3zFVjK" id="xxE$BM$OyC" role="3zH0cK">
               <node concept="3clFbS" id="xxE$BM$OyD" role="2VODD2">
-                <node concept="3clFbF" id="xxE$BM$OJP" role="3cqZAp">
-                  <node concept="3cpWs3" id="xxE$BM$P33" role="3clFbG">
-                    <node concept="2OqwBi" id="xxE$BM$PSv" role="3uHU7w">
-                      <node concept="2OqwBi" id="xxE$BM$PrM" role="2Oq$k0">
-                        <node concept="30H73N" id="xxE$BM$P7S" role="2Oq$k0" />
-                        <node concept="3TrEf2" id="xxE$BM$PGy" role="2OqNvi">
-                          <ref role="3Tt5mk" to="2c95:5yxqZJwzrde" resolve="image" />
+                <node concept="3clFbF" id="4XyruUDDrd3" role="3cqZAp">
+                  <node concept="3cpWs3" id="4XyruUDDufF" role="3clFbG">
+                    <node concept="Xl_RD" id="4XyruUDDuiO" role="3uHU7B">
+                      <property role="Xl_RC" value="#" />
+                    </node>
+                    <node concept="2YIFZM" id="3x8tM34lyS8" role="3uHU7w">
+                      <ref role="37wK5l" to="znf5:52iEUv_OK3m" resolve="getOriginalStableId" />
+                      <ref role="1Pybhc" to="znf5:4XyruUDBFl$" resolve="DocGeneratorHelper" />
+                      <node concept="2OqwBi" id="3x8tM34lyS9" role="37wK5m">
+                        <node concept="1iwH7S" id="3x8tM34lySa" role="2Oq$k0" />
+                        <node concept="12$id9" id="3x8tM34lySb" role="2OqNvi">
+                          <node concept="2OqwBi" id="3x8tM34lzBo" role="12$y8L">
+                            <node concept="30H73N" id="3x8tM34lySc" role="2Oq$k0" />
+                            <node concept="3TrEf2" id="3x8tM34l$i2" role="2OqNvi">
+                              <ref role="3Tt5mk" to="2c95:5yxqZJwzrde" resolve="image" />
+                            </node>
+                          </node>
                         </node>
                       </node>
-                      <node concept="2qgKlT" id="xxE$BM$Qmr" role="2OqNvi">
-                        <ref role="37wK5l" to="4gky:6jiGbW_aIil" resolve="stableId" />
-                      </node>
-                    </node>
-                    <node concept="Xl_RD" id="xxE$BM$OJO" role="3uHU7B">
-                      <property role="Xl_RC" value="#" />
                     </node>
                   </node>
                 </node>
@@ -1972,21 +2005,25 @@
             <property role="P4ACc" value="22a8c356-ae1a-4079-96b0-d5e7c21ae7c4/839091667655539422/839091667655539425" />
             <node concept="3zFVjK" id="xxE$BM_84W" role="3zH0cK">
               <node concept="3clFbS" id="xxE$BM_84X" role="2VODD2">
-                <node concept="3clFbF" id="xxE$BM_84Y" role="3cqZAp">
-                  <node concept="3cpWs3" id="xxE$BM_84Z" role="3clFbG">
-                    <node concept="2OqwBi" id="xxE$BM_850" role="3uHU7w">
-                      <node concept="2OqwBi" id="xxE$BM_851" role="2Oq$k0">
-                        <node concept="30H73N" id="xxE$BM_852" role="2Oq$k0" />
-                        <node concept="3TrEf2" id="xxE$BM_8K6" role="2OqNvi">
-                          <ref role="3Tt5mk" to="2c95:2TZO3DbvhAJ" resolve="target" />
+                <node concept="3clFbF" id="4XyruUDD_Rg" role="3cqZAp">
+                  <node concept="3cpWs3" id="4XyruUDDBaC" role="3clFbG">
+                    <node concept="Xl_RD" id="4XyruUDDBaG" role="3uHU7B">
+                      <property role="Xl_RC" value="#" />
+                    </node>
+                    <node concept="2YIFZM" id="3x8tM34lEBu" role="3uHU7w">
+                      <ref role="37wK5l" to="znf5:52iEUv_OK3m" resolve="getOriginalStableId" />
+                      <ref role="1Pybhc" to="znf5:4XyruUDBFl$" resolve="DocGeneratorHelper" />
+                      <node concept="2OqwBi" id="3x8tM34lEBv" role="37wK5m">
+                        <node concept="1iwH7S" id="3x8tM34lEBw" role="2Oq$k0" />
+                        <node concept="12$id9" id="3x8tM34lEBx" role="2OqNvi">
+                          <node concept="2OqwBi" id="3x8tM34lF76" role="12$y8L">
+                            <node concept="30H73N" id="3x8tM34lEBy" role="2Oq$k0" />
+                            <node concept="3TrEf2" id="3x8tM34lFXL" role="2OqNvi">
+                              <ref role="3Tt5mk" to="2c95:2TZO3DbvhAJ" resolve="target" />
+                            </node>
+                          </node>
                         </node>
                       </node>
-                      <node concept="2qgKlT" id="xxE$BM_854" role="2OqNvi">
-                        <ref role="37wK5l" to="4gky:6jiGbW_aIil" resolve="stableId" />
-                      </node>
-                    </node>
-                    <node concept="Xl_RD" id="xxE$BM_855" role="3uHU7B">
-                      <property role="Xl_RC" value="#" />
                     </node>
                   </node>
                 </node>
@@ -2085,15 +2122,19 @@
                     <property role="P4ACc" value="22a8c356-ae1a-4079-96b0-d5e7c21ae7c4/839091667655539422/839091667655539425" />
                     <node concept="3zFVjK" id="xxE$BMDjAZ" role="3zH0cK">
                       <node concept="3clFbS" id="xxE$BMDjB0" role="2VODD2">
-                        <node concept="3clFbF" id="xxE$BMDjB1" role="3cqZAp">
-                          <node concept="3cpWs3" id="xxE$BMFlxa" role="3clFbG">
-                            <node concept="Xl_RD" id="xxE$BMFlxe" role="3uHU7B">
+                        <node concept="3clFbF" id="4XyruUDDVhU" role="3cqZAp">
+                          <node concept="3cpWs3" id="4XyruUDDVuM" role="3clFbG">
+                            <node concept="Xl_RD" id="4XyruUDDV_T" role="3uHU7B">
                               <property role="Xl_RC" value="#" />
                             </node>
-                            <node concept="2OqwBi" id="xxE$BMDjB2" role="3uHU7w">
-                              <node concept="30H73N" id="xxE$BMDjB3" role="2Oq$k0" />
-                              <node concept="2qgKlT" id="xxE$BMDjB4" role="2OqNvi">
-                                <ref role="37wK5l" to="4gky:6jiGbW_aIil" resolve="stableId" />
+                            <node concept="2YIFZM" id="3x8tM34lGX8" role="3uHU7w">
+                              <ref role="37wK5l" to="znf5:52iEUv_OK3m" resolve="getOriginalStableId" />
+                              <ref role="1Pybhc" to="znf5:4XyruUDBFl$" resolve="DocGeneratorHelper" />
+                              <node concept="2OqwBi" id="3x8tM34lGX9" role="37wK5m">
+                                <node concept="1iwH7S" id="3x8tM34lGXa" role="2Oq$k0" />
+                                <node concept="12$id9" id="3x8tM34lGXb" role="2OqNvi">
+                                  <node concept="30H73N" id="3x8tM34lGXc" role="12$y8L" />
+                                </node>
                               </node>
                             </node>
                           </node>
@@ -2482,15 +2523,19 @@
                 <property role="P4ACc" value="22a8c356-ae1a-4079-96b0-d5e7c21ae7c4/839091667655539422/839091667655539425" />
                 <node concept="3zFVjK" id="xxE$BMDh96" role="3zH0cK">
                   <node concept="3clFbS" id="xxE$BMDh97" role="2VODD2">
-                    <node concept="3clFbF" id="xxE$BMDhaL" role="3cqZAp">
-                      <node concept="3cpWs3" id="xxE$BMFhMm" role="3clFbG">
-                        <node concept="Xl_RD" id="xxE$BMFhZl" role="3uHU7B">
+                    <node concept="3clFbF" id="4XyruUDDYxB" role="3cqZAp">
+                      <node concept="3cpWs3" id="4XyruUDDYDR" role="3clFbG">
+                        <node concept="Xl_RD" id="4XyruUDDYDV" role="3uHU7B">
                           <property role="Xl_RC" value="#" />
                         </node>
-                        <node concept="2OqwBi" id="xxE$BMDhvS" role="3uHU7w">
-                          <node concept="30H73N" id="xxE$BMDhaK" role="2Oq$k0" />
-                          <node concept="2qgKlT" id="xxE$BMDi6L" role="2OqNvi">
-                            <ref role="37wK5l" to="4gky:6jiGbW_aIil" resolve="stableId" />
+                        <node concept="2YIFZM" id="3x8tM34lInt" role="3uHU7w">
+                          <ref role="37wK5l" to="znf5:52iEUv_OK3m" resolve="getOriginalStableId" />
+                          <ref role="1Pybhc" to="znf5:4XyruUDBFl$" resolve="DocGeneratorHelper" />
+                          <node concept="2OqwBi" id="3x8tM34lInu" role="37wK5m">
+                            <node concept="1iwH7S" id="3x8tM34lInv" role="2Oq$k0" />
+                            <node concept="12$id9" id="3x8tM34lInw" role="2OqNvi">
+                              <node concept="30H73N" id="3x8tM34lInx" role="12$y8L" />
+                            </node>
                           </node>
                         </node>
                       </node>

--- a/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc.gen_xhtml/com.mbeddr.doc.gen_xhtml.mpl
+++ b/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc.gen_xhtml/com.mbeddr.doc.gen_xhtml.mpl
@@ -33,6 +33,7 @@
         <dependency reexport="false">b0f8641f-bd77-4421-8425-30d9088a82f7(org.apache.commons)</dependency>
         <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
         <dependency reexport="true">ae6d8005-36be-4cb6-945b-8c8cfc033c51(jetbrains.mps.ide.httpsupport.runtime)</dependency>
+        <dependency reexport="false">2374bc90-7e37-41f1-a9c4-c2e35194c36a(com.mbeddr.doc)</dependency>
       </dependencies>
       <languageVersions>
         <language slang="l:d4280a54-f6df-4383-aa41-d1b2bffa7eb1:com.mbeddr.core.base" version="6" />

--- a/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc.gen_xhtml/generator/template/com/mbeddr/doc/gen_xhtml/generator/template/main@generator.mps
+++ b/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc.gen_xhtml/generator/template/com/mbeddr/doc/gen_xhtml/generator/template/main@generator.mps
@@ -26,6 +26,7 @@
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" />
     <import index="iuxj" ref="r:64db3a92-5968-4a73-b456-34504a2d97a6(jetbrains.mps.core.xml.structure)" />
     <import index="hwgx" ref="r:fd2980c8-676c-4b19-b524-18c70e02f8b7(com.mbeddr.core.base.behavior)" />
+    <import index="znf5" ref="r:07597124-beb3-41b7-beb1-a882af3ded40(com.mbeddr.doc.plugin)" />
     <import index="3t5i" ref="r:717da79d-5632-4537-9680-813308745bcf(com.mbeddr.doc.gen_xhtml.defaults)" implicit="true" />
     <import index="tapt" ref="r:6dfc533c-9e3b-4d5e-b950-90f8ce29851b(com.mbeddr.doc.gen_xhtml.behavior)" implicit="true" />
   </imports>
@@ -287,6 +288,9 @@
       </concept>
     </language>
     <language id="d7706f63-9be2-479c-a3da-ae92af1e64d5" name="jetbrains.mps.lang.generator.generationContext">
+      <concept id="1229477454423" name="jetbrains.mps.lang.generator.generationContext.structure.GenerationContextOp_GetOriginalCopiedInputByOutput" flags="nn" index="12$id9">
+        <child id="1229477520175" name="outputNode" index="12$y8L" />
+      </concept>
       <concept id="1216860049635" name="jetbrains.mps.lang.generator.generationContext.structure.TemplateFunctionParameter_generationContext" flags="nn" index="1iwH7S" />
     </language>
     <language id="3a13115c-633c-4c5c-bbcc-75c4219e9555" name="jetbrains.mps.lang.quotation">
@@ -1737,21 +1741,25 @@
                 <property role="P4ACc" value="479c7a8c-02f9-43b5-9139-d910cb22f298/6666499814681541919/6666499814681541920" />
                 <node concept="3zFVjK" id="QRmqzHSc11" role="3zH0cK">
                   <node concept="3clFbS" id="QRmqzHSc12" role="2VODD2">
-                    <node concept="3clFbF" id="QRmqzHSc13" role="3cqZAp">
-                      <node concept="3cpWs3" id="QRmqzHSc14" role="3clFbG">
-                        <node concept="2OqwBi" id="QRmqzHSc15" role="3uHU7w">
-                          <node concept="2OqwBi" id="QRmqzHSc16" role="2Oq$k0">
-                            <node concept="30H73N" id="QRmqzHSc17" role="2Oq$k0" />
-                            <node concept="3TrEf2" id="QRmqzHSc18" role="2OqNvi">
-                              <ref role="3Tt5mk" to="2c95:5yxqZJwzrde" resolve="image" />
+                    <node concept="3clFbF" id="4XyruUDEmA8" role="3cqZAp">
+                      <node concept="3cpWs3" id="4XyruUDEmAa" role="3clFbG">
+                        <node concept="Xl_RD" id="4XyruUDEmAg" role="3uHU7B">
+                          <property role="Xl_RC" value="#" />
+                        </node>
+                        <node concept="2YIFZM" id="3x8tM34lWUB" role="3uHU7w">
+                          <ref role="37wK5l" to="znf5:52iEUv_OK3m" resolve="getOriginalStableId" />
+                          <ref role="1Pybhc" to="znf5:4XyruUDBFl$" resolve="DocGeneratorHelper" />
+                          <node concept="2OqwBi" id="3x8tM34lWUC" role="37wK5m">
+                            <node concept="1iwH7S" id="3x8tM34lWUD" role="2Oq$k0" />
+                            <node concept="12$id9" id="3x8tM34lWUE" role="2OqNvi">
+                              <node concept="2OqwBi" id="3x8tM34lXnw" role="12$y8L">
+                                <node concept="30H73N" id="3x8tM34lWUF" role="2Oq$k0" />
+                                <node concept="3TrEf2" id="3x8tM34lYgd" role="2OqNvi">
+                                  <ref role="3Tt5mk" to="2c95:5yxqZJwzrde" resolve="image" />
+                                </node>
+                              </node>
                             </node>
                           </node>
-                          <node concept="2qgKlT" id="6jiGbW_JMDM" role="2OqNvi">
-                            <ref role="37wK5l" to="4gky:6jiGbW_aIil" resolve="stableId" />
-                          </node>
-                        </node>
-                        <node concept="Xl_RD" id="QRmqzHSc1a" role="3uHU7B">
-                          <property role="Xl_RC" value="#" />
                         </node>
                       </node>
                     </node>
@@ -1811,7 +1819,7 @@
                   <node concept="3zFVjK" id="QRmqzHTkhp" role="3zH0cK">
                     <node concept="3clFbS" id="QRmqzHTkhq" role="2VODD2">
                       <node concept="3clFbF" id="QRmqzHTkkq" role="3cqZAp">
-                        <node concept="3cpWs3" id="QRmqzHTkkr" role="3clFbG">
+                        <node concept="3cpWs3" id="4XyruUDEtZa" role="3clFbG">
                           <node concept="3cpWs3" id="10MSw5ZOJWZ" role="3uHU7B">
                             <node concept="2YIFZM" id="10MSw5ZOK_Y" role="3uHU7B">
                               <ref role="37wK5l" to="jobd:10MSw5ZOuCE" resolve="getRefWordPath" />
@@ -1823,15 +1831,19 @@
                               <property role="Xl_RC" value="#" />
                             </node>
                           </node>
-                          <node concept="2OqwBi" id="QRmqzHTkks" role="3uHU7w">
-                            <node concept="2OqwBi" id="QRmqzHTkkt" role="2Oq$k0">
-                              <node concept="30H73N" id="QRmqzHTkku" role="2Oq$k0" />
-                              <node concept="3TrEf2" id="QRmqzHTkkv" role="2OqNvi">
-                                <ref role="3Tt5mk" to="2c95:2TZO3DbvhAJ" resolve="target" />
+                          <node concept="2YIFZM" id="3x8tM34m0qc" role="3uHU7w">
+                            <ref role="37wK5l" to="znf5:52iEUv_OK3m" resolve="getOriginalStableId" />
+                            <ref role="1Pybhc" to="znf5:4XyruUDBFl$" resolve="DocGeneratorHelper" />
+                            <node concept="2OqwBi" id="3x8tM34m0qd" role="37wK5m">
+                              <node concept="1iwH7S" id="3x8tM34m0qe" role="2Oq$k0" />
+                              <node concept="12$id9" id="3x8tM34m0qf" role="2OqNvi">
+                                <node concept="2OqwBi" id="3x8tM34m0S7" role="12$y8L">
+                                  <node concept="30H73N" id="3x8tM34m0qg" role="2Oq$k0" />
+                                  <node concept="3TrEf2" id="3x8tM34m1ji" role="2OqNvi">
+                                    <ref role="3Tt5mk" to="2c95:2TZO3DbvhAJ" resolve="target" />
+                                  </node>
+                                </node>
                               </node>
-                            </node>
-                            <node concept="2qgKlT" id="6jiGbW_Gics" role="2OqNvi">
-                              <ref role="37wK5l" to="4gky:6jiGbW_aIil" resolve="stableId" />
                             </node>
                           </node>
                         </node>
@@ -2247,11 +2259,15 @@
                     <property role="P4ACc" value="479c7a8c-02f9-43b5-9139-d910cb22f298/6666499814681541919/6666499814681541920" />
                     <node concept="3zFVjK" id="2pZZiEv36mu" role="3zH0cK">
                       <node concept="3clFbS" id="2pZZiEv36mv" role="2VODD2">
-                        <node concept="3clFbF" id="2pZZiEv36mw" role="3cqZAp">
-                          <node concept="2OqwBi" id="2pZZiEv36mx" role="3clFbG">
-                            <node concept="30H73N" id="2pZZiEv36my" role="2Oq$k0" />
-                            <node concept="2qgKlT" id="2pZZiEv36mz" role="2OqNvi">
-                              <ref role="37wK5l" to="4gky:6jiGbW_aIil" resolve="stableId" />
+                        <node concept="3clFbF" id="4XyruUDE9Hy" role="3cqZAp">
+                          <node concept="2YIFZM" id="3x8tM34lODR" role="3clFbG">
+                            <ref role="37wK5l" to="znf5:52iEUv_OK3m" resolve="getOriginalStableId" />
+                            <ref role="1Pybhc" to="znf5:4XyruUDBFl$" resolve="DocGeneratorHelper" />
+                            <node concept="2OqwBi" id="3x8tM34lODS" role="37wK5m">
+                              <node concept="1iwH7S" id="3x8tM34lODT" role="2Oq$k0" />
+                              <node concept="12$id9" id="3x8tM34lODU" role="2OqNvi">
+                                <node concept="30H73N" id="3x8tM34lODV" role="12$y8L" />
+                              </node>
                             </node>
                           </node>
                         </node>
@@ -2400,11 +2416,15 @@
                     <property role="P4ACc" value="479c7a8c-02f9-43b5-9139-d910cb22f298/6666499814681541919/6666499814681541920" />
                     <node concept="3zFVjK" id="2pZZiEv36IA" role="3zH0cK">
                       <node concept="3clFbS" id="2pZZiEv36IB" role="2VODD2">
-                        <node concept="3clFbF" id="2pZZiEv36IC" role="3cqZAp">
-                          <node concept="2OqwBi" id="2pZZiEv36ID" role="3clFbG">
-                            <node concept="30H73N" id="2pZZiEv36IE" role="2Oq$k0" />
-                            <node concept="2qgKlT" id="2pZZiEv36IF" role="2OqNvi">
-                              <ref role="37wK5l" to="4gky:6jiGbW_aIil" resolve="stableId" />
+                        <node concept="3clFbF" id="4XyruUDE9L_" role="3cqZAp">
+                          <node concept="2YIFZM" id="3x8tM34lOIU" role="3clFbG">
+                            <ref role="37wK5l" to="znf5:52iEUv_OK3m" resolve="getOriginalStableId" />
+                            <ref role="1Pybhc" to="znf5:4XyruUDBFl$" resolve="DocGeneratorHelper" />
+                            <node concept="2OqwBi" id="3x8tM34lOIV" role="37wK5m">
+                              <node concept="1iwH7S" id="3x8tM34lOIW" role="2Oq$k0" />
+                              <node concept="12$id9" id="3x8tM34lOIX" role="2OqNvi">
+                                <node concept="30H73N" id="3x8tM34lOIY" role="12$y8L" />
+                              </node>
                             </node>
                           </node>
                         </node>
@@ -2553,11 +2573,15 @@
                     <property role="P4ACc" value="479c7a8c-02f9-43b5-9139-d910cb22f298/6666499814681541919/6666499814681541920" />
                     <node concept="3zFVjK" id="2pZZiEv37Xx" role="3zH0cK">
                       <node concept="3clFbS" id="2pZZiEv37Xy" role="2VODD2">
-                        <node concept="3clFbF" id="2pZZiEv37Xz" role="3cqZAp">
-                          <node concept="2OqwBi" id="2pZZiEv37X$" role="3clFbG">
-                            <node concept="30H73N" id="2pZZiEv37X_" role="2Oq$k0" />
-                            <node concept="2qgKlT" id="2pZZiEv37XA" role="2OqNvi">
-                              <ref role="37wK5l" to="4gky:6jiGbW_aIil" resolve="stableId" />
+                        <node concept="3clFbF" id="4XyruUDE9PK" role="3cqZAp">
+                          <node concept="2YIFZM" id="3x8tM34lONX" role="3clFbG">
+                            <ref role="37wK5l" to="znf5:52iEUv_OK3m" resolve="getOriginalStableId" />
+                            <ref role="1Pybhc" to="znf5:4XyruUDBFl$" resolve="DocGeneratorHelper" />
+                            <node concept="2OqwBi" id="3x8tM34lONY" role="37wK5m">
+                              <node concept="1iwH7S" id="3x8tM34lONZ" role="2Oq$k0" />
+                              <node concept="12$id9" id="3x8tM34lOO0" role="2OqNvi">
+                                <node concept="30H73N" id="3x8tM34lOO1" role="12$y8L" />
+                              </node>
                             </node>
                           </node>
                         </node>
@@ -2706,11 +2730,15 @@
                     <property role="P4ACc" value="479c7a8c-02f9-43b5-9139-d910cb22f298/6666499814681541919/6666499814681541920" />
                     <node concept="3zFVjK" id="2pZZiEv39iu" role="3zH0cK">
                       <node concept="3clFbS" id="2pZZiEv39iv" role="2VODD2">
-                        <node concept="3clFbF" id="2pZZiEv39iw" role="3cqZAp">
-                          <node concept="2OqwBi" id="2pZZiEv39ix" role="3clFbG">
-                            <node concept="30H73N" id="2pZZiEv39iy" role="2Oq$k0" />
-                            <node concept="2qgKlT" id="2pZZiEv39iz" role="2OqNvi">
-                              <ref role="37wK5l" to="4gky:6jiGbW_aIil" resolve="stableId" />
+                        <node concept="3clFbF" id="4XyruUDE9U3" role="3cqZAp">
+                          <node concept="2YIFZM" id="3x8tM34lOT0" role="3clFbG">
+                            <ref role="37wK5l" to="znf5:52iEUv_OK3m" resolve="getOriginalStableId" />
+                            <ref role="1Pybhc" to="znf5:4XyruUDBFl$" resolve="DocGeneratorHelper" />
+                            <node concept="2OqwBi" id="3x8tM34lOT1" role="37wK5m">
+                              <node concept="1iwH7S" id="3x8tM34lOT2" role="2Oq$k0" />
+                              <node concept="12$id9" id="3x8tM34lOT3" role="2OqNvi">
+                                <node concept="30H73N" id="3x8tM34lOT4" role="12$y8L" />
+                              </node>
                             </node>
                           </node>
                         </node>
@@ -2859,11 +2887,15 @@
                     <property role="P4ACc" value="479c7a8c-02f9-43b5-9139-d910cb22f298/6666499814681541919/6666499814681541920" />
                     <node concept="3zFVjK" id="2pZZiEv3bKu" role="3zH0cK">
                       <node concept="3clFbS" id="2pZZiEv3bKv" role="2VODD2">
-                        <node concept="3clFbF" id="2pZZiEv3bKw" role="3cqZAp">
-                          <node concept="2OqwBi" id="2pZZiEv3bKx" role="3clFbG">
-                            <node concept="30H73N" id="2pZZiEv3bKy" role="2Oq$k0" />
-                            <node concept="2qgKlT" id="2pZZiEv3bKz" role="2OqNvi">
-                              <ref role="37wK5l" to="4gky:6jiGbW_aIil" resolve="stableId" />
+                        <node concept="3clFbF" id="4XyruUDE9Yu" role="3cqZAp">
+                          <node concept="2YIFZM" id="3x8tM34lOY3" role="3clFbG">
+                            <ref role="37wK5l" to="znf5:52iEUv_OK3m" resolve="getOriginalStableId" />
+                            <ref role="1Pybhc" to="znf5:4XyruUDBFl$" resolve="DocGeneratorHelper" />
+                            <node concept="2OqwBi" id="3x8tM34lOY4" role="37wK5m">
+                              <node concept="1iwH7S" id="3x8tM34lOY5" role="2Oq$k0" />
+                              <node concept="12$id9" id="3x8tM34lOY6" role="2OqNvi">
+                                <node concept="30H73N" id="3x8tM34lOY7" role="12$y8L" />
+                              </node>
                             </node>
                           </node>
                         </node>
@@ -3012,11 +3044,15 @@
                     <property role="P4ACc" value="479c7a8c-02f9-43b5-9139-d910cb22f298/6666499814681541919/6666499814681541920" />
                     <node concept="3zFVjK" id="4zO5iT9tsAK" role="3zH0cK">
                       <node concept="3clFbS" id="4zO5iT9tsAL" role="2VODD2">
-                        <node concept="3clFbF" id="4zO5iT9tsAM" role="3cqZAp">
-                          <node concept="2OqwBi" id="4zO5iT9tsAN" role="3clFbG">
-                            <node concept="30H73N" id="4zO5iT9tsAO" role="2Oq$k0" />
-                            <node concept="2qgKlT" id="4zO5iT9tsAP" role="2OqNvi">
-                              <ref role="37wK5l" to="4gky:6jiGbW_aIil" resolve="stableId" />
+                        <node concept="3clFbF" id="4XyruUDEa31" role="3cqZAp">
+                          <node concept="2YIFZM" id="3x8tM34lPiN" role="3clFbG">
+                            <ref role="37wK5l" to="znf5:52iEUv_OK3m" resolve="getOriginalStableId" />
+                            <ref role="1Pybhc" to="znf5:4XyruUDBFl$" resolve="DocGeneratorHelper" />
+                            <node concept="2OqwBi" id="3x8tM34lPiO" role="37wK5m">
+                              <node concept="1iwH7S" id="3x8tM34lPiP" role="2Oq$k0" />
+                              <node concept="12$id9" id="3x8tM34lPiQ" role="2OqNvi">
+                                <node concept="30H73N" id="3x8tM34lPiR" role="12$y8L" />
+                              </node>
                             </node>
                           </node>
                         </node>
@@ -3164,11 +3200,15 @@
                   <property role="P4ACc" value="479c7a8c-02f9-43b5-9139-d910cb22f298/6666499814681541919/6666499814681541920" />
                   <node concept="3zFVjK" id="2HzhasNyuzF" role="3zH0cK">
                     <node concept="3clFbS" id="2HzhasNyuzG" role="2VODD2">
-                      <node concept="3clFbF" id="2HzhasNyuzH" role="3cqZAp">
-                        <node concept="2OqwBi" id="2HzhasNyuzI" role="3clFbG">
-                          <node concept="30H73N" id="2HzhasNyuzJ" role="2Oq$k0" />
-                          <node concept="2qgKlT" id="6jiGbW_GjkF" role="2OqNvi">
-                            <ref role="37wK5l" to="4gky:6jiGbW_aIil" resolve="stableId" />
+                      <node concept="3clFbF" id="4XyruUDEa7G" role="3cqZAp">
+                        <node concept="2YIFZM" id="3x8tM34lPnQ" role="3clFbG">
+                          <ref role="37wK5l" to="znf5:52iEUv_OK3m" resolve="getOriginalStableId" />
+                          <ref role="1Pybhc" to="znf5:4XyruUDBFl$" resolve="DocGeneratorHelper" />
+                          <node concept="2OqwBi" id="3x8tM34lPnR" role="37wK5m">
+                            <node concept="1iwH7S" id="3x8tM34lPnS" role="2Oq$k0" />
+                            <node concept="12$id9" id="3x8tM34lPnT" role="2OqNvi">
+                              <node concept="30H73N" id="3x8tM34lPnU" role="12$y8L" />
+                            </node>
                           </node>
                         </node>
                       </node>
@@ -3264,11 +3304,15 @@
                   <property role="P4ACc" value="479c7a8c-02f9-43b5-9139-d910cb22f298/6666499814681541919/6666499814681541920" />
                   <node concept="3zFVjK" id="4vQSg$AqR0a" role="3zH0cK">
                     <node concept="3clFbS" id="4vQSg$AqR0b" role="2VODD2">
-                      <node concept="3clFbF" id="4vQSg$AqR0c" role="3cqZAp">
-                        <node concept="2OqwBi" id="4vQSg$AqR0d" role="3clFbG">
-                          <node concept="30H73N" id="4vQSg$AqR0e" role="2Oq$k0" />
-                          <node concept="2qgKlT" id="6jiGbW_Gjc9" role="2OqNvi">
-                            <ref role="37wK5l" to="4gky:6jiGbW_aIil" resolve="stableId" />
+                      <node concept="3clFbF" id="4XyruUDEagf" role="3cqZAp">
+                        <node concept="2YIFZM" id="3x8tM34lPsT" role="3clFbG">
+                          <ref role="37wK5l" to="znf5:52iEUv_OK3m" resolve="getOriginalStableId" />
+                          <ref role="1Pybhc" to="znf5:4XyruUDBFl$" resolve="DocGeneratorHelper" />
+                          <node concept="2OqwBi" id="3x8tM34lPsU" role="37wK5m">
+                            <node concept="1iwH7S" id="3x8tM34lPsV" role="2Oq$k0" />
+                            <node concept="12$id9" id="3x8tM34lPsW" role="2OqNvi">
+                              <node concept="30H73N" id="3x8tM34lPsX" role="12$y8L" />
+                            </node>
                           </node>
                         </node>
                       </node>
@@ -3364,11 +3408,15 @@
                   <property role="P4ACc" value="479c7a8c-02f9-43b5-9139-d910cb22f298/6666499814681541919/6666499814681541920" />
                   <node concept="3zFVjK" id="4vQSg$AqR0L" role="3zH0cK">
                     <node concept="3clFbS" id="4vQSg$AqR0M" role="2VODD2">
-                      <node concept="3clFbF" id="4vQSg$AqR0N" role="3cqZAp">
-                        <node concept="2OqwBi" id="4vQSg$AqR0O" role="3clFbG">
-                          <node concept="30H73N" id="4vQSg$AqR0P" role="2Oq$k0" />
-                          <node concept="2qgKlT" id="6jiGbW_GiUX" role="2OqNvi">
-                            <ref role="37wK5l" to="4gky:6jiGbW_aIil" resolve="stableId" />
+                      <node concept="3clFbF" id="4XyruUDEala" role="3cqZAp">
+                        <node concept="2YIFZM" id="3x8tM34lPxW" role="3clFbG">
+                          <ref role="37wK5l" to="znf5:52iEUv_OK3m" resolve="getOriginalStableId" />
+                          <ref role="1Pybhc" to="znf5:4XyruUDBFl$" resolve="DocGeneratorHelper" />
+                          <node concept="2OqwBi" id="3x8tM34lPxX" role="37wK5m">
+                            <node concept="1iwH7S" id="3x8tM34lPxY" role="2Oq$k0" />
+                            <node concept="12$id9" id="3x8tM34lPxZ" role="2OqNvi">
+                              <node concept="30H73N" id="3x8tM34lPy0" role="12$y8L" />
+                            </node>
                           </node>
                         </node>
                       </node>
@@ -3464,11 +3512,15 @@
                   <property role="P4ACc" value="479c7a8c-02f9-43b5-9139-d910cb22f298/6666499814681541919/6666499814681541920" />
                   <node concept="3zFVjK" id="2HzhasNz5WB" role="3zH0cK">
                     <node concept="3clFbS" id="2HzhasNz5WC" role="2VODD2">
-                      <node concept="3clFbF" id="2HzhasNz5WD" role="3cqZAp">
-                        <node concept="2OqwBi" id="2HzhasNz5WE" role="3clFbG">
-                          <node concept="30H73N" id="2HzhasNz5WF" role="2Oq$k0" />
-                          <node concept="2qgKlT" id="6jiGbW_Gjtd" role="2OqNvi">
-                            <ref role="37wK5l" to="4gky:6jiGbW_aIil" resolve="stableId" />
+                      <node concept="3clFbF" id="4XyruUDEaqd" role="3cqZAp">
+                        <node concept="2YIFZM" id="3x8tM34lPAZ" role="3clFbG">
+                          <ref role="37wK5l" to="znf5:52iEUv_OK3m" resolve="getOriginalStableId" />
+                          <ref role="1Pybhc" to="znf5:4XyruUDBFl$" resolve="DocGeneratorHelper" />
+                          <node concept="2OqwBi" id="3x8tM34lPB0" role="37wK5m">
+                            <node concept="1iwH7S" id="3x8tM34lPB1" role="2Oq$k0" />
+                            <node concept="12$id9" id="3x8tM34lPB2" role="2OqNvi">
+                              <node concept="30H73N" id="3x8tM34lPB3" role="12$y8L" />
+                            </node>
                           </node>
                         </node>
                       </node>
@@ -3581,11 +3633,15 @@
                   <property role="P4ACc" value="479c7a8c-02f9-43b5-9139-d910cb22f298/6666499814681541919/6666499814681541920" />
                   <node concept="3zFVjK" id="QRmqzIatxF" role="3zH0cK">
                     <node concept="3clFbS" id="QRmqzIatxG" role="2VODD2">
-                      <node concept="3clFbF" id="QRmqzIatxH" role="3cqZAp">
-                        <node concept="2OqwBi" id="QRmqzIatxI" role="3clFbG">
-                          <node concept="30H73N" id="QRmqzIatxJ" role="2Oq$k0" />
-                          <node concept="2qgKlT" id="6jiGbW_Gj3B" role="2OqNvi">
-                            <ref role="37wK5l" to="4gky:6jiGbW_aIil" resolve="stableId" />
+                      <node concept="3clFbF" id="4XyruUDEavo" role="3cqZAp">
+                        <node concept="2YIFZM" id="3x8tM34lPG2" role="3clFbG">
+                          <ref role="37wK5l" to="znf5:52iEUv_OK3m" resolve="getOriginalStableId" />
+                          <ref role="1Pybhc" to="znf5:4XyruUDBFl$" resolve="DocGeneratorHelper" />
+                          <node concept="2OqwBi" id="3x8tM34lPG3" role="37wK5m">
+                            <node concept="1iwH7S" id="3x8tM34lPG4" role="2Oq$k0" />
+                            <node concept="12$id9" id="3x8tM34lPG5" role="2OqNvi">
+                              <node concept="30H73N" id="3x8tM34lPG6" role="12$y8L" />
+                            </node>
                           </node>
                         </node>
                       </node>
@@ -3681,11 +3737,15 @@
                   <property role="P4ACc" value="479c7a8c-02f9-43b5-9139-d910cb22f298/6666499814681541919/6666499814681541920" />
                   <node concept="3zFVjK" id="4zO5iT9ts2F" role="3zH0cK">
                     <node concept="3clFbS" id="4zO5iT9ts2G" role="2VODD2">
-                      <node concept="3clFbF" id="4zO5iT9ts2H" role="3cqZAp">
-                        <node concept="2OqwBi" id="4zO5iT9ts2I" role="3clFbG">
-                          <node concept="30H73N" id="4zO5iT9ts2J" role="2Oq$k0" />
-                          <node concept="2qgKlT" id="4zO5iT9ts2K" role="2OqNvi">
-                            <ref role="37wK5l" to="4gky:6jiGbW_aIil" resolve="stableId" />
+                      <node concept="3clFbF" id="4XyruUDEaQg" role="3cqZAp">
+                        <node concept="2YIFZM" id="3x8tM34lPL5" role="3clFbG">
+                          <ref role="37wK5l" to="znf5:52iEUv_OK3m" resolve="getOriginalStableId" />
+                          <ref role="1Pybhc" to="znf5:4XyruUDBFl$" resolve="DocGeneratorHelper" />
+                          <node concept="2OqwBi" id="3x8tM34lPL6" role="37wK5m">
+                            <node concept="1iwH7S" id="3x8tM34lPL7" role="2Oq$k0" />
+                            <node concept="12$id9" id="3x8tM34lPL8" role="2OqNvi">
+                              <node concept="30H73N" id="3x8tM34lPL9" role="12$y8L" />
+                            </node>
                           </node>
                         </node>
                       </node>
@@ -3931,11 +3991,15 @@
                 <property role="P4ACc" value="479c7a8c-02f9-43b5-9139-d910cb22f298/6666499814681541919/6666499814681541920" />
                 <node concept="3zFVjK" id="5pyBnOITvNq" role="3zH0cK">
                   <node concept="3clFbS" id="5pyBnOITvNr" role="2VODD2">
-                    <node concept="3clFbF" id="5pyBnOITvNs" role="3cqZAp">
-                      <node concept="2OqwBi" id="5pyBnOITvNt" role="3clFbG">
-                        <node concept="30H73N" id="5pyBnOITvNu" role="2Oq$k0" />
-                        <node concept="2qgKlT" id="6jiGbW_JG4W" role="2OqNvi">
-                          <ref role="37wK5l" to="4gky:6jiGbW_aIil" resolve="stableId" />
+                    <node concept="3clFbF" id="4XyruUDEcLR" role="3cqZAp">
+                      <node concept="2YIFZM" id="3x8tM34lRwm" role="3clFbG">
+                        <ref role="37wK5l" to="znf5:52iEUv_OK3m" resolve="getOriginalStableId" />
+                        <ref role="1Pybhc" to="znf5:4XyruUDBFl$" resolve="DocGeneratorHelper" />
+                        <node concept="2OqwBi" id="3x8tM34lRwn" role="37wK5m">
+                          <node concept="1iwH7S" id="3x8tM34lRwo" role="2Oq$k0" />
+                          <node concept="12$id9" id="3x8tM34lRwp" role="2OqNvi">
+                            <node concept="30H73N" id="3x8tM34lRwq" role="12$y8L" />
+                          </node>
                         </node>
                       </node>
                     </node>
@@ -3984,11 +4048,15 @@
                 <property role="P4ACc" value="479c7a8c-02f9-43b5-9139-d910cb22f298/6666499814681541919/6666499814681541920" />
                 <node concept="3zFVjK" id="5pyBnOIWMik" role="3zH0cK">
                   <node concept="3clFbS" id="5pyBnOIWMil" role="2VODD2">
-                    <node concept="3clFbF" id="5pyBnOIWMim" role="3cqZAp">
-                      <node concept="2OqwBi" id="5pyBnOIWMin" role="3clFbG">
-                        <node concept="30H73N" id="5pyBnOIWMio" role="2Oq$k0" />
-                        <node concept="2qgKlT" id="6jiGbW_JIC0" role="2OqNvi">
-                          <ref role="37wK5l" to="4gky:6jiGbW_aIil" resolve="stableId" />
+                    <node concept="3clFbF" id="4XyruUDEcSe" role="3cqZAp">
+                      <node concept="2YIFZM" id="3x8tM34lRxN" role="3clFbG">
+                        <ref role="37wK5l" to="znf5:52iEUv_OK3m" resolve="getOriginalStableId" />
+                        <ref role="1Pybhc" to="znf5:4XyruUDBFl$" resolve="DocGeneratorHelper" />
+                        <node concept="2OqwBi" id="3x8tM34lRxO" role="37wK5m">
+                          <node concept="1iwH7S" id="3x8tM34lRxP" role="2Oq$k0" />
+                          <node concept="12$id9" id="3x8tM34lRxQ" role="2OqNvi">
+                            <node concept="30H73N" id="3x8tM34lRxR" role="12$y8L" />
+                          </node>
                         </node>
                       </node>
                     </node>
@@ -4389,11 +4457,15 @@
                 <property role="P4ACc" value="479c7a8c-02f9-43b5-9139-d910cb22f298/6666499814681541919/6666499814681541920" />
                 <node concept="3zFVjK" id="5wmuVxvUQTD" role="3zH0cK">
                   <node concept="3clFbS" id="5wmuVxvUQTE" role="2VODD2">
-                    <node concept="3clFbF" id="5wmuVxvUR4j" role="3cqZAp">
-                      <node concept="2OqwBi" id="5wmuVxvURbL" role="3clFbG">
-                        <node concept="30H73N" id="5wmuVxvUR4i" role="2Oq$k0" />
-                        <node concept="2qgKlT" id="6jiGbW_JHjy" role="2OqNvi">
-                          <ref role="37wK5l" to="4gky:6jiGbW_aIil" resolve="stableId" />
+                    <node concept="3clFbF" id="4XyruUDE2TY" role="3cqZAp">
+                      <node concept="2YIFZM" id="4XyruUDCSw4" role="3clFbG">
+                        <ref role="37wK5l" to="znf5:52iEUv_OK3m" resolve="getOriginalStableId" />
+                        <ref role="1Pybhc" to="znf5:4XyruUDBFl$" resolve="DocGeneratorHelper" />
+                        <node concept="2OqwBi" id="3x8tM34lh5m" role="37wK5m">
+                          <node concept="1iwH7S" id="3x8tM34lgEW" role="2Oq$k0" />
+                          <node concept="12$id9" id="3x8tM34lhw7" role="2OqNvi">
+                            <node concept="30H73N" id="3x8tM34lhx3" role="12$y8L" />
+                          </node>
                         </node>
                       </node>
                     </node>
@@ -5215,21 +5287,25 @@
                     <property role="2qtEX9" value="text" />
                     <node concept="3zFVjK" id="QRmqzJkppQ" role="3zH0cK">
                       <node concept="3clFbS" id="QRmqzJkppR" role="2VODD2">
-                        <node concept="3clFbF" id="QRmqzJkppS" role="3cqZAp">
-                          <node concept="3cpWs3" id="QRmqzJkppT" role="3clFbG">
-                            <node concept="2OqwBi" id="QRmqzJkppU" role="3uHU7w">
-                              <node concept="2OqwBi" id="QRmqzJkpXe" role="2Oq$k0">
-                                <node concept="30H73N" id="QRmqzJkppV" role="2Oq$k0" />
-                                <node concept="3TrEf2" id="QRmqzJkqi3" role="2OqNvi">
-                                  <ref role="3Tt5mk" to="lsus:QRmqzJj_2X" resolve="section" />
+                        <node concept="3clFbF" id="4XyruUDEeHY" role="3cqZAp">
+                          <node concept="3cpWs3" id="4XyruUDEg12" role="3clFbG">
+                            <node concept="Xl_RD" id="4XyruUDEg3z" role="3uHU7B">
+                              <property role="Xl_RC" value="#" />
+                            </node>
+                            <node concept="2YIFZM" id="3x8tM34lTf9" role="3uHU7w">
+                              <ref role="37wK5l" to="znf5:52iEUv_OK3m" resolve="getOriginalStableId" />
+                              <ref role="1Pybhc" to="znf5:4XyruUDBFl$" resolve="DocGeneratorHelper" />
+                              <node concept="2OqwBi" id="3x8tM34lTfa" role="37wK5m">
+                                <node concept="1iwH7S" id="3x8tM34lTfb" role="2Oq$k0" />
+                                <node concept="12$id9" id="3x8tM34lTfc" role="2OqNvi">
+                                  <node concept="2OqwBi" id="3x8tM34lTCE" role="12$y8L">
+                                    <node concept="30H73N" id="3x8tM34lTfd" role="2Oq$k0" />
+                                    <node concept="3TrEf2" id="3x8tM34lUp7" role="2OqNvi">
+                                      <ref role="3Tt5mk" to="lsus:QRmqzJj_2X" resolve="section" />
+                                    </node>
+                                  </node>
                                 </node>
                               </node>
-                              <node concept="2qgKlT" id="6jiGbW_GhiO" role="2OqNvi">
-                                <ref role="37wK5l" to="4gky:6jiGbW_aIil" resolve="stableId" />
-                              </node>
-                            </node>
-                            <node concept="Xl_RD" id="QRmqzJkppX" role="3uHU7B">
-                              <property role="Xl_RC" value="#" />
                             </node>
                           </node>
                         </node>
@@ -5325,21 +5401,25 @@
                   <property role="2qtEX9" value="text" />
                   <node concept="3zFVjK" id="QRmqzJHPro" role="3zH0cK">
                     <node concept="3clFbS" id="QRmqzJHPrp" role="2VODD2">
-                      <node concept="3clFbF" id="QRmqzJHPrq" role="3cqZAp">
-                        <node concept="3cpWs3" id="QRmqzJHPrr" role="3clFbG">
-                          <node concept="2OqwBi" id="QRmqzJHPrs" role="3uHU7w">
-                            <node concept="2OqwBi" id="QRmqzJHPrt" role="2Oq$k0">
-                              <node concept="30H73N" id="QRmqzJHPru" role="2Oq$k0" />
-                              <node concept="3TrEf2" id="QRmqzJHPrv" role="2OqNvi">
-                                <ref role="3Tt5mk" to="lsus:QRmqzJj_2X" resolve="section" />
+                      <node concept="3clFbF" id="4XyruUDEgUS" role="3cqZAp">
+                        <node concept="3cpWs3" id="4XyruUDEgXU" role="3clFbG">
+                          <node concept="Xl_RD" id="4XyruUDEgXY" role="3uHU7B">
+                            <property role="Xl_RC" value="#" />
+                          </node>
+                          <node concept="2YIFZM" id="3x8tM34lUqk" role="3uHU7w">
+                            <ref role="37wK5l" to="znf5:52iEUv_OK3m" resolve="getOriginalStableId" />
+                            <ref role="1Pybhc" to="znf5:4XyruUDBFl$" resolve="DocGeneratorHelper" />
+                            <node concept="2OqwBi" id="3x8tM34lUql" role="37wK5m">
+                              <node concept="1iwH7S" id="3x8tM34lUqm" role="2Oq$k0" />
+                              <node concept="12$id9" id="3x8tM34lUqn" role="2OqNvi">
+                                <node concept="2OqwBi" id="3x8tM34lUsc" role="12$y8L">
+                                  <node concept="30H73N" id="3x8tM34lUqo" role="2Oq$k0" />
+                                  <node concept="3TrEf2" id="3x8tM34lUxM" role="2OqNvi">
+                                    <ref role="3Tt5mk" to="lsus:QRmqzJj_2X" resolve="section" />
+                                  </node>
+                                </node>
                               </node>
                             </node>
-                            <node concept="2qgKlT" id="6jiGbW_GeII" role="2OqNvi">
-                              <ref role="37wK5l" to="4gky:6jiGbW_aIil" resolve="stableId" />
-                            </node>
-                          </node>
-                          <node concept="Xl_RD" id="QRmqzJHPrx" role="3uHU7B">
-                            <property role="Xl_RC" value="#" />
                           </node>
                         </node>
                       </node>

--- a/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/languageModels/behavior.mps
+++ b/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/languageModels/behavior.mps
@@ -8404,11 +8404,8 @@
                     <node concept="37vLTw" id="73FPRWNYFqn" role="37wK5m">
                       <ref role="3cqZAo" node="6jiGbW_zIT$" resolve="USER_OBJECT_KEY" />
                     </node>
-                    <node concept="1rXfSq" id="73FPRWNYFqg" role="37wK5m">
-                      <ref role="37wK5l" node="73FPRWNYEdD" resolve="computeStableId" />
-                      <node concept="37vLTw" id="73FPRWNYFqh" role="37wK5m">
-                        <ref role="3cqZAo" node="6jiGbW_zIQs" resolve="n" />
-                      </node>
+                    <node concept="37vLTw" id="5CV8POq$aFc" role="37wK5m">
+                      <ref role="3cqZAo" node="73FPRWNYESx" resolve="newStableId" />
                     </node>
                   </node>
                 </node>

--- a/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/languageModels/plugin.mps
+++ b/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/languageModels/plugin.mps
@@ -326,6 +326,30 @@
         <child id="1199569916463" name="body" index="1bW5cS" />
       </concept>
     </language>
+    <language id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc">
+      <concept id="5858074156537516430" name="jetbrains.mps.baseLanguage.javadoc.structure.ReturnBlockDocTag" flags="ng" index="x79VA">
+        <property id="5858074156537516431" name="text" index="x79VB" />
+      </concept>
+      <concept id="6832197706140518104" name="jetbrains.mps.baseLanguage.javadoc.structure.DocMethodParameterReference" flags="ng" index="zr_55" />
+      <concept id="6832197706140518103" name="jetbrains.mps.baseLanguage.javadoc.structure.BaseParameterReference" flags="ng" index="zr_5a">
+        <reference id="6832197706140518108" name="param" index="zr_51" />
+      </concept>
+      <concept id="5349172909345501395" name="jetbrains.mps.baseLanguage.javadoc.structure.BaseDocComment" flags="ng" index="P$AiS">
+        <child id="8465538089690331502" name="body" index="TZ5H$" />
+        <child id="5383422241790532083" name="tags" index="3nqlJM" />
+      </concept>
+      <concept id="5349172909345532724" name="jetbrains.mps.baseLanguage.javadoc.structure.MethodDocComment" flags="ng" index="P$JXv" />
+      <concept id="8465538089690881930" name="jetbrains.mps.baseLanguage.javadoc.structure.ParameterBlockDocTag" flags="ng" index="TUZQ0">
+        <property id="8465538089690881934" name="text" index="TUZQ4" />
+        <child id="6832197706140518123" name="parameter" index="zr_5Q" />
+      </concept>
+      <concept id="8465538089690331500" name="jetbrains.mps.baseLanguage.javadoc.structure.CommentLine" flags="ng" index="TZ5HA">
+        <child id="8970989240999019149" name="part" index="1dT_Ay" />
+      </concept>
+      <concept id="8970989240999019143" name="jetbrains.mps.baseLanguage.javadoc.structure.TextCommentLinePart" flags="ng" index="1dT_AC">
+        <property id="8970989240999019144" name="text" index="1dT_AB" />
+      </concept>
+    </language>
     <language id="696c1165-4a59-463b-bc5d-902caab85dd0" name="jetbrains.mps.make.facet">
       <concept id="3344436107830227889" name="jetbrains.mps.make.facet.structure.ForeignParametersComponentExpression" flags="nn" index="2bn25q" />
       <concept id="3344436107830227888" name="jetbrains.mps.make.facet.structure.ForeignParametersExpression" flags="nn" index="2bn25r">
@@ -449,6 +473,9 @@
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
@@ -4451,6 +4478,78 @@
     <node concept="3uibUv" id="3kcKtVhMzZm" role="EKbjA">
       <ref role="3uigEE" to="wyt6:~Runnable" resolve="Runnable" />
     </node>
+  </node>
+  <node concept="312cEu" id="4XyruUDBFl$">
+    <property role="TrG5h" value="DocGeneratorHelper" />
+    <node concept="2tJIrI" id="2JVFIvwCtAD" role="jymVt" />
+    <node concept="2YIFZL" id="52iEUv_OK3m" role="jymVt">
+      <property role="TrG5h" value="getOriginalStableId" />
+      <node concept="3Tm1VV" id="52iEUv_OK3n" role="1B3o_S" />
+      <node concept="17QB3L" id="52iEUv_OK3o" role="3clF45" />
+      <node concept="37vLTG" id="52iEUv_OK3d" role="3clF46">
+        <property role="TrG5h" value="originalNode" />
+        <node concept="3Tqbb2" id="52iEUv_OK3e" role="1tU5fm" />
+      </node>
+      <node concept="3clFbS" id="52iEUv_OK2R" role="3clF47">
+        <node concept="3clFbF" id="52iEUv_OK2Z" role="3cqZAp">
+          <node concept="3K4zz7" id="52iEUv_OK30" role="3clFbG">
+            <node concept="2OqwBi" id="52iEUv_OK31" role="3K4E3e">
+              <node concept="1PxgMI" id="52iEUv_OK32" role="2Oq$k0">
+                <node concept="chp4Y" id="52iEUv_OK33" role="3oSUPX">
+                  <ref role="cht4Q" to="2c95:6jiGbW_JBH_" resolve="IDocReferencable" />
+                </node>
+                <node concept="37vLTw" id="52iEUv_OK34" role="1m5AlR">
+                  <ref role="3cqZAo" node="52iEUv_OK3d" resolve="originalNode" />
+                </node>
+              </node>
+              <node concept="2qgKlT" id="52iEUv_OK35" role="2OqNvi">
+                <ref role="37wK5l" to="4gky:6jiGbW_aIil" resolve="stableId" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="52iEUv_OK36" role="3K4Cdx">
+              <node concept="37vLTw" id="52iEUv_OK37" role="2Oq$k0">
+                <ref role="3cqZAo" node="52iEUv_OK3d" resolve="originalNode" />
+              </node>
+              <node concept="1mIQ4w" id="52iEUv_OK38" role="2OqNvi">
+                <node concept="chp4Y" id="52iEUv_OK39" role="cj9EA">
+                  <ref role="cht4Q" to="2c95:6jiGbW_JBH_" resolve="IDocReferencable" />
+                </node>
+              </node>
+            </node>
+            <node concept="2YIFZM" id="6jiGbW_zKoi" role="3K4GZi">
+              <ref role="1Pybhc" to="4gky:6jiGbW_zIPK" resolve="StableIdHelper" />
+              <ref role="37wK5l" to="4gky:6jiGbW_zIQb" resolve="getStableId" />
+              <node concept="37vLTw" id="3x8tM34l6Ul" role="37wK5m">
+                <ref role="3cqZAo" node="52iEUv_OK3d" resolve="originalNode" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="P$JXv" id="4XyruUDBaii" role="lGtFl">
+        <node concept="TZ5HA" id="4XyruUDBaij" role="TZ5H$">
+          <node concept="1dT_AC" id="4XyruUDBaik" role="1dT_Ay">
+            <property role="1dT_AB" value="Tries to get the stable ID from the original model in case it was a IDocReferencable" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="3x8tM34ld_8" role="TZ5H$">
+          <node concept="1dT_AC" id="3x8tM34ld_9" role="1dT_Ay">
+            <property role="1dT_AB" value="Otherwise generates a new stable ID" />
+          </node>
+        </node>
+        <node concept="TUZQ0" id="4XyruUDBail" role="3nqlJM">
+          <property role="TUZQ4" value=" from original imput model" />
+          <node concept="zr_55" id="4XyruUDBain" role="zr_5Q">
+            <ref role="zr_51" node="52iEUv_OK3d" resolve="originalNode" />
+          </node>
+        </node>
+        <node concept="x79VA" id="4XyruUDBair" role="3nqlJM">
+          <property role="x79VB" value="stable id based on the node id from the original model" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="4XyruUDBFmR" role="jymVt" />
+    <node concept="3Tm1VV" id="4XyruUDBFl_" role="1B3o_S" />
   </node>
 </model>
 

--- a/code/languages/com.mbeddr.doc/solutions/com.mbeddr.doc.markdown.sandbox/models/com.mbeddr.doc.markdown.sandbox.doc2markdown.mps
+++ b/code/languages/com.mbeddr.doc/solutions/com.mbeddr.doc.markdown.sandbox/models/com.mbeddr.doc.markdown.sandbox.doc2markdown.mps
@@ -542,8 +542,16 @@
         </node>
       </node>
     </node>
+    <node concept="$CzcT" id="4yqSQKZf0cK" role="1_0VJ0">
+      <node concept="1_0j5j" id="4yqSQKZf0cM" role="$CzcU">
+        <ref role="1_0j5g" node="4yqSQKZf08U" resolve="SubDocumentForDirectInclude" />
+      </node>
+    </node>
     <node concept="1_0j5j" id="1Gd_uyNeHgT" role="1DXQ57">
       <ref role="1_0j5g" node="1Gd_uyNeHer" resolve="SubDocument" />
+    </node>
+    <node concept="1_0j5j" id="4yqSQKZf0cO" role="1DXQ57">
+      <ref role="1_0j5g" node="4yqSQKZf08U" resolve="SubDocumentForDirectInclude" />
     </node>
   </node>
   <node concept="1_08Dk" id="1Gd_uyNesUv">
@@ -597,6 +605,22 @@
       </node>
     </node>
     <node concept="1YFc4a" id="7YublcAIHp1" role="2wNnkt" />
+  </node>
+  <node concept="1_1swa" id="4yqSQKZf08U">
+    <property role="TrG5h" value="SubDocumentForDirectInclude" />
+    <property role="yApLE" value="3" />
+    <ref role="G9hjw" node="5xsBLDLCa4c" resolve="MarkdownConfig" />
+    <node concept="1_0VNX" id="4yqSQKZf0ab" role="1_0VJ0">
+      <property role="TrG5h" value="ThirdSection" />
+      <property role="1_0VJr" value="The section" />
+      <node concept="1_0LV8" id="4yqSQKZf0ac" role="1_0VJ0">
+        <node concept="19SGf9" id="4yqSQKZf0ad" role="1_0LWR">
+          <node concept="19SUe$" id="4yqSQKZf0ae" role="19SJt6">
+            <property role="19SUeA" value="text for the third section - &#10;The SIDs of the generated links from the TOC should stay identical after multiple &#10;generation runs. " />
+          </node>
+        </node>
+      </node>
+    </node>
   </node>
 </model>
 

--- a/code/languages/com.mbeddr.doc/solutions/com.mbeddr.doc.test.documents/com.mbeddr.doc.test.documents.msd
+++ b/code/languages/com.mbeddr.doc/solutions/com.mbeddr.doc.test.documents/com.mbeddr.doc.test.documents.msd
@@ -9,9 +9,14 @@
     <facet type="java" compile="mps" classes="mps" ext="no">
       <classes generated="true" path="${module}/classes_gen" />
     </facet>
+    <facet type="tests" />
   </facets>
   <dependencies>
     <dependency reexport="false">f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)</dependency>
+    <dependency reexport="false">2374bc90-7e37-41f1-a9c4-c2e35194c36a(com.mbeddr.doc)</dependency>
+    <dependency reexport="false">b0f8641f-bd77-4421-8425-30d9088a82f7(org.apache.commons)</dependency>
+    <dependency reexport="false">39983771-4e9b-401b-a1a9-1da6c777c843(MPS.ThirdParty)</dependency>
+    <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:d4280a54-f6df-4383-aa41-d1b2bffa7eb1:com.mbeddr.core.base" version="6" />
@@ -28,17 +33,20 @@
     <language slang="l:7a060fae-09e0-4372-be36-6696d6554c0e:com.mbeddr.mpsutil.review.annotation" version="0" />
     <language slang="l:92d2ea16-5a42-4fdf-a676-c7604efe3504:de.slisson.mps.richtext" version="0" />
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
+    <language slang="l:443f4c36-fcf5-4eb6-9500-8d06ed259e3e:jetbrains.mps.baseLanguage.classifiers" version="0" />
     <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
     <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="2" />
     <language slang="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" version="2" />
     <language slang="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" version="0" />
     <language slang="l:daafa647-f1f7-4b0b-b096-69cd7c8408c0:jetbrains.mps.baseLanguage.regexp" version="0" />
     <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
+    <language slang="l:f61473f9-130f-42f6-b98d-6c438812c2f6:jetbrains.mps.baseLanguage.unitTest" version="1" />
     <language slang="l:479c7a8c-02f9-43b5-9139-d910cb22f298:jetbrains.mps.core.xml" version="0" />
     <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
     <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
     <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="5" />
     <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="19" />
+    <language slang="l:8585453e-6bfb-4d80-98de-b16074f1d86c:jetbrains.mps.lang.test" version="6" />
     <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
     <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
   </languageVersions>
@@ -46,13 +54,41 @@
     <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
     <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
     <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
+    <module reference="1ed103c3-3aa6-49b7-9c21-6765ee11f224(MPS.Editor)" version="0" />
+    <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
+    <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
+    <module reference="39983771-4e9b-401b-a1a9-1da6c777c843(MPS.ThirdParty)" version="0" />
+    <module reference="d4280a54-f6df-4383-aa41-d1b2bffa7eb1(com.mbeddr.core.base)" version="3" />
+    <module reference="2374bc90-7e37-41f1-a9c4-c2e35194c36a(com.mbeddr.doc)" version="0" />
     <module reference="4078ebaa-02fd-430a-ab03-975592a2372c(com.mbeddr.doc.test.documents)" version="0" />
+    <module reference="63e0e566-5131-447e-90e3-12ea330e1a00(com.mbeddr.mpsutil.blutil)" version="0" />
+    <module reference="d3a0fd26-445a-466c-900e-10444ddfed52(com.mbeddr.mpsutil.filepicker)" version="0" />
+    <module reference="d09a16fb-1d68-4a92-a5a4-20b4b2f86a62(com.mbeddr.mpsutil.jung)" version="0" />
+    <module reference="b4d28e19-7d2d-47e9-943e-3a41f97a0e52(com.mbeddr.mpsutil.plantuml.node)" version="0" />
+    <module reference="848ef45d-e560-4e35-853c-f35a64cc135c(de.itemis.mps.editor.celllayout.runtime)" version="0" />
+    <module reference="24c96a96-b7a1-4f30-82da-0f8e279a2661(de.itemis.mps.editor.celllayout.styles)" version="0" />
+    <module reference="5c13c612-0f7b-4f0a-ab8b-565186b418de(de.itemis.mps.mouselistener.runtime)" version="0" />
+    <module reference="cce85e64-7b37-4ad5-b0e6-9d18324cdfb3(de.itemis.mps.selection.runtime)" version="0" />
+    <module reference="dc038ceb-b7ea-4fea-ac12-55f7400e97ba(de.slisson.mps.editor.multiline.runtime)" version="0" />
+    <module reference="f0fff802-6d26-4d2e-b89d-391357265626(de.slisson.mps.hacks.editor)" version="0" />
+    <module reference="92d2ea16-5a42-4fdf-a676-c7604efe3504(de.slisson.mps.richtext)" version="0" />
     <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
+    <module reference="fd392034-7849-419d-9071-12563d152375(jetbrains.mps.baseLanguage.closures)" version="0" />
+    <module reference="83888646-71ce-4f1c-9c53-c54016f6ad4f(jetbrains.mps.baseLanguage.collections)" version="0" />
+    <module reference="daafa647-f1f7-4b0b-b096-69cd7c8408c0(jetbrains.mps.baseLanguage.regexp)" version="0" />
     <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
+    <module reference="23865718-e2ed-41b5-a132-0da1d04e266d(jetbrains.mps.ide.httpsupport.manager)" version="0" />
+    <module reference="ae6d8005-36be-4cb6-945b-8c8cfc033c51(jetbrains.mps.ide.httpsupport.runtime)" version="0" />
     <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
+    <module reference="d936855b-48da-4812-a8a0-2bfddd633ac5(jetbrains.mps.lang.behavior.api)" version="0" />
     <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
+    <module reference="446c26eb-2b7b-4bf0-9b35-f83fa582753e(jetbrains.mps.lang.modelapi)" version="0" />
+    <module reference="d7eb0a2a-bd50-4576-beae-e4a89db35f20(jetbrains.mps.lang.scopes.runtime)" version="0" />
+    <module reference="7866978e-a0f0-4cc7-81bc-4d213d9375e1(jetbrains.mps.lang.smodel)" version="1" />
+    <module reference="c72da2b9-7cce-4447-8389-f407dc1158b7(jetbrains.mps.lang.structure)" version="0" />
     <module reference="9ded098b-ad6a-4657-bfd9-48636cfe8bc3(jetbrains.mps.lang.traceable)" version="0" />
+    <module reference="b0f8641f-bd77-4421-8425-30d9088a82f7(org.apache.commons)" version="0" />
   </dependencyVersions>
 </solution>
 

--- a/code/languages/com.mbeddr.doc/solutions/com.mbeddr.doc.test.documents/models/com.mbeddr.doc.test.documents.doc_refs.mps
+++ b/code/languages/com.mbeddr.doc/solutions/com.mbeddr.doc.test.documents/models/com.mbeddr.doc.test.documents.doc_refs.mps
@@ -151,11 +151,19 @@
         </node>
       </node>
     </node>
+    <node concept="$CzcT" id="4yqSQKZfZXX" role="1_0VJ0">
+      <node concept="1_0j5j" id="4yqSQKZfZXZ" role="$CzcU">
+        <ref role="1_0j5g" to="lluw:4yqSQKZg0Sn" resolve="sub_document_forStableID" />
+      </node>
+    </node>
     <node concept="1_0j5j" id="8QSRajVLPm" role="1DXQ57">
       <ref role="1_0j5g" to="lluw:2khznRHyx6K" resolve="sub_document_2" />
     </node>
     <node concept="1_0j5j" id="8QSRajVLPQ" role="1DXQ57">
       <ref role="1_0j5g" to="lluw:2khznRHyxyJ" resolve="sub_document_3" />
+    </node>
+    <node concept="1_0j5j" id="4yqSQKZg96m" role="1DXQ57">
+      <ref role="1_0j5g" to="lluw:4yqSQKZg0Sn" resolve="sub_document_forStableID" />
     </node>
   </node>
 </model>

--- a/code/languages/com.mbeddr.doc/solutions/com.mbeddr.doc.test.documents/models/com.mbeddr.doc.test.documents.tests@tests.mps
+++ b/code/languages/com.mbeddr.doc/solutions/com.mbeddr.doc.test.documents/models/com.mbeddr.doc.test.documents.tests@tests.mps
@@ -1,0 +1,738 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:190b1a39-4ce1-4891-a558-cd7736899b32(com.mbeddr.doc.test.documents.tests@tests)">
+  <persistence version="9" />
+  <languages>
+    <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="6" />
+    <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="1" />
+    <use id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc" version="2" />
+    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
+    <use id="c7fb639f-be78-4307-89b0-b5959c3fa8c8" name="jetbrains.mps.lang.text" version="0" />
+    <use id="2dec0852-3a21-4c4e-a68c-b05236cc37f2" name="com.mbeddr.doc.gen_xhtml" version="1" />
+    <use id="479c7a8c-02f9-43b5-9139-d910cb22f298" name="jetbrains.mps.core.xml" version="0" />
+  </languages>
+  <imports>
+    <import index="lluw" ref="r:260e0933-d20e-4f4f-88cb-1c3cbbf973a8(com.mbeddr.doc.test.documents.doc2_1)" />
+    <import index="2c95" ref="r:5f7188a9-e7b4-4a2e-bef9-38d2cf379fdc(com.mbeddr.doc.structure)" />
+    <import index="4gky" ref="r:e1dfab1d-c7a7-43e7-9f26-028afd483e82(com.mbeddr.doc.behavior)" />
+    <import index="guwi" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.io(JDK/)" />
+    <import index="qajb" ref="39983771-4e9b-401b-a1a9-1da6c777c843/java:org.jsoup(MPS.ThirdParty/)" />
+    <import index="b3ru" ref="39983771-4e9b-401b-a1a9-1da6c777c843/java:org.jsoup.nodes(MPS.ThirdParty/)" />
+    <import index="btm1" ref="b0f8641f-bd77-4421-8425-30d9088a82f7/java:org.apache.commons.lang3(org.apache.commons/)" />
+    <import index="z1c3" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.project(MPS.Core/)" />
+    <import index="3ju5" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.vfs(MPS.Core/)" />
+    <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" />
+    <import index="8oaq" ref="b0f8641f-bd77-4421-8425-30d9088a82f7/java:org.apache.commons.io(org.apache.commons/)" />
+    <import index="mhbf" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.model(MPS.OpenAPI/)" implicit="true" />
+    <import index="w827" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.vfs.openapi(MPS.Core/)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
+      <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
+        <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
+      </concept>
+      <concept id="1225469856668" name="jetbrains.mps.lang.test.structure.ModelExpression" flags="nn" index="1jGwE1" />
+      <concept id="1216913645126" name="jetbrains.mps.lang.test.structure.NodesTestCase" flags="lg" index="1lH9Xt">
+        <property id="2616911529524314943" name="accessMode" index="3DII0k" />
+        <child id="1216993439383" name="methods" index="1qtyYc" />
+        <child id="1217501895093" name="testMethods" index="1SL9yI" />
+      </concept>
+      <concept id="1225978065297" name="jetbrains.mps.lang.test.structure.SimpleNodeTest" flags="ng" index="1LZb2c" />
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
+        <child id="1145553007750" name="creator" index="2ShVmc" />
+      </concept>
+      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
+        <property id="1070475926801" name="value" index="Xl_RC" />
+      </concept>
+      <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
+        <reference id="1144433194310" name="classConcept" index="1Pybhc" />
+      </concept>
+      <concept id="1164991038168" name="jetbrains.mps.baseLanguage.structure.ThrowStatement" flags="nn" index="YS8fn">
+        <child id="1164991057263" name="throwable" index="YScLw" />
+      </concept>
+      <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
+      <concept id="1070534934090" name="jetbrains.mps.baseLanguage.structure.CastExpression" flags="nn" index="10QFUN">
+        <child id="1070534934091" name="type" index="10QFUM" />
+        <child id="1070534934092" name="expression" index="10QFUP" />
+      </concept>
+      <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
+        <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ngI" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
+      </concept>
+      <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
+        <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
+      </concept>
+      <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
+      <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
+      <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
+        <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
+      <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
+        <child id="1164879685961" name="throwsItem" index="Sfmx6" />
+        <child id="1068580123133" name="returnType" index="3clF45" />
+        <child id="1068580123134" name="parameter" index="3clF46" />
+        <child id="1068580123135" name="body" index="3clF47" />
+      </concept>
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
+        <child id="1068580123160" name="condition" index="3clFbw" />
+        <child id="1068580123161" name="ifTrue" index="3clFbx" />
+      </concept>
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
+      <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
+        <child id="1068581517676" name="expression" index="3cqZAk" />
+      </concept>
+      <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
+        <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
+      </concept>
+      <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
+      <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
+      </concept>
+      <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk" />
+      <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
+        <reference id="1107535924139" name="classifier" index="3uigEE" />
+      </concept>
+      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
+        <child id="1081773367579" name="rightExpression" index="3uHU7w" />
+        <child id="1081773367580" name="leftExpression" index="3uHU7B" />
+      </concept>
+      <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
+      <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="nn" index="3SKdUt">
+        <child id="8356039341262087992" name="line" index="1aUNEU" />
+      </concept>
+      <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
+    </language>
+    <language id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc">
+      <concept id="5349172909345501395" name="jetbrains.mps.baseLanguage.javadoc.structure.BaseDocComment" flags="ng" index="P$AiS">
+        <child id="8465538089690331502" name="body" index="TZ5H$" />
+      </concept>
+      <concept id="5349172909345532724" name="jetbrains.mps.baseLanguage.javadoc.structure.MethodDocComment" flags="ng" index="P$JXv" />
+      <concept id="8465538089690331500" name="jetbrains.mps.baseLanguage.javadoc.structure.CommentLine" flags="ng" index="TZ5HA">
+        <child id="8970989240999019149" name="part" index="1dT_Ay" />
+      </concept>
+      <concept id="8970989240999019143" name="jetbrains.mps.baseLanguage.javadoc.structure.TextCommentLinePart" flags="ng" index="1dT_AC">
+        <property id="8970989240999019144" name="text" index="1dT_AB" />
+      </concept>
+    </language>
+    <language id="443f4c36-fcf5-4eb6-9500-8d06ed259e3e" name="jetbrains.mps.baseLanguage.classifiers">
+      <concept id="1205752633985" name="jetbrains.mps.baseLanguage.classifiers.structure.ThisClassifierExpression" flags="nn" index="2WthIp" />
+      <concept id="1205756064662" name="jetbrains.mps.baseLanguage.classifiers.structure.IMemberOperation" flags="ngI" index="2WEnae">
+        <reference id="1205756909548" name="member" index="2WH_rO" />
+      </concept>
+      <concept id="1205769003971" name="jetbrains.mps.baseLanguage.classifiers.structure.DefaultClassifierMethodDeclaration" flags="ng" index="2XrIbr" />
+      <concept id="1205769149993" name="jetbrains.mps.baseLanguage.classifiers.structure.DefaultClassifierMethodCallOperation" flags="nn" index="2XshWL">
+        <child id="1205770614681" name="actualArgument" index="2XxRq1" />
+      </concept>
+    </language>
+    <language id="446c26eb-2b7b-4bf0-9b35-f83fa582753e" name="jetbrains.mps.lang.modelapi">
+      <concept id="4733039728785194814" name="jetbrains.mps.lang.modelapi.structure.NamedNodeReference" flags="ng" index="ZC_QK">
+        <reference id="7256306938026143658" name="target" index="2aWVGs" />
+        <child id="7256306938026143676" name="child" index="2aWVGa" />
+      </concept>
+    </language>
+    <language id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest">
+      <concept id="8427750732757990717" name="jetbrains.mps.baseLanguage.unitTest.structure.BinaryAssert" flags="nn" index="3tpDYu">
+        <child id="8427750732757990725" name="actual" index="3tpDZA" />
+        <child id="8427750732757990724" name="expected" index="3tpDZB" />
+      </concept>
+      <concept id="1171978097730" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertEquals" flags="nn" index="3vlDli" />
+      <concept id="1171981022339" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertTrue" flags="nn" index="3vwNmj">
+        <child id="1171981057159" name="condition" index="3vwVQn" />
+      </concept>
+      <concept id="1172073500303" name="jetbrains.mps.baseLanguage.unitTest.structure.Message" flags="ng" index="3_1$Yv">
+        <child id="1172073511101" name="message" index="3_1BAH" />
+      </concept>
+      <concept id="1172075514136" name="jetbrains.mps.baseLanguage.unitTest.structure.MessageHolder" flags="ngI" index="3_9gw8">
+        <child id="1172075534298" name="message" index="3_9lra" />
+      </concept>
+    </language>
+    <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="7400021826774799413" name="jetbrains.mps.lang.smodel.structure.NodePointerExpression" flags="ng" index="2tJFMh">
+        <child id="7400021826774799510" name="ref" index="2tJFKM" />
+      </concept>
+      <concept id="4065387505485742749" name="jetbrains.mps.lang.smodel.structure.AbstractPointerResolveOperation" flags="ng" index="2yCiFS">
+        <child id="3648723375513868575" name="repositoryArg" index="Vysub" />
+      </concept>
+      <concept id="1143234257716" name="jetbrains.mps.lang.smodel.structure.Node_GetModelOperation" flags="nn" index="I4A8Y" />
+      <concept id="1145404486709" name="jetbrains.mps.lang.smodel.structure.SemanticDowncastExpression" flags="nn" index="2JrnkZ">
+        <child id="1145404616321" name="leftExpression" index="2JrQYb" />
+      </concept>
+      <concept id="3648723375513868532" name="jetbrains.mps.lang.smodel.structure.NodePointer_ResolveOperation" flags="ng" index="Vyspw" />
+      <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
+        <reference id="1138405853777" name="concept" index="ehGHo" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+    <language id="c7fb639f-be78-4307-89b0-b5959c3fa8c8" name="jetbrains.mps.lang.text">
+      <concept id="155656958578482948" name="jetbrains.mps.lang.text.structure.Word" flags="nn" index="3oM_SD">
+        <property id="155656958578482949" name="value" index="3oM_SC" />
+      </concept>
+      <concept id="2535923850359271782" name="jetbrains.mps.lang.text.structure.Line" flags="nn" index="1PaTwC">
+        <child id="2535923850359271783" name="elements" index="1PaTwD" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="1lH9Xt" id="4yqSQKZiyMZ">
+    <property role="3DII0k" value="2hh8MJdVwqX/command" />
+    <property role="TrG5h" value="StableIDTest" />
+    <node concept="2XrIbr" id="4yqSQKZk3Mg" role="1qtyYc">
+      <property role="TrG5h" value="sectionInQuestion" />
+      <node concept="3Tqbb2" id="4yqSQKZk3MY" role="3clF45">
+        <ref role="ehGHo" to="2c95:2TZO3Dbv6N7" resolve="Section" />
+      </node>
+      <node concept="3clFbS" id="4yqSQKZk3Mi" role="3clF47">
+        <node concept="3clFbF" id="4yqSQKZk3Ow" role="3cqZAp">
+          <node concept="2OqwBi" id="4yqSQKZk3Oy" role="3clFbG">
+            <node concept="2tJFMh" id="4yqSQKZk3Oz" role="2Oq$k0">
+              <node concept="ZC_QK" id="4yqSQKZk3O$" role="2tJFKM">
+                <ref role="2aWVGs" to="lluw:4yqSQKZg0Sn" resolve="sub_document_forStableID" />
+                <node concept="ZC_QK" id="4yqSQKZk3O_" role="2aWVGa">
+                  <ref role="2aWVGs" to="lluw:4yqSQKZg3eo" resolve="sectionSHouldHaveStableId" />
+                </node>
+              </node>
+            </node>
+            <node concept="Vyspw" id="4yqSQKZk3OA" role="2OqNvi">
+              <node concept="2OqwBi" id="4yqSQKZk3OB" role="Vysub">
+                <node concept="2JrnkZ" id="4yqSQKZk3OC" role="2Oq$k0">
+                  <node concept="1jGwE1" id="4yqSQKZk3OD" role="2JrQYb" />
+                </node>
+                <node concept="liA8E" id="4yqSQKZk3OE" role="2OqNvi">
+                  <ref role="37wK5l" to="mhbf:~SModel.getRepository()" resolve="getRepository" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2XrIbr" id="1Q6TvmyDFHY" role="1qtyYc">
+      <property role="TrG5h" value="getModuleRelativePath" />
+      <node concept="3uibUv" id="1Q6TvmyDHjH" role="3clF45">
+        <ref role="3uigEE" to="3ju5:~IFile" resolve="IFile" />
+      </node>
+      <node concept="3clFbS" id="1Q6TvmyDFI0" role="3clF47">
+        <node concept="3clFbJ" id="1Q6TvmyDI4E" role="3cqZAp">
+          <node concept="3y3z36" id="1Q6TvmyDIC3" role="3clFbw">
+            <node concept="10Nm6u" id="1Q6TvmyDJ11" role="3uHU7w" />
+            <node concept="2OqwBi" id="1Q6TvmyEggG" role="3uHU7B">
+              <node concept="37vLTw" id="1Q6TvmyDI4N" role="2Oq$k0">
+                <ref role="3cqZAo" node="1Q6TvmyDI4h" resolve="module" />
+              </node>
+              <node concept="liA8E" id="1Q6TvmyEhpV" role="2OqNvi">
+                <ref role="37wK5l" to="z1c3:~AbstractModule.getModuleSourceDir()" resolve="getModuleSourceDir" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbS" id="1Q6TvmyDI4G" role="3clFbx">
+            <node concept="3SKdUt" id="1Q6TvmyEeXH" role="3cqZAp">
+              <node concept="1PaTwC" id="1Q6TvmyEeXI" role="1aUNEU">
+                <node concept="3oM_SD" id="1Q6TvmyEfFD" role="1PaTwD">
+                  <property role="3oM_SC" value="module" />
+                </node>
+                <node concept="3oM_SD" id="1Q6TvmyEfFE" role="1PaTwD">
+                  <property role="3oM_SC" value="placed" />
+                </node>
+                <node concept="3oM_SD" id="1Q6TvmyEfFF" role="1PaTwD">
+                  <property role="3oM_SC" value="inside" />
+                </node>
+                <node concept="3oM_SD" id="1Q6TvmyEfFG" role="1PaTwD">
+                  <property role="3oM_SC" value=".jar" />
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs8" id="1Q6TvmyKgmS" role="3cqZAp">
+              <node concept="3cpWsn" id="1Q6TvmyKgmT" role="3cpWs9">
+                <property role="TrG5h" value="bundledHome" />
+                <node concept="3uibUv" id="1Q6TvmyKcjJ" role="1tU5fm">
+                  <ref role="3uigEE" to="3ju5:~IFile" resolve="IFile" />
+                </node>
+                <node concept="2OqwBi" id="1Q6TvmyKgmU" role="33vP2m">
+                  <node concept="2OqwBi" id="1Q6TvmyKgmV" role="2Oq$k0">
+                    <node concept="37vLTw" id="1Q6TvmyKgmW" role="2Oq$k0">
+                      <ref role="3cqZAo" node="1Q6TvmyDI4h" resolve="module" />
+                    </node>
+                    <node concept="liA8E" id="1Q6TvmyKgmX" role="2OqNvi">
+                      <ref role="37wK5l" to="z1c3:~AbstractModule.getModuleSourceDir()" resolve="getModuleSourceDir" />
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="1Q6TvmyKgmY" role="2OqNvi">
+                    <ref role="37wK5l" to="3ju5:~IFile.getBundleHome()" resolve="getBundleHome" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbJ" id="1Q6TvmyDJ1j" role="3cqZAp">
+              <node concept="1Wc70l" id="1Q6TvmyDPH8" role="3clFbw">
+                <node concept="3y3z36" id="1Q6TvmyDU9g" role="3uHU7w">
+                  <node concept="10Nm6u" id="1Q6TvmyDUdF" role="3uHU7w" />
+                  <node concept="37vLTw" id="1Q6TvmyKgmZ" role="3uHU7B">
+                    <ref role="3cqZAo" node="1Q6TvmyKgmT" resolve="bundledHome" />
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="1Q6TvmyDJ1E" role="3uHU7B">
+                  <node concept="37vLTw" id="1Q6TvmyDJ1s" role="2Oq$k0">
+                    <ref role="3cqZAo" node="1Q6TvmyDI4h" resolve="module" />
+                  </node>
+                  <node concept="liA8E" id="1Q6TvmyDNgh" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~AbstractModule.isPackaged()" resolve="isPackaged" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbS" id="1Q6TvmyDJ1l" role="3clFbx">
+                <node concept="3SKdUt" id="1Q6Tvmz2u2j" role="3cqZAp">
+                  <node concept="1PaTwC" id="1Q6Tvmz2u2k" role="1aUNEU">
+                    <node concept="3oM_SD" id="1Q6Tvmz2uch" role="1PaTwD">
+                      <property role="3oM_SC" value="usage" />
+                    </node>
+                    <node concept="3oM_SD" id="1Q6Tvmz2uci" role="1PaTwD">
+                      <property role="3oM_SC" value="of" />
+                    </node>
+                    <node concept="3oM_SD" id="1Q6Tvmz2ucj" role="1PaTwD">
+                      <property role="3oM_SC" value="non" />
+                    </node>
+                    <node concept="3oM_SD" id="1Q6Tvmz2uck" role="1PaTwD">
+                      <property role="3oM_SC" value="deprecated" />
+                    </node>
+                    <node concept="3oM_SD" id="1Q6Tvmz2ucl" role="1PaTwD">
+                      <property role="3oM_SC" value="API" />
+                    </node>
+                    <node concept="3oM_SD" id="1Q6Tvmz2uco" role="1PaTwD">
+                      <property role="3oM_SC" value="is" />
+                    </node>
+                    <node concept="3oM_SD" id="1Q6Tvmz2ucp" role="1PaTwD">
+                      <property role="3oM_SC" value="not" />
+                    </node>
+                    <node concept="3oM_SD" id="1Q6Tvmz2ucq" role="1PaTwD">
+                      <property role="3oM_SC" value="able" />
+                    </node>
+                    <node concept="3oM_SD" id="1Q6Tvmz2ucr" role="1PaTwD">
+                      <property role="3oM_SC" value="to" />
+                    </node>
+                    <node concept="3oM_SD" id="1Q6Tvmz2ucs" role="1PaTwD">
+                      <property role="3oM_SC" value="locate" />
+                    </node>
+                    <node concept="3oM_SD" id="1Q6Tvmz2uct" role="1PaTwD">
+                      <property role="3oM_SC" value="files" />
+                    </node>
+                    <node concept="3oM_SD" id="1Q6Tvmz2ucu" role="1PaTwD">
+                      <property role="3oM_SC" value="inside" />
+                    </node>
+                    <node concept="3oM_SD" id="1Q6Tvmz2ucv" role="1PaTwD">
+                      <property role="3oM_SC" value=".jars" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3cpWs8" id="1Q6TvmyF1Ii" role="3cqZAp">
+                  <node concept="3cpWsn" id="1Q6TvmyF1Ij" role="3cpWs9">
+                    <property role="TrG5h" value="file" />
+                    <node concept="3uibUv" id="1Q6TvmyF1p4" role="1tU5fm">
+                      <ref role="3uigEE" to="3ju5:~IFile" resolve="IFile" />
+                    </node>
+                    <node concept="2OqwBi" id="1Q6TvmyF1Ik" role="33vP2m">
+                      <node concept="2OqwBi" id="1Q6TvmyF1Il" role="2Oq$k0">
+                        <node concept="37vLTw" id="1Q6TvmyF1Im" role="2Oq$k0">
+                          <ref role="3cqZAo" node="1Q6TvmyKgmT" resolve="bundledHome" />
+                        </node>
+                        <node concept="liA8E" id="1Q6TvmyF1In" role="2OqNvi">
+                          <ref role="37wK5l" to="3ju5:~IFile.getFileSystem()" resolve="getFileSystem" />
+                        </node>
+                      </node>
+                      <node concept="liA8E" id="1Q6TvmyF1Io" role="2OqNvi">
+                        <ref role="37wK5l" to="w827:~FileSystem.getFile(java.lang.String)" resolve="getFile" />
+                        <node concept="3cpWs3" id="1Q6TvmyF1Ip" role="37wK5m">
+                          <node concept="37vLTw" id="1Q6TvmyF1Iq" role="3uHU7w">
+                            <ref role="3cqZAo" node="1Q6TvmyDI4n" resolve="path" />
+                          </node>
+                          <node concept="3cpWs3" id="1Q6TvmyF1Ir" role="3uHU7B">
+                            <node concept="2OqwBi" id="1Q6TvmyF1Is" role="3uHU7B">
+                              <node concept="37vLTw" id="1Q6TvmyF1It" role="2Oq$k0">
+                                <ref role="3cqZAo" node="1Q6TvmyKgmT" resolve="bundledHome" />
+                              </node>
+                              <node concept="liA8E" id="1Q6TvmyF1Iu" role="2OqNvi">
+                                <ref role="37wK5l" to="3ju5:~IFile.getPath()" resolve="getPath" />
+                              </node>
+                            </node>
+                            <node concept="Xl_RD" id="1Q6TvmyF1Iv" role="3uHU7w">
+                              <property role="Xl_RC" value="!/" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3cpWs6" id="1Q6TvmyETyC" role="3cqZAp">
+                  <node concept="37vLTw" id="1Q6TvmyF1Iw" role="3cqZAk">
+                    <ref role="3cqZAo" node="1Q6TvmyF1Ij" resolve="file" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs8" id="1Q6TvmyEjHE" role="3cqZAp">
+              <node concept="3cpWsn" id="1Q6TvmyEjHF" role="3cpWs9">
+                <property role="TrG5h" value="relative" />
+                <node concept="3uibUv" id="1Q6TvmyEjH3" role="1tU5fm">
+                  <ref role="3uigEE" to="3ju5:~IFile" resolve="IFile" />
+                </node>
+                <node concept="2OqwBi" id="1Q6TvmyEjHG" role="33vP2m">
+                  <node concept="2OqwBi" id="1Q6TvmyEjHH" role="2Oq$k0">
+                    <node concept="37vLTw" id="1Q6TvmyEjHI" role="2Oq$k0">
+                      <ref role="3cqZAo" node="1Q6TvmyDI4h" resolve="module" />
+                    </node>
+                    <node concept="liA8E" id="1Q6TvmyEjHJ" role="2OqNvi">
+                      <ref role="37wK5l" to="z1c3:~AbstractModule.getModuleSourceDir()" resolve="getModuleSourceDir" />
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="1Q6TvmyEjHK" role="2OqNvi">
+                    <ref role="37wK5l" to="3ju5:~IFile.getDescendant(java.lang.String)" resolve="getDescendant" />
+                    <node concept="37vLTw" id="1Q6TvmyEjHL" role="37wK5m">
+                      <ref role="3cqZAo" node="1Q6TvmyDI4n" resolve="path" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs6" id="1Q6TvmyEka2" role="3cqZAp">
+              <node concept="37vLTw" id="1Q6TvmyEka4" role="3cqZAk">
+                <ref role="3cqZAo" node="1Q6TvmyEjHF" resolve="relative" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="YS8fn" id="1Q6TvmyEkmi" role="3cqZAp">
+          <node concept="2ShNRf" id="1Q6TvmyEkmm" role="YScLw">
+            <node concept="1pGfFk" id="1Q6TvmyEmDW" role="2ShVmc">
+              <property role="373rjd" value="true" />
+              <ref role="37wK5l" to="wyt6:~RuntimeException.&lt;init&gt;(java.lang.String)" resolve="RuntimeException" />
+              <node concept="Xl_RD" id="1Q6TvmyEmNf" role="37wK5m">
+                <property role="Xl_RC" value="Module does not have src dir" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="1Q6TvmyDI4h" role="3clF46">
+        <property role="TrG5h" value="module" />
+        <node concept="3uibUv" id="1Q6TvmyDI4g" role="1tU5fm">
+          <ref role="3uigEE" to="z1c3:~AbstractModule" resolve="AbstractModule" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="1Q6TvmyDI4n" role="3clF46">
+        <property role="TrG5h" value="path" />
+        <node concept="17QB3L" id="1Q6TvmyDI4x" role="1tU5fm" />
+      </node>
+    </node>
+    <node concept="2XrIbr" id="4yqSQKZlizU" role="1qtyYc">
+      <property role="TrG5h" value="sectionStableID" />
+      <node concept="17QB3L" id="4yqSQKZliUb" role="3clF45" />
+      <node concept="3clFbS" id="4yqSQKZlizW" role="3clF47">
+        <node concept="3clFbF" id="4yqSQKZliUd" role="3cqZAp">
+          <node concept="2YIFZM" id="4yqSQKZliUf" role="3clFbG">
+            <ref role="37wK5l" to="4gky:6jiGbW_zIQb" resolve="getStableId" />
+            <ref role="1Pybhc" to="4gky:6jiGbW_zIPK" resolve="StableIdHelper" />
+            <node concept="2OqwBi" id="4yqSQKZljGT" role="37wK5m">
+              <node concept="2WthIp" id="4yqSQKZljGW" role="2Oq$k0" />
+              <node concept="2XshWL" id="4yqSQKZljGY" role="2OqNvi">
+                <ref role="2WH_rO" node="4yqSQKZk3Mg" resolve="sectionInQuestion" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="4yqSQKZiyP$" role="1SL9yI">
+      <property role="TrG5h" value="CheckStableIDsCalculation" />
+      <node concept="3cqZAl" id="4yqSQKZiyP_" role="3clF45" />
+      <node concept="3clFbS" id="4yqSQKZiyPD" role="3clF47">
+        <node concept="3cpWs8" id="4yqSQKZiJ7H" role="3cqZAp">
+          <node concept="3cpWsn" id="4yqSQKZiJ7I" role="3cpWs9">
+            <property role="TrG5h" value="section" />
+            <node concept="3Tqbb2" id="4yqSQKZiJ7A" role="1tU5fm">
+              <ref role="ehGHo" to="2c95:2TZO3Dbv6N7" resolve="Section" />
+            </node>
+            <node concept="2OqwBi" id="4yqSQKZk3Sg" role="33vP2m">
+              <node concept="2WthIp" id="4yqSQKZk3Sj" role="2Oq$k0" />
+              <node concept="2XshWL" id="4yqSQKZk3Sl" role="2OqNvi">
+                <ref role="2WH_rO" node="4yqSQKZk3Mg" resolve="sectionInQuestion" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="4yqSQKZiQem" role="3cqZAp">
+          <node concept="3cpWsn" id="4yqSQKZiQep" role="3cpWs9">
+            <property role="TrG5h" value="expected" />
+            <node concept="17QB3L" id="4yqSQKZiQek" role="1tU5fm" />
+            <node concept="3cpWs3" id="4yqSQKZlbFJ" role="33vP2m">
+              <node concept="Xl_RD" id="4yqSQKZiQgt" role="3uHU7B">
+                <property role="Xl_RC" value="sid" />
+              </node>
+              <node concept="2YIFZM" id="73FPRWNYEmy" role="3uHU7w">
+                <ref role="37wK5l" to="btm1:~StringUtils.deleteWhitespace(java.lang.String)" resolve="deleteWhitespace" />
+                <ref role="1Pybhc" to="btm1:~StringUtils" resolve="StringUtils" />
+                <node concept="2OqwBi" id="73FPRWNYEmz" role="37wK5m">
+                  <node concept="2OqwBi" id="73FPRWNYEm$" role="2Oq$k0">
+                    <node concept="2JrnkZ" id="73FPRWNYEm_" role="2Oq$k0">
+                      <node concept="37vLTw" id="73FPRWNYEmA" role="2JrQYb">
+                        <ref role="3cqZAo" node="4yqSQKZiJ7I" resolve="section" />
+                      </node>
+                    </node>
+                    <node concept="liA8E" id="73FPRWNYEmB" role="2OqNvi">
+                      <ref role="37wK5l" to="mhbf:~SNode.getNodeId()" resolve="getNodeId" />
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="73FPRWNYEmC" role="2OqNvi">
+                    <ref role="37wK5l" to="wyt6:~Object.toString()" resolve="toString" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3vlDli" id="4yqSQKZiQtK" role="3cqZAp">
+          <node concept="37vLTw" id="4yqSQKZiQuG" role="3tpDZB">
+            <ref role="3cqZAo" node="4yqSQKZiQep" resolve="expected" />
+          </node>
+          <node concept="2YIFZM" id="4yqSQKZiRQU" role="3tpDZA">
+            <ref role="37wK5l" to="4gky:6jiGbW_zIQb" resolve="getStableId" />
+            <ref role="1Pybhc" to="4gky:6jiGbW_zIPK" resolve="StableIdHelper" />
+            <node concept="37vLTw" id="4yqSQKZiRRN" role="37wK5m">
+              <ref role="3cqZAo" node="4yqSQKZiJ7I" resolve="section" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="P$JXv" id="4yqSQKZiJtc" role="lGtFl">
+        <node concept="TZ5HA" id="4yqSQKZiJtd" role="TZ5H$">
+          <node concept="1dT_AC" id="4yqSQKZiJte" role="1dT_Ay">
+            <property role="1dT_AB" value="It is important that the target node lives outside of the test model, because the" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="4yqSQKZiJu5" role="TZ5H$">
+          <node concept="1dT_AC" id="4yqSQKZiJu6" role="1dT_Ay">
+            <property role="1dT_AB" value="content of the test model is copied into the transient model and Node-IDs would change otherwise." />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="4yqSQKZkZX9" role="1SL9yI">
+      <property role="TrG5h" value="checkMainDocHTMLFileIsGenerated" />
+      <node concept="3cqZAl" id="4yqSQKZkZXa" role="3clF45" />
+      <node concept="3clFbS" id="4yqSQKZkZXe" role="3clF47">
+        <node concept="3cpWs8" id="1Q6TvmyTU$Q" role="3cqZAp">
+          <node concept="3cpWsn" id="1Q6TvmyTU$R" role="3cpWs9">
+            <property role="TrG5h" value="file" />
+            <node concept="3uibUv" id="1Q6TvmyTtYj" role="1tU5fm">
+              <ref role="3uigEE" to="3ju5:~IFile" resolve="IFile" />
+            </node>
+            <node concept="2OqwBi" id="1Q6TvmyTU$S" role="33vP2m">
+              <node concept="2WthIp" id="1Q6TvmyTU$T" role="2Oq$k0" />
+              <node concept="2XshWL" id="1Q6TvmyTU$U" role="2OqNvi">
+                <ref role="2WH_rO" node="1Q6TvmyDFHY" resolve="getModuleRelativePath" />
+                <node concept="10QFUN" id="1Q6TvmyTU$V" role="2XxRq1">
+                  <node concept="3uibUv" id="1Q6TvmyTU$W" role="10QFUM">
+                    <ref role="3uigEE" to="z1c3:~AbstractModule" resolve="AbstractModule" />
+                  </node>
+                  <node concept="2OqwBi" id="1Q6TvmyTU$X" role="10QFUP">
+                    <node concept="2JrnkZ" id="1Q6TvmyTU$Y" role="2Oq$k0">
+                      <node concept="2OqwBi" id="1Q6TvmyTU$Z" role="2JrQYb">
+                        <node concept="2OqwBi" id="1Q6TvmyTU_0" role="2Oq$k0">
+                          <node concept="2WthIp" id="1Q6TvmyTU_1" role="2Oq$k0" />
+                          <node concept="2XshWL" id="1Q6TvmyTU_2" role="2OqNvi">
+                            <ref role="2WH_rO" node="4yqSQKZk3Mg" resolve="sectionInQuestion" />
+                          </node>
+                        </node>
+                        <node concept="I4A8Y" id="1Q6TvmyTU_3" role="2OqNvi" />
+                      </node>
+                    </node>
+                    <node concept="liA8E" id="1Q6TvmyTU_4" role="2OqNvi">
+                      <ref role="37wK5l" to="mhbf:~SModel.getModule()" resolve="getModule" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="Xl_RD" id="1Q6TvmyTU_5" role="2XxRq1">
+                  <property role="Xl_RC" value="doc_gen/com/mbeddr/doc/test/documents/doc_refs/MainDoc.html" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3vwNmj" id="4yqSQKZl00e" role="3cqZAp">
+          <node concept="2OqwBi" id="1Q6TvmyJHli" role="3vwVQn">
+            <node concept="37vLTw" id="1Q6TvmyWXkj" role="2Oq$k0">
+              <ref role="3cqZAo" node="1Q6TvmyTU$R" resolve="file" />
+            </node>
+            <node concept="liA8E" id="1Q6TvmyJHlx" role="2OqNvi">
+              <ref role="37wK5l" to="3ju5:~IFile.exists()" resolve="exists" />
+            </node>
+          </node>
+          <node concept="3_1$Yv" id="4yqSQKZl00i" role="3_9lra">
+            <node concept="3cpWs3" id="1Q6TvmyTXgR" role="3_1BAH">
+              <node concept="2OqwBi" id="1Q6TvmyTY8j" role="3uHU7w">
+                <node concept="37vLTw" id="1Q6TvmyTXyx" role="2Oq$k0">
+                  <ref role="3cqZAo" node="1Q6TvmyTU$R" resolve="file" />
+                </node>
+                <node concept="liA8E" id="1Q6TvmyTYAE" role="2OqNvi">
+                  <ref role="37wK5l" to="3ju5:~IFile.getPath()" resolve="getPath" />
+                </node>
+              </node>
+              <node concept="Xl_RD" id="4yqSQKZl00j" role="3uHU7B">
+                <property role="Xl_RC" value="No generated HTML file found under " />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3uibUv" id="1Q6TvmyZlke" role="Sfmx6">
+        <ref role="3uigEE" to="guwi:~IOException" resolve="IOException" />
+      </node>
+    </node>
+    <node concept="1LZb2c" id="4yqSQKZjZ1j" role="1SL9yI">
+      <property role="TrG5h" value="checkForStableIDInHtmlFile" />
+      <node concept="3cqZAl" id="4yqSQKZjZ1k" role="3clF45" />
+      <node concept="3clFbS" id="4yqSQKZjZ1o" role="3clF47">
+        <node concept="3cpWs8" id="1Q6Tvmz1R2W" role="3cqZAp">
+          <node concept="3cpWsn" id="1Q6Tvmz1R2X" role="3cpWs9">
+            <property role="TrG5h" value="file" />
+            <node concept="3uibUv" id="1Q6Tvmz1PFt" role="1tU5fm">
+              <ref role="3uigEE" to="3ju5:~IFile" resolve="IFile" />
+            </node>
+            <node concept="2OqwBi" id="1Q6Tvmz1R2Y" role="33vP2m">
+              <node concept="2WthIp" id="1Q6Tvmz1R2Z" role="2Oq$k0" />
+              <node concept="2XshWL" id="1Q6Tvmz1R30" role="2OqNvi">
+                <ref role="2WH_rO" node="1Q6TvmyDFHY" resolve="getModuleRelativePath" />
+                <node concept="10QFUN" id="1Q6Tvmz1R31" role="2XxRq1">
+                  <node concept="3uibUv" id="1Q6Tvmz1R32" role="10QFUM">
+                    <ref role="3uigEE" to="z1c3:~AbstractModule" resolve="AbstractModule" />
+                  </node>
+                  <node concept="2OqwBi" id="1Q6Tvmz1R33" role="10QFUP">
+                    <node concept="2JrnkZ" id="1Q6Tvmz1R34" role="2Oq$k0">
+                      <node concept="2OqwBi" id="1Q6Tvmz1R35" role="2JrQYb">
+                        <node concept="2OqwBi" id="1Q6Tvmz1R36" role="2Oq$k0">
+                          <node concept="2WthIp" id="1Q6Tvmz1R37" role="2Oq$k0" />
+                          <node concept="2XshWL" id="1Q6Tvmz1R38" role="2OqNvi">
+                            <ref role="2WH_rO" node="4yqSQKZk3Mg" resolve="sectionInQuestion" />
+                          </node>
+                        </node>
+                        <node concept="I4A8Y" id="1Q6Tvmz1R39" role="2OqNvi" />
+                      </node>
+                    </node>
+                    <node concept="liA8E" id="1Q6Tvmz1R3a" role="2OqNvi">
+                      <ref role="37wK5l" to="mhbf:~SModel.getModule()" resolve="getModule" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="Xl_RD" id="1Q6Tvmz1R3b" role="2XxRq1">
+                  <property role="Xl_RC" value="doc_gen/com/mbeddr/doc/test/documents/doc_refs/MainDoc.html" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="4yqSQKZl6vB" role="3cqZAp">
+          <node concept="3cpWsn" id="4yqSQKZl6vC" role="3cpWs9">
+            <property role="TrG5h" value="mainDoc" />
+            <node concept="3uibUv" id="4yqSQKZl6hV" role="1tU5fm">
+              <ref role="3uigEE" to="b3ru:~Document" resolve="Document" />
+            </node>
+            <node concept="2YIFZM" id="1Q6Tvmz2c42" role="33vP2m">
+              <ref role="37wK5l" to="qajb:~Jsoup.parse(java.io.InputStream,java.lang.String,java.lang.String)" resolve="parse" />
+              <ref role="1Pybhc" to="qajb:~Jsoup" resolve="Jsoup" />
+              <node concept="2OqwBi" id="1Q6Tvmz2c43" role="37wK5m">
+                <node concept="37vLTw" id="1Q6Tvmz2c44" role="2Oq$k0">
+                  <ref role="3cqZAo" node="1Q6Tvmz1R2X" resolve="file" />
+                </node>
+                <node concept="liA8E" id="1Q6Tvmz2c45" role="2OqNvi">
+                  <ref role="37wK5l" to="3ju5:~IFile.openInputStream()" resolve="openInputStream" />
+                </node>
+              </node>
+              <node concept="Xl_RD" id="1Q6Tvmz2hC7" role="37wK5m">
+                <property role="Xl_RC" value="UTF-8" />
+              </node>
+              <node concept="Xl_RD" id="1Q6Tvmz2eNz" role="37wK5m">
+                <property role="Xl_RC" value="" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3vwNmj" id="1Q6Tvmz2pmG" role="3cqZAp">
+          <node concept="3y3z36" id="1Q6Tvmz2qh$" role="3vwVQn">
+            <node concept="10Nm6u" id="1Q6Tvmz2qtT" role="3uHU7w" />
+            <node concept="37vLTw" id="1Q6Tvmz2pqI" role="3uHU7B">
+              <ref role="3cqZAo" node="4yqSQKZl6vC" resolve="mainDoc" />
+            </node>
+          </node>
+          <node concept="3_1$Yv" id="1Q6Tvmz2qDM" role="3_9lra">
+            <node concept="Xl_RD" id="1Q6Tvmz2qHm" role="3_1BAH">
+              <property role="Xl_RC" value="No JSoup document found" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="4yqSQKZll0y" role="3cqZAp">
+          <node concept="3cpWsn" id="4yqSQKZll0z" role="3cpWs9">
+            <property role="TrG5h" value="sectionHeader" />
+            <node concept="3uibUv" id="4yqSQKZlkJe" role="1tU5fm">
+              <ref role="3uigEE" to="b3ru:~Element" resolve="Element" />
+            </node>
+            <node concept="2OqwBi" id="4yqSQKZll0$" role="33vP2m">
+              <node concept="37vLTw" id="4yqSQKZll0_" role="2Oq$k0">
+                <ref role="3cqZAo" node="4yqSQKZl6vC" resolve="mainDoc" />
+              </node>
+              <node concept="liA8E" id="4yqSQKZll0A" role="2OqNvi">
+                <ref role="37wK5l" to="b3ru:~Element.getElementById(java.lang.String)" resolve="getElementById" />
+                <node concept="2OqwBi" id="4yqSQKZll0B" role="37wK5m">
+                  <node concept="2WthIp" id="4yqSQKZll0C" role="2Oq$k0" />
+                  <node concept="2XshWL" id="4yqSQKZll0D" role="2OqNvi">
+                    <ref role="2WH_rO" node="4yqSQKZlizU" resolve="sectionStableID" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3vwNmj" id="4yqSQKZllD2" role="3cqZAp">
+          <node concept="3y3z36" id="4yqSQKZlmmt" role="3vwVQn">
+            <node concept="10Nm6u" id="4yqSQKZlmvE" role="3uHU7w" />
+            <node concept="37vLTw" id="4yqSQKZllEW" role="3uHU7B">
+              <ref role="3cqZAo" node="4yqSQKZll0z" resolve="sectionHeader" />
+            </node>
+          </node>
+          <node concept="3_1$Yv" id="5CV8POq$0yx" role="3_9lra">
+            <node concept="Xl_RD" id="5CV8POq$1tK" role="3_1BAH">
+              <property role="Xl_RC" value="No stable ID found for header" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3uibUv" id="4yqSQKZl6g0" role="Sfmx6">
+        <ref role="3uigEE" to="guwi:~IOException" resolve="IOException" />
+      </node>
+    </node>
+  </node>
+  <node concept="2XOHcx" id="4yqSQKZiyOb">
+    <property role="2XOHcw" value="${mbeddr.github.core.home}/code/languages/com.mbeddr.doc" />
+  </node>
+</model>
+

--- a/code/languages/com.mbeddr.doc/solutions/com.mbeddr.doc.test.documents/models/com.mbeddr.doc.test.documents.transitiveIncludes.mps
+++ b/code/languages/com.mbeddr.doc/solutions/com.mbeddr.doc.test.documents/models/com.mbeddr.doc.test.documents.transitiveIncludes.mps
@@ -5,7 +5,6 @@
     <use id="2dec0852-3a21-4c4e-a68c-b05236cc37f2" name="com.mbeddr.doc.gen_xhtml" version="1" />
     <use id="92d2ea16-5a42-4fdf-a676-c7604efe3504" name="de.slisson.mps.richtext" version="0" />
     <use id="d3a0fd26-445a-466c-900e-10444ddfed52" name="com.mbeddr.mpsutil.filepicker" version="0" />
-    <use id="d4280a54-f6df-4383-aa41-d1b2bffa7eb1" name="com.mbeddr.core.base" version="6" />
     <use id="2374bc90-7e37-41f1-a9c4-c2e35194c36a" name="com.mbeddr.doc" version="5" />
   </languages>
   <imports />

--- a/code/languages/com.mbeddr.doc/solutions/com.mbeddr.doc.test.documents/models/doc2_1.mps
+++ b/code/languages/com.mbeddr.doc/solutions/com.mbeddr.doc.test.documents/models/doc2_1.mps
@@ -2,7 +2,6 @@
 <model ref="r:260e0933-d20e-4f4f-88cb-1c3cbbf973a8(com.mbeddr.doc.test.documents.doc2_1)">
   <persistence version="9" />
   <languages>
-    <use id="2dec0852-3a21-4c4e-a68c-b05236cc37f2" name="com.mbeddr.doc.gen_xhtml" version="1" />
     <use id="2374bc90-7e37-41f1-a9c4-c2e35194c36a" name="com.mbeddr.doc" version="5" />
   </languages>
   <imports>
@@ -101,8 +100,8 @@
     </node>
   </node>
   <node concept="1_1swa" id="2khznRHyxyJ">
-    <property role="yApLE" value="1" />
     <property role="TrG5h" value="sub_document_3" />
+    <property role="yApLE" value="1" />
     <ref role="G9hjw" to="gzw8:2khznRHyx6c" resolve="Config" />
     <node concept="1_0VNX" id="2khznRHyxyK" role="1_0VJ0">
       <property role="TrG5h" value="thirdsection" />
@@ -140,6 +139,22 @@
     </node>
     <node concept="1_0j5j" id="4eRbT2iDalh" role="1DXQ57">
       <ref role="1_0j5g" node="2khznRHyx6K" resolve="sub_document_2" />
+    </node>
+  </node>
+  <node concept="1_1swa" id="4yqSQKZg0Sn">
+    <property role="TrG5h" value="sub_document_forStableID" />
+    <property role="yApLE" value="3" />
+    <ref role="G9hjw" to="gzw8:2khznRHyx6c" resolve="Config" />
+    <node concept="1_0VNX" id="4yqSQKZg3eo" role="1_0VJ0">
+      <property role="TrG5h" value="sectionSHouldHaveStableId" />
+      <property role="1_0VJr" value="The thrid section" />
+      <node concept="1_0LV8" id="4yqSQKZg3ep" role="1_0VJ0">
+        <node concept="19SGf9" id="4yqSQKZg3eq" role="1_0LWR">
+          <node concept="19SUe$" id="4yqSQKZg3er" role="19SJt6">
+            <property role="19SUeA" value="(ﾉ◕ヮ◕)ﾉ*:･ﾟ✧" />
+          </node>
+        </node>
+      </node>
     </node>
   </node>
 </model>

--- a/code/languages/com.mbeddr.platform.build/solutions/com.mbeddr.platform.tests.build/models/com.mbeddr.platform.tests.build.mps
+++ b/code/languages/com.mbeddr.platform.build/solutions/com.mbeddr.platform.tests.build/models/com.mbeddr.platform.tests.build.mps
@@ -2819,10 +2819,11 @@
         <property role="BnDLt" value="true" />
         <property role="TrG5h" value="com.mbeddr.doc.test.documents" />
         <property role="3LESm3" value="4078ebaa-02fd-430a-ab03-975592a2372c" />
+        <property role="aoJFB" value="eYcmk9QOlj/sources_and_tests" />
         <node concept="3rtmxn" id="3xFG3bj5cRg" role="3bR31x">
           <node concept="3LXTmp" id="3xFG3bj5cRh" role="3rtmxm">
             <node concept="3qWCbU" id="3xFG3bj5cRi" role="3LXTna">
-              <property role="3qWCbO" value="icons/**, resources/**" />
+              <property role="3qWCbO" value="icons/**, resources/**, doc_gen/**" />
             </node>
             <node concept="398BVA" id="3xFG3bj5cRj" role="3LXTmr">
               <ref role="398BVh" node="7eF9rfAnzU3" resolve="mbeddr.github.core.home" />
@@ -2901,6 +2902,26 @@
             <ref role="3bR37D" to="ffeo:7Kfy9QB6KYb" resolve="jetbrains.mps.baseLanguage" />
           </node>
         </node>
+        <node concept="1SiIV0" id="4yqSQKZiSYC" role="3bR37C">
+          <node concept="3bR9La" id="4yqSQKZiSYD" role="1SiIV1">
+            <ref role="3bR37D" to="al5i:1YMM4SJ2m0" resolve="com.mbeddr.doc" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="5CV8POqzRMh" role="3bR37C">
+          <node concept="3bR9La" id="5CV8POqzRMi" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="5CV8POqzRMj" role="3bR37C">
+          <node concept="3bR9La" id="5CV8POqzRMk" role="1SiIV1">
+            <ref role="3bR37D" to="90a9:3$A0JaN5bpX" resolve="MPS.ThirdParty" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="5CV8POqzRMl" role="3bR37C">
+          <node concept="3bR9La" id="5CV8POqzRMm" role="1SiIV1">
+            <ref role="3bR37D" to="90a9:PE3B26QCrP" resolve="org.apache.commons" />
+          </node>
+        </node>
       </node>
     </node>
     <node concept="22LTRH" id="7eF9rfAnzVt" role="1hWBAP">
@@ -2956,6 +2977,9 @@
       </node>
       <node concept="22LTRM" id="6n0otOpmfAs" role="22LTRK">
         <ref role="22LTRN" node="6n0otOpkQ9s" resolve="test.com.mbeddr.mpsutil.logicalChild" />
+      </node>
+      <node concept="22LTRM" id="4yqSQKZiTcM" role="22LTRK">
+        <ref role="22LTRN" node="4pIcGABAzoW" resolve="com.mbeddr.doc.test.documents" />
       </node>
     </node>
     <node concept="2igEWh" id="3HpWboH_Z$G" role="1hWBAP">

--- a/code/languages/com.mbeddr.platform.build/solutions/com.mbeddr.platform/models/com/mbeddr/platform/build.mps
+++ b/code/languages/com.mbeddr.platform.build/solutions/com.mbeddr.platform/models/com/mbeddr/platform/build.mps
@@ -14741,6 +14741,11 @@
               </node>
             </node>
           </node>
+          <node concept="1SiIV0" id="4XyruUDFTlZ" role="3bR37C">
+            <node concept="3bR9La" id="4XyruUDFTm0" role="1SiIV1">
+              <ref role="3bR37D" node="1YMM4SJ2m0" resolve="com.mbeddr.doc" />
+            </node>
+          </node>
         </node>
         <node concept="1SiIV0" id="1YMM4SJ8q7" role="3bR37C">
           <node concept="1Busua" id="1YMM4SJ8q8" role="1SiIV1">


### PR DESCRIPTION
This PR addresses https://github.com/mbeddr/mbeddr.core/issues/2958 and uses original node IDs for generating SIDs (stable IDs) where possible. 

In addition some rudimental tests were added to check for generation of stable IDs.

**Explanations**
Previously, only node.StableID() was utilized. By default, the behavior method is applied to the node within the generator model (transient). The node ID is updated every time because the generator always creates a copy of all nodes and transfers them to the transient model.

To obtain **real** stable IDs, we need to use the IDs from the original model. However, in some cases, a node may not have been present in the original model because it was previously transformed or created in another generator. Initially, I did not include an “instance of” check when accessing the original node, but it has been identified that this can lead to unexpected results.

The “instance of” check serves as a safety net. If an original instance exists, it is used. Otherwise, the same logic as usual is applied.
