### PR TITLE
ProjectScope during command line build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is _loosely_ based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). The project does _not_ follow
 Semantic Versioning and the changes are simply documented in reverse chronological order, grouped by calendar month.
 
+# July 2025
+
+## com.mbeddr.core.base
+- `com.mbeddr.core.base.ProjectScope` failed during a command line build
+
+  During test execution there was an additional temporary project open. That's why the strategy of
+  choosing the single open project didn't work.
+  The fallback logic of choosing the most recent focused window doesn't work in a headless environment
+  and even a normal IDE environment isn't a reliable strategy.
+
+  The new strategy is to find the project that contains the current module and as a fallback to
+  include all open projects.
+
 # May 2025
 
 ## com.mbeddr.doc

--- a/code/languages/com.mbeddr.build/solutions/com.mbeddr.core.tests.build/models/com/mbeddr/core/tests/build/build.mps
+++ b/code/languages/com.mbeddr.build/solutions/com.mbeddr.core.tests.build/models/com/mbeddr/core/tests/build/build.mps
@@ -1077,6 +1077,11 @@
             </node>
           </node>
         </node>
+        <node concept="1SiIV0" id="3V7vYlt_PUJ" role="3bR37C">
+          <node concept="3bR9La" id="3V7vYlt_PUK" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:ymnOULAU0H" resolve="jetbrains.mps.lang.test" />
+          </node>
+        </node>
       </node>
     </node>
     <node concept="398rNT" id="7eF9rfAuuuc" role="1l3spd">

--- a/code/languages/com.mbeddr.cc/languages/com.mbeddr.cc.requirements.c/languageModels/intentions.mps
+++ b/code/languages/com.mbeddr.cc/languages/com.mbeddr.cc.requirements.c/languageModels/intentions.mps
@@ -171,7 +171,7 @@
       </concept>
     </language>
     <language id="b92f861d-0184-446d-b88b-6dcf0e070241" name="com.mbeddr.mpsutil.intentions">
-      <concept id="5846558918537398687" name="com.mbeddr.mpsutil.intentions.structure.GroupAnnotation" flags="ng" index="1SWQZ3">
+      <concept id="5846558918537398687" name="com.mbeddr.mpsutil.intentions.structure.SectionAnnotation" flags="ng" index="1SWQZ3">
         <property id="5846558918537400330" name="label" index="1SWRpm" />
       </concept>
     </language>

--- a/code/languages/com.mbeddr.cc/languages/com.mbeddr.cc.requirements.csv/languageModels/intentions.mps
+++ b/code/languages/com.mbeddr.cc/languages/com.mbeddr.cc.requirements.csv/languageModels/intentions.mps
@@ -79,7 +79,7 @@
       <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
     </language>
     <language id="b92f861d-0184-446d-b88b-6dcf0e070241" name="com.mbeddr.mpsutil.intentions">
-      <concept id="5846558918537398687" name="com.mbeddr.mpsutil.intentions.structure.GroupAnnotation" flags="ng" index="1SWQZ3">
+      <concept id="5846558918537398687" name="com.mbeddr.mpsutil.intentions.structure.SectionAnnotation" flags="ng" index="1SWQZ3">
         <property id="5846558918537400330" name="label" index="1SWRpm" />
       </concept>
     </language>

--- a/code/languages/com.mbeddr.cc/languages/com.mbeddr.cc.requirements.report/languageModels/intentions.mps
+++ b/code/languages/com.mbeddr.cc/languages/com.mbeddr.cc.requirements.report/languageModels/intentions.mps
@@ -68,7 +68,7 @@
       </concept>
     </language>
     <language id="b92f861d-0184-446d-b88b-6dcf0e070241" name="com.mbeddr.mpsutil.intentions">
-      <concept id="5846558918537398687" name="com.mbeddr.mpsutil.intentions.structure.GroupAnnotation" flags="ng" index="1SWQZ3">
+      <concept id="5846558918537398687" name="com.mbeddr.mpsutil.intentions.structure.SectionAnnotation" flags="ng" index="1SWQZ3">
         <property id="5846558918537400330" name="label" index="1SWRpm" />
       </concept>
     </language>

--- a/code/languages/com.mbeddr.cc/languages/com.mbeddr.cc.requirements.scenarios/languageModels/intentions.mps
+++ b/code/languages/com.mbeddr.cc/languages/com.mbeddr.cc.requirements.scenarios/languageModels/intentions.mps
@@ -75,7 +75,7 @@
       <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
     </language>
     <language id="b92f861d-0184-446d-b88b-6dcf0e070241" name="com.mbeddr.mpsutil.intentions">
-      <concept id="5846558918537398687" name="com.mbeddr.mpsutil.intentions.structure.GroupAnnotation" flags="ng" index="1SWQZ3">
+      <concept id="5846558918537398687" name="com.mbeddr.mpsutil.intentions.structure.SectionAnnotation" flags="ng" index="1SWQZ3">
         <property id="5846558918537400330" name="label" index="1SWRpm" />
       </concept>
     </language>

--- a/code/languages/com.mbeddr.cc/languages/com.mbeddr.cc.requirements/languageModels/intentions.mps
+++ b/code/languages/com.mbeddr.cc/languages/com.mbeddr.cc.requirements/languageModels/intentions.mps
@@ -167,7 +167,7 @@
       </concept>
     </language>
     <language id="b92f861d-0184-446d-b88b-6dcf0e070241" name="com.mbeddr.mpsutil.intentions">
-      <concept id="5846558918537398687" name="com.mbeddr.mpsutil.intentions.structure.GroupAnnotation" flags="ng" index="1SWQZ3">
+      <concept id="5846558918537398687" name="com.mbeddr.mpsutil.intentions.structure.SectionAnnotation" flags="ng" index="1SWQZ3">
         <property id="5846558918537400330" name="label" index="1SWRpm" />
       </concept>
     </language>

--- a/code/languages/com.mbeddr.cc/languages/com.mbeddr.cc.trace/languageModels/intentions.mps
+++ b/code/languages/com.mbeddr.cc/languages/com.mbeddr.cc.trace/languageModels/intentions.mps
@@ -93,7 +93,7 @@
       <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
     </language>
     <language id="b92f861d-0184-446d-b88b-6dcf0e070241" name="com.mbeddr.mpsutil.intentions">
-      <concept id="5846558918537398687" name="com.mbeddr.mpsutil.intentions.structure.GroupAnnotation" flags="ng" index="1SWQZ3">
+      <concept id="5846558918537398687" name="com.mbeddr.mpsutil.intentions.structure.SectionAnnotation" flags="ng" index="1SWQZ3">
         <property id="5846558918537400330" name="label" index="1SWRpm" />
       </concept>
     </language>

--- a/code/languages/com.mbeddr.cc/languages/com.mbeddr.cc.var.annotations/languageModels/intentions.mps
+++ b/code/languages/com.mbeddr.cc/languages/com.mbeddr.cc.var.annotations/languageModels/intentions.mps
@@ -108,7 +108,7 @@
       <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
     </language>
     <language id="b92f861d-0184-446d-b88b-6dcf0e070241" name="com.mbeddr.mpsutil.intentions">
-      <concept id="5846558918537398687" name="com.mbeddr.mpsutil.intentions.structure.GroupAnnotation" flags="ng" index="1SWQZ3">
+      <concept id="5846558918537398687" name="com.mbeddr.mpsutil.intentions.structure.SectionAnnotation" flags="ng" index="1SWQZ3">
         <property id="5846558918537400330" name="label" index="1SWRpm" />
       </concept>
     </language>

--- a/code/languages/com.mbeddr.cc/languages/com.mbeddr.cc.var.c/languageModels/intentions.mps
+++ b/code/languages/com.mbeddr.cc/languages/com.mbeddr.cc.var.c/languageModels/intentions.mps
@@ -66,7 +66,7 @@
       <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
     </language>
     <language id="b92f861d-0184-446d-b88b-6dcf0e070241" name="com.mbeddr.mpsutil.intentions">
-      <concept id="5846558918537398687" name="com.mbeddr.mpsutil.intentions.structure.GroupAnnotation" flags="ng" index="1SWQZ3">
+      <concept id="5846558918537398687" name="com.mbeddr.mpsutil.intentions.structure.SectionAnnotation" flags="ng" index="1SWQZ3">
         <property id="5846558918537400330" name="label" index="1SWRpm" />
       </concept>
     </language>

--- a/code/languages/com.mbeddr.cc/languages/com.mbeddr.cc.var.composition/languageModels/intentions.mps
+++ b/code/languages/com.mbeddr.cc/languages/com.mbeddr.cc.var.composition/languageModels/intentions.mps
@@ -54,7 +54,7 @@
       <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
     </language>
     <language id="b92f861d-0184-446d-b88b-6dcf0e070241" name="com.mbeddr.mpsutil.intentions">
-      <concept id="5846558918537398687" name="com.mbeddr.mpsutil.intentions.structure.GroupAnnotation" flags="ng" index="1SWQZ3">
+      <concept id="5846558918537398687" name="com.mbeddr.mpsutil.intentions.structure.SectionAnnotation" flags="ng" index="1SWQZ3">
         <property id="5846558918537400330" name="label" index="1SWRpm" />
       </concept>
     </language>

--- a/code/languages/com.mbeddr.cc/languages/com.mbeddr.cc.var.fm/languageModels/intentions.mps
+++ b/code/languages/com.mbeddr.cc/languages/com.mbeddr.cc.var.fm/languageModels/intentions.mps
@@ -97,7 +97,7 @@
       </concept>
     </language>
     <language id="b92f861d-0184-446d-b88b-6dcf0e070241" name="com.mbeddr.mpsutil.intentions">
-      <concept id="5846558918537398687" name="com.mbeddr.mpsutil.intentions.structure.GroupAnnotation" flags="ng" index="1SWQZ3">
+      <concept id="5846558918537398687" name="com.mbeddr.mpsutil.intentions.structure.SectionAnnotation" flags="ng" index="1SWQZ3">
         <property id="5846558918537400330" name="label" index="1SWRpm" />
       </concept>
     </language>

--- a/code/languages/com.mbeddr.cc/languages/com.mbeddr.cc.var.rt/languageModels/intentions.mps
+++ b/code/languages/com.mbeddr.cc/languages/com.mbeddr.cc.var.rt/languageModels/intentions.mps
@@ -29,7 +29,7 @@
       </concept>
     </language>
     <language id="b92f861d-0184-446d-b88b-6dcf0e070241" name="com.mbeddr.mpsutil.intentions">
-      <concept id="5846558918537398687" name="com.mbeddr.mpsutil.intentions.structure.GroupAnnotation" flags="ng" index="1SWQZ3">
+      <concept id="5846558918537398687" name="com.mbeddr.mpsutil.intentions.structure.SectionAnnotation" flags="ng" index="1SWQZ3">
         <property id="5846558918537400330" name="label" index="1SWRpm" />
       </concept>
     </language>

--- a/code/languages/com.mbeddr.core/languages/com.mbeddr.core.buildconfig/languageModels/intentions.mps
+++ b/code/languages/com.mbeddr.core/languages/com.mbeddr.core.buildconfig/languageModels/intentions.mps
@@ -114,7 +114,7 @@
       <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
     </language>
     <language id="b92f861d-0184-446d-b88b-6dcf0e070241" name="com.mbeddr.mpsutil.intentions">
-      <concept id="5846558918537398687" name="com.mbeddr.mpsutil.intentions.structure.GroupAnnotation" flags="ng" index="1SWQZ3">
+      <concept id="5846558918537398687" name="com.mbeddr.mpsutil.intentions.structure.SectionAnnotation" flags="ng" index="1SWQZ3">
         <property id="5846558918537400330" name="label" index="1SWRpm" />
       </concept>
     </language>

--- a/code/languages/com.mbeddr.core/languages/com.mbeddr.core.cinterpreter/languageModels/intentions.mps
+++ b/code/languages/com.mbeddr.core/languages/com.mbeddr.core.cinterpreter/languageModels/intentions.mps
@@ -47,7 +47,7 @@
       </concept>
     </language>
     <language id="b92f861d-0184-446d-b88b-6dcf0e070241" name="com.mbeddr.mpsutil.intentions">
-      <concept id="5846558918537398687" name="com.mbeddr.mpsutil.intentions.structure.GroupAnnotation" flags="ng" index="1SWQZ3">
+      <concept id="5846558918537398687" name="com.mbeddr.mpsutil.intentions.structure.SectionAnnotation" flags="ng" index="1SWQZ3">
         <property id="5846558918537400330" name="label" index="1SWRpm" />
       </concept>
     </language>

--- a/code/languages/com.mbeddr.core/languages/com.mbeddr.core.embedded/languageModels/intentions.mps
+++ b/code/languages/com.mbeddr.core/languages/com.mbeddr.core.embedded/languageModels/intentions.mps
@@ -57,7 +57,7 @@
       </concept>
     </language>
     <language id="b92f861d-0184-446d-b88b-6dcf0e070241" name="com.mbeddr.mpsutil.intentions">
-      <concept id="5846558918537398687" name="com.mbeddr.mpsutil.intentions.structure.GroupAnnotation" flags="ng" index="1SWQZ3">
+      <concept id="5846558918537398687" name="com.mbeddr.mpsutil.intentions.structure.SectionAnnotation" flags="ng" index="1SWQZ3">
         <property id="5846558918537400330" name="label" index="1SWRpm" />
       </concept>
     </language>

--- a/code/languages/com.mbeddr.core/languages/com.mbeddr.core.expressions/languageModels/intentions.mps
+++ b/code/languages/com.mbeddr.core/languages/com.mbeddr.core.expressions/languageModels/intentions.mps
@@ -115,7 +115,7 @@
       <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
     </language>
     <language id="b92f861d-0184-446d-b88b-6dcf0e070241" name="com.mbeddr.mpsutil.intentions">
-      <concept id="5846558918537398687" name="com.mbeddr.mpsutil.intentions.structure.GroupAnnotation" flags="ng" index="1SWQZ3">
+      <concept id="5846558918537398687" name="com.mbeddr.mpsutil.intentions.structure.SectionAnnotation" flags="ng" index="1SWQZ3">
         <property id="5846558918537400330" name="label" index="1SWRpm" />
       </concept>
     </language>

--- a/code/languages/com.mbeddr.core/languages/com.mbeddr.core.modules/languageModels/intentions.mps
+++ b/code/languages/com.mbeddr.core/languages/com.mbeddr.core.modules/languageModels/intentions.mps
@@ -184,7 +184,7 @@
       <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
     </language>
     <language id="b92f861d-0184-446d-b88b-6dcf0e070241" name="com.mbeddr.mpsutil.intentions">
-      <concept id="5846558918537398687" name="com.mbeddr.mpsutil.intentions.structure.GroupAnnotation" flags="ng" index="1SWQZ3">
+      <concept id="5846558918537398687" name="com.mbeddr.mpsutil.intentions.structure.SectionAnnotation" flags="ng" index="1SWQZ3">
         <property id="5846558918537400330" name="label" index="1SWRpm" />
       </concept>
     </language>

--- a/code/languages/com.mbeddr.core/languages/com.mbeddr.core.statements/languageModels/intentions.mps
+++ b/code/languages/com.mbeddr.core/languages/com.mbeddr.core.statements/languageModels/intentions.mps
@@ -100,7 +100,7 @@
       <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
     </language>
     <language id="b92f861d-0184-446d-b88b-6dcf0e070241" name="com.mbeddr.mpsutil.intentions">
-      <concept id="5846558918537398687" name="com.mbeddr.mpsutil.intentions.structure.GroupAnnotation" flags="ng" index="1SWQZ3">
+      <concept id="5846558918537398687" name="com.mbeddr.mpsutil.intentions.structure.SectionAnnotation" flags="ng" index="1SWQZ3">
         <property id="5846558918537400330" name="label" index="1SWRpm" />
       </concept>
     </language>

--- a/code/languages/com.mbeddr.core/languages/com.mbeddr.core.udt/languageModels/intentions.mps
+++ b/code/languages/com.mbeddr.core/languages/com.mbeddr.core.udt/languageModels/intentions.mps
@@ -114,7 +114,7 @@
       <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
     </language>
     <language id="b92f861d-0184-446d-b88b-6dcf0e070241" name="com.mbeddr.mpsutil.intentions">
-      <concept id="5846558918537398687" name="com.mbeddr.mpsutil.intentions.structure.GroupAnnotation" flags="ng" index="1SWQZ3">
+      <concept id="5846558918537398687" name="com.mbeddr.mpsutil.intentions.structure.SectionAnnotation" flags="ng" index="1SWQZ3">
         <property id="5846558918537400330" name="label" index="1SWRpm" />
       </concept>
     </language>

--- a/code/languages/com.mbeddr.core/languages/com.mbeddr.core.unittest/languageModels/intentions.mps
+++ b/code/languages/com.mbeddr.core/languages/com.mbeddr.core.unittest/languageModels/intentions.mps
@@ -111,7 +111,7 @@
       <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
     </language>
     <language id="b92f861d-0184-446d-b88b-6dcf0e070241" name="com.mbeddr.mpsutil.intentions">
-      <concept id="5846558918537398687" name="com.mbeddr.mpsutil.intentions.structure.GroupAnnotation" flags="ng" index="1SWQZ3">
+      <concept id="5846558918537398687" name="com.mbeddr.mpsutil.intentions.structure.SectionAnnotation" flags="ng" index="1SWQZ3">
         <property id="5846558918537400330" name="label" index="1SWRpm" />
       </concept>
     </language>

--- a/code/languages/com.mbeddr.core/languages/com.mbeddr.core.util/languageModels/intentions.mps
+++ b/code/languages/com.mbeddr.core/languages/com.mbeddr.core.util/languageModels/intentions.mps
@@ -127,7 +127,7 @@
       <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
     </language>
     <language id="b92f861d-0184-446d-b88b-6dcf0e070241" name="com.mbeddr.mpsutil.intentions">
-      <concept id="5846558918537398687" name="com.mbeddr.mpsutil.intentions.structure.GroupAnnotation" flags="ng" index="1SWQZ3">
+      <concept id="5846558918537398687" name="com.mbeddr.mpsutil.intentions.structure.SectionAnnotation" flags="ng" index="1SWQZ3">
         <property id="5846558918537400330" name="label" index="1SWRpm" />
       </concept>
     </language>

--- a/code/languages/com.mbeddr.core/tests/test.assessments/models/test.assessments@tests.mps
+++ b/code/languages/com.mbeddr.core/tests/test.assessments/models/test.assessments@tests.mps
@@ -6,18 +6,20 @@
     <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="1" />
     <use id="2ae9b0c0-0e87-4510-aa2a-9949fa0436bf" name="test.assessments.testlang" version="-1" />
     <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
+    <use id="7d323e61-8358-4656-a071-a2bb68438615" name="com.mbeddr.core.codereview" version="0" />
   </languages>
   <imports>
     <import index="hikj" ref="r:08e46f36-ad08-4837-aae6-df5fffab661d(test.assessments.testlang.structure)" />
     <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
+    <import index="vs0r" ref="r:f7764ca4-8c75-4049-922b-08516400a727(com.mbeddr.core.base.structure)" />
     <import index="hwgx" ref="r:fd2980c8-676c-4b19-b524-18c70e02f8b7(com.mbeddr.core.base.behavior)" implicit="true" />
-    <import index="vs0r" ref="r:f7764ca4-8c75-4049-922b-08516400a727(com.mbeddr.core.base.structure)" implicit="true" />
   </imports>
   <registry>
     <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
       <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
         <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
       </concept>
+      <concept id="1225469856668" name="jetbrains.mps.lang.test.structure.ModelExpression" flags="nn" index="1jGwE1" />
       <concept id="1216913645126" name="jetbrains.mps.lang.test.structure.NodesTestCase" flags="lg" index="1lH9Xt">
         <property id="2616911529524314943" name="accessMode" index="3DII0k" />
         <child id="1217501822150" name="nodesToCheck" index="1SKRRt" />
@@ -90,7 +92,13 @@
         <child id="1199569916463" name="body" index="1bW5cS" />
       </concept>
     </language>
+    <language id="7d323e61-8358-4656-a071-a2bb68438615" name="com.mbeddr.core.codereview">
+      <concept id="4901333676674651668" name="com.mbeddr.core.codereview.structure.ReviewAssessmentQuery" flags="ng" index="3RRLWm">
+        <child id="8490595898229198814" name="scope" index="28wUw_" />
+      </concept>
+    </language>
     <language id="d4280a54-f6df-4383-aa41-d1b2bffa7eb1" name="com.mbeddr.core.base">
+      <concept id="6277307617439377002" name="com.mbeddr.core.base.structure.ProjectScope" flags="ng" index="2GjDLI" />
       <concept id="8375407818529178006" name="com.mbeddr.core.base.structure.TextBlock" flags="ng" index="OjmMv">
         <child id="8375407818529178007" name="text" index="OjmMu" />
       </concept>
@@ -128,6 +136,9 @@
       <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
         <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
       </concept>
+      <concept id="1138411891628" name="jetbrains.mps.lang.smodel.structure.SNodeOperation" flags="nn" index="eCIE_">
+        <child id="1144104376918" name="parameter" index="1xVPHs" />
+      </concept>
       <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
       <concept id="4693937538533521280" name="jetbrains.mps.lang.smodel.structure.OfConceptOperation" flags="ng" index="v3k3i">
         <child id="4693937538533538124" name="requestedConcept" index="v3oSu" />
@@ -136,12 +147,16 @@
         <child id="6733348108486823193" name="leftExpression" index="1m5AlR" />
         <child id="3906496115198199033" name="conceptArgument" index="3oSUPX" />
       </concept>
+      <concept id="1171305280644" name="jetbrains.mps.lang.smodel.structure.Node_GetDescendantsOperation" flags="nn" index="2Rf3mk" />
       <concept id="3562215692195599741" name="jetbrains.mps.lang.smodel.structure.SLinkImplicitSelect" flags="nn" index="13MTOL">
         <reference id="3562215692195600259" name="link" index="13MTZf" />
       </concept>
       <concept id="1139613262185" name="jetbrains.mps.lang.smodel.structure.Node_GetParentOperation" flags="nn" index="1mfA1w" />
       <concept id="1139621453865" name="jetbrains.mps.lang.smodel.structure.Node_IsInstanceOfOperation" flags="nn" index="1mIQ4w">
         <child id="1177027386292" name="conceptArgument" index="cj9EA" />
+      </concept>
+      <concept id="1144101972840" name="jetbrains.mps.lang.smodel.structure.OperationParm_Concept" flags="ng" index="1xMEDy">
+        <child id="1207343664468" name="conceptArgument" index="ri$Ld" />
       </concept>
       <concept id="1140137987495" name="jetbrains.mps.lang.smodel.structure.SNodeTypeCastExpression" flags="nn" index="1PxgMI" />
       <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
@@ -182,10 +197,14 @@
       <concept id="1204796164442" name="jetbrains.mps.baseLanguage.collections.structure.InternalSequenceOperation" flags="nn" index="23sCx2">
         <child id="1204796294226" name="closure" index="23t8la" />
       </concept>
+      <concept id="1151689724996" name="jetbrains.mps.baseLanguage.collections.structure.SequenceType" flags="in" index="A3Dl8">
+        <child id="1151689745422" name="elementType" index="A3Ik2" />
+      </concept>
       <concept id="1151702311717" name="jetbrains.mps.baseLanguage.collections.structure.ToListOperation" flags="nn" index="ANE8D" />
       <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="nn" index="34oBXx" />
       <concept id="1165525191778" name="jetbrains.mps.baseLanguage.collections.structure.GetFirstOperation" flags="nn" index="1uHKPH" />
       <concept id="1202128969694" name="jetbrains.mps.baseLanguage.collections.structure.SelectOperation" flags="nn" index="3$u5V9" />
+      <concept id="1176501494711" name="jetbrains.mps.baseLanguage.collections.structure.IsNotEmptyOperation" flags="nn" index="3GX2aA" />
     </language>
   </registry>
   <node concept="1lH9Xt" id="6v0bPePA6ac">
@@ -543,6 +562,9 @@
       <node concept="3pwaUv" id="5Z2CJwRn$uR" role="1qenE9">
         <property role="TrG5h" value="sorting" />
         <property role="1Ema5g" value="true" />
+        <node concept="3xLA65" id="5Z2CJwRnK9F" role="lGtFl">
+          <property role="TrG5h" value="sorting" />
+        </node>
         <node concept="3ilFYh" id="5Z2CJwRn$uT" role="3pwbkY">
           <node concept="3ilFYD" id="5Z2CJwRn$uX" role="3ilUJ_">
             <property role="3ilQhQ" value="200" />
@@ -557,14 +579,81 @@
             <property role="3ilFYC" value="baz" />
           </node>
         </node>
-        <node concept="3xLA65" id="5Z2CJwRnK9F" role="lGtFl">
-          <property role="TrG5h" value="sorting" />
-        </node>
       </node>
     </node>
   </node>
   <node concept="2XOHcx" id="6v0bPePBkpS">
     <property role="2XOHcw" value="${mbeddr.github.core.home}/code/languages/com.mbeddr.core" />
+  </node>
+  <node concept="1lH9Xt" id="3V7vYltn9XS">
+    <property role="TrG5h" value="ProjectScopeTest" />
+    <property role="3DII0k" value="2hh8MJdVwqX/command" />
+    <node concept="1LZb2c" id="3V7vYltn9Zp" role="1SL9yI">
+      <property role="TrG5h" value="projectScopedAssement" />
+      <node concept="3cqZAl" id="3V7vYltn9Zq" role="3clF45" />
+      <node concept="3clFbS" id="3V7vYltn9Zr" role="3clF47">
+        <node concept="3cpWs8" id="3V7vYltnovP" role="3cqZAp">
+          <node concept="3cpWsn" id="3V7vYltnovQ" role="3cpWs9">
+            <property role="TrG5h" value="scope" />
+            <node concept="3Tqbb2" id="3V7vYltnovl" role="1tU5fm">
+              <ref role="ehGHo" to="vs0r:5stuwjVkYpE" resolve="ProjectScope" />
+            </node>
+            <node concept="2OqwBi" id="3V7vYltnovR" role="33vP2m">
+              <node concept="2OqwBi" id="3V7vYltnovS" role="2Oq$k0">
+                <node concept="3xONca" id="3V7vYltnovT" role="2Oq$k0">
+                  <ref role="3xOPvv" node="3V7vYltna0e" resolve="projectScoped" />
+                </node>
+                <node concept="2Rf3mk" id="3V7vYltnovU" role="2OqNvi">
+                  <node concept="1xMEDy" id="3V7vYltnovV" role="1xVPHs">
+                    <node concept="chp4Y" id="3V7vYltnovW" role="ri$Ld">
+                      <ref role="cht4Q" to="vs0r:5stuwjVkYpE" resolve="ProjectScope" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="1uHKPH" id="3V7vYltnovX" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="3V7vYltnpeP" role="3cqZAp">
+          <node concept="3cpWsn" id="3V7vYltnpeQ" role="3cpWs9">
+            <property role="TrG5h" value="elements" />
+            <node concept="A3Dl8" id="3V7vYltnp9z" role="1tU5fm">
+              <node concept="3Tqbb2" id="3V7vYltnp9A" role="A3Ik2" />
+            </node>
+            <node concept="2OqwBi" id="3V7vYltnpeR" role="33vP2m">
+              <node concept="37vLTw" id="3V7vYltnpeS" role="2Oq$k0">
+                <ref role="3cqZAo" node="3V7vYltnovQ" resolve="scope" />
+              </node>
+              <node concept="2qgKlT" id="3V7vYltnpeT" role="2OqNvi">
+                <ref role="37wK5l" to="hwgx:7nkDZJXluPi" resolve="findElements" />
+                <node concept="1jGwE1" id="3V7vYltnpeU" role="37wK5m" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3vwNmj" id="3V7vYltnrxP" role="3cqZAp">
+          <node concept="2OqwBi" id="3V7vYltnrZ1" role="3vwVQn">
+            <node concept="37vLTw" id="3V7vYltnryJ" role="2Oq$k0">
+              <ref role="3cqZAo" node="3V7vYltnpeQ" resolve="elements" />
+            </node>
+            <node concept="3GX2aA" id="3V7vYltnuXV" role="2OqNvi" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="3V7vYltna0a" role="1SKRRt">
+      <node concept="3pwaUv" id="3V7vYltna0b" role="1qenE9">
+        <property role="TrG5h" value="sorting" />
+        <property role="1Ema5g" value="true" />
+        <node concept="3RRLWm" id="3V7vYltna0c" role="3pwbkY">
+          <node concept="2GjDLI" id="3V7vYltna0d" role="28wUw_" />
+        </node>
+        <node concept="3xLA65" id="3V7vYltna0e" role="lGtFl">
+          <property role="TrG5h" value="projectScoped" />
+        </node>
+      </node>
+    </node>
   </node>
 </model>
 

--- a/code/languages/com.mbeddr.core/tests/test.assessments/models/test.assessments@tests.mps
+++ b/code/languages/com.mbeddr.core/tests/test.assessments/models/test.assessments@tests.mps
@@ -7,12 +7,15 @@
     <use id="2ae9b0c0-0e87-4510-aa2a-9949fa0436bf" name="test.assessments.testlang" version="-1" />
     <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
     <use id="7d323e61-8358-4656-a071-a2bb68438615" name="com.mbeddr.core.codereview" version="0" />
+    <use id="c7fb639f-be78-4307-89b0-b5959c3fa8c8" name="jetbrains.mps.lang.text" version="0" />
   </languages>
   <imports>
     <import index="hikj" ref="r:08e46f36-ad08-4837-aae6-df5fffab661d(test.assessments.testlang.structure)" />
     <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
     <import index="vs0r" ref="r:f7764ca4-8c75-4049-922b-08516400a727(com.mbeddr.core.base.structure)" />
+    <import index="tp5g" ref="r:00000000-0000-4000-0000-011c89590388(jetbrains.mps.lang.test.structure)" />
     <import index="hwgx" ref="r:fd2980c8-676c-4b19-b524-18c70e02f8b7(com.mbeddr.core.base.behavior)" implicit="true" />
+    <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
   </imports>
   <registry>
     <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
@@ -52,6 +55,7 @@
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
+      <concept id="1225271283259" name="jetbrains.mps.baseLanguage.structure.NPEEqualsExpression" flags="nn" index="17R0WA" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
       </concept>
@@ -77,6 +81,13 @@
       <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
+      </concept>
+      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
+        <child id="1081773367579" name="rightExpression" index="3uHU7w" />
+        <child id="1081773367580" name="leftExpression" index="3uHU7B" />
+      </concept>
+      <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="nn" index="3SKdUt">
+        <child id="8356039341262087992" name="line" index="1aUNEU" />
       </concept>
     </language>
     <language id="92d2ea16-5a42-4fdf-a676-c7604efe3504" name="de.slisson.mps.richtext">
@@ -180,6 +191,14 @@
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
     </language>
+    <language id="c7fb639f-be78-4307-89b0-b5959c3fa8c8" name="jetbrains.mps.lang.text">
+      <concept id="155656958578482948" name="jetbrains.mps.lang.text.structure.Word" flags="nn" index="3oM_SD">
+        <property id="155656958578482949" name="value" index="3oM_SC" />
+      </concept>
+      <concept id="2535923850359271782" name="jetbrains.mps.lang.text.structure.Line" flags="nn" index="1PaTwC">
+        <child id="2535923850359271783" name="elements" index="1PaTwD" />
+      </concept>
+    </language>
     <language id="2ae9b0c0-0e87-4510-aa2a-9949fa0436bf" name="test.assessments.testlang">
       <concept id="7476027418010357954" name="test.assessments.testlang.structure.TestAssessmentQuery" flags="ng" index="3ilFYh">
         <child id="7476027418010420406" name="resultsToReturn" index="3ilUJ_" />
@@ -203,6 +222,7 @@
       <concept id="1151702311717" name="jetbrains.mps.baseLanguage.collections.structure.ToListOperation" flags="nn" index="ANE8D" />
       <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="nn" index="34oBXx" />
       <concept id="1165525191778" name="jetbrains.mps.baseLanguage.collections.structure.GetFirstOperation" flags="nn" index="1uHKPH" />
+      <concept id="1202120902084" name="jetbrains.mps.baseLanguage.collections.structure.WhereOperation" flags="nn" index="3zZkjj" />
       <concept id="1202128969694" name="jetbrains.mps.baseLanguage.collections.structure.SelectOperation" flags="nn" index="3$u5V9" />
       <concept id="1176501494711" name="jetbrains.mps.baseLanguage.collections.structure.IsNotEmptyOperation" flags="nn" index="3GX2aA" />
     </language>
@@ -632,10 +652,82 @@
             </node>
           </node>
         </node>
+        <node concept="3clFbH" id="7ZOb3c6Mvy1" role="3cqZAp" />
+        <node concept="3SKdUt" id="7ZOb3c6MvCL" role="3cqZAp">
+          <node concept="1PaTwC" id="7ZOb3c6MvCM" role="1aUNEU">
+            <node concept="3oM_SD" id="7pWpqSnYPt6" role="1PaTwD">
+              <property role="3oM_SC" value="Check" />
+            </node>
+            <node concept="3oM_SD" id="7pWpqSnYPt7" role="1PaTwD">
+              <property role="3oM_SC" value="that" />
+            </node>
+            <node concept="3oM_SD" id="7pWpqSnYPG0" role="1PaTwD">
+              <property role="3oM_SC" value="a" />
+            </node>
+            <node concept="3oM_SD" id="7pWpqSnYPTv" role="1PaTwD">
+              <property role="3oM_SC" value="node" />
+            </node>
+            <node concept="3oM_SD" id="7pWpqSnYPTw" role="1PaTwD">
+              <property role="3oM_SC" value="of" />
+            </node>
+            <node concept="3oM_SD" id="7pWpqSnYPTx" role="1PaTwD">
+              <property role="3oM_SC" value="the" />
+            </node>
+            <node concept="3oM_SD" id="7pWpqSnYPTy" role="1PaTwD">
+              <property role="3oM_SC" value="current" />
+            </node>
+            <node concept="3oM_SD" id="7pWpqSnYPTz" role="1PaTwD">
+              <property role="3oM_SC" value="model" />
+            </node>
+            <node concept="3oM_SD" id="7pWpqSnYPT$" role="1PaTwD">
+              <property role="3oM_SC" value="is" />
+            </node>
+            <node concept="3oM_SD" id="7pWpqSnYPT_" role="1PaTwD">
+              <property role="3oM_SC" value="in" />
+            </node>
+            <node concept="3oM_SD" id="7pWpqSnYPTA" role="1PaTwD">
+              <property role="3oM_SC" value="scope" />
+            </node>
+          </node>
+        </node>
         <node concept="3vwNmj" id="3V7vYltnrxP" role="3cqZAp">
           <node concept="2OqwBi" id="3V7vYltnrZ1" role="3vwVQn">
-            <node concept="37vLTw" id="3V7vYltnryJ" role="2Oq$k0">
-              <ref role="3cqZAo" node="3V7vYltnpeQ" resolve="elements" />
+            <node concept="2OqwBi" id="3V7vYlt__tW" role="2Oq$k0">
+              <node concept="2OqwBi" id="3V7vYlt_Cgn" role="2Oq$k0">
+                <node concept="37vLTw" id="3V7vYltnryJ" role="2Oq$k0">
+                  <ref role="3cqZAo" node="3V7vYltnpeQ" resolve="elements" />
+                </node>
+                <node concept="v3k3i" id="3V7vYlt_Czt" role="2OqNvi">
+                  <node concept="chp4Y" id="3V7vYlt_C_R" role="v3oSu">
+                    <ref role="cht4Q" to="tp5g:hBxLA2s" resolve="TestNodeAnnotation" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3zZkjj" id="3V7vYlt_BLh" role="2OqNvi">
+                <node concept="1bVj0M" id="3V7vYlt_BLj" role="23t8la">
+                  <node concept="3clFbS" id="3V7vYlt_BLk" role="1bW5cS">
+                    <node concept="3clFbF" id="3V7vYlt_CXC" role="3cqZAp">
+                      <node concept="17R0WA" id="3V7vYlt_I1j" role="3clFbG">
+                        <node concept="2OqwBi" id="3V7vYlt_DfC" role="3uHU7B">
+                          <node concept="37vLTw" id="3V7vYlt_CXB" role="2Oq$k0">
+                            <ref role="3cqZAo" node="3V7vYlt_BLl" resolve="it" />
+                          </node>
+                          <node concept="3TrcHB" id="3V7vYlt_E_M" role="2OqNvi">
+                            <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                          </node>
+                        </node>
+                        <node concept="Xl_RD" id="3V7vYlt_GUY" role="3uHU7w">
+                          <property role="Xl_RC" value="projectScoped" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="gl6BB" id="3V7vYlt_BLl" role="1bW2Oz">
+                    <property role="TrG5h" value="it" />
+                    <node concept="2jxLKc" id="3V7vYlt_BLm" role="1tU5fm" />
+                  </node>
+                </node>
+              </node>
             </node>
             <node concept="3GX2aA" id="3V7vYltnuXV" role="2OqNvi" />
           </node>

--- a/code/languages/com.mbeddr.core/tests/test.assessments/test.assessments.msd
+++ b/code/languages/com.mbeddr.core/tests/test.assessments/test.assessments.msd
@@ -17,6 +17,7 @@
   </dependencies>
   <languageVersions>
     <language slang="l:d4280a54-f6df-4383-aa41-d1b2bffa7eb1:com.mbeddr.core.base" version="6" />
+    <language slang="l:7d323e61-8358-4656-a071-a2bb68438615:com.mbeddr.core.codereview" version="0" />
     <language slang="l:63e0e566-5131-447e-90e3-12ea330e1a00:com.mbeddr.mpsutil.blutil" version="3" />
     <language slang="l:d3a0fd26-445a-466c-900e-10444ddfed52:com.mbeddr.mpsutil.filepicker" version="0" />
     <language slang="l:d09a16fb-1d68-4a92-a5a4-20b4b2f86a62:com.mbeddr.mpsutil.jung" version="0" />

--- a/code/languages/com.mbeddr.core/tests/test.assessments/test.assessments.msd
+++ b/code/languages/com.mbeddr.core/tests/test.assessments/test.assessments.msd
@@ -14,6 +14,7 @@
   <dependencies>
     <dependency reexport="false">d4280a54-f6df-4383-aa41-d1b2bffa7eb1(com.mbeddr.core.base)</dependency>
     <dependency reexport="false">2ae9b0c0-0e87-4510-aa2a-9949fa0436bf(test.assessments.testlang)</dependency>
+    <dependency reexport="false">8585453e-6bfb-4d80-98de-b16074f1d86c(jetbrains.mps.lang.test)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:d4280a54-f6df-4383-aa41-d1b2bffa7eb1:com.mbeddr.core.base" version="6" />
@@ -33,6 +34,7 @@
     <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
     <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="19" />
     <language slang="l:8585453e-6bfb-4d80-98de-b16074f1d86c:jetbrains.mps.lang.test" version="6" />
+    <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
     <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
     <language slang="l:2ae9b0c0-0e87-4510-aa2a-9949fa0436bf:test.assessments.testlang" version="0" />
   </languageVersions>
@@ -56,10 +58,12 @@
     <module reference="f0fff802-6d26-4d2e-b89d-391357265626(de.slisson.mps.hacks.editor)" version="0" />
     <module reference="92d2ea16-5a42-4fdf-a676-c7604efe3504(de.slisson.mps.richtext)" version="0" />
     <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
+    <module reference="443f4c36-fcf5-4eb6-9500-8d06ed259e3e(jetbrains.mps.baseLanguage.classifiers)" version="0" />
     <module reference="fd392034-7849-419d-9071-12563d152375(jetbrains.mps.baseLanguage.closures)" version="0" />
     <module reference="83888646-71ce-4f1c-9c53-c54016f6ad4f(jetbrains.mps.baseLanguage.collections)" version="0" />
     <module reference="daafa647-f1f7-4b0b-b096-69cd7c8408c0(jetbrains.mps.baseLanguage.regexp)" version="0" />
     <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
+    <module reference="f61473f9-130f-42f6-b98d-6c438812c2f6(jetbrains.mps.baseLanguage.unitTest)" version="0" />
     <module reference="23865718-e2ed-41b5-a132-0da1d04e266d(jetbrains.mps.ide.httpsupport.manager)" version="0" />
     <module reference="ae6d8005-36be-4cb6-945b-8c8cfc033c51(jetbrains.mps.ide.httpsupport.runtime)" version="0" />
     <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
@@ -69,6 +73,7 @@
     <module reference="d7eb0a2a-bd50-4576-beae-e4a89db35f20(jetbrains.mps.lang.scopes.runtime)" version="0" />
     <module reference="7866978e-a0f0-4cc7-81bc-4d213d9375e1(jetbrains.mps.lang.smodel)" version="1" />
     <module reference="c72da2b9-7cce-4447-8389-f407dc1158b7(jetbrains.mps.lang.structure)" version="0" />
+    <module reference="8585453e-6bfb-4d80-98de-b16074f1d86c(jetbrains.mps.lang.test)" version="0" />
     <module reference="9ded098b-ad6a-4657-bfd9-48636cfe8bc3(jetbrains.mps.lang.traceable)" version="0" />
     <module reference="c540669f-7495-4f0f-b5fc-81eb94934084(test.assessments)" version="0" />
     <module reference="2ae9b0c0-0e87-4510-aa2a-9949fa0436bf(test.assessments.testlang)" version="0" />

--- a/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/languageModels/intentions.mps
+++ b/code/languages/com.mbeddr.doc/languages/com.mbeddr.doc/languageModels/intentions.mps
@@ -141,7 +141,7 @@
       <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
     </language>
     <language id="b92f861d-0184-446d-b88b-6dcf0e070241" name="com.mbeddr.mpsutil.intentions">
-      <concept id="5846558918537398687" name="com.mbeddr.mpsutil.intentions.structure.GroupAnnotation" flags="ng" index="1SWQZ3">
+      <concept id="5846558918537398687" name="com.mbeddr.mpsutil.intentions.structure.SectionAnnotation" flags="ng" index="1SWQZ3">
         <property id="5846558918537400330" name="label" index="1SWRpm" />
       </concept>
     </language>

--- a/code/languages/com.mbeddr.doc/languages/terms/languageModels/intentions.mps
+++ b/code/languages/com.mbeddr.doc/languages/terms/languageModels/intentions.mps
@@ -101,7 +101,7 @@
       <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
     </language>
     <language id="b92f861d-0184-446d-b88b-6dcf0e070241" name="com.mbeddr.mpsutil.intentions">
-      <concept id="5846558918537398687" name="com.mbeddr.mpsutil.intentions.structure.GroupAnnotation" flags="ng" index="1SWQZ3">
+      <concept id="5846558918537398687" name="com.mbeddr.mpsutil.intentions.structure.SectionAnnotation" flags="ng" index="1SWQZ3">
         <property id="5846558918537400330" name="label" index="1SWRpm" />
       </concept>
     </language>

--- a/code/languages/com.mbeddr.ext/languages/com.mbeddr.ext.components.mock/languageModels/intentions.mps
+++ b/code/languages/com.mbeddr.ext/languages/com.mbeddr.ext.components.mock/languageModels/intentions.mps
@@ -35,7 +35,7 @@
       </concept>
     </language>
     <language id="b92f861d-0184-446d-b88b-6dcf0e070241" name="com.mbeddr.mpsutil.intentions">
-      <concept id="5846558918537398687" name="com.mbeddr.mpsutil.intentions.structure.GroupAnnotation" flags="ng" index="1SWQZ3">
+      <concept id="5846558918537398687" name="com.mbeddr.mpsutil.intentions.structure.SectionAnnotation" flags="ng" index="1SWQZ3">
         <property id="5846558918537400330" name="label" index="1SWRpm" />
       </concept>
     </language>

--- a/code/languages/com.mbeddr.ext/languages/com.mbeddr.ext.components.statemachine/languageModels/com.mbeddr.ext.components.statemachine.intentions.mps
+++ b/code/languages/com.mbeddr.ext/languages/com.mbeddr.ext.components.statemachine/languageModels/com.mbeddr.ext.components.statemachine.intentions.mps
@@ -74,7 +74,7 @@
       <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
     </language>
     <language id="b92f861d-0184-446d-b88b-6dcf0e070241" name="com.mbeddr.mpsutil.intentions">
-      <concept id="5846558918537398687" name="com.mbeddr.mpsutil.intentions.structure.GroupAnnotation" flags="ng" index="1SWQZ3">
+      <concept id="5846558918537398687" name="com.mbeddr.mpsutil.intentions.structure.SectionAnnotation" flags="ng" index="1SWQZ3">
         <property id="5846558918537400330" name="label" index="1SWRpm" />
       </concept>
     </language>

--- a/code/languages/com.mbeddr.ext/languages/com.mbeddr.ext.components/languageModels/intentions.mps
+++ b/code/languages/com.mbeddr.ext/languages/com.mbeddr.ext.components/languageModels/intentions.mps
@@ -99,7 +99,7 @@
       <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
     </language>
     <language id="b92f861d-0184-446d-b88b-6dcf0e070241" name="com.mbeddr.mpsutil.intentions">
-      <concept id="5846558918537398687" name="com.mbeddr.mpsutil.intentions.structure.GroupAnnotation" flags="ng" index="1SWQZ3">
+      <concept id="5846558918537398687" name="com.mbeddr.mpsutil.intentions.structure.SectionAnnotation" flags="ng" index="1SWQZ3">
         <property id="5846558918537400330" name="label" index="1SWRpm" />
       </concept>
     </language>

--- a/code/languages/com.mbeddr.ext/languages/com.mbeddr.ext.compositecomponents/languageModels/intentions.mps
+++ b/code/languages/com.mbeddr.ext/languages/com.mbeddr.ext.compositecomponents/languageModels/intentions.mps
@@ -84,7 +84,7 @@
       <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
     </language>
     <language id="b92f861d-0184-446d-b88b-6dcf0e070241" name="com.mbeddr.mpsutil.intentions">
-      <concept id="5846558918537398687" name="com.mbeddr.mpsutil.intentions.structure.GroupAnnotation" flags="ng" index="1SWQZ3">
+      <concept id="5846558918537398687" name="com.mbeddr.mpsutil.intentions.structure.SectionAnnotation" flags="ng" index="1SWQZ3">
         <property id="5846558918537400330" name="label" index="1SWRpm" />
       </concept>
     </language>

--- a/code/languages/com.mbeddr.ext/languages/com.mbeddr.ext.concurrency/languageModels/intentions.mps
+++ b/code/languages/com.mbeddr.ext/languages/com.mbeddr.ext.concurrency/languageModels/intentions.mps
@@ -68,7 +68,7 @@
       <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
     </language>
     <language id="b92f861d-0184-446d-b88b-6dcf0e070241" name="com.mbeddr.mpsutil.intentions">
-      <concept id="5846558918537398687" name="com.mbeddr.mpsutil.intentions.structure.GroupAnnotation" flags="ng" index="1SWQZ3">
+      <concept id="5846558918537398687" name="com.mbeddr.mpsutil.intentions.structure.SectionAnnotation" flags="ng" index="1SWQZ3">
         <property id="5846558918537400330" name="label" index="1SWRpm" />
       </concept>
     </language>

--- a/code/languages/com.mbeddr.ext/languages/com.mbeddr.ext.math/languageModels/intentions.mps
+++ b/code/languages/com.mbeddr.ext/languages/com.mbeddr.ext.math/languageModels/intentions.mps
@@ -51,7 +51,7 @@
       <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
     </language>
     <language id="b92f861d-0184-446d-b88b-6dcf0e070241" name="com.mbeddr.mpsutil.intentions">
-      <concept id="5846558918537398687" name="com.mbeddr.mpsutil.intentions.structure.GroupAnnotation" flags="ng" index="1SWQZ3">
+      <concept id="5846558918537398687" name="com.mbeddr.mpsutil.intentions.structure.SectionAnnotation" flags="ng" index="1SWQZ3">
         <property id="5846558918537400330" name="label" index="1SWRpm" />
       </concept>
     </language>

--- a/code/languages/com.mbeddr.ext/languages/com.mbeddr.ext.serialization/languageModels/intentions.mps
+++ b/code/languages/com.mbeddr.ext/languages/com.mbeddr.ext.serialization/languageModels/intentions.mps
@@ -38,7 +38,7 @@
       </concept>
     </language>
     <language id="b92f861d-0184-446d-b88b-6dcf0e070241" name="com.mbeddr.mpsutil.intentions">
-      <concept id="5846558918537398687" name="com.mbeddr.mpsutil.intentions.structure.GroupAnnotation" flags="ng" index="1SWQZ3">
+      <concept id="5846558918537398687" name="com.mbeddr.mpsutil.intentions.structure.SectionAnnotation" flags="ng" index="1SWQZ3">
         <property id="5846558918537400330" name="label" index="1SWRpm" />
       </concept>
     </language>

--- a/code/languages/com.mbeddr.ext/languages/com.mbeddr.ext.statemachines/languageModels/intentions.mps
+++ b/code/languages/com.mbeddr.ext/languages/com.mbeddr.ext.statemachines/languageModels/intentions.mps
@@ -119,7 +119,7 @@
       <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
     </language>
     <language id="b92f861d-0184-446d-b88b-6dcf0e070241" name="com.mbeddr.mpsutil.intentions">
-      <concept id="5846558918537398687" name="com.mbeddr.mpsutil.intentions.structure.GroupAnnotation" flags="ng" index="1SWQZ3">
+      <concept id="5846558918537398687" name="com.mbeddr.mpsutil.intentions.structure.SectionAnnotation" flags="ng" index="1SWQZ3">
         <property id="5846558918537400330" name="label" index="1SWRpm" />
       </concept>
     </language>

--- a/code/languages/com.mbeddr.ext/languages/com.mbeddr.ext.units/languageModels/intentions.mps
+++ b/code/languages/com.mbeddr.ext/languages/com.mbeddr.ext.units/languageModels/intentions.mps
@@ -94,7 +94,7 @@
       <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
     </language>
     <language id="b92f861d-0184-446d-b88b-6dcf0e070241" name="com.mbeddr.mpsutil.intentions">
-      <concept id="5846558918537398687" name="com.mbeddr.mpsutil.intentions.structure.GroupAnnotation" flags="ng" index="1SWQZ3">
+      <concept id="5846558918537398687" name="com.mbeddr.mpsutil.intentions.structure.SectionAnnotation" flags="ng" index="1SWQZ3">
         <property id="5846558918537400330" name="label" index="1SWRpm" />
       </concept>
     </language>

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.core.base/com.mbeddr.core.base.mpl
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.core.base/com.mbeddr.core.base.mpl
@@ -110,6 +110,7 @@
     <dependency reexport="false">528ff3b9-5fc4-40dd-931f-c6ce3650640e(jetbrains.mps.lang.migration.runtime)</dependency>
     <dependency reexport="false">f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)</dependency>
     <dependency reexport="false">9e24fcdc-a232-4d24-8c95-1f525946191a(com.mbeddr.core.base.pluginSolution)</dependency>
+    <dependency reexport="false">39983771-4e9b-401b-a1a9-1da6c777c843(MPS.ThirdParty)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:63e0e566-5131-447e-90e3-12ea330e1a00:com.mbeddr.mpsutil.blutil" version="3" />
@@ -186,6 +187,7 @@
     <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
     <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
+    <module reference="39983771-4e9b-401b-a1a9-1da6c777c843(MPS.ThirdParty)" version="0" />
     <module reference="86441d7a-e194-42da-81a5-2161ec62a379(MPS.Workbench)" version="0" />
     <module reference="d4280a54-f6df-4383-aa41-d1b2bffa7eb1(com.mbeddr.core.base)" version="3" />
     <module reference="9e24fcdc-a232-4d24-8c95-1f525946191a(com.mbeddr.core.base.pluginSolution)" version="0" />

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.core.base/models/behavior.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.core.base/models/behavior.mps
@@ -70,10 +70,13 @@
     <import index="6xgk" ref="r:6e9ad488-5df2-49e4-8c01-8a7f3812adf7(jetbrains.mps.lang.scopes.runtime)" />
     <import index="z1c5" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.project(MPS.Platform/)" />
     <import index="d244" ref="r:0a882e21-5553-485b-8777-3b0ace5a0d84(com.mbeddr.core.base.pluginSolution.plugin)" />
+    <import index="4nm9" ref="39983771-4e9b-401b-a1a9-1da6c777c843/java:com.intellij.openapi.project(MPS.ThirdParty/)" />
+    <import index="4nma" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.project(MPS.IDEA/)" />
+    <import index="alof" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.ide.project(MPS.Platform/)" />
     <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" implicit="true" />
     <import index="tpce" ref="r:00000000-0000-4000-0000-011c89590292(jetbrains.mps.lang.structure.structure)" implicit="true" />
     <import index="z8iw" ref="r:dfdf3542-dbcf-43df-870a-3c3504b3c840(jetbrains.mps.baseLanguage.collections.custom)" implicit="true" />
-    <import index="jkny" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.wm(MPS.IDEA/)" implicit="true" />
+    <import index="31cb" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.extapi.module(MPS.Core/)" implicit="true" />
   </imports>
   <registry>
     <language id="af65afd8-f0dd-4942-87d9-63a55f2a9db1" name="jetbrains.mps.lang.behavior">
@@ -96,6 +99,10 @@
       <concept id="1225194691553" name="jetbrains.mps.lang.behavior.structure.ThisNodeExpression" flags="nn" index="13iPFW" />
     </language>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1224071154655" name="jetbrains.mps.baseLanguage.structure.AsExpression" flags="nn" index="0kSF2">
+        <child id="1224071154657" name="classifierType" index="0kSFW" />
+        <child id="1224071154656" name="expression" index="0kSFX" />
+      </concept>
       <concept id="1080223426719" name="jetbrains.mps.baseLanguage.structure.OrExpression" flags="nn" index="22lmx$" />
       <concept id="1219920932475" name="jetbrains.mps.baseLanguage.structure.VariableArityType" flags="in" index="8X2XB">
         <child id="1219921048460" name="componentType" index="8Xvag" />
@@ -209,6 +216,9 @@
         <property id="1176718929932" name="isFinal" index="3TUv4t" />
         <child id="1068431790190" name="initializer" index="33vP2m" />
       </concept>
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ngI" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
+      </concept>
       <concept id="1092119917967" name="jetbrains.mps.baseLanguage.structure.MulExpression" flags="nn" index="17qRlL" />
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
@@ -286,7 +296,6 @@
       </concept>
       <concept id="1160998861373" name="jetbrains.mps.baseLanguage.structure.AssertStatement" flags="nn" index="1gVbGN">
         <child id="1160998896846" name="condition" index="1gVkn0" />
-        <child id="1160998916832" name="message" index="1gVpfI" />
       </concept>
       <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
@@ -614,10 +623,14 @@
       </concept>
       <concept id="1160600644654" name="jetbrains.mps.baseLanguage.collections.structure.ListCreatorWithInit" flags="nn" index="Tc6Ow" />
       <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="nn" index="TSZUe" />
+      <concept id="4611582986551314327" name="jetbrains.mps.baseLanguage.collections.structure.OfTypeOperation" flags="nn" index="UnYns">
+        <child id="4611582986551314344" name="requestedType" index="UnYnz" />
+      </concept>
       <concept id="1160666733551" name="jetbrains.mps.baseLanguage.collections.structure.AddAllElementsOperation" flags="nn" index="X8dFx" />
       <concept id="1240217271293" name="jetbrains.mps.baseLanguage.collections.structure.LinkedHashSetCreator" flags="nn" index="32HrFt" />
       <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="nn" index="34oBXx" />
       <concept id="1175845471038" name="jetbrains.mps.baseLanguage.collections.structure.ReverseOperation" flags="nn" index="35Qw8J" />
+      <concept id="1240325842691" name="jetbrains.mps.baseLanguage.collections.structure.AsSequenceOperation" flags="nn" index="39bAoz" />
       <concept id="3055999550620853964" name="jetbrains.mps.baseLanguage.collections.structure.RemoveWhereOperation" flags="nn" index="1aUR6E" />
       <concept id="1201792049884" name="jetbrains.mps.baseLanguage.collections.structure.TranslateOperation" flags="nn" index="3goQfb" />
       <concept id="1178286324487" name="jetbrains.mps.baseLanguage.collections.structure.SortDirection" flags="nn" index="1nlBCl" />
@@ -651,6 +664,7 @@
       </concept>
       <concept id="1176501494711" name="jetbrains.mps.baseLanguage.collections.structure.IsNotEmptyOperation" flags="nn" index="3GX2aA" />
       <concept id="1172254888721" name="jetbrains.mps.baseLanguage.collections.structure.ContainsOperation" flags="nn" index="3JPx81" />
+      <concept id="31378964227347002" name="jetbrains.mps.baseLanguage.collections.structure.SelectNotNullOperation" flags="ng" index="1KnU$U" />
       <concept id="8293956702609956630" name="jetbrains.mps.baseLanguage.collections.structure.MultiForEachVariableReference" flags="nn" index="3M$PaV">
         <reference id="8293956702609966325" name="variable" index="3M$S_o" />
       </concept>
@@ -659,6 +673,7 @@
       </concept>
       <concept id="5686963296372475025" name="jetbrains.mps.baseLanguage.collections.structure.QueueType" flags="in" index="3O6Q9H" />
       <concept id="1180964022718" name="jetbrains.mps.baseLanguage.collections.structure.ConcatOperation" flags="nn" index="3QWeyG" />
+      <concept id="1178894719932" name="jetbrains.mps.baseLanguage.collections.structure.DistinctOperation" flags="nn" index="1VAtEI" />
     </language>
   </registry>
   <node concept="13h7C7" id="65XyadYNwtL">
@@ -17345,289 +17360,140 @@
       <ref role="13i0hy" node="7nkDZJXluPi" resolve="findElements" />
       <node concept="3Tm1VV" id="5stuwjVl1RO" role="1B3o_S" />
       <node concept="3clFbS" id="5stuwjVl1RU" role="3clF47">
-        <node concept="3cpWs8" id="5stuwjVnF$r" role="3cqZAp">
-          <node concept="3cpWsn" id="5stuwjVnF$s" role="3cpWs9">
-            <property role="TrG5h" value="openProjects" />
-            <node concept="3uibUv" id="65$z0AN9zMJ" role="1tU5fm">
-              <ref role="3uigEE" to="33ny:~List" resolve="List" />
-              <node concept="3uibUv" id="65$z0AN9Adn" role="11_B2D">
+        <node concept="3cpWs8" id="3V7vYltwoos" role="3cqZAp">
+          <node concept="3cpWsn" id="3V7vYltwoot" role="3cpWs9">
+            <property role="TrG5h" value="module" />
+            <node concept="3uibUv" id="3V7vYltwnST" role="1tU5fm">
+              <ref role="3uigEE" to="z1c3:~AbstractModule" resolve="AbstractModule" />
+            </node>
+            <node concept="0kSF2" id="3V7vYltwoou" role="33vP2m">
+              <node concept="3uibUv" id="3V7vYltwoov" role="0kSFW">
+                <ref role="3uigEE" to="z1c3:~AbstractModule" resolve="AbstractModule" />
+              </node>
+              <node concept="2OqwBi" id="3V7vYltwoow" role="0kSFX">
+                <node concept="2JrnkZ" id="3V7vYltwoox" role="2Oq$k0">
+                  <node concept="37vLTw" id="3V7vYltwooy" role="2JrQYb">
+                    <ref role="3cqZAo" node="5stuwjVl1RV" resolve="currentModel" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="3V7vYltwooz" role="2OqNvi">
+                  <ref role="37wK5l" to="mhbf:~SModel.getModule()" resolve="getModule" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="3V7vYlt$F1y" role="3cqZAp">
+          <node concept="3cpWsn" id="3V7vYlt$F1z" role="3cpWs9">
+            <property role="TrG5h" value="projects" />
+            <node concept="_YKpA" id="3V7vYlt$EWR" role="1tU5fm">
+              <node concept="3uibUv" id="3V7vYlt$EWU" role="_ZDj9">
                 <ref role="3uigEE" to="z1c3:~Project" resolve="Project" />
               </node>
             </node>
-            <node concept="2OqwBi" id="5stuwjVnF$t" role="33vP2m">
-              <node concept="2YIFZM" id="5stuwjVnF$u" role="2Oq$k0">
-                <ref role="1Pybhc" to="z1c3:~ProjectManager" resolve="ProjectManager" />
-                <ref role="37wK5l" to="z1c3:~ProjectManager.getInstance()" resolve="getInstance" />
-              </node>
-              <node concept="liA8E" id="5stuwjVnF$v" role="2OqNvi">
-                <ref role="37wK5l" to="z1c3:~ProjectManager.getOpenedProjects()" resolve="getOpenedProjects" />
+            <node concept="BsUDl" id="3V7vYlt$F1$" role="33vP2m">
+              <ref role="37wK5l" node="3V7vYltwK3m" resolve="getProjects" />
+              <node concept="37vLTw" id="3V7vYlt$F1_" role="37wK5m">
+                <ref role="3cqZAo" node="3V7vYltwoot" resolve="module" />
               </node>
             </node>
           </node>
         </node>
-        <node concept="3cpWs8" id="5stuwjVnI$5" role="3cqZAp">
-          <node concept="3cpWsn" id="5stuwjVnI$6" role="3cpWs9">
-            <property role="TrG5h" value="proj" />
-            <node concept="3uibUv" id="5stuwjVnIzV" role="1tU5fm">
-              <ref role="3uigEE" to="z1c3:~Project" resolve="Project" />
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbJ" id="1k7U37YwqqX" role="3cqZAp">
-          <node concept="3clFbS" id="1k7U37YwqqZ" role="3clFbx">
-            <node concept="3clFbF" id="1k7U37YwwWb" role="3cqZAp">
-              <node concept="37vLTI" id="1k7U37Ywx07" role="3clFbG">
-                <node concept="37vLTw" id="1k7U37YwwW9" role="37vLTJ">
-                  <ref role="3cqZAo" node="5stuwjVnI$6" resolve="proj" />
-                </node>
-                <node concept="2OqwBi" id="65$z0AN9Dkw" role="37vLTx">
-                  <node concept="37vLTw" id="5stuwjVnI$9" role="2Oq$k0">
-                    <ref role="3cqZAo" node="5stuwjVnF$s" resolve="openProjects" />
+        <node concept="3cpWs6" id="3V7vYlt_zi5" role="3cqZAp">
+          <node concept="2OqwBi" id="3V7vYlt_zi7" role="3cqZAk">
+            <node concept="2OqwBi" id="3V7vYlt_zi8" role="2Oq$k0">
+              <node concept="2OqwBi" id="3V7vYlt_zi9" role="2Oq$k0">
+                <node concept="2OqwBi" id="3V7vYlt_zia" role="2Oq$k0">
+                  <node concept="37vLTw" id="3V7vYlt_zib" role="2Oq$k0">
+                    <ref role="3cqZAo" node="3V7vYlt$F1z" resolve="projects" />
                   </node>
-                  <node concept="liA8E" id="65$z0AN9F6X" role="2OqNvi">
-                    <ref role="37wK5l" to="33ny:~List.get(int)" resolve="get" />
-                    <node concept="3cmrfG" id="65$z0AN9Gq8" role="37wK5m">
-                      <property role="3cmrfH" value="0" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="3clFbC" id="1k7U37Ywvmq" role="3clFbw">
-            <node concept="3cmrfG" id="1k7U37YwwrJ" role="3uHU7w">
-              <property role="3cmrfH" value="1" />
-            </node>
-            <node concept="2OqwBi" id="1k7U37YwsWE" role="3uHU7B">
-              <node concept="37vLTw" id="1k7U37YwrJq" role="2Oq$k0">
-                <ref role="3cqZAo" node="5stuwjVnF$s" resolve="openProjects" />
-              </node>
-              <node concept="liA8E" id="1k7U37Ywuos" role="2OqNvi">
-                <ref role="37wK5l" to="33ny:~List.size()" resolve="size" />
-              </node>
-            </node>
-          </node>
-          <node concept="9aQIb" id="1k7U37Ywxap" role="9aQIa">
-            <node concept="3clFbS" id="1k7U37Ywxaq" role="9aQI4">
-              <node concept="3SKdUt" id="1k7U37YwyHX" role="3cqZAp">
-                <node concept="1PaTwC" id="1k7U37YwyHY" role="1aUNEU">
-                  <node concept="3oM_SD" id="1k7U37YwyHZ" role="1PaTwD">
-                    <property role="3oM_SC" value="in" />
-                  </node>
-                  <node concept="3oM_SD" id="1k7U37YwyIz" role="1PaTwD">
-                    <property role="3oM_SC" value="case" />
-                  </node>
-                  <node concept="3oM_SD" id="1k7U37YwyIC" role="1PaTwD">
-                    <property role="3oM_SC" value="of" />
-                  </node>
-                  <node concept="3oM_SD" id="1k7U37YwyIR" role="1PaTwD">
-                    <property role="3oM_SC" value="multiple" />
-                  </node>
-                  <node concept="3oM_SD" id="1k7U37YwyJ8" role="1PaTwD">
-                    <property role="3oM_SC" value="open" />
-                  </node>
-                  <node concept="3oM_SD" id="1k7U37YwyJj" role="1PaTwD">
-                    <property role="3oM_SC" value="projects," />
-                  </node>
-                  <node concept="3oM_SD" id="1k7U37YwyJS" role="1PaTwD">
-                    <property role="3oM_SC" value="using" />
-                  </node>
-                  <node concept="3oM_SD" id="1k7U37YwyKB" role="1PaTwD">
-                    <property role="3oM_SC" value="first" />
-                  </node>
-                  <node concept="3oM_SD" id="1k7U37YwyM0" role="1PaTwD">
-                    <property role="3oM_SC" value="from" />
-                  </node>
-                  <node concept="3oM_SD" id="1k7U37YwyMr" role="1PaTwD">
-                    <property role="3oM_SC" value="the" />
-                  </node>
-                  <node concept="3oM_SD" id="1k7U37YwyMK" role="1PaTwD">
-                    <property role="3oM_SC" value="list" />
-                  </node>
-                  <node concept="3oM_SD" id="1k7U37YwyN7" role="1PaTwD">
-                    <property role="3oM_SC" value="is" />
-                  </node>
-                  <node concept="3oM_SD" id="1k7U37YwyNC" role="1PaTwD">
-                    <property role="3oM_SC" value="not" />
-                  </node>
-                  <node concept="3oM_SD" id="1k7U37YwyO3" role="1PaTwD">
-                    <property role="3oM_SC" value="reliable" />
-                  </node>
-                  <node concept="3oM_SD" id="1k7U37YwyOK" role="1PaTwD">
-                    <property role="3oM_SC" value="anymore" />
-                  </node>
-                </node>
-              </node>
-              <node concept="3SKdUt" id="1k7U37YwyTC" role="3cqZAp">
-                <node concept="1PaTwC" id="1k7U37YwyTD" role="1aUNEU">
-                  <node concept="3oM_SD" id="1k7U37YwyUX" role="1PaTwD">
-                    <property role="3oM_SC" value="therefore" />
-                  </node>
-                  <node concept="3oM_SD" id="1k7U37YwyV8" role="1PaTwD">
-                    <property role="3oM_SC" value="we" />
-                  </node>
-                  <node concept="3oM_SD" id="1k7U37YwyVd" role="1PaTwD">
-                    <property role="3oM_SC" value="try" />
-                  </node>
-                  <node concept="3oM_SD" id="1k7U37YwyV$" role="1PaTwD">
-                    <property role="3oM_SC" value="to" />
-                  </node>
-                  <node concept="3oM_SD" id="1k7U37YwyVP" role="1PaTwD">
-                    <property role="3oM_SC" value="retrieve" />
-                  </node>
-                  <node concept="3oM_SD" id="1k7U37YwyWo" role="1PaTwD">
-                    <property role="3oM_SC" value="the" />
-                  </node>
-                  <node concept="3oM_SD" id="1k7U37YwyWH" role="1PaTwD">
-                    <property role="3oM_SC" value="project" />
-                  </node>
-                  <node concept="3oM_SD" id="1k7U37YwyXc" role="1PaTwD">
-                    <property role="3oM_SC" value="from" />
-                  </node>
-                  <node concept="3oM_SD" id="1k7U37YwyX_" role="1PaTwD">
-                    <property role="3oM_SC" value="the" />
-                  </node>
-                  <node concept="3oM_SD" id="1k7U37YwyXS" role="1PaTwD">
-                    <property role="3oM_SC" value="focused" />
-                  </node>
-                  <node concept="3oM_SD" id="1k7U37YwyY_" role="1PaTwD">
-                    <property role="3oM_SC" value="window" />
-                  </node>
-                  <node concept="3oM_SD" id="1k7U37YwyZc" role="1PaTwD">
-                    <property role="3oM_SC" value="(s." />
-                  </node>
-                  <node concept="3oM_SD" id="1k7U37Ywz1t" role="1PaTwD">
-                    <property role="3oM_SC" value="also" />
-                  </node>
-                  <node concept="3oM_SD" id="1k7U37Ywzad" role="1PaTwD">
-                    <property role="3oM_SC" value="CurrentProjectAccessUtil)" />
-                  </node>
-                </node>
-              </node>
-              <node concept="3cpWs8" id="1k7U37Yw$0D" role="3cqZAp">
-                <node concept="3cpWsn" id="1k7U37Yw$0E" role="3cpWs9">
-                  <property role="TrG5h" value="mostRecentFocusedWindow" />
-                  <node concept="3uibUv" id="1k7U37Yw$0c" role="1tU5fm">
-                    <ref role="3uigEE" to="z60i:~Window" resolve="Window" />
-                  </node>
-                  <node concept="2OqwBi" id="1k7U37Yw$0F" role="33vP2m">
-                    <node concept="2YIFZM" id="1k7U37Yw$0G" role="2Oq$k0">
-                      <ref role="37wK5l" to="b9kz:~WindowManagerEx.getInstanceEx()" resolve="getInstanceEx" />
-                      <ref role="1Pybhc" to="b9kz:~WindowManagerEx" resolve="WindowManagerEx" />
-                    </node>
-                    <node concept="liA8E" id="1k7U37Yw$0H" role="2OqNvi">
-                      <ref role="37wK5l" to="jkny:~WindowManager.getMostRecentFocusedWindow()" resolve="getMostRecentFocusedWindow" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="3cpWs8" id="1k7U37Yw$LV" role="3cqZAp">
-                <node concept="3cpWsn" id="1k7U37Yw$LW" role="3cpWs9">
-                  <property role="TrG5h" value="dataContext" />
-                  <node concept="3uibUv" id="1k7U37Yw$Lr" role="1tU5fm">
-                    <ref role="3uigEE" to="qkt:~DataContext" resolve="DataContext" />
-                  </node>
-                  <node concept="2OqwBi" id="1k7U37Yw$LX" role="33vP2m">
-                    <node concept="2YIFZM" id="1k7U37Yw$LY" role="2Oq$k0">
-                      <ref role="37wK5l" to="ddhc:~DataManager.getInstance()" resolve="getInstance" />
-                      <ref role="1Pybhc" to="ddhc:~DataManager" resolve="DataManager" />
-                    </node>
-                    <node concept="liA8E" id="1k7U37Yw$LZ" role="2OqNvi">
-                      <ref role="37wK5l" to="ddhc:~DataManager.getDataContext(java.awt.Component)" resolve="getDataContext" />
-                      <node concept="37vLTw" id="1k7U37Yw$M0" role="37wK5m">
-                        <ref role="3cqZAo" node="1k7U37Yw$0E" resolve="mostRecentFocusedWindow" />
+                  <node concept="3goQfb" id="3V7vYlt_zic" role="2OqNvi">
+                    <node concept="1bVj0M" id="3V7vYlt_zid" role="23t8la">
+                      <node concept="3clFbS" id="3V7vYlt_zie" role="1bW5cS">
+                        <node concept="3clFbF" id="3V7vYlt_zif" role="3cqZAp">
+                          <node concept="2OqwBi" id="3V7vYlt_zig" role="3clFbG">
+                            <node concept="2OqwBi" id="3V7vYlt_zih" role="2Oq$k0">
+                              <node concept="37vLTw" id="3V7vYlt_zii" role="2Oq$k0">
+                                <ref role="3cqZAo" node="3V7vYlt_zil" resolve="project" />
+                              </node>
+                              <node concept="liA8E" id="3V7vYlt_zij" role="2OqNvi">
+                                <ref role="37wK5l" to="z1c3:~Project.getScope()" resolve="getScope" />
+                              </node>
+                            </node>
+                            <node concept="liA8E" id="3V7vYlt_zik" role="2OqNvi">
+                              <ref role="37wK5l" to="w1kc:~BaseScope.getModels()" resolve="getModels" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="gl6BB" id="3V7vYlt_zil" role="1bW2Oz">
+                        <property role="TrG5h" value="project" />
+                        <node concept="2jxLKc" id="3V7vYlt_zim" role="1tU5fm" />
                       </node>
                     </node>
                   </node>
                 </node>
-              </node>
-              <node concept="3clFbF" id="1k7U37Ywy_P" role="3cqZAp">
-                <node concept="37vLTI" id="1k7U37YwyDL" role="3clFbG">
-                  <node concept="37vLTw" id="1k7U37Ywy_O" role="37vLTJ">
-                    <ref role="3cqZAo" node="5stuwjVnI$6" resolve="proj" />
-                  </node>
-                  <node concept="2OqwBi" id="1k7U37YwNoh" role="37vLTx">
-                    <node concept="10M0yZ" id="1k7U37YwN2z" role="2Oq$k0">
-                      <ref role="3cqZAo" to="qq03:~MPSCommonDataKeys.MPS_PROJECT" resolve="MPS_PROJECT" />
-                      <ref role="1PxDUh" to="qq03:~MPSCommonDataKeys" resolve="MPSCommonDataKeys" />
-                    </node>
-                    <node concept="liA8E" id="1k7U37YwNPk" role="2OqNvi">
-                      <ref role="37wK5l" to="qkt:~DataKey.getData(com.intellij.openapi.actionSystem.DataContext)" resolve="getData" />
-                      <node concept="37vLTw" id="1k7U37YwNYR" role="37wK5m">
-                        <ref role="3cqZAo" node="1k7U37Yw$LW" resolve="dataContext" />
+                <node concept="3$u5V9" id="3V7vYlt_zin" role="2OqNvi">
+                  <node concept="1bVj0M" id="3V7vYlt_zio" role="23t8la">
+                    <node concept="3clFbS" id="3V7vYlt_zip" role="1bW5cS">
+                      <node concept="3SKdUt" id="7pWpqSo1C6v" role="3cqZAp">
+                        <node concept="1PaTwC" id="7pWpqSo1C6w" role="1aUNEU">
+                          <node concept="3oM_SD" id="7pWpqSo1Ck_" role="1PaTwD">
+                            <property role="3oM_SC" value="compile" />
+                          </node>
+                          <node concept="3oM_SD" id="7pWpqSo1DBz" role="1PaTwD">
+                            <property role="3oM_SC" value="time" />
+                          </node>
+                          <node concept="3oM_SD" id="7pWpqSo1DB$" role="1PaTwD">
+                            <property role="3oM_SC" value="upcast" />
+                          </node>
+                          <node concept="3oM_SD" id="7pWpqSo1CJ_" role="1PaTwD">
+                            <property role="3oM_SC" value="" />
+                          </node>
+                        </node>
                       </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="1gVbGN" id="1k7U37YwPd9" role="3cqZAp">
-                <node concept="3y3z36" id="1k7U37YwPBB" role="1gVkn0">
-                  <node concept="10Nm6u" id="1k7U37YwPJ1" role="3uHU7w" />
-                  <node concept="37vLTw" id="1k7U37YwPm2" role="3uHU7B">
-                    <ref role="3cqZAo" node="5stuwjVnI$6" resolve="proj" />
-                  </node>
-                </node>
-                <node concept="Xl_RD" id="1k7U37YwPKn" role="1gVpfI">
-                  <property role="Xl_RC" value="Failed to retrieve project from the focused window" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3cpWs8" id="5stuwjVnRo4" role="3cqZAp">
-          <node concept="3cpWsn" id="5stuwjVnRo7" role="3cpWs9">
-            <property role="TrG5h" value="res" />
-            <node concept="2I9FWS" id="5stuwjVnRo2" role="1tU5fm" />
-            <node concept="2ShNRf" id="5stuwjVnRyq" role="33vP2m">
-              <node concept="2T8Vx0" id="5stuwjVnRyo" role="2ShVmc">
-                <node concept="2I9FWS" id="5stuwjVnRyp" role="2T96Bj" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="2Gpval" id="5stuwjVnLXA" role="3cqZAp">
-          <node concept="2GrKxI" id="5stuwjVnLXC" role="2Gsz3X">
-            <property role="TrG5h" value="m" />
-          </node>
-          <node concept="3clFbS" id="5stuwjVnLXG" role="2LFqv$">
-            <node concept="3clFbF" id="5stuwjVnV5y" role="3cqZAp">
-              <node concept="2OqwBi" id="5stuwjVnVpD" role="3clFbG">
-                <node concept="37vLTw" id="5stuwjVnV5w" role="2Oq$k0">
-                  <ref role="3cqZAo" node="5stuwjVnRo7" resolve="res" />
-                </node>
-                <node concept="X8dFx" id="5stuwjVnY2X" role="2OqNvi">
-                  <node concept="2OqwBi" id="5stuwjVnUUc" role="25WWJ7">
-                    <node concept="1eOMI4" id="1k7U37YwjAi" role="2Oq$k0">
-                      <node concept="10QFUN" id="1k7U37YwjAf" role="1eOMHV">
-                        <node concept="H_c77" id="1k7U37YwkDG" role="10QFUM" />
-                        <node concept="2GrUjf" id="1k7U37YwjAk" role="10QFUP">
-                          <ref role="2Gs0qQ" node="5stuwjVnLXC" resolve="m" />
+                      <node concept="3cpWs8" id="3V7vYlt_ziq" role="3cqZAp">
+                        <node concept="3cpWsn" id="3V7vYlt_zir" role="3cpWs9">
+                          <property role="TrG5h" value="m" />
+                          <node concept="H_c77" id="3V7vYlt_zis" role="1tU5fm" />
+                          <node concept="37vLTw" id="3V7vYlt_zit" role="33vP2m">
+                            <ref role="3cqZAo" node="3V7vYlt_ziw" resolve="it" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbF" id="3V7vYlt_ziu" role="3cqZAp">
+                        <node concept="37vLTw" id="3V7vYlt_ziv" role="3clFbG">
+                          <ref role="3cqZAo" node="3V7vYlt_zir" resolve="m" />
                         </node>
                       </node>
                     </node>
-                    <node concept="2SmgA7" id="5stuwjVnV4x" role="2OqNvi" />
+                    <node concept="gl6BB" id="3V7vYlt_ziw" role="1bW2Oz">
+                      <property role="TrG5h" value="it" />
+                      <node concept="2jxLKc" id="3V7vYlt_zix" role="1tU5fm" />
+                    </node>
                   </node>
                 </node>
               </node>
+              <node concept="1VAtEI" id="3V7vYlt_ziy" role="2OqNvi" />
             </node>
-          </node>
-          <node concept="2OqwBi" id="2x4nHT4_e94" role="2GsD0m">
-            <node concept="2OqwBi" id="5stuwjVnLDH" role="2Oq$k0">
-              <node concept="37vLTw" id="5stuwjVnLDI" role="2Oq$k0">
-                <ref role="3cqZAo" node="5stuwjVnI$6" resolve="proj" />
+            <node concept="3goQfb" id="3V7vYlt_ziz" role="2OqNvi">
+              <node concept="1bVj0M" id="3V7vYlt_zi$" role="23t8la">
+                <node concept="3clFbS" id="3V7vYlt_zi_" role="1bW5cS">
+                  <node concept="3clFbF" id="3V7vYlt_ziA" role="3cqZAp">
+                    <node concept="2OqwBi" id="3V7vYlt_ziB" role="3clFbG">
+                      <node concept="37vLTw" id="3V7vYlt_ziC" role="2Oq$k0">
+                        <ref role="3cqZAo" node="3V7vYlt_ziE" resolve="it" />
+                      </node>
+                      <node concept="2SmgA7" id="3V7vYlt_ziD" role="2OqNvi" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="gl6BB" id="3V7vYlt_ziE" role="1bW2Oz">
+                  <property role="TrG5h" value="it" />
+                  <node concept="2jxLKc" id="3V7vYlt_ziF" role="1tU5fm" />
+                </node>
               </node>
-              <node concept="liA8E" id="1k7U37Yw6sq" role="2OqNvi">
-                <ref role="37wK5l" to="z1c3:~Project.getScope()" resolve="getScope" />
-              </node>
             </node>
-            <node concept="liA8E" id="2x4nHT4_eOB" role="2OqNvi">
-              <ref role="37wK5l" to="w1kc:~BaseScope.getModels()" resolve="getModels" />
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="5stuwjVnRGN" role="3cqZAp">
-          <node concept="37vLTw" id="5stuwjVnRGL" role="3clFbG">
-            <ref role="3cqZAo" node="5stuwjVnRo7" resolve="res" />
           </node>
         </node>
       </node>
@@ -17637,6 +17503,317 @@
       </node>
       <node concept="A3Dl8" id="5stuwjVl1RX" role="3clF45">
         <node concept="3Tqbb2" id="5stuwjVl1RY" role="A3Ik2" />
+      </node>
+    </node>
+    <node concept="13i0hz" id="3V7vYltwK3m" role="13h7CS">
+      <property role="TrG5h" value="getProjects" />
+      <node concept="37vLTG" id="3V7vYltwNjs" role="3clF46">
+        <property role="TrG5h" value="module" />
+        <node concept="3uibUv" id="3V7vYltwO24" role="1tU5fm">
+          <ref role="3uigEE" to="z1c3:~AbstractModule" resolve="AbstractModule" />
+        </node>
+        <node concept="2AHcQZ" id="7pWpqSo1F7F" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
+        </node>
+      </node>
+      <node concept="3Tm6S6" id="3V7vYltwKC_" role="1B3o_S" />
+      <node concept="_YKpA" id="3V7vYltxMcE" role="3clF45">
+        <node concept="3uibUv" id="3V7vYltxMcF" role="_ZDj9">
+          <ref role="3uigEE" to="z1c3:~Project" resolve="Project" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="3V7vYltwK3p" role="3clF47">
+        <node concept="3cpWs8" id="3V7vYltxXIa" role="3cqZAp">
+          <node concept="3cpWsn" id="3V7vYltxXIb" role="3cpWs9">
+            <property role="TrG5h" value="pm" />
+            <node concept="3uibUv" id="3V7vYltxXte" role="1tU5fm">
+              <ref role="3uigEE" to="4nm9:~ProjectManager" resolve="ProjectManager" />
+            </node>
+            <node concept="2YIFZM" id="3V7vYltxXIc" role="33vP2m">
+              <ref role="37wK5l" to="4nm9:~ProjectManager.getInstanceIfCreated()" resolve="getInstanceIfCreated" />
+              <ref role="1Pybhc" to="4nm9:~ProjectManager" resolve="ProjectManager" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="3V7vYltxYLE" role="3cqZAp">
+          <node concept="3clFbS" id="3V7vYltxYLG" role="3clFbx">
+            <node concept="3cpWs6" id="3V7vYlty24b" role="3cqZAp">
+              <node concept="2ShNRf" id="3V7vYlty2E2" role="3cqZAk">
+                <node concept="Tc6Ow" id="3V7vYlty2DY" role="2ShVmc">
+                  <node concept="3uibUv" id="3V7vYlty2DZ" role="HW$YZ">
+                    <ref role="3uigEE" to="z1c3:~Project" resolve="Project" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbC" id="3V7vYlty0cl" role="3clFbw">
+            <node concept="10Nm6u" id="3V7vYlty1qv" role="3uHU7w" />
+            <node concept="37vLTw" id="3V7vYltxZ4t" role="3uHU7B">
+              <ref role="3cqZAo" node="3V7vYltxXIb" resolve="pm" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="3V7vYltyajo" role="3cqZAp">
+          <node concept="3cpWsn" id="3V7vYltyajp" role="3cpWs9">
+            <property role="TrG5h" value="ideaProjects" />
+            <node concept="_YKpA" id="3V7vYltya2j" role="1tU5fm">
+              <node concept="3uibUv" id="3V7vYltya2m" role="_ZDj9">
+                <ref role="3uigEE" to="4nma:~Project" resolve="Project" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="3V7vYltyajq" role="33vP2m">
+              <node concept="2OqwBi" id="3V7vYltyajr" role="2Oq$k0">
+                <node concept="2OqwBi" id="3V7vYltyajs" role="2Oq$k0">
+                  <node concept="37vLTw" id="3V7vYltyajt" role="2Oq$k0">
+                    <ref role="3cqZAo" node="3V7vYltxXIb" resolve="pm" />
+                  </node>
+                  <node concept="liA8E" id="3V7vYltyaju" role="2OqNvi">
+                    <ref role="37wK5l" to="4nm9:~ProjectManager.getOpenProjects()" resolve="getOpenProjects" />
+                  </node>
+                </node>
+                <node concept="39bAoz" id="3V7vYltyajv" role="2OqNvi" />
+              </node>
+              <node concept="ANE8D" id="3V7vYltyajw" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="3V7vYltyBl8" role="3cqZAp">
+          <node concept="3cpWsn" id="3V7vYltyBl9" role="3cpWs9">
+            <property role="TrG5h" value="allMpsProjects" />
+            <node concept="_YKpA" id="3V7vYltyHN7" role="1tU5fm">
+              <node concept="3uibUv" id="3V7vYltyHN9" role="_ZDj9">
+                <ref role="3uigEE" to="z1c3:~Project" resolve="Project" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="3V7vYltyDNA" role="33vP2m">
+              <node concept="2OqwBi" id="3V7vYltyBla" role="2Oq$k0">
+                <node concept="2OqwBi" id="3V7vYltyBlb" role="2Oq$k0">
+                  <node concept="37vLTw" id="3V7vYltyBlc" role="2Oq$k0">
+                    <ref role="3cqZAo" node="3V7vYltyajp" resolve="ideaProjects" />
+                  </node>
+                  <node concept="3$u5V9" id="3V7vYltyBld" role="2OqNvi">
+                    <node concept="1bVj0M" id="3V7vYltyBle" role="23t8la">
+                      <node concept="3clFbS" id="3V7vYltyBlf" role="1bW5cS">
+                        <node concept="3cpWs8" id="3V7vYlt$sRG" role="3cqZAp">
+                          <node concept="3cpWsn" id="3V7vYlt$sRH" role="3cpWs9">
+                            <property role="TrG5h" value="mpsProject" />
+                            <node concept="3uibUv" id="3V7vYlt$swY" role="1tU5fm">
+                              <ref role="3uigEE" to="z1c3:~Project" resolve="Project" />
+                            </node>
+                            <node concept="2YIFZM" id="3V7vYlt$sRI" role="33vP2m">
+                              <ref role="37wK5l" to="alof:~ProjectHelper.fromIdeaProject(com.intellij.openapi.project.Project)" resolve="fromIdeaProject" />
+                              <ref role="1Pybhc" to="alof:~ProjectHelper" resolve="ProjectHelper" />
+                              <node concept="37vLTw" id="3V7vYlt$sRJ" role="37wK5m">
+                                <ref role="3cqZAo" node="3V7vYltyBlj" resolve="it" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3clFbF" id="3V7vYltyBlg" role="3cqZAp">
+                          <node concept="37vLTw" id="3V7vYlt$sRK" role="3clFbG">
+                            <ref role="3cqZAo" node="3V7vYlt$sRH" resolve="mpsProject" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="gl6BB" id="3V7vYltyBlj" role="1bW2Oz">
+                        <property role="TrG5h" value="it" />
+                        <node concept="2jxLKc" id="3V7vYltyBlk" role="1tU5fm" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="1KnU$U" id="3V7vYltyBll" role="2OqNvi" />
+              </node>
+              <node concept="ANE8D" id="3V7vYltyFHO" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="7pWpqSo1K16" role="3cqZAp">
+          <node concept="3clFbS" id="7pWpqSo1K18" role="3clFbx">
+            <node concept="3cpWs6" id="7pWpqSo1NQg" role="3cqZAp">
+              <node concept="37vLTw" id="7pWpqSo1Pbn" role="3cqZAk">
+                <ref role="3cqZAo" node="3V7vYltyBl9" resolve="allMpsProjects" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbC" id="7pWpqSo1LLm" role="3clFbw">
+            <node concept="10Nm6u" id="7pWpqSo1MQK" role="3uHU7w" />
+            <node concept="37vLTw" id="7pWpqSo1KIg" role="3uHU7B">
+              <ref role="3cqZAo" node="3V7vYltwNjs" resolve="module" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="3V7vYltyI$8" role="3cqZAp" />
+        <node concept="3cpWs8" id="3V7vYltzZOh" role="3cqZAp">
+          <node concept="3cpWsn" id="3V7vYltzZOi" role="3cpWs9">
+            <property role="TrG5h" value="filteredProjects" />
+            <node concept="_YKpA" id="3V7vYlt$7_o" role="1tU5fm">
+              <node concept="3uibUv" id="3V7vYlt$7_q" role="_ZDj9">
+                <ref role="3uigEE" to="z1c3:~Project" resolve="Project" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="3V7vYlt$2SC" role="33vP2m">
+              <node concept="2OqwBi" id="3V7vYltzZOj" role="2Oq$k0">
+                <node concept="37vLTw" id="3V7vYltzZOk" role="2Oq$k0">
+                  <ref role="3cqZAo" node="3V7vYltyBl9" resolve="allMpsProjects" />
+                </node>
+                <node concept="3zZkjj" id="3V7vYltzZOl" role="2OqNvi">
+                  <node concept="1bVj0M" id="3V7vYltzZOm" role="23t8la">
+                    <node concept="3clFbS" id="3V7vYltzZOn" role="1bW5cS">
+                      <node concept="3SKdUt" id="7pWpqSo0QLk" role="3cqZAp">
+                        <node concept="1PaTwC" id="7pWpqSo0QLl" role="1aUNEU">
+                          <node concept="3oM_SD" id="7pWpqSo0Rp3" role="1PaTwD">
+                            <property role="3oM_SC" value="This" />
+                          </node>
+                          <node concept="3oM_SD" id="7pWpqSo1v4y" role="1PaTwD">
+                            <property role="3oM_SC" value="is" />
+                          </node>
+                          <node concept="3oM_SD" id="7pWpqSo1vFu" role="1PaTwD">
+                            <property role="3oM_SC" value="a" />
+                          </node>
+                          <node concept="3oM_SD" id="7pWpqSo1w9g" role="1PaTwD">
+                            <property role="3oM_SC" value="similar" />
+                          </node>
+                          <node concept="3oM_SD" id="7pWpqSo0TpG" role="1PaTwD">
+                            <property role="3oM_SC" value="strategy" />
+                          </node>
+                          <node concept="3oM_SD" id="7pWpqSo1z5$" role="1PaTwD">
+                            <property role="3oM_SC" value="to" />
+                          </node>
+                          <node concept="3oM_SD" id="7pWpqSo0Yka" role="1PaTwD">
+                            <property role="3oM_SC" value="the" />
+                          </node>
+                          <node concept="3oM_SD" id="7pWpqSo0YPF" role="1PaTwD">
+                            <property role="3oM_SC" value="one" />
+                          </node>
+                          <node concept="3oM_SD" id="7pWpqSo0ZfC" role="1PaTwD">
+                            <property role="3oM_SC" value="used" />
+                          </node>
+                          <node concept="3oM_SD" id="7pWpqSo1zAJ" role="1PaTwD">
+                            <property role="3oM_SC" value="in" />
+                          </node>
+                          <node concept="3oM_SD" id="7pWpqSo13Ue" role="1PaTwD">
+                            <property role="3oM_SC" value="jetbrains.mps.project.SModuleOperations.getProjectForModule" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbJ" id="7pWpqSo15YR" role="3cqZAp">
+                        <node concept="3clFbS" id="7pWpqSo15YT" role="3clFbx">
+                          <node concept="3cpWs6" id="7pWpqSo1tee" role="3cqZAp">
+                            <node concept="3clFbT" id="7pWpqSo1unz" role="3cqZAk">
+                              <property role="3clFbU" value="true" />
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="17R0WA" id="7pWpqSo1rlP" role="3clFbw">
+                          <node concept="37vLTw" id="7pWpqSo1s9U" role="3uHU7w">
+                            <ref role="3cqZAo" node="3V7vYltzZOE" resolve="project" />
+                          </node>
+                          <node concept="2EnYce" id="7pWpqSo1nfK" role="3uHU7B">
+                            <node concept="1eOMI4" id="7pWpqSo1ib3" role="2Oq$k0">
+                              <node concept="0kSF2" id="7pWpqSo1cWq" role="1eOMHV">
+                                <node concept="3uibUv" id="7pWpqSo1cWs" role="0kSFW">
+                                  <ref role="3uigEE" to="z1c3:~ProjectRepository" resolve="ProjectRepository" />
+                                </node>
+                                <node concept="2OqwBi" id="7pWpqSo19oZ" role="0kSFX">
+                                  <node concept="37vLTw" id="7pWpqSo16AL" role="2Oq$k0">
+                                    <ref role="3cqZAo" node="3V7vYltwNjs" resolve="module" />
+                                  </node>
+                                  <node concept="liA8E" id="7pWpqSo1c8J" role="2OqNvi">
+                                    <ref role="37wK5l" to="31cb:~SModuleBase.getRepository()" resolve="getRepository" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="liA8E" id="7pWpqSo1o2E" role="2OqNvi">
+                              <ref role="37wK5l" to="z1c3:~ProjectRepository.getProject()" resolve="getProject" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3cpWs8" id="3V7vYltzZOo" role="3cqZAp">
+                        <node concept="3cpWsn" id="3V7vYltzZOp" role="3cpWs9">
+                          <property role="TrG5h" value="moduleOwners" />
+                          <node concept="2hMVRd" id="3V7vYltzZOq" role="1tU5fm">
+                            <node concept="3uibUv" id="3V7vYltzZOr" role="2hN53Y">
+                              <ref role="3uigEE" to="w1kc:~MPSModuleOwner" resolve="MPSModuleOwner" />
+                            </node>
+                          </node>
+                          <node concept="2OqwBi" id="3V7vYltzZOs" role="33vP2m">
+                            <node concept="2ShNRf" id="3V7vYltzZOt" role="2Oq$k0">
+                              <node concept="1pGfFk" id="3V7vYltzZOu" role="2ShVmc">
+                                <property role="373rjd" value="true" />
+                                <ref role="37wK5l" to="w1kc:~ModuleRepositoryFacade.&lt;init&gt;(jetbrains.mps.project.Project)" resolve="ModuleRepositoryFacade" />
+                                <node concept="37vLTw" id="3V7vYltzZOv" role="37wK5m">
+                                  <ref role="3cqZAo" node="3V7vYltzZOE" resolve="project" />
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="liA8E" id="3V7vYltzZOw" role="2OqNvi">
+                              <ref role="37wK5l" to="w1kc:~ModuleRepositoryFacade.getModuleOwners(org.jetbrains.mps.openapi.module.SModule)" resolve="getModuleOwners" />
+                              <node concept="37vLTw" id="3V7vYltzZOx" role="37wK5m">
+                                <ref role="3cqZAo" node="3V7vYltwNjs" resolve="module" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbF" id="3V7vYltzZOy" role="3cqZAp">
+                        <node concept="2OqwBi" id="3V7vYltzZOz" role="3clFbG">
+                          <node concept="2OqwBi" id="3V7vYltzZO$" role="2Oq$k0">
+                            <node concept="37vLTw" id="3V7vYltzZO_" role="2Oq$k0">
+                              <ref role="3cqZAo" node="3V7vYltzZOp" resolve="moduleOwners" />
+                            </node>
+                            <node concept="UnYns" id="3V7vYltzZOA" role="2OqNvi">
+                              <node concept="3uibUv" id="3V7vYltzZOB" role="UnYnz">
+                                <ref role="3uigEE" to="z1c3:~Project" resolve="Project" />
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="3JPx81" id="3V7vYltzZOC" role="2OqNvi">
+                            <node concept="37vLTw" id="3V7vYltzZOD" role="25WWJ7">
+                              <ref role="3cqZAo" node="3V7vYltzZOE" resolve="project" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="gl6BB" id="3V7vYltzZOE" role="1bW2Oz">
+                      <property role="TrG5h" value="project" />
+                      <node concept="2jxLKc" id="3V7vYltzZOF" role="1tU5fm" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="ANE8D" id="3V7vYlt$6as" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="3V7vYlt$c2B" role="3cqZAp">
+          <node concept="3clFbS" id="3V7vYlt$c2D" role="3clFbx">
+            <node concept="3cpWs6" id="3V7vYlt$lLa" role="3cqZAp">
+              <node concept="37vLTw" id="3V7vYlt$mS5" role="3cqZAk">
+                <ref role="3cqZAo" node="3V7vYltzZOi" resolve="filteredProjects" />
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="3V7vYlt$gDl" role="3clFbw">
+            <node concept="37vLTw" id="3V7vYlt$cAy" role="2Oq$k0">
+              <ref role="3cqZAo" node="3V7vYltzZOi" resolve="filteredProjects" />
+            </node>
+            <node concept="3GX2aA" id="3V7vYlt$kQt" role="2OqNvi" />
+          </node>
+        </node>
+        <node concept="3clFbH" id="7pWpqSo1RgD" role="3cqZAp" />
+        <node concept="3cpWs6" id="3V7vYlt$yFy" role="3cqZAp">
+          <node concept="37vLTw" id="3V7vYlt$$xL" role="3cqZAk">
+            <ref role="3cqZAo" node="3V7vYltyBl9" resolve="allMpsProjects" />
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="3V7vYltwRao" role="2AJF6D">
+        <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
       </node>
     </node>
   </node>

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.core.base/models/intentions.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.core.base/models/intentions.mps
@@ -173,7 +173,7 @@
       <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
     </language>
     <language id="b92f861d-0184-446d-b88b-6dcf0e070241" name="com.mbeddr.mpsutil.intentions">
-      <concept id="5846558918537398687" name="com.mbeddr.mpsutil.intentions.structure.GroupAnnotation" flags="ng" index="1SWQZ3">
+      <concept id="5846558918537398687" name="com.mbeddr.mpsutil.intentions.structure.SectionAnnotation" flags="ng" index="1SWQZ3">
         <property id="5846558918537400330" name="label" index="1SWRpm" />
       </concept>
     </language>

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.core.codereview/models/intentions.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.core.codereview/models/intentions.mps
@@ -75,7 +75,7 @@
       <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
     </language>
     <language id="b92f861d-0184-446d-b88b-6dcf0e070241" name="com.mbeddr.mpsutil.intentions">
-      <concept id="5846558918537398687" name="com.mbeddr.mpsutil.intentions.structure.GroupAnnotation" flags="ng" index="1SWQZ3">
+      <concept id="5846558918537398687" name="com.mbeddr.mpsutil.intentions.structure.SectionAnnotation" flags="ng" index="1SWQZ3">
         <property id="5846558918537400330" name="label" index="1SWRpm" />
       </concept>
     </language>

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.filepicker/models/intentions.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.filepicker/models/intentions.mps
@@ -97,7 +97,7 @@
       </concept>
     </language>
     <language id="b92f861d-0184-446d-b88b-6dcf0e070241" name="com.mbeddr.mpsutil.intentions">
-      <concept id="5846558918537398687" name="com.mbeddr.mpsutil.intentions.structure.GroupAnnotation" flags="ng" index="1SWQZ3">
+      <concept id="5846558918537398687" name="com.mbeddr.mpsutil.intentions.structure.SectionAnnotation" flags="ng" index="1SWQZ3">
         <property id="5846558918537400330" name="label" index="1SWRpm" />
       </concept>
     </language>

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.interpreter/languageModels/intentions.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.interpreter/languageModels/intentions.mps
@@ -64,7 +64,7 @@
       </concept>
     </language>
     <language id="b92f861d-0184-446d-b88b-6dcf0e070241" name="com.mbeddr.mpsutil.intentions">
-      <concept id="5846558918537398687" name="com.mbeddr.mpsutil.intentions.structure.GroupAnnotation" flags="ng" index="1SWQZ3">
+      <concept id="5846558918537398687" name="com.mbeddr.mpsutil.intentions.structure.SectionAnnotation" flags="ng" index="1SWQZ3">
         <property id="5846558918537400330" name="label" index="1SWRpm" />
       </concept>
     </language>

--- a/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.review/languageModels/intentions.mps
+++ b/code/languages/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.review/languageModels/intentions.mps
@@ -85,7 +85,7 @@
       </concept>
     </language>
     <language id="b92f861d-0184-446d-b88b-6dcf0e070241" name="com.mbeddr.mpsutil.intentions">
-      <concept id="5846558918537398687" name="com.mbeddr.mpsutil.intentions.structure.GroupAnnotation" flags="ng" index="1SWQZ3">
+      <concept id="5846558918537398687" name="com.mbeddr.mpsutil.intentions.structure.SectionAnnotation" flags="ng" index="1SWQZ3">
         <property id="5846558918537400330" name="label" index="1SWRpm" />
       </concept>
     </language>

--- a/code/languages/com.mbeddr.platform.build/solutions/com.mbeddr.platform/models/com/mbeddr/platform/build.mps
+++ b/code/languages/com.mbeddr.platform.build/solutions/com.mbeddr.platform/models/com/mbeddr/platform/build.mps
@@ -13993,6 +13993,11 @@
             <ref role="3bR37D" node="$bJ0jguQdz" resolve="com.mbeddr.core.base.pluginSolution" />
           </node>
         </node>
+        <node concept="1SiIV0" id="3V7vYltw10S" role="3bR37C">
+          <node concept="3bR9La" id="3V7vYltw10T" role="1SiIV1">
+            <ref role="3bR37D" to="90a9:3$A0JaN5bpX" resolve="MPS.ThirdParty" />
+          </node>
+        </node>
       </node>
     </node>
     <node concept="2G$12M" id="7Nsh5Tc2mTg" role="3989C9">


### PR DESCRIPTION
Fixes https://github.com/mbeddr/mbeddr.core/issues/3047

`com.mbeddr.core.base.ProjectScope` failed during a command line build

  During test execution there was an additional temporary project open. That's why the strategy of
  choosing the single open project didn't work.
  The fallback logic of choosing the most recent focused window doesn't work in a headless environment
  and even a normal IDE environment isn't a reliable strategy.

  The new strategy is to find the project that contains the current module and as a fallback to
  include all open projects.

## Checklist for creating a good PR (can be deleted)

- [x] I've described my change in the CHANGELOG.md if it is visible to users of the platform (**mandatory**).
- [x] I've selected the correct [base branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-base-branch-of-a-pull-request).
- [x] I have checked my code (edge cases, no errors) and corrected any misspellings.
- [x] I have added comments to my code in areas where the code is hard to understand.
