### PR TITLE
updated JBR version for 2025.1 release

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,4 +3,4 @@ common = "de.itemis.mps.gradle.common:1.29.+"
 jbr-toolchain = "com.specificlanguages.jbr-toolchain:1.0.2"
 
 [libraries]
-jbr = "com.jetbrains.jdk:jbr_jcef:21.0.5-b631.16"
+jbr = "com.jetbrains.jdk:jbr_jcef:21.0.6-b895.109"


### PR DESCRIPTION
Use JBR version from the final MPS 2025.1 release.