### PR TITLE
spreadsheet.libs module doesn't need empty models/ root

### DIFF
--- a/code/languages/com.mbeddr.doc/solutions/com.mbeddr.spreadsheet.libs/com.mbeddr.spreadsheet.libs.msd
+++ b/code/languages/com.mbeddr.doc/solutions/com.mbeddr.spreadsheet.libs/com.mbeddr.spreadsheet.libs.msd
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <solution name="com.mbeddr.spreadsheet.libs" uuid="fc506c9e-94ac-4d65-9950-01def4cba278" moduleVersion="0">
   <models>
-    <modelRoot contentPath="${module}" type="default">
-      <sourceRoot location="models" />
-    </modelRoot>
     <modelRoot contentPath="${module}/lib" type="java_classes">
       <sourceRoot location="commons-codec.jar" />
       <sourceRoot location="commons-collections4.jar" />


### PR DESCRIPTION
It's stub-only solution.
Empty root yields annoying "Models have not been found within the SourceRoot..." warning in build log.
