### PR TITLE
mpsutil.actionsfilter: load the default profile on startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ Semantic Versioning and the changes are simply documented in reverse chronologic
 
 ## com.mbeddr.mpsutil.actionsfilter
 
-- The actionsfilter plugin now correctly initializes when opening an RCP for the first time.
+- The actionsfilter plugin now correctly initializes when opening an RCP for the first time and also loads the default actions profile.
 
 # May 2025
 

--- a/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.actionsfilter.runtime/models/com/mbeddr/mpsutil/actionsfilter/runtime.mps
+++ b/code/languages/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.actionsfilter.runtime/models/com/mbeddr/mpsutil/actionsfilter/runtime.mps
@@ -12858,6 +12858,16 @@
             </node>
           </node>
         </node>
+        <node concept="3clFbF" id="5a0RZVMtxif" role="3cqZAp">
+          <node concept="2OqwBi" id="5a0RZVMtyio" role="3clFbG">
+            <node concept="37vLTw" id="5a0RZVMtxid" role="2Oq$k0">
+              <ref role="3cqZAo" node="5vQUrnx8Uc2" resolve="myState" />
+            </node>
+            <node concept="liA8E" id="5a0RZVMtAZa" role="2OqNvi">
+              <ref role="37wK5l" node="3NH93czz7Rw" resolve="ensureHasProfiles" />
+            </node>
+          </node>
+        </node>
         <node concept="3cpWs8" id="7xgxWxJ7qDJ" role="3cqZAp">
           <node concept="3cpWsn" id="7xgxWxJ7qDK" role="3cpWs9">
             <property role="TrG5h" value="instance" />


### PR DESCRIPTION
This was only done when opening the preference component in the past.