### PR TITLE
sbom: include only runtime configs to the sbom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is _loosely_ based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). The project does _not_ follow
 Semantic Versioning and the changes are simply documented in reverse chronological order, grouped by calendar month.
 
+# June 2025
+
+## com.mbeddr.platform publication
+
+### Changed
+
+- Published SBOM contains dependencies only from runtime configurations. This covers bundled libraries and all runtime 
+  dependencies like used language libraries, JBR and MPS. The latter is however currently not yet included due to a restriction 
+  of the CycloneDX gradle plugin.
+
 # May 2025
 
 ## com.mbeddr.doc

--- a/subprojects/com.mbeddr/platform/build.gradle
+++ b/subprojects/com.mbeddr/platform/build.gradle
@@ -276,4 +276,11 @@ cyclonedxBom {
     outputFormat = "json"
     // Don't include license texts in generated SBOMs
     includeLicenseText = false
+    // Include runtime deps only (bundled libs, language libs, mps, jbr)
+    def runtimeConfigs = bundledDeps.collect {it.configName }
+    runtimeConfigs << configurations.mpsLibraries.name
+    // TODO: mps config cannot be handled by cyclonedxBom, since it's located in com.mbeddr project
+    //runtimeConfigs << project(':com.mbeddr').configurations.mps.name
+    runtimeConfigs << 'jbr'
+    includeConfigs = runtimeConfigs
 }


### PR DESCRIPTION
Generated platform SBOM contains now only the runtime dependencies: bundled libraries, language libraries, mps and jbr.