### PR TITLE
Improve copying of custom cells and editors with custom swing components to plain text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is _loosely_ based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). The project does _not_ follow
 Semantic Versioning and the changes are simply documented in reverse chronological order, grouped by calendar month.
 
+# August 2025
+
+- Copying of custom cells and editors with custom swing components to plain text was improved.
+
 # July 2025
 
 ## com.mbeddr.core.base

--- a/code/applications/com.mbeddr.build-examples/solutions/com.baselanguage.unless.build/models/com/baselanguage/unless/build/build.mps
+++ b/code/applications/com.mbeddr.build-examples/solutions/com.baselanguage.unless.build/models/com/baselanguage/unless/build/build.mps
@@ -105,15 +105,13 @@
       <concept id="1500819558095907805" name="jetbrains.mps.build.mps.structure.BuildMps_Group" flags="ng" index="2G$12M">
         <child id="1500819558095907806" name="modules" index="2G$12L" />
       </concept>
+      <concept id="8971171305100238972" name="jetbrains.mps.build.mps.structure.BuildMps_ModuleDependencyTargetLanguage" flags="ng" index="Rbm2T">
+        <reference id="3189788309731922643" name="language" index="1E1Vl2" />
+      </concept>
       <concept id="868032131020265945" name="jetbrains.mps.build.mps.structure.BuildMPSPlugin" flags="ng" index="3b7kt6" />
       <concept id="5253498789149381388" name="jetbrains.mps.build.mps.structure.BuildMps_Module" flags="ng" index="3bQrTs">
-        <property id="1500819558096356884" name="doNotCompile" index="2GAjPV" />
         <child id="5253498789149547825" name="sources" index="3bR31x" />
         <child id="5253498789149547704" name="dependencies" index="3bR37C" />
-      </concept>
-      <concept id="5253498789149585690" name="jetbrains.mps.build.mps.structure.BuildMps_ModuleDependencyOnModule" flags="ng" index="3bR9La">
-        <property id="5253498789149547713" name="reexport" index="3bR36h" />
-        <reference id="5253498789149547705" name="module" index="3bR37D" />
       </concept>
       <concept id="763829979718664966" name="jetbrains.mps.build.mps.structure.BuildMps_ModuleResources" flags="ng" index="3rtmxn">
         <child id="763829979718664967" name="files" index="3rtmxm" />
@@ -126,6 +124,12 @@
         <property id="6535001758416941941" name="createStaticRefs" index="3Ej$Sc" />
       </concept>
       <concept id="5507251971038816436" name="jetbrains.mps.build.mps.structure.BuildMps_Generator" flags="ng" index="1yeLz9" />
+      <concept id="4278635856200817744" name="jetbrains.mps.build.mps.structure.BuildMps_ModuleModelRoot" flags="ng" index="1BupzO">
+        <property id="8137134783396907368" name="convert2binary" index="1Hdu6h" />
+        <property id="8137134783396676838" name="extracted" index="1HemKv" />
+        <property id="2889113830911481881" name="deployFolderName" index="3ZfqAx" />
+        <child id="8137134783396676835" name="location" index="1HemKq" />
+      </concept>
       <concept id="4278635856200794926" name="jetbrains.mps.build.mps.structure.BuildMps_ModuleDependencyExtendLanguage" flags="ng" index="1Busua">
         <reference id="4278635856200794928" name="language" index="1Busuk" />
       </concept>
@@ -218,7 +222,6 @@
         <property role="BnDLt" value="true" />
         <property role="TrG5h" value="com.baselanguage.unless" />
         <property role="3LESm3" value="a6c9731c-e688-447f-8d50-3cf76b24e87d" />
-        <property role="2GAjPV" value="false" />
         <node concept="398BVA" id="5R4ngrtFxYl" role="3LF7KH">
           <ref role="398BVh" node="7uZw0yZ2_Jf" resolve="unless.home" />
           <node concept="2Ry0Ak" id="5R4ngrtFxYt" role="iGT6I">
@@ -234,12 +237,30 @@
         <node concept="1yeLz9" id="2iaA4fp$PX2" role="1TViLv">
           <property role="TrG5h" value="com.baselanguage.unless#2633084349332274686" />
           <property role="3LESm3" value="ff4e4034-35f4-4a89-8bb2-ea650170919b" />
-          <property role="2GAjPV" value="false" />
-        </node>
-        <node concept="1SiIV0" id="4Rn9djDkh3t" role="3bR37C">
-          <node concept="3bR9La" id="4Rn9djDkh3u" role="1SiIV1">
-            <property role="3bR36h" value="false" />
-            <ref role="3bR37D" to="ffeo:7Kfy9QB6KYb" resolve="jetbrains.mps.baseLanguage" />
+          <node concept="1BupzO" id="1NwKXFI1$9p" role="3bR31x">
+            <property role="3ZfqAx" value="generator/template" />
+            <property role="1Hdu6h" value="true" />
+            <property role="1HemKv" value="true" />
+            <node concept="3LXTmp" id="1NwKXFI1$9q" role="1HemKq">
+              <node concept="398BVA" id="1NwKXFI1$9k" role="3LXTmr">
+                <ref role="398BVh" node="7uZw0yZ2_Jf" resolve="unless.home" />
+                <node concept="2Ry0Ak" id="1NwKXFI1$9l" role="iGT6I">
+                  <property role="2Ry0Am" value="languages" />
+                  <node concept="2Ry0Ak" id="1NwKXFI1$9m" role="2Ry0An">
+                    <property role="2Ry0Am" value="com.baselanguage.unless" />
+                    <node concept="2Ry0Ak" id="1NwKXFI1$9n" role="2Ry0An">
+                      <property role="2Ry0Am" value="generator" />
+                      <node concept="2Ry0Ak" id="1NwKXFI1$9o" role="2Ry0An">
+                        <property role="2Ry0Am" value="template" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3qWCbU" id="1NwKXFI1$9r" role="3LXTna">
+                <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+              </node>
+            </node>
           </node>
         </node>
         <node concept="1SiIV0" id="4Rn9djDkh3v" role="3bR37C">
@@ -261,6 +282,33 @@
                 </node>
               </node>
             </node>
+          </node>
+        </node>
+        <node concept="1BupzO" id="1NwKXFI1$9f" role="3bR31x">
+          <property role="3ZfqAx" value="models" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="1NwKXFI1$9g" role="1HemKq">
+            <node concept="398BVA" id="1NwKXFI1$9b" role="3LXTmr">
+              <ref role="398BVh" node="7uZw0yZ2_Jf" resolve="unless.home" />
+              <node concept="2Ry0Ak" id="1NwKXFI1$9c" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="1NwKXFI1$9d" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.baselanguage.unless" />
+                  <node concept="2Ry0Ak" id="1NwKXFI1$9e" role="2Ry0An">
+                    <property role="2Ry0Am" value="models" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="1NwKXFI1$9h" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="1NwKXFI1$9i" role="3bR37C">
+          <node concept="Rbm2T" id="1NwKXFI1$9j" role="1SiIV1">
+            <ref role="1E1Vl2" to="ffeo:7Kfy9QB6KYb" resolve="jetbrains.mps.baseLanguage" />
           </node>
         </node>
       </node>

--- a/code/applications/com.mbeddr.documentation/solutions/com.mbeddr.mpsutil.interpreter.documentation/models/com/mbeddr/mpsutil/interpreter/documentation/docs.mps
+++ b/code/applications/com.mbeddr.documentation/solutions/com.mbeddr.mpsutil.interpreter.documentation/models/com/mbeddr/mpsutil/interpreter/documentation/docs.mps
@@ -2492,7 +2492,7 @@
                   <node concept="3z_lpY" id="1Y3rEQ3jGG5" role="19SJt6">
                     <node concept="2NCZwO" id="1Y3rEQ3jGG6" role="3z_lpZ">
                       <node concept="2NCMab" id="1Y3rEQ3jGGd" role="2NCMaf">
-                        <ref role="2NCMaa" to="2ahs:1PWW75uO1Wf" resolve="EvaluatorMissingException" />
+                        <ref role="2NCMaa" to="2ahs:1PWW75uO1Wf" resolve="EvaluatorNotApplicableException" />
                       </node>
                     </node>
                   </node>

--- a/code/applications/tutorial-dsls-extensions/languages/mbeddr.tutorial.extreqref/languageModels/editor.mps
+++ b/code/applications/tutorial-dsls-extensions/languages/mbeddr.tutorial.extreqref/languageModels/editor.mps
@@ -64,7 +64,7 @@
         <property id="1073389577007" name="text" index="3F0ifm" />
       </concept>
       <concept id="1073389658414" name="jetbrains.mps.lang.editor.structure.CellModel_Property" flags="sg" stub="730538219796134133" index="3F0A7n" />
-      <concept id="1219418625346" name="jetbrains.mps.lang.editor.structure.IStyleContainer" flags="ng" index="3F0Thp">
+      <concept id="1219418625346" name="jetbrains.mps.lang.editor.structure.IStyleContainer" flags="ngI" index="3F0Thp">
         <child id="1219418656006" name="styleItem" index="3F10Kt" />
       </concept>
       <concept id="1176474535556" name="jetbrains.mps.lang.editor.structure.QueryFunction_JComponent" flags="in" index="3Fmcul" />
@@ -111,7 +111,7 @@
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <child id="1068431790190" name="initializer" index="33vP2m" />
       </concept>
-      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ng" index="366HgL">
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ngI" index="366HgL">
         <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
       </concept>
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
@@ -150,7 +150,7 @@
       </concept>
       <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
       <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
-      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
@@ -167,7 +167,7 @@
         <child id="1081773367580" name="leftExpression" index="3uHU7B" />
       </concept>
       <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
-      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ngI" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
       </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
@@ -200,7 +200,7 @@
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
-      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
     </language>

--- a/code/applications/tutorial-dsls-extensions/languages/mbeddr.tutorial.extreqref/languageModels/editor.mps
+++ b/code/applications/tutorial-dsls-extensions/languages/mbeddr.tutorial.extreqref/languageModels/editor.mps
@@ -4,6 +4,7 @@
   <languages>
     <use id="63650c59-16c8-498a-99c8-005c7ee9515d" name="jetbrains.mps.lang.access" version="0" />
     <use id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor" version="14" />
+    <use id="62971cbe-fd2f-4135-b001-ee6cb7a74436" name="nl.f1re.mps.editor.swing" version="0" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
@@ -63,7 +64,7 @@
         <property id="1073389577007" name="text" index="3F0ifm" />
       </concept>
       <concept id="1073389658414" name="jetbrains.mps.lang.editor.structure.CellModel_Property" flags="sg" stub="730538219796134133" index="3F0A7n" />
-      <concept id="1219418625346" name="jetbrains.mps.lang.editor.structure.IStyleContainer" flags="ngI" index="3F0Thp">
+      <concept id="1219418625346" name="jetbrains.mps.lang.editor.structure.IStyleContainer" flags="ng" index="3F0Thp">
         <child id="1219418656006" name="styleItem" index="3F10Kt" />
       </concept>
       <concept id="1176474535556" name="jetbrains.mps.lang.editor.structure.QueryFunction_JComponent" flags="in" index="3Fmcul" />
@@ -110,6 +111,9 @@
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <child id="1068431790190" name="initializer" index="33vP2m" />
       </concept>
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ng" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
+      </concept>
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
@@ -146,7 +150,7 @@
       </concept>
       <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
       <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
-      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
@@ -163,7 +167,7 @@
         <child id="1081773367580" name="leftExpression" index="3uHU7B" />
       </concept>
       <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
-      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ngI" index="1B3ioH">
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
       </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
@@ -179,6 +183,9 @@
       </concept>
       <concept id="8974276187400348177" name="jetbrains.mps.lang.access.structure.ExecuteCommandStatement" flags="nn" index="1QHqEO" />
     </language>
+    <language id="62971cbe-fd2f-4135-b001-ee6cb7a74436" name="nl.f1re.mps.editor.swing">
+      <concept id="8659612544238797919" name="nl.f1re.mps.editor.swing.structure.CellModel_CustomJComponent" flags="sg" stub="8659612544238937882" index="fWXJ_" />
+    </language>
     <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
       <concept id="2524418899405758586" name="jetbrains.mps.baseLanguage.closures.structure.InferredClosureParameterDeclaration" flags="ig" index="gl6BB" />
       <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
@@ -193,7 +200,7 @@
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
-      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
     </language>
@@ -344,9 +351,10 @@
       </node>
     </node>
     <node concept="3EZMnI" id="2juwowPilu1" role="6VMZX">
-      <node concept="3gTLQM" id="2juwowPkM8E" role="3EZMnx">
-        <node concept="3Fmcul" id="2juwowPkM8G" role="3FoqZy">
-          <node concept="3clFbS" id="2juwowPkM8I" role="2VODD2">
+      <node concept="2iRkQZ" id="2juwowPilu2" role="2iSdaV" />
+      <node concept="fWXJ_" id="5vhcTL2lpun" role="3EZMnx">
+        <node concept="3Fmcul" id="5vhcTL2lpup" role="3FoqZy">
+          <node concept="3clFbS" id="5vhcTL2lpur" role="2VODD2">
             <node concept="3cpWs8" id="2juwowPkMHB" role="3cqZAp">
               <node concept="3cpWsn" id="2juwowPkMHC" role="3cpWs9">
                 <property role="TrG5h" value="b" />
@@ -354,7 +362,8 @@
                   <ref role="3uigEE" to="dxuu:~JButton" resolve="JButton" />
                 </node>
                 <node concept="2ShNRf" id="2juwowPkNiB" role="33vP2m">
-                  <node concept="1pGfFk" id="2juwowPkNQO" role="2ShVmc">
+                  <node concept="1pGfFk" id="5vhcTL2lzLK" role="2ShVmc">
+                    <property role="373rjd" value="true" />
                     <ref role="37wK5l" to="dxuu:~JButton.&lt;init&gt;(java.lang.String)" resolve="JButton" />
                     <node concept="Xl_RD" id="2juwowPkO9M" role="37wK5m">
                       <property role="Xl_RC" value="Update Reference" />
@@ -461,7 +470,6 @@
           </node>
         </node>
       </node>
-      <node concept="2iRkQZ" id="2juwowPilu2" role="2iSdaV" />
       <node concept="3EZMnI" id="2juwowPilu3" role="3EZMnx">
         <node concept="l2Vlx" id="2juwowPilu4" role="2iSdaV" />
         <node concept="3F0ifn" id="2juwowPilu5" role="3EZMnx">

--- a/code/applications/tutorial-dsls-extensions/languages/mbeddr.tutorial.extreqref/mbeddr.tutorial.extreqref.mpl
+++ b/code/applications/tutorial-dsls-extensions/languages/mbeddr.tutorial.extreqref/mbeddr.tutorial.extreqref.mpl
@@ -119,6 +119,7 @@
     <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
     <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
     <language slang="l:7a5dda62-9140-4668-ab76-d5ed1746f2b2:jetbrains.mps.lang.typesystem" version="5" />
+    <language slang="l:62971cbe-fd2f-4135-b001-ee6cb7a74436:nl.f1re.mps.editor.swing" version="0" />
   </languageVersions>
   <dependencyVersions>
     <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
@@ -143,6 +144,7 @@
     <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
     <module reference="fd392034-7849-419d-9071-12563d152375(jetbrains.mps.baseLanguage.closures)" version="0" />
     <module reference="83888646-71ce-4f1c-9c53-c54016f6ad4f(jetbrains.mps.baseLanguage.collections)" version="0" />
+    <module reference="daafa647-f1f7-4b0b-b096-69cd7c8408c0(jetbrains.mps.baseLanguage.regexp)" version="0" />
     <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
     <module reference="23865718-e2ed-41b5-a132-0da1d04e266d(jetbrains.mps.ide.httpsupport.manager)" version="0" />
     <module reference="ae6d8005-36be-4cb6-945b-8c8cfc033c51(jetbrains.mps.ide.httpsupport.runtime)" version="0" />

--- a/code/applications/tutorial/solutions/com.mbeddr.tutorial.startup/models/com/mbeddr/tutorial/startup/plugin.mps
+++ b/code/applications/tutorial/solutions/com.mbeddr.tutorial.startup/models/com/mbeddr/tutorial/startup/plugin.mps
@@ -70,7 +70,7 @@
         <reference id="1217252646389" name="key" index="1DUlNI" />
       </concept>
       <concept id="1217252428768" name="jetbrains.mps.lang.plugin.structure.ActionDataParameterReferenceOperation" flags="nn" index="1DTwFV" />
-      <concept id="1217413147516" name="jetbrains.mps.lang.plugin.structure.ActionParameter" flags="ng" index="1NuADB">
+      <concept id="1217413147516" name="jetbrains.mps.lang.plugin.structure.ActionParameter" flags="ngI" index="1NuADB">
         <child id="5538333046911298738" name="condition" index="1oa70y" />
       </concept>
     </language>
@@ -99,7 +99,7 @@
       <concept id="1188207840427" name="jetbrains.mps.baseLanguage.structure.AnnotationInstance" flags="nn" index="2AHcQZ">
         <reference id="1188208074048" name="annotation" index="2AI5Lk" />
       </concept>
-      <concept id="1188208481402" name="jetbrains.mps.baseLanguage.structure.HasAnnotation" flags="ng" index="2AJDlI">
+      <concept id="1188208481402" name="jetbrains.mps.baseLanguage.structure.HasAnnotation" flags="ngI" index="2AJDlI">
         <child id="1188208488637" name="annotation" index="2AJF6D" />
       </concept>
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
@@ -170,7 +170,7 @@
         <child id="1154542793668" name="componentType" index="3g7fb8" />
         <child id="1154542803372" name="initValue" index="3g7hyw" />
       </concept>
-      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
@@ -190,7 +190,7 @@
         <child id="1081773367580" name="leftExpression" index="3uHU7B" />
       </concept>
       <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
-      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ngI" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
       </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
@@ -217,7 +217,7 @@
       <concept id="1213999088275" name="jetbrains.mps.baseLanguage.classifiers.structure.DefaultClassifierFieldDeclaration" flags="ig" index="2BZ0e9" />
       <concept id="1213999117680" name="jetbrains.mps.baseLanguage.classifiers.structure.DefaultClassifierFieldAccessOperation" flags="nn" index="2BZ7hE" />
       <concept id="1205752633985" name="jetbrains.mps.baseLanguage.classifiers.structure.ThisClassifierExpression" flags="nn" index="2WthIp" />
-      <concept id="1205756064662" name="jetbrains.mps.baseLanguage.classifiers.structure.IMemberOperation" flags="ng" index="2WEnae">
+      <concept id="1205756064662" name="jetbrains.mps.baseLanguage.classifiers.structure.IMemberOperation" flags="ngI" index="2WEnae">
         <reference id="1205756909548" name="member" index="2WH_rO" />
       </concept>
     </language>
@@ -248,7 +248,7 @@
       <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
         <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
       </concept>
-      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
       <concept id="4222318806802425298" name="jetbrains.mps.lang.core.structure.SuppressErrorsAnnotation" flags="ng" index="15s5l7">

--- a/code/languages/com.mbeddr.cc/languages/com.mbeddr.cc.requirements.c/c.mpl
+++ b/code/languages/com.mbeddr.cc/languages/com.mbeddr.cc.requirements.c/c.mpl
@@ -199,6 +199,7 @@
     <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
     <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
     <language slang="l:7a5dda62-9140-4668-ab76-d5ed1746f2b2:jetbrains.mps.lang.typesystem" version="5" />
+    <language slang="l:62971cbe-fd2f-4135-b001-ee6cb7a74436:nl.f1re.mps.editor.swing" version="0" />
   </languageVersions>
   <dependencyVersions>
     <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />

--- a/code/languages/com.mbeddr.cc/languages/com.mbeddr.cc.requirements.c/languageModels/editor.mps
+++ b/code/languages/com.mbeddr.cc/languages/com.mbeddr.cc.requirements.c/languageModels/editor.mps
@@ -104,10 +104,10 @@
       <concept id="1186415722038" name="jetbrains.mps.lang.editor.structure.FontSizeStyleClassItem" flags="ln" index="VSNWy">
         <child id="1221064706952" name="query" index="1d8cEk" />
       </concept>
-      <concept id="1630016958697718209" name="jetbrains.mps.lang.editor.structure.IMenuReference_Default" flags="ng" index="2Z_bC8">
+      <concept id="1630016958697718209" name="jetbrains.mps.lang.editor.structure.IMenuReference_Default" flags="ngI" index="2Z_bC8">
         <reference id="1630016958698373342" name="concept" index="2ZyFGn" />
       </concept>
-      <concept id="1630016958697344083" name="jetbrains.mps.lang.editor.structure.IMenu_Concept" flags="ng" index="2ZABuq">
+      <concept id="1630016958697344083" name="jetbrains.mps.lang.editor.structure.IMenu_Concept" flags="ngI" index="2ZABuq">
         <reference id="6591946374543067572" name="conceptDeclaration" index="aqKnT" />
         <child id="5991739802479788259" name="type" index="22hAXT" />
       </concept>
@@ -147,7 +147,7 @@
         <property id="1073389577007" name="text" index="3F0ifm" />
       </concept>
       <concept id="1073389658414" name="jetbrains.mps.lang.editor.structure.CellModel_Property" flags="sg" stub="730538219796134133" index="3F0A7n" />
-      <concept id="1219418625346" name="jetbrains.mps.lang.editor.structure.IStyleContainer" flags="ng" index="3F0Thp">
+      <concept id="1219418625346" name="jetbrains.mps.lang.editor.structure.IStyleContainer" flags="ngI" index="3F0Thp">
         <child id="1219418656006" name="styleItem" index="3F10Kt" />
       </concept>
       <concept id="1073389882823" name="jetbrains.mps.lang.editor.structure.CellModel_RefNode" flags="sg" stub="730538219795960754" index="3F1sOY" />
@@ -161,7 +161,7 @@
         <child id="1225900141900" name="modelAccessor" index="1HlULh" />
       </concept>
       <concept id="5624877018226900666" name="jetbrains.mps.lang.editor.structure.TransformationMenu" flags="ng" index="3ICUPy" />
-      <concept id="5624877018228267058" name="jetbrains.mps.lang.editor.structure.ITransformationMenu" flags="ng" index="3INCJE">
+      <concept id="5624877018228267058" name="jetbrains.mps.lang.editor.structure.ITransformationMenu" flags="ngI" index="3INCJE">
         <child id="1638911550608572412" name="sections" index="IW6Ez" />
       </concept>
       <concept id="1161622981231" name="jetbrains.mps.lang.editor.structure.ConceptFunctionParameter_editorContext" flags="nn" index="1Q80Hx" />
@@ -190,7 +190,7 @@
       <concept id="1188207840427" name="jetbrains.mps.baseLanguage.structure.AnnotationInstance" flags="nn" index="2AHcQZ">
         <reference id="1188208074048" name="annotation" index="2AI5Lk" />
       </concept>
-      <concept id="1188208481402" name="jetbrains.mps.baseLanguage.structure.HasAnnotation" flags="ng" index="2AJDlI">
+      <concept id="1188208481402" name="jetbrains.mps.baseLanguage.structure.HasAnnotation" flags="ngI" index="2AJDlI">
         <child id="1188208488637" name="annotation" index="2AJF6D" />
       </concept>
       <concept id="1095950406618" name="jetbrains.mps.baseLanguage.structure.DivExpression" flags="nn" index="FJ1c_" />
@@ -223,7 +223,7 @@
         <property id="1176718929932" name="isFinal" index="3TUv4t" />
         <child id="1068431790190" name="initializer" index="33vP2m" />
       </concept>
-      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ng" index="366HgL">
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ngI" index="366HgL">
         <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
       </concept>
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
@@ -282,7 +282,7 @@
       <concept id="1081516740877" name="jetbrains.mps.baseLanguage.structure.NotExpression" flags="nn" index="3fqX7Q">
         <child id="1081516765348" name="expression" index="3fr31v" />
       </concept>
-      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
@@ -299,7 +299,7 @@
         <child id="1081773367580" name="leftExpression" index="3uHU7B" />
       </concept>
       <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
-      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ngI" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
       </concept>
       <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="nn" index="3SKdUt">
@@ -378,7 +378,7 @@
         <child id="8155811638124638369" name="groupHeader" index="18hjfo" />
         <child id="8155811638124638371" name="childHeaders" index="18hjfq" />
       </concept>
-      <concept id="5662204344885760731" name="de.slisson.mps.tables.structure.IStylable" flags="ng" index="1g0I81">
+      <concept id="5662204344885760731" name="de.slisson.mps.tables.structure.IStylable" flags="ngI" index="1g0I81">
         <child id="5662204344887343006" name="style" index="1geGt4" />
       </concept>
       <concept id="5662204344885763446" name="de.slisson.mps.tables.structure.TableStyle" flags="ng" index="1g0IQG" />
@@ -445,7 +445,7 @@
       <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
         <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
       </concept>
-      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
     </language>

--- a/code/languages/com.mbeddr.cc/languages/com.mbeddr.cc.requirements.c/languageModels/editor.mps
+++ b/code/languages/com.mbeddr.cc/languages/com.mbeddr.cc.requirements.c/languageModels/editor.mps
@@ -10,6 +10,7 @@
     <use id="c72da2b9-7cce-4447-8389-f407dc1158b7" name="jetbrains.mps.lang.structure" version="9" />
     <use id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor" version="14" />
     <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="12" />
+    <use id="62971cbe-fd2f-4135-b001-ee6cb7a74436" name="nl.f1re.mps.editor.swing" version="0" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
@@ -103,10 +104,10 @@
       <concept id="1186415722038" name="jetbrains.mps.lang.editor.structure.FontSizeStyleClassItem" flags="ln" index="VSNWy">
         <child id="1221064706952" name="query" index="1d8cEk" />
       </concept>
-      <concept id="1630016958697718209" name="jetbrains.mps.lang.editor.structure.IMenuReference_Default" flags="ngI" index="2Z_bC8">
+      <concept id="1630016958697718209" name="jetbrains.mps.lang.editor.structure.IMenuReference_Default" flags="ng" index="2Z_bC8">
         <reference id="1630016958698373342" name="concept" index="2ZyFGn" />
       </concept>
-      <concept id="1630016958697344083" name="jetbrains.mps.lang.editor.structure.IMenu_Concept" flags="ngI" index="2ZABuq">
+      <concept id="1630016958697344083" name="jetbrains.mps.lang.editor.structure.IMenu_Concept" flags="ng" index="2ZABuq">
         <reference id="6591946374543067572" name="conceptDeclaration" index="aqKnT" />
         <child id="5991739802479788259" name="type" index="22hAXT" />
       </concept>
@@ -146,7 +147,7 @@
         <property id="1073389577007" name="text" index="3F0ifm" />
       </concept>
       <concept id="1073389658414" name="jetbrains.mps.lang.editor.structure.CellModel_Property" flags="sg" stub="730538219796134133" index="3F0A7n" />
-      <concept id="1219418625346" name="jetbrains.mps.lang.editor.structure.IStyleContainer" flags="ngI" index="3F0Thp">
+      <concept id="1219418625346" name="jetbrains.mps.lang.editor.structure.IStyleContainer" flags="ng" index="3F0Thp">
         <child id="1219418656006" name="styleItem" index="3F10Kt" />
       </concept>
       <concept id="1073389882823" name="jetbrains.mps.lang.editor.structure.CellModel_RefNode" flags="sg" stub="730538219795960754" index="3F1sOY" />
@@ -160,7 +161,7 @@
         <child id="1225900141900" name="modelAccessor" index="1HlULh" />
       </concept>
       <concept id="5624877018226900666" name="jetbrains.mps.lang.editor.structure.TransformationMenu" flags="ng" index="3ICUPy" />
-      <concept id="5624877018228267058" name="jetbrains.mps.lang.editor.structure.ITransformationMenu" flags="ngI" index="3INCJE">
+      <concept id="5624877018228267058" name="jetbrains.mps.lang.editor.structure.ITransformationMenu" flags="ng" index="3INCJE">
         <child id="1638911550608572412" name="sections" index="IW6Ez" />
       </concept>
       <concept id="1161622981231" name="jetbrains.mps.lang.editor.structure.ConceptFunctionParameter_editorContext" flags="nn" index="1Q80Hx" />
@@ -189,7 +190,7 @@
       <concept id="1188207840427" name="jetbrains.mps.baseLanguage.structure.AnnotationInstance" flags="nn" index="2AHcQZ">
         <reference id="1188208074048" name="annotation" index="2AI5Lk" />
       </concept>
-      <concept id="1188208481402" name="jetbrains.mps.baseLanguage.structure.HasAnnotation" flags="ngI" index="2AJDlI">
+      <concept id="1188208481402" name="jetbrains.mps.baseLanguage.structure.HasAnnotation" flags="ng" index="2AJDlI">
         <child id="1188208488637" name="annotation" index="2AJF6D" />
       </concept>
       <concept id="1095950406618" name="jetbrains.mps.baseLanguage.structure.DivExpression" flags="nn" index="FJ1c_" />
@@ -221,6 +222,9 @@
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <property id="1176718929932" name="isFinal" index="3TUv4t" />
         <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ng" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
       </concept>
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
@@ -278,7 +282,7 @@
       <concept id="1081516740877" name="jetbrains.mps.baseLanguage.structure.NotExpression" flags="nn" index="3fqX7Q">
         <child id="1081516765348" name="expression" index="3fr31v" />
       </concept>
-      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
@@ -295,7 +299,7 @@
         <child id="1081773367580" name="leftExpression" index="3uHU7B" />
       </concept>
       <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
-      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ngI" index="1B3ioH">
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
       </concept>
       <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="nn" index="3SKdUt">
@@ -314,6 +318,12 @@
         <child id="8974276187400348171" name="commandClosureLiteral" index="1QHqEI" />
       </concept>
       <concept id="8974276187400348177" name="jetbrains.mps.lang.access.structure.ExecuteCommandStatement" flags="nn" index="1QHqEO" />
+    </language>
+    <language id="62971cbe-fd2f-4135-b001-ee6cb7a74436" name="nl.f1re.mps.editor.swing">
+      <concept id="8659612544244790000" name="nl.f1re.mps.editor.swing.structure.QueryFunction_String" flags="ig" index="05MPa" />
+      <concept id="8659612544238797919" name="nl.f1re.mps.editor.swing.structure.CellModel_CustomJComponent" flags="sg" stub="8659612544238937882" index="fWXJ_">
+        <child id="8659612544238938786" name="toStringFunction" index="fNvko" />
+      </concept>
     </language>
     <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
       <concept id="2524418899405758586" name="jetbrains.mps.baseLanguage.closures.structure.InferredClosureParameterDeclaration" flags="ig" index="gl6BB" />
@@ -368,7 +378,7 @@
         <child id="8155811638124638369" name="groupHeader" index="18hjfo" />
         <child id="8155811638124638371" name="childHeaders" index="18hjfq" />
       </concept>
-      <concept id="5662204344885760731" name="de.slisson.mps.tables.structure.IStylable" flags="ngI" index="1g0I81">
+      <concept id="5662204344885760731" name="de.slisson.mps.tables.structure.IStylable" flags="ng" index="1g0I81">
         <child id="5662204344887343006" name="style" index="1geGt4" />
       </concept>
       <concept id="5662204344885763446" name="de.slisson.mps.tables.structure.TableStyle" flags="ng" index="1g0IQG" />
@@ -435,7 +445,7 @@
       <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
         <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
       </concept>
-      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
     </language>
@@ -2416,241 +2426,239 @@
           </node>
         </node>
       </node>
-      <node concept="3EZMnI" id="dfV14BYn6v" role="3EZMnx">
-        <node concept="l2Vlx" id="dfV14BYn6w" role="2iSdaV" />
-        <node concept="3gTLQM" id="dfV14BYn6x" role="3EZMnx">
-          <node concept="3Fmcul" id="dfV14BYn6y" role="3FoqZy">
-            <node concept="3clFbS" id="dfV14BYn6z" role="2VODD2">
-              <node concept="3cpWs8" id="dfV14BYn6$" role="3cqZAp">
-                <node concept="3cpWsn" id="dfV14BYn6_" role="3cpWs9">
-                  <property role="TrG5h" value="tc" />
-                  <node concept="3Tqbb2" id="dfV14BYn6A" role="1tU5fm">
-                    <ref role="ehGHo" to="3vkx:35Kh8LWrQIH" resolve="RTestCase" />
+      <node concept="fWXJ_" id="5vhcTL2maGz" role="3EZMnx">
+        <node concept="3Fmcul" id="5vhcTL2maG_" role="3FoqZy">
+          <node concept="3clFbS" id="5vhcTL2maGB" role="2VODD2">
+            <node concept="3cpWs8" id="5vhcTL2mohP" role="3cqZAp">
+              <node concept="3cpWsn" id="5vhcTL2mohQ" role="3cpWs9">
+                <property role="TrG5h" value="tc" />
+                <node concept="3Tqbb2" id="5vhcTL2mohR" role="1tU5fm">
+                  <ref role="ehGHo" to="3vkx:35Kh8LWrQIH" resolve="RTestCase" />
+                </node>
+                <node concept="1PxgMI" id="5vhcTL2mohS" role="33vP2m">
+                  <node concept="2OqwBi" id="5vhcTL2mohT" role="1m5AlR">
+                    <node concept="pncrf" id="5vhcTL2mohU" role="2Oq$k0" />
+                    <node concept="1mfA1w" id="5vhcTL2mohV" role="2OqNvi" />
                   </node>
-                  <node concept="1PxgMI" id="dfV14BYn6B" role="33vP2m">
-                    <node concept="2OqwBi" id="dfV14BYn6C" role="1m5AlR">
-                      <node concept="pncrf" id="dfV14BYn6D" role="2Oq$k0" />
-                      <node concept="1mfA1w" id="dfV14BYn6E" role="2OqNvi" />
+                  <node concept="chp4Y" id="5vhcTL2mohW" role="3oSUPX">
+                    <ref role="cht4Q" to="3vkx:35Kh8LWrQIH" resolve="RTestCase" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs8" id="5vhcTL2mohX" role="3cqZAp">
+              <node concept="3cpWsn" id="5vhcTL2mohY" role="3cpWs9">
+                <property role="TrG5h" value="nl" />
+                <node concept="3Tqbb2" id="5vhcTL2mohZ" role="1tU5fm">
+                  <ref role="ehGHo" to="mj1l:7FQByU3CrDB" resolve="NumberLiteral" />
+                </node>
+                <node concept="1PxgMI" id="5vhcTL2moi0" role="33vP2m">
+                  <node concept="2OqwBi" id="5vhcTL2moi1" role="1m5AlR">
+                    <node concept="2OqwBi" id="5vhcTL2moi2" role="2Oq$k0">
+                      <node concept="37vLTw" id="5vhcTL2moi3" role="2Oq$k0">
+                        <ref role="3cqZAo" node="5vhcTL2mohQ" resolve="tc" />
+                      </node>
+                      <node concept="3Tsc0h" id="5vhcTL2moi4" role="2OqNvi">
+                        <ref role="3TtcxE" to="3vkx:35Kh8LWrThu" resolve="params" />
+                      </node>
                     </node>
-                    <node concept="chp4Y" id="79i$vAY7gmD" role="3oSUPX">
-                      <ref role="cht4Q" to="3vkx:35Kh8LWrQIH" resolve="RTestCase" />
+                    <node concept="liA8E" id="5vhcTL2moi5" role="2OqNvi">
+                      <ref role="37wK5l" to="33ny:~List.get(int)" resolve="get" />
+                      <node concept="3cmrfG" id="5vhcTL2moi6" role="37wK5m">
+                        <property role="3cmrfH" value="1" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="chp4Y" id="5vhcTL2moi7" role="3oSUPX">
+                    <ref role="cht4Q" to="mj1l:7FQByU3CrDB" resolve="NumberLiteral" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs8" id="5vhcTL2moi8" role="3cqZAp">
+              <node concept="3cpWsn" id="5vhcTL2moi9" role="3cpWs9">
+                <property role="TrG5h" value="value" />
+                <node concept="3uibUv" id="5vhcTL2moia" role="1tU5fm">
+                  <ref role="3uigEE" to="wyt6:~Integer" resolve="Integer" />
+                </node>
+                <node concept="2YIFZM" id="5vhcTL2moib" role="33vP2m">
+                  <ref role="1Pybhc" to="wyt6:~Integer" resolve="Integer" />
+                  <ref role="37wK5l" to="wyt6:~Integer.valueOf(java.lang.String)" resolve="valueOf" />
+                  <node concept="2OqwBi" id="5vhcTL2moic" role="37wK5m">
+                    <node concept="37vLTw" id="5vhcTL2moid" role="2Oq$k0">
+                      <ref role="3cqZAo" node="5vhcTL2mohY" resolve="nl" />
+                    </node>
+                    <node concept="3TrcHB" id="5vhcTL2moie" role="2OqNvi">
+                      <ref role="3TsBF5" to="mj1l:1UQ4qqfV3yK" resolve="value" />
                     </node>
                   </node>
                 </node>
               </node>
-              <node concept="3cpWs8" id="dfV14BYn6F" role="3cqZAp">
-                <node concept="3cpWsn" id="dfV14BYn6G" role="3cpWs9">
-                  <property role="TrG5h" value="nl" />
-                  <node concept="3Tqbb2" id="dfV14BYn6H" role="1tU5fm">
-                    <ref role="ehGHo" to="mj1l:7FQByU3CrDB" resolve="NumberLiteral" />
-                  </node>
-                  <node concept="1PxgMI" id="dfV14BYn6I" role="33vP2m">
-                    <node concept="2OqwBi" id="dfV14BYn6J" role="1m5AlR">
-                      <node concept="2OqwBi" id="dfV14BYn6K" role="2Oq$k0">
-                        <node concept="37vLTw" id="dfV14BYn6L" role="2Oq$k0">
-                          <ref role="3cqZAo" node="dfV14BYn6_" resolve="tc" />
-                        </node>
-                        <node concept="3Tsc0h" id="dfV14BYn6M" role="2OqNvi">
-                          <ref role="3TtcxE" to="3vkx:35Kh8LWrThu" resolve="params" />
-                        </node>
-                      </node>
-                      <node concept="liA8E" id="dfV14BYn6N" role="2OqNvi">
-                        <ref role="37wK5l" to="33ny:~List.get(int)" resolve="get" />
-                        <node concept="3cmrfG" id="dfV14BYn6O" role="37wK5m">
-                          <property role="3cmrfH" value="1" />
-                        </node>
-                      </node>
+            </node>
+            <node concept="3cpWs8" id="5vhcTL2moif" role="3cqZAp">
+              <node concept="3cpWsn" id="5vhcTL2moig" role="3cpWs9">
+                <property role="TrG5h" value="slider" />
+                <property role="3TUv4t" value="true" />
+                <node concept="3uibUv" id="5vhcTL2moih" role="1tU5fm">
+                  <ref role="3uigEE" to="dxuu:~JSlider" resolve="JSlider" />
+                </node>
+                <node concept="2ShNRf" id="5vhcTL2moii" role="33vP2m">
+                  <node concept="1pGfFk" id="5vhcTL2mwR7" role="2ShVmc">
+                    <property role="373rjd" value="true" />
+                    <ref role="37wK5l" to="dxuu:~JSlider.&lt;init&gt;(int,int,int,int)" resolve="JSlider" />
+                    <node concept="10M0yZ" id="5vhcTL2moim" role="37wK5m">
+                      <ref role="1PxDUh" to="dxuu:~JSlider" resolve="JSlider" />
+                      <ref role="3cqZAo" to="dxuu:~SwingConstants.HORIZONTAL" resolve="HORIZONTAL" />
                     </node>
-                    <node concept="chp4Y" id="79i$vAY7gmC" role="3oSUPX">
-                      <ref role="cht4Q" to="mj1l:7FQByU3CrDB" resolve="NumberLiteral" />
+                    <node concept="3cmrfG" id="5vhcTL2moin" role="37wK5m">
+                      <property role="3cmrfH" value="0" />
+                    </node>
+                    <node concept="3cmrfG" id="5vhcTL2moio" role="37wK5m">
+                      <property role="3cmrfH" value="100" />
+                    </node>
+                    <node concept="10M0yZ" id="5vhcTL2moip" role="37wK5m">
+                      <ref role="3cqZAo" to="1v9t:$bJ0jgVdf9" resolve="sliderValue" />
+                      <ref role="1PxDUh" to="1v9t:$bJ0jgVdf3" resolve="DebugHelper" />
                     </node>
                   </node>
                 </node>
               </node>
-              <node concept="3cpWs8" id="dfV14BYn6P" role="3cqZAp">
-                <node concept="3cpWsn" id="dfV14BYn6Q" role="3cpWs9">
-                  <property role="TrG5h" value="value" />
-                  <node concept="3uibUv" id="dfV14BYn6R" role="1tU5fm">
-                    <ref role="3uigEE" to="wyt6:~Integer" resolve="Integer" />
-                  </node>
-                  <node concept="2YIFZM" id="dfV14BYn6S" role="33vP2m">
-                    <ref role="1Pybhc" to="wyt6:~Integer" resolve="Integer" />
-                    <ref role="37wK5l" to="wyt6:~Integer.valueOf(java.lang.String)" resolve="valueOf" />
-                    <node concept="2OqwBi" id="dfV14BYn6T" role="37wK5m">
-                      <node concept="37vLTw" id="dfV14BYn6U" role="2Oq$k0">
-                        <ref role="3cqZAo" node="dfV14BYn6G" resolve="nl" />
-                      </node>
-                      <node concept="3TrcHB" id="dfV14BYn6V" role="2OqNvi">
-                        <ref role="3TsBF5" to="mj1l:1UQ4qqfV3yK" resolve="value" />
-                      </node>
-                    </node>
-                  </node>
+            </node>
+            <node concept="3clFbF" id="5vhcTL2moiy" role="3cqZAp">
+              <node concept="2OqwBi" id="5vhcTL2moiz" role="3clFbG">
+                <node concept="37vLTw" id="5vhcTL2moi$" role="2Oq$k0">
+                  <ref role="3cqZAo" node="5vhcTL2moig" resolve="slider" />
                 </node>
-              </node>
-              <node concept="3cpWs8" id="dfV14BYn6W" role="3cqZAp">
-                <node concept="3cpWsn" id="dfV14BYn6X" role="3cpWs9">
-                  <property role="TrG5h" value="slider" />
-                  <property role="3TUv4t" value="true" />
-                  <node concept="3uibUv" id="dfV14BYn6Y" role="1tU5fm">
-                    <ref role="3uigEE" to="dxuu:~JSlider" resolve="JSlider" />
-                  </node>
-                  <node concept="2ShNRf" id="dfV14BYn6Z" role="33vP2m">
-                    <node concept="1pGfFk" id="dfV14BYn70" role="2ShVmc">
-                      <ref role="37wK5l" to="dxuu:~JSlider.&lt;init&gt;(int,int,int,int)" resolve="JSlider" />
-                      <node concept="10M0yZ" id="dfV14BYn71" role="37wK5m">
-                        <ref role="1PxDUh" to="dxuu:~JSlider" resolve="JSlider" />
-                        <ref role="3cqZAo" to="dxuu:~SwingConstants.HORIZONTAL" resolve="HORIZONTAL" />
-                      </node>
-                      <node concept="3cmrfG" id="dfV14BYn72" role="37wK5m">
-                        <property role="3cmrfH" value="0" />
-                      </node>
-                      <node concept="3cmrfG" id="dfV14BYn73" role="37wK5m">
-                        <property role="3cmrfH" value="100" />
-                      </node>
-                      <node concept="10M0yZ" id="dfV14BYn74" role="37wK5m">
-                        <ref role="3cqZAo" to="1v9t:$bJ0jgVdf9" resolve="sliderValue" />
-                        <ref role="1PxDUh" to="1v9t:$bJ0jgVdf3" resolve="DebugHelper" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="3clFbF" id="dfV14BYn75" role="3cqZAp">
-                <node concept="2OqwBi" id="dfV14BYn76" role="3clFbG">
-                  <node concept="37vLTw" id="dfV14BYn77" role="2Oq$k0">
-                    <ref role="3cqZAo" node="dfV14BYn6X" resolve="slider" />
-                  </node>
-                  <node concept="liA8E" id="dfV14BYn78" role="2OqNvi">
-                    <ref role="37wK5l" to="dxuu:~JSlider.addChangeListener(javax.swing.event.ChangeListener)" resolve="addChangeListener" />
-                    <node concept="2ShNRf" id="dfV14BYn79" role="37wK5m">
-                      <node concept="YeOm9" id="dfV14BYn7a" role="2ShVmc">
-                        <node concept="1Y3b0j" id="dfV14BYn7b" role="YeSDq">
-                          <property role="2bfB8j" value="true" />
-                          <ref role="1Y3XeK" to="gsia:~ChangeListener" resolve="ChangeListener" />
-                          <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
-                          <node concept="3Tm1VV" id="dfV14BYn7c" role="1B3o_S" />
-                          <node concept="3clFb_" id="dfV14BYn7d" role="jymVt">
-                            <property role="1EzhhJ" value="false" />
-                            <property role="TrG5h" value="stateChanged" />
-                            <property role="DiZV1" value="false" />
-                            <node concept="3Tm1VV" id="dfV14BYn7e" role="1B3o_S" />
-                            <node concept="3cqZAl" id="dfV14BYn7f" role="3clF45" />
-                            <node concept="37vLTG" id="dfV14BYn7g" role="3clF46">
-                              <property role="TrG5h" value="p0" />
-                              <node concept="3uibUv" id="dfV14BYn7h" role="1tU5fm">
-                                <ref role="3uigEE" to="gsia:~ChangeEvent" resolve="ChangeEvent" />
-                              </node>
+                <node concept="liA8E" id="5vhcTL2moi_" role="2OqNvi">
+                  <ref role="37wK5l" to="dxuu:~JSlider.addChangeListener(javax.swing.event.ChangeListener)" resolve="addChangeListener" />
+                  <node concept="2ShNRf" id="5vhcTL2moiA" role="37wK5m">
+                    <node concept="YeOm9" id="5vhcTL2moiB" role="2ShVmc">
+                      <node concept="1Y3b0j" id="5vhcTL2moiC" role="YeSDq">
+                        <property role="2bfB8j" value="true" />
+                        <ref role="1Y3XeK" to="gsia:~ChangeListener" resolve="ChangeListener" />
+                        <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
+                        <node concept="3Tm1VV" id="5vhcTL2moiD" role="1B3o_S" />
+                        <node concept="3clFb_" id="5vhcTL2moiE" role="jymVt">
+                          <property role="1EzhhJ" value="false" />
+                          <property role="TrG5h" value="stateChanged" />
+                          <property role="DiZV1" value="false" />
+                          <node concept="3Tm1VV" id="5vhcTL2moiF" role="1B3o_S" />
+                          <node concept="3cqZAl" id="5vhcTL2moiG" role="3clF45" />
+                          <node concept="37vLTG" id="5vhcTL2moiH" role="3clF46">
+                            <property role="TrG5h" value="p0" />
+                            <node concept="3uibUv" id="5vhcTL2moiI" role="1tU5fm">
+                              <ref role="3uigEE" to="gsia:~ChangeEvent" resolve="ChangeEvent" />
                             </node>
-                            <node concept="3clFbS" id="dfV14BYn7i" role="3clF47" />
                           </node>
+                          <node concept="3clFbS" id="5vhcTL2moiJ" role="3clF47" />
                         </node>
                       </node>
                     </node>
                   </node>
                 </node>
               </node>
-              <node concept="3clFbF" id="dfV14BYn7j" role="3cqZAp">
-                <node concept="2OqwBi" id="dfV14BYn7k" role="3clFbG">
-                  <node concept="37vLTw" id="dfV14BYn7l" role="2Oq$k0">
-                    <ref role="3cqZAo" node="dfV14BYn6X" resolve="slider" />
-                  </node>
-                  <node concept="liA8E" id="dfV14BYn7m" role="2OqNvi">
-                    <ref role="37wK5l" to="z60i:~Component.addMouseListener(java.awt.event.MouseListener)" resolve="addMouseListener" />
-                    <node concept="2ShNRf" id="dfV14BYn7n" role="37wK5m">
-                      <node concept="YeOm9" id="dfV14BYn7o" role="2ShVmc">
-                        <node concept="1Y3b0j" id="dfV14BYn7p" role="YeSDq">
-                          <property role="2bfB8j" value="true" />
-                          <ref role="37wK5l" to="hyam:~MouseAdapter.&lt;init&gt;()" resolve="MouseAdapter" />
-                          <ref role="1Y3XeK" to="hyam:~MouseAdapter" resolve="MouseAdapter" />
-                          <node concept="3Tm1VV" id="dfV14BYn7q" role="1B3o_S" />
-                          <node concept="3clFb_" id="dfV14BYn7r" role="jymVt">
-                            <property role="1EzhhJ" value="false" />
-                            <property role="TrG5h" value="mouseReleased" />
-                            <property role="DiZV1" value="false" />
-                            <node concept="3Tm1VV" id="dfV14BYn7s" role="1B3o_S" />
-                            <node concept="3cqZAl" id="dfV14BYn7t" role="3clF45" />
-                            <node concept="37vLTG" id="dfV14BYn7u" role="3clF46">
-                              <property role="TrG5h" value="event" />
-                              <node concept="3uibUv" id="dfV14BYn7v" role="1tU5fm">
-                                <ref role="3uigEE" to="hyam:~MouseEvent" resolve="MouseEvent" />
-                              </node>
+            </node>
+            <node concept="3clFbF" id="5vhcTL2moiK" role="3cqZAp">
+              <node concept="2OqwBi" id="5vhcTL2moiL" role="3clFbG">
+                <node concept="37vLTw" id="5vhcTL2moiM" role="2Oq$k0">
+                  <ref role="3cqZAo" node="5vhcTL2moig" resolve="slider" />
+                </node>
+                <node concept="liA8E" id="5vhcTL2moiN" role="2OqNvi">
+                  <ref role="37wK5l" to="z60i:~Component.addMouseListener(java.awt.event.MouseListener)" resolve="addMouseListener" />
+                  <node concept="2ShNRf" id="5vhcTL2moiO" role="37wK5m">
+                    <node concept="YeOm9" id="5vhcTL2moiP" role="2ShVmc">
+                      <node concept="1Y3b0j" id="5vhcTL2moiQ" role="YeSDq">
+                        <property role="2bfB8j" value="true" />
+                        <ref role="37wK5l" to="hyam:~MouseAdapter.&lt;init&gt;()" resolve="MouseAdapter" />
+                        <ref role="1Y3XeK" to="hyam:~MouseAdapter" resolve="MouseAdapter" />
+                        <node concept="3Tm1VV" id="5vhcTL2moiR" role="1B3o_S" />
+                        <node concept="3clFb_" id="5vhcTL2moiS" role="jymVt">
+                          <property role="1EzhhJ" value="false" />
+                          <property role="TrG5h" value="mouseReleased" />
+                          <property role="DiZV1" value="false" />
+                          <node concept="3Tm1VV" id="5vhcTL2moiT" role="1B3o_S" />
+                          <node concept="3cqZAl" id="5vhcTL2moiU" role="3clF45" />
+                          <node concept="37vLTG" id="5vhcTL2moiV" role="3clF46">
+                            <property role="TrG5h" value="event" />
+                            <node concept="3uibUv" id="5vhcTL2moiW" role="1tU5fm">
+                              <ref role="3uigEE" to="hyam:~MouseEvent" resolve="MouseEvent" />
                             </node>
-                            <node concept="3clFbS" id="dfV14BYn7w" role="3clF47">
-                              <node concept="1QHqEO" id="dfV14BYn7x" role="3cqZAp">
-                                <node concept="1QHqEC" id="dfV14BYn7y" role="1QHqEI">
-                                  <node concept="3clFbS" id="dfV14BYn7z" role="1bW5cS">
-                                    <node concept="3cpWs8" id="dfV14BYn7$" role="3cqZAp">
-                                      <node concept="3cpWsn" id="dfV14BYn7_" role="3cpWs9">
-                                        <property role="TrG5h" value="s" />
-                                        <node concept="10Oyi0" id="dfV14BYn7A" role="1tU5fm" />
-                                        <node concept="2OqwBi" id="dfV14BYn7B" role="33vP2m">
-                                          <node concept="37vLTw" id="dfV14BYn7C" role="2Oq$k0">
-                                            <ref role="3cqZAo" node="dfV14BYn6X" resolve="slider" />
-                                          </node>
-                                          <node concept="liA8E" id="dfV14BYn7D" role="2OqNvi">
-                                            <ref role="37wK5l" to="dxuu:~JSlider.getValue()" resolve="getValue" />
-                                          </node>
+                          </node>
+                          <node concept="3clFbS" id="5vhcTL2moiX" role="3clF47">
+                            <node concept="1QHqEO" id="5vhcTL2moiY" role="3cqZAp">
+                              <node concept="1QHqEC" id="5vhcTL2moiZ" role="1QHqEI">
+                                <node concept="3clFbS" id="5vhcTL2moj0" role="1bW5cS">
+                                  <node concept="3cpWs8" id="5vhcTL2moj1" role="3cqZAp">
+                                    <node concept="3cpWsn" id="5vhcTL2moj2" role="3cpWs9">
+                                      <property role="TrG5h" value="s" />
+                                      <node concept="10Oyi0" id="5vhcTL2moj3" role="1tU5fm" />
+                                      <node concept="2OqwBi" id="5vhcTL2moj4" role="33vP2m">
+                                        <node concept="37vLTw" id="5vhcTL2moj5" role="2Oq$k0">
+                                          <ref role="3cqZAo" node="5vhcTL2moig" resolve="slider" />
+                                        </node>
+                                        <node concept="liA8E" id="5vhcTL2moj6" role="2OqNvi">
+                                          <ref role="37wK5l" to="dxuu:~JSlider.getValue()" resolve="getValue" />
                                         </node>
                                       </node>
                                     </node>
-                                    <node concept="3clFbF" id="dfV14BYn7E" role="3cqZAp">
-                                      <node concept="37vLTI" id="dfV14BYn7F" role="3clFbG">
-                                        <node concept="37vLTw" id="dfV14BYn7G" role="37vLTJ">
-                                          <ref role="3cqZAo" node="dfV14BYn6Q" resolve="value" />
-                                        </node>
-                                        <node concept="3cpWs3" id="dfV14BYn7H" role="37vLTx">
-                                          <node concept="37vLTw" id="dfV14BYn7I" role="3uHU7w">
-                                            <ref role="3cqZAo" node="dfV14BYn7_" resolve="s" />
-                                          </node>
-                                          <node concept="10M0yZ" id="dfV14BYn7J" role="3uHU7B">
-                                            <ref role="1PxDUh" to="1v9t:$bJ0jgVdf3" resolve="DebugHelper" />
-                                            <ref role="3cqZAo" to="1v9t:$bJ0jgVdf5" resolve="originalValue" />
-                                          </node>
-                                        </node>
+                                  </node>
+                                  <node concept="3clFbF" id="5vhcTL2moj7" role="3cqZAp">
+                                    <node concept="37vLTI" id="5vhcTL2moj8" role="3clFbG">
+                                      <node concept="37vLTw" id="5vhcTL2moj9" role="37vLTJ">
+                                        <ref role="3cqZAo" node="5vhcTL2moi9" resolve="value" />
                                       </node>
-                                    </node>
-                                    <node concept="3clFbF" id="dfV14BYn7K" role="3cqZAp">
-                                      <node concept="37vLTI" id="dfV14BYn7L" role="3clFbG">
-                                        <node concept="37vLTw" id="dfV14BYn7M" role="37vLTx">
-                                          <ref role="3cqZAo" node="dfV14BYn7_" resolve="s" />
+                                      <node concept="3cpWs3" id="5vhcTL2moja" role="37vLTx">
+                                        <node concept="37vLTw" id="5vhcTL2mojb" role="3uHU7w">
+                                          <ref role="3cqZAo" node="5vhcTL2moj2" resolve="s" />
                                         </node>
-                                        <node concept="10M0yZ" id="dfV14BYn7N" role="37vLTJ">
+                                        <node concept="10M0yZ" id="5vhcTL2mojc" role="3uHU7B">
                                           <ref role="1PxDUh" to="1v9t:$bJ0jgVdf3" resolve="DebugHelper" />
-                                          <ref role="3cqZAo" to="1v9t:$bJ0jgVdf9" resolve="sliderValue" />
+                                          <ref role="3cqZAo" to="1v9t:$bJ0jgVdf5" resolve="originalValue" />
                                         </node>
                                       </node>
                                     </node>
-                                    <node concept="3clFbF" id="dfV14BYn7O" role="3cqZAp">
-                                      <node concept="37vLTI" id="dfV14BYn7P" role="3clFbG">
-                                        <node concept="3cpWs3" id="dfV14BYn7Q" role="37vLTx">
-                                          <node concept="Xl_RD" id="dfV14BYn7R" role="3uHU7w">
-                                            <property role="Xl_RC" value="" />
-                                          </node>
-                                          <node concept="37vLTw" id="dfV14BYn7S" role="3uHU7B">
-                                            <ref role="3cqZAo" node="dfV14BYn6Q" resolve="value" />
-                                          </node>
+                                  </node>
+                                  <node concept="3clFbF" id="5vhcTL2mojd" role="3cqZAp">
+                                    <node concept="37vLTI" id="5vhcTL2moje" role="3clFbG">
+                                      <node concept="37vLTw" id="5vhcTL2mojf" role="37vLTx">
+                                        <ref role="3cqZAo" node="5vhcTL2moj2" resolve="s" />
+                                      </node>
+                                      <node concept="10M0yZ" id="5vhcTL2mojg" role="37vLTJ">
+                                        <ref role="1PxDUh" to="1v9t:$bJ0jgVdf3" resolve="DebugHelper" />
+                                        <ref role="3cqZAo" to="1v9t:$bJ0jgVdf9" resolve="sliderValue" />
+                                      </node>
+                                    </node>
+                                  </node>
+                                  <node concept="3clFbF" id="5vhcTL2mojh" role="3cqZAp">
+                                    <node concept="37vLTI" id="5vhcTL2moji" role="3clFbG">
+                                      <node concept="3cpWs3" id="5vhcTL2mojj" role="37vLTx">
+                                        <node concept="Xl_RD" id="5vhcTL2mojk" role="3uHU7w">
+                                          <property role="Xl_RC" value="" />
                                         </node>
-                                        <node concept="2OqwBi" id="dfV14BYn7T" role="37vLTJ">
-                                          <node concept="37vLTw" id="dfV14BYn7U" role="2Oq$k0">
-                                            <ref role="3cqZAo" node="dfV14BYn6G" resolve="nl" />
-                                          </node>
-                                          <node concept="3TrcHB" id="dfV14BYn7V" role="2OqNvi">
-                                            <ref role="3TsBF5" to="mj1l:1UQ4qqfV3yK" resolve="value" />
-                                          </node>
+                                        <node concept="37vLTw" id="5vhcTL2mojl" role="3uHU7B">
+                                          <ref role="3cqZAo" node="5vhcTL2moi9" resolve="value" />
+                                        </node>
+                                      </node>
+                                      <node concept="2OqwBi" id="5vhcTL2mojm" role="37vLTJ">
+                                        <node concept="37vLTw" id="5vhcTL2mojn" role="2Oq$k0">
+                                          <ref role="3cqZAo" node="5vhcTL2mohY" resolve="nl" />
+                                        </node>
+                                        <node concept="3TrcHB" id="5vhcTL2mojo" role="2OqNvi">
+                                          <ref role="3TsBF5" to="mj1l:1UQ4qqfV3yK" resolve="value" />
                                         </node>
                                       </node>
                                     </node>
-                                    <node concept="3clFbF" id="dfV14BYn7W" role="3cqZAp">
-                                      <node concept="2YIFZM" id="dfV14BYn7X" role="3clFbG">
-                                        <ref role="1Pybhc" to="1v9t:$bJ0jgVdf3" resolve="DebugHelper" />
-                                        <ref role="37wK5l" to="1v9t:$bJ0jgVdg0" resolve="update" />
-                                        <node concept="2OqwBi" id="dfV14BYn7Y" role="37wK5m">
-                                          <node concept="pncrf" id="dfV14BYn7Z" role="2Oq$k0" />
-                                          <node concept="2Xjw5R" id="dfV14BYn80" role="2OqNvi">
-                                            <node concept="1xMEDy" id="dfV14BYn81" role="1xVPHs">
-                                              <node concept="chp4Y" id="dfV14BYn82" role="ri$Ld">
-                                                <ref role="cht4Q" to="3vkx:35Kh8LWrQIH" resolve="RTestCase" />
-                                              </node>
+                                  </node>
+                                  <node concept="3clFbF" id="5vhcTL2mojp" role="3cqZAp">
+                                    <node concept="2YIFZM" id="5vhcTL2mojq" role="3clFbG">
+                                      <ref role="1Pybhc" to="1v9t:$bJ0jgVdf3" resolve="DebugHelper" />
+                                      <ref role="37wK5l" to="1v9t:$bJ0jgVdg0" resolve="update" />
+                                      <node concept="2OqwBi" id="5vhcTL2mojr" role="37wK5m">
+                                        <node concept="pncrf" id="5vhcTL2mojs" role="2Oq$k0" />
+                                        <node concept="2Xjw5R" id="5vhcTL2mojt" role="2OqNvi">
+                                          <node concept="1xMEDy" id="5vhcTL2moju" role="1xVPHs">
+                                            <node concept="chp4Y" id="5vhcTL2mojv" role="ri$Ld">
+                                              <ref role="cht4Q" to="3vkx:35Kh8LWrQIH" resolve="RTestCase" />
                                             </node>
                                           </node>
                                         </node>
@@ -2658,17 +2666,17 @@
                                     </node>
                                   </node>
                                 </node>
-                                <node concept="2OqwBi" id="3k8awrIkjn5" role="ukAjM">
-                                  <node concept="1Q80Hx" id="3k8awrIkiyP" role="2Oq$k0" />
-                                  <node concept="liA8E" id="3k8awrIkjGs" role="2OqNvi">
-                                    <ref role="37wK5l" to="cj4x:~EditorContext.getRepository()" resolve="getRepository" />
-                                  </node>
+                              </node>
+                              <node concept="2OqwBi" id="5vhcTL2mojw" role="ukAjM">
+                                <node concept="1Q80Hx" id="5vhcTL2mojx" role="2Oq$k0" />
+                                <node concept="liA8E" id="5vhcTL2mojy" role="2OqNvi">
+                                  <ref role="37wK5l" to="cj4x:~EditorContext.getRepository()" resolve="getRepository" />
                                 </node>
                               </node>
                             </node>
-                            <node concept="2AHcQZ" id="dfV14BYn83" role="2AJF6D">
-                              <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-                            </node>
+                          </node>
+                          <node concept="2AHcQZ" id="5vhcTL2mojz" role="2AJF6D">
+                            <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
                           </node>
                         </node>
                       </node>
@@ -2676,26 +2684,40 @@
                   </node>
                 </node>
               </node>
-              <node concept="3clFbF" id="dfV14BYn84" role="3cqZAp">
-                <node concept="37vLTw" id="dfV14BYn85" role="3clFbG">
-                  <ref role="3cqZAo" node="dfV14BYn6X" resolve="slider" />
+            </node>
+            <node concept="3clFbF" id="5vhcTL2moj$" role="3cqZAp">
+              <node concept="37vLTw" id="5vhcTL2moj_" role="3clFbG">
+                <ref role="3cqZAo" node="5vhcTL2moig" resolve="slider" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="pkWqt" id="5vhcTL2mkLu" role="pqm2j">
+          <node concept="3clFbS" id="5vhcTL2mkLv" role="2VODD2">
+            <node concept="3clFbF" id="5vhcTL2ml3N" role="3cqZAp">
+              <node concept="2OqwBi" id="5vhcTL2ml3O" role="3clFbG">
+                <node concept="2OqwBi" id="5vhcTL2ml3P" role="2Oq$k0">
+                  <node concept="pncrf" id="5vhcTL2ml3Q" role="2Oq$k0" />
+                  <node concept="2qgKlT" id="5vhcTL2ml3R" role="2OqNvi">
+                    <ref role="37wK5l" to="hkt1:dfV14BWZ$n" resolve="getDebuggedTest" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="5vhcTL2ml3S" role="2OqNvi">
+                  <ref role="37wK5l" to="1v9t:dfV14BXf84" resolve="isShowSlider" />
                 </node>
               </node>
             </node>
           </node>
         </node>
-        <node concept="pkWqt" id="dfV14BYn86" role="pqm2j">
-          <node concept="3clFbS" id="dfV14BYn87" role="2VODD2">
-            <node concept="3clFbF" id="dfV14BYn88" role="3cqZAp">
-              <node concept="2OqwBi" id="dfV14BYoJl" role="3clFbG">
-                <node concept="2OqwBi" id="dfV14BYn89" role="2Oq$k0">
-                  <node concept="pncrf" id="dfV14BYn8a" role="2Oq$k0" />
-                  <node concept="2qgKlT" id="dfV14BYoCT" role="2OqNvi">
-                    <ref role="37wK5l" to="hkt1:dfV14BWZ$n" resolve="getDebuggedTest" />
-                  </node>
-                </node>
-                <node concept="liA8E" id="dfV14BYp1L" role="2OqNvi">
-                  <ref role="37wK5l" to="1v9t:dfV14BXf84" resolve="isShowSlider" />
+        <node concept="05MPa" id="5vhcTL2_ywA" role="fNvko">
+          <node concept="3clFbS" id="5vhcTL2_ywB" role="2VODD2">
+            <node concept="3clFbF" id="5vhcTL2_$Ch" role="3cqZAp">
+              <node concept="2YIFZM" id="5vhcTL2__l0" role="3clFbG">
+                <ref role="37wK5l" to="wyt6:~String.valueOf(int)" resolve="valueOf" />
+                <ref role="1Pybhc" to="wyt6:~String" resolve="String" />
+                <node concept="10M0yZ" id="5vhcTL2__l2" role="37wK5m">
+                  <ref role="1PxDUh" to="1v9t:$bJ0jgVdf3" resolve="DebugHelper" />
+                  <ref role="3cqZAo" to="1v9t:$bJ0jgVdf9" resolve="sliderValue" />
                 </node>
               </node>
             </node>
@@ -2706,43 +2728,43 @@
         <node concept="2iRfu4" id="dfV14BYn8e" role="2iSdaV" />
         <node concept="Rtstu" id="dfV14BYpQ8" role="3EZMnx" />
         <node concept="3XFhqQ" id="dfV14BYn8f" role="3EZMnx" />
-        <node concept="3gTLQM" id="dfV14BYn8g" role="3EZMnx">
-          <node concept="3Fmcul" id="dfV14BYn8h" role="3FoqZy">
-            <node concept="3clFbS" id="dfV14BYn8i" role="2VODD2">
-              <node concept="3clFbF" id="dfV14BYn8j" role="3cqZAp">
-                <node concept="2OqwBi" id="dfV14BYn8k" role="3clFbG">
-                  <node concept="2ShNRf" id="dfV14BYn8l" role="2Oq$k0">
-                    <node concept="YeOm9" id="dfV14BYn8m" role="2ShVmc">
-                      <node concept="1Y3b0j" id="dfV14BYn8n" role="YeSDq">
+        <node concept="fWXJ_" id="5vhcTL2ntvy" role="3EZMnx">
+          <node concept="3Fmcul" id="5vhcTL2ntv$" role="3FoqZy">
+            <node concept="3clFbS" id="5vhcTL2ntvA" role="2VODD2">
+              <node concept="3clFbF" id="5vhcTL2nvK5" role="3cqZAp">
+                <node concept="2OqwBi" id="5vhcTL2nvK6" role="3clFbG">
+                  <node concept="2ShNRf" id="5vhcTL2nvK7" role="2Oq$k0">
+                    <node concept="YeOm9" id="5vhcTL2nvK8" role="2ShVmc">
+                      <node concept="1Y3b0j" id="5vhcTL2nvK9" role="YeSDq">
                         <property role="2bfB8j" value="true" />
                         <ref role="1Y3XeK" to="r4b4:3slbD0C7Kn7" resolve="CommandButton" />
                         <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
-                        <node concept="3Tm1VV" id="dfV14BYn8o" role="1B3o_S" />
-                        <node concept="3clFb_" id="dfV14BYn8p" role="jymVt">
+                        <node concept="3Tm1VV" id="5vhcTL2nvKa" role="1B3o_S" />
+                        <node concept="3clFb_" id="5vhcTL2nvKb" role="jymVt">
                           <property role="TrG5h" value="perform" />
                           <property role="1EzhhJ" value="false" />
-                          <node concept="3cqZAl" id="dfV14BYn8q" role="3clF45" />
-                          <node concept="3Tm1VV" id="dfV14BYn8r" role="1B3o_S" />
-                          <node concept="37vLTG" id="dfV14BYn8s" role="3clF46">
+                          <node concept="3cqZAl" id="5vhcTL2nvKc" role="3clF45" />
+                          <node concept="3Tm1VV" id="5vhcTL2nvKd" role="1B3o_S" />
+                          <node concept="37vLTG" id="5vhcTL2nvKe" role="3clF46">
                             <property role="TrG5h" value="n" />
-                            <node concept="3Tqbb2" id="dfV14BYn8t" role="1tU5fm" />
+                            <node concept="3Tqbb2" id="5vhcTL2nvKf" role="1tU5fm" />
                           </node>
-                          <node concept="3clFbS" id="dfV14BYn8u" role="3clF47">
-                            <node concept="3clFbF" id="dfV14BYn8v" role="3cqZAp">
-                              <node concept="2YIFZM" id="dfV14BYn8w" role="3clFbG">
+                          <node concept="3clFbS" id="5vhcTL2nvKg" role="3clF47">
+                            <node concept="3clFbF" id="5vhcTL2nvKh" role="3cqZAp">
+                              <node concept="2YIFZM" id="5vhcTL2nvKi" role="3clFbG">
                                 <ref role="1Pybhc" to="1v9t:$bJ0jgVdf3" resolve="DebugHelper" />
                                 <ref role="37wK5l" to="1v9t:$bJ0jgVdgv" resolve="clear" />
-                                <node concept="2OqwBi" id="dfV14BYn8x" role="37wK5m">
-                                  <node concept="pncrf" id="dfV14BYn8y" role="2Oq$k0" />
-                                  <node concept="2Xjw5R" id="dfV14BYn8z" role="2OqNvi">
-                                    <node concept="1xMEDy" id="dfV14BYn8$" role="1xVPHs">
-                                      <node concept="chp4Y" id="dfV14BYn8_" role="ri$Ld">
+                                <node concept="2OqwBi" id="5vhcTL2nvKj" role="37wK5m">
+                                  <node concept="pncrf" id="5vhcTL2nvKk" role="2Oq$k0" />
+                                  <node concept="2Xjw5R" id="5vhcTL2nvKl" role="2OqNvi">
+                                    <node concept="1xMEDy" id="5vhcTL2nvKm" role="1xVPHs">
+                                      <node concept="chp4Y" id="5vhcTL2nvKn" role="ri$Ld">
                                         <ref role="cht4Q" to="3vkx:34d3$NxXi73" resolve="RCalculation" />
                                       </node>
                                     </node>
                                   </node>
                                 </node>
-                                <node concept="1Q80Hx" id="4yPv6wmTu_D" role="37wK5m" />
+                                <node concept="1Q80Hx" id="5vhcTL2nvKo" role="37wK5m" />
                               </node>
                             </node>
                           </node>
@@ -2750,13 +2772,13 @@
                       </node>
                     </node>
                   </node>
-                  <node concept="liA8E" id="dfV14BYn8G" role="2OqNvi">
+                  <node concept="liA8E" id="5vhcTL2nvKp" role="2OqNvi">
                     <ref role="37wK5l" to="r4b4:7v73aKiqUWd" resolve="create" />
-                    <node concept="pncrf" id="dfV14BYn8H" role="37wK5m" />
-                    <node concept="Xl_RD" id="dfV14BYn8I" role="37wK5m">
+                    <node concept="pncrf" id="5vhcTL2nvKq" role="37wK5m" />
+                    <node concept="Xl_RD" id="5vhcTL2nvKr" role="37wK5m">
                       <property role="Xl_RC" value="Clear" />
                     </node>
-                    <node concept="3cmrfG" id="dfV14BYn8J" role="37wK5m">
+                    <node concept="3cmrfG" id="5vhcTL2nvKs" role="37wK5m">
                       <property role="3cmrfH" value="7" />
                     </node>
                   </node>
@@ -2765,146 +2787,140 @@
             </node>
           </node>
         </node>
-        <node concept="3EZMnI" id="dfV14BYn8K" role="3EZMnx">
-          <node concept="l2Vlx" id="dfV14BYn8L" role="2iSdaV" />
-          <node concept="3gTLQM" id="dfV14BYn8M" role="3EZMnx">
-            <node concept="3Fmcul" id="dfV14BYn8N" role="3FoqZy">
-              <node concept="3clFbS" id="dfV14BYn8O" role="2VODD2">
-                <node concept="3clFbF" id="dfV14BYn8P" role="3cqZAp">
-                  <node concept="2OqwBi" id="dfV14BYn8Q" role="3clFbG">
-                    <node concept="2ShNRf" id="dfV14BYn8R" role="2Oq$k0">
-                      <node concept="YeOm9" id="dfV14BYn8S" role="2ShVmc">
-                        <node concept="1Y3b0j" id="dfV14BYn8T" role="YeSDq">
-                          <property role="2bfB8j" value="true" />
-                          <ref role="1Y3XeK" to="r4b4:CPtprWNoFw" resolve="UtilButton" />
-                          <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
-                          <node concept="3Tm1VV" id="dfV14BYn8U" role="1B3o_S" />
-                          <node concept="3clFb_" id="dfV14BYn8V" role="jymVt">
-                            <property role="TrG5h" value="perform" />
-                            <property role="1EzhhJ" value="false" />
-                            <node concept="3cqZAl" id="dfV14BYn8W" role="3clF45" />
-                            <node concept="3Tm1VV" id="dfV14BYn8X" role="1B3o_S" />
-                            <node concept="37vLTG" id="dfV14BYn8Y" role="3clF46">
-                              <property role="TrG5h" value="n" />
-                              <node concept="3Tqbb2" id="dfV14BYn8Z" role="1tU5fm" />
-                            </node>
-                            <node concept="3clFbS" id="dfV14BYn90" role="3clF47">
-                              <node concept="3clFbF" id="dfV14BYn91" role="3cqZAp">
-                                <node concept="2YIFZM" id="dfV14BYn92" role="3clFbG">
-                                  <ref role="1Pybhc" to="1v9t:$bJ0jgVdf3" resolve="DebugHelper" />
-                                  <ref role="37wK5l" to="1v9t:$bJ0jgVdfe" resolve="debug" />
-                                  <node concept="1PxgMI" id="dfV14BYn93" role="37wK5m">
-                                    <node concept="2OqwBi" id="dfV14BYn94" role="1m5AlR">
-                                      <node concept="37vLTw" id="dfV14BYn96" role="2Oq$k0">
-                                        <ref role="3cqZAo" node="dfV14BYn8Y" resolve="n" />
-                                      </node>
-                                      <node concept="YCak7" id="dfV14BYn98" role="2OqNvi" />
+        <node concept="fWXJ_" id="5vhcTL2nzM4" role="3EZMnx">
+          <node concept="3Fmcul" id="5vhcTL2nzM6" role="3FoqZy">
+            <node concept="3clFbS" id="5vhcTL2nzM8" role="2VODD2">
+              <node concept="3clFbF" id="5vhcTL2nBJp" role="3cqZAp">
+                <node concept="2OqwBi" id="5vhcTL2nBJq" role="3clFbG">
+                  <node concept="2ShNRf" id="5vhcTL2nBJr" role="2Oq$k0">
+                    <node concept="YeOm9" id="5vhcTL2nBJs" role="2ShVmc">
+                      <node concept="1Y3b0j" id="5vhcTL2nBJt" role="YeSDq">
+                        <property role="2bfB8j" value="true" />
+                        <ref role="1Y3XeK" to="r4b4:CPtprWNoFw" resolve="UtilButton" />
+                        <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
+                        <node concept="3Tm1VV" id="5vhcTL2nBJu" role="1B3o_S" />
+                        <node concept="3clFb_" id="5vhcTL2nBJv" role="jymVt">
+                          <property role="TrG5h" value="perform" />
+                          <property role="1EzhhJ" value="false" />
+                          <node concept="3cqZAl" id="5vhcTL2nBJw" role="3clF45" />
+                          <node concept="3Tm1VV" id="5vhcTL2nBJx" role="1B3o_S" />
+                          <node concept="37vLTG" id="5vhcTL2nBJy" role="3clF46">
+                            <property role="TrG5h" value="n" />
+                            <node concept="3Tqbb2" id="5vhcTL2nBJz" role="1tU5fm" />
+                          </node>
+                          <node concept="3clFbS" id="5vhcTL2nBJ$" role="3clF47">
+                            <node concept="3clFbF" id="5vhcTL2nBJ_" role="3cqZAp">
+                              <node concept="2YIFZM" id="5vhcTL2nBJA" role="3clFbG">
+                                <ref role="1Pybhc" to="1v9t:$bJ0jgVdf3" resolve="DebugHelper" />
+                                <ref role="37wK5l" to="1v9t:$bJ0jgVdfe" resolve="debug" />
+                                <node concept="1PxgMI" id="5vhcTL2nBJB" role="37wK5m">
+                                  <node concept="2OqwBi" id="5vhcTL2nBJC" role="1m5AlR">
+                                    <node concept="37vLTw" id="5vhcTL2nBJD" role="2Oq$k0">
+                                      <ref role="3cqZAo" node="5vhcTL2nBJy" resolve="n" />
                                     </node>
-                                    <node concept="chp4Y" id="79i$vAY7gmF" role="3oSUPX">
-                                      <ref role="cht4Q" to="3vkx:35Kh8LWrQIH" resolve="RTestCase" />
-                                    </node>
+                                    <node concept="YCak7" id="5vhcTL2nBJE" role="2OqNvi" />
                                   </node>
-                                  <node concept="3clFbT" id="dfV14BYn99" role="37wK5m">
-                                    <property role="3clFbU" value="true" />
+                                  <node concept="chp4Y" id="5vhcTL2nBJF" role="3oSUPX">
+                                    <ref role="cht4Q" to="3vkx:35Kh8LWrQIH" resolve="RTestCase" />
                                   </node>
-                                  <node concept="1Q80Hx" id="7gatZB67BDO" role="37wK5m" />
                                 </node>
+                                <node concept="3clFbT" id="5vhcTL2nBJG" role="37wK5m">
+                                  <property role="3clFbU" value="true" />
+                                </node>
+                                <node concept="1Q80Hx" id="5vhcTL2nBJH" role="37wK5m" />
                               </node>
                             </node>
                           </node>
                         </node>
                       </node>
                     </node>
-                    <node concept="liA8E" id="dfV14BYn9g" role="2OqNvi">
-                      <ref role="37wK5l" to="r4b4:CPtprWNBIs" resolve="createDownButton" />
-                      <node concept="pncrf" id="dfV14BYn9h" role="37wK5m" />
-                    </node>
+                  </node>
+                  <node concept="liA8E" id="5vhcTL2nBJI" role="2OqNvi">
+                    <ref role="37wK5l" to="r4b4:CPtprWNBIs" resolve="createDownButton" />
+                    <node concept="pncrf" id="5vhcTL2nBJJ" role="37wK5m" />
                   </node>
                 </node>
               </node>
             </node>
           </node>
-          <node concept="pkWqt" id="dfV14BYn9i" role="pqm2j">
-            <node concept="3clFbS" id="dfV14BYn9j" role="2VODD2">
-              <node concept="3clFbF" id="dfV14BYn9k" role="3cqZAp">
-                <node concept="3y3z36" id="dfV14BYn9l" role="3clFbG">
-                  <node concept="10Nm6u" id="dfV14BYn9m" role="3uHU7w" />
-                  <node concept="2OqwBi" id="dfV14BYn9n" role="3uHU7B">
-                    <node concept="pncrf" id="dfV14BYn9p" role="2Oq$k0" />
-                    <node concept="YCak7" id="dfV14BYn9r" role="2OqNvi" />
+          <node concept="pkWqt" id="5vhcTL2n$VA" role="pqm2j">
+            <node concept="3clFbS" id="5vhcTL2n$VB" role="2VODD2">
+              <node concept="3clFbF" id="5vhcTL2n$VD" role="3cqZAp">
+                <node concept="3y3z36" id="5vhcTL2n$VE" role="3clFbG">
+                  <node concept="10Nm6u" id="5vhcTL2n$VF" role="3uHU7w" />
+                  <node concept="2OqwBi" id="5vhcTL2n$VG" role="3uHU7B">
+                    <node concept="pncrf" id="5vhcTL2n$VH" role="2Oq$k0" />
+                    <node concept="YCak7" id="5vhcTL2n$VI" role="2OqNvi" />
                   </node>
                 </node>
               </node>
             </node>
           </node>
         </node>
-        <node concept="3EZMnI" id="dfV14BYn9s" role="3EZMnx">
-          <node concept="l2Vlx" id="dfV14BYn9t" role="2iSdaV" />
-          <node concept="3gTLQM" id="dfV14BYn9u" role="3EZMnx">
-            <node concept="3Fmcul" id="dfV14BYn9v" role="3FoqZy">
-              <node concept="3clFbS" id="dfV14BYn9w" role="2VODD2">
-                <node concept="3clFbF" id="dfV14BYn9x" role="3cqZAp">
-                  <node concept="2OqwBi" id="dfV14BYn9y" role="3clFbG">
-                    <node concept="2ShNRf" id="dfV14BYn9z" role="2Oq$k0">
-                      <node concept="YeOm9" id="dfV14BYn9$" role="2ShVmc">
-                        <node concept="1Y3b0j" id="dfV14BYn9_" role="YeSDq">
-                          <property role="2bfB8j" value="true" />
-                          <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
-                          <ref role="1Y3XeK" to="r4b4:CPtprWNoFw" resolve="UtilButton" />
-                          <node concept="3Tm1VV" id="dfV14BYn9A" role="1B3o_S" />
-                          <node concept="3clFb_" id="dfV14BYn9B" role="jymVt">
-                            <property role="TrG5h" value="perform" />
-                            <property role="1EzhhJ" value="false" />
-                            <node concept="3cqZAl" id="dfV14BYn9C" role="3clF45" />
-                            <node concept="3Tm1VV" id="dfV14BYn9D" role="1B3o_S" />
-                            <node concept="37vLTG" id="dfV14BYn9E" role="3clF46">
-                              <property role="TrG5h" value="n" />
-                              <node concept="3Tqbb2" id="dfV14BYn9F" role="1tU5fm" />
-                            </node>
-                            <node concept="3clFbS" id="dfV14BYn9G" role="3clF47">
-                              <node concept="3clFbF" id="dfV14BYn9H" role="3cqZAp">
-                                <node concept="2YIFZM" id="dfV14BYn9I" role="3clFbG">
-                                  <ref role="1Pybhc" to="1v9t:$bJ0jgVdf3" resolve="DebugHelper" />
-                                  <ref role="37wK5l" to="1v9t:$bJ0jgVdfe" resolve="debug" />
-                                  <node concept="1PxgMI" id="dfV14BYn9J" role="37wK5m">
-                                    <node concept="2OqwBi" id="dfV14BYn9K" role="1m5AlR">
-                                      <node concept="37vLTw" id="dfV14BYn9M" role="2Oq$k0">
-                                        <ref role="3cqZAo" node="dfV14BYn9E" resolve="n" />
-                                      </node>
-                                      <node concept="YBYNd" id="dfV14BYn9O" role="2OqNvi" />
+        <node concept="fWXJ_" id="5vhcTL2nEIK" role="3EZMnx">
+          <node concept="3Fmcul" id="5vhcTL2nEIM" role="3FoqZy">
+            <node concept="3clFbS" id="5vhcTL2nEIO" role="2VODD2">
+              <node concept="3clFbF" id="dfV14BYn9x" role="3cqZAp">
+                <node concept="2OqwBi" id="dfV14BYn9y" role="3clFbG">
+                  <node concept="2ShNRf" id="dfV14BYn9z" role="2Oq$k0">
+                    <node concept="YeOm9" id="dfV14BYn9$" role="2ShVmc">
+                      <node concept="1Y3b0j" id="dfV14BYn9_" role="YeSDq">
+                        <property role="2bfB8j" value="true" />
+                        <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
+                        <ref role="1Y3XeK" to="r4b4:CPtprWNoFw" resolve="UtilButton" />
+                        <node concept="3Tm1VV" id="dfV14BYn9A" role="1B3o_S" />
+                        <node concept="3clFb_" id="dfV14BYn9B" role="jymVt">
+                          <property role="TrG5h" value="perform" />
+                          <property role="1EzhhJ" value="false" />
+                          <node concept="3cqZAl" id="dfV14BYn9C" role="3clF45" />
+                          <node concept="3Tm1VV" id="dfV14BYn9D" role="1B3o_S" />
+                          <node concept="37vLTG" id="dfV14BYn9E" role="3clF46">
+                            <property role="TrG5h" value="n" />
+                            <node concept="3Tqbb2" id="dfV14BYn9F" role="1tU5fm" />
+                          </node>
+                          <node concept="3clFbS" id="dfV14BYn9G" role="3clF47">
+                            <node concept="3clFbF" id="dfV14BYn9H" role="3cqZAp">
+                              <node concept="2YIFZM" id="dfV14BYn9I" role="3clFbG">
+                                <ref role="1Pybhc" to="1v9t:$bJ0jgVdf3" resolve="DebugHelper" />
+                                <ref role="37wK5l" to="1v9t:$bJ0jgVdfe" resolve="debug" />
+                                <node concept="1PxgMI" id="dfV14BYn9J" role="37wK5m">
+                                  <node concept="2OqwBi" id="dfV14BYn9K" role="1m5AlR">
+                                    <node concept="37vLTw" id="dfV14BYn9M" role="2Oq$k0">
+                                      <ref role="3cqZAo" node="dfV14BYn9E" resolve="n" />
                                     </node>
-                                    <node concept="chp4Y" id="79i$vAY7gmG" role="3oSUPX">
-                                      <ref role="cht4Q" to="3vkx:35Kh8LWrQIH" resolve="RTestCase" />
-                                    </node>
+                                    <node concept="YBYNd" id="dfV14BYn9O" role="2OqNvi" />
                                   </node>
-                                  <node concept="3clFbT" id="dfV14BYn9P" role="37wK5m">
-                                    <property role="3clFbU" value="true" />
+                                  <node concept="chp4Y" id="79i$vAY7gmG" role="3oSUPX">
+                                    <ref role="cht4Q" to="3vkx:35Kh8LWrQIH" resolve="RTestCase" />
                                   </node>
-                                  <node concept="1Q80Hx" id="7gatZB67BKW" role="37wK5m" />
                                 </node>
+                                <node concept="3clFbT" id="dfV14BYn9P" role="37wK5m">
+                                  <property role="3clFbU" value="true" />
+                                </node>
+                                <node concept="1Q80Hx" id="7gatZB67BKW" role="37wK5m" />
                               </node>
                             </node>
                           </node>
                         </node>
                       </node>
                     </node>
-                    <node concept="liA8E" id="dfV14BYn9W" role="2OqNvi">
-                      <ref role="37wK5l" to="r4b4:CPtprWNoFZ" resolve="createUpButton" />
-                      <node concept="pncrf" id="dfV14BYn9X" role="37wK5m" />
-                    </node>
+                  </node>
+                  <node concept="liA8E" id="dfV14BYn9W" role="2OqNvi">
+                    <ref role="37wK5l" to="r4b4:CPtprWNoFZ" resolve="createUpButton" />
+                    <node concept="pncrf" id="dfV14BYn9X" role="37wK5m" />
                   </node>
                 </node>
               </node>
             </node>
           </node>
-          <node concept="pkWqt" id="dfV14BYn9Y" role="pqm2j">
-            <node concept="3clFbS" id="dfV14BYn9Z" role="2VODD2">
-              <node concept="3clFbF" id="dfV14BYna0" role="3cqZAp">
-                <node concept="3y3z36" id="dfV14BYna1" role="3clFbG">
-                  <node concept="10Nm6u" id="dfV14BYna2" role="3uHU7w" />
-                  <node concept="2OqwBi" id="dfV14BYna3" role="3uHU7B">
-                    <node concept="pncrf" id="dfV14BYna5" role="2Oq$k0" />
-                    <node concept="YBYNd" id="dfV14BYna7" role="2OqNvi" />
+          <node concept="pkWqt" id="5vhcTL2nNP1" role="pqm2j">
+            <node concept="3clFbS" id="5vhcTL2nNP2" role="2VODD2">
+              <node concept="3clFbF" id="5vhcTL2nFA0" role="3cqZAp">
+                <node concept="3y3z36" id="5vhcTL2nFA1" role="3clFbG">
+                  <node concept="10Nm6u" id="5vhcTL2nFA2" role="3uHU7w" />
+                  <node concept="2OqwBi" id="5vhcTL2nFA3" role="3uHU7B">
+                    <node concept="pncrf" id="5vhcTL2nFA4" role="2Oq$k0" />
+                    <node concept="YBYNd" id="5vhcTL2nFA5" role="2OqNvi" />
                   </node>
                 </node>
               </node>

--- a/code/languages/com.mbeddr.cc/languages/com.mbeddr.cc.requirements/languageModels/editor.mps
+++ b/code/languages/com.mbeddr.cc/languages/com.mbeddr.cc.requirements/languageModels/editor.mps
@@ -6,6 +6,7 @@
     <use id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor" version="14" />
     <use id="b1ab8c10-c118-4755-bf2a-cebab35cf533" name="jetbrains.mps.lang.editor.tooltips" version="0" />
     <use id="774bf8a0-62e5-41e1-af63-f4812e60e48b" name="jetbrains.mps.baseLanguage.checkedDots" version="0" />
+    <use id="62971cbe-fd2f-4135-b001-ee6cb7a74436" name="nl.f1re.mps.editor.swing" version="0" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
@@ -374,6 +375,9 @@
     </language>
     <language id="774bf8a0-62e5-41e1-af63-f4812e60e48b" name="jetbrains.mps.baseLanguage.checkedDots">
       <concept id="4079382982702596667" name="jetbrains.mps.baseLanguage.checkedDots.structure.CheckedDotExpression" flags="nn" index="2EnYce" />
+    </language>
+    <language id="62971cbe-fd2f-4135-b001-ee6cb7a74436" name="nl.f1re.mps.editor.swing">
+      <concept id="8659612544238797919" name="nl.f1re.mps.editor.swing.structure.CellModel_CustomJComponent" flags="sg" stub="8659612544238937882" index="fWXJ_" />
     </language>
     <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
       <concept id="2524418899405758586" name="jetbrains.mps.baseLanguage.closures.structure.InferredClosureParameterDeclaration" flags="ig" index="gl6BB" />
@@ -1163,9 +1167,9 @@
             </node>
           </node>
         </node>
-        <node concept="3gTLQM" id="3slbD0C6umT" role="3EZMnx">
-          <node concept="3Fmcul" id="3slbD0C6umU" role="3FoqZy">
-            <node concept="3clFbS" id="3slbD0C6umV" role="2VODD2">
+        <node concept="fWXJ_" id="5vhcTL2KbvF" role="3EZMnx">
+          <node concept="3Fmcul" id="5vhcTL2KbvH" role="3FoqZy">
+            <node concept="3clFbS" id="5vhcTL2KbvJ" role="2VODD2">
               <node concept="3clFbF" id="3slbD0C6zb0" role="3cqZAp">
                 <node concept="2OqwBi" id="3slbD0C6zbv" role="3clFbG">
                   <node concept="2ShNRf" id="3slbD0C6zb1" role="2Oq$k0">
@@ -1228,9 +1232,9 @@
             </node>
           </node>
         </node>
-        <node concept="3gTLQM" id="3slbD0C6J1m" role="3EZMnx">
-          <node concept="3Fmcul" id="3slbD0C6J1n" role="3FoqZy">
-            <node concept="3clFbS" id="3slbD0C6J1o" role="2VODD2">
+        <node concept="fWXJ_" id="5vhcTL2Knz9" role="3EZMnx">
+          <node concept="3Fmcul" id="5vhcTL2Knzb" role="3FoqZy">
+            <node concept="3clFbS" id="5vhcTL2Knzd" role="2VODD2">
               <node concept="3clFbF" id="3slbD0C6J1p" role="3cqZAp">
                 <node concept="2OqwBi" id="3slbD0C6J1q" role="3clFbG">
                   <node concept="2ShNRf" id="3slbD0C6J1r" role="2Oq$k0">
@@ -1293,9 +1297,9 @@
             </node>
           </node>
         </node>
-        <node concept="3gTLQM" id="3slbD0C6EFx" role="3EZMnx">
-          <node concept="3Fmcul" id="3slbD0C6EFy" role="3FoqZy">
-            <node concept="3clFbS" id="3slbD0C6EFz" role="2VODD2">
+        <node concept="fWXJ_" id="5vhcTL2Kwoe" role="3EZMnx">
+          <node concept="3Fmcul" id="5vhcTL2Kwog" role="3FoqZy">
+            <node concept="3clFbS" id="5vhcTL2Kwoi" role="2VODD2">
               <node concept="3clFbF" id="3slbD0C6EF$" role="3cqZAp">
                 <node concept="2OqwBi" id="3slbD0C6EF_" role="3clFbG">
                   <node concept="2ShNRf" id="3slbD0C6EFA" role="2Oq$k0">
@@ -1397,9 +1401,9 @@
             </node>
           </node>
         </node>
-        <node concept="3gTLQM" id="3slbD0C6J1M" role="3EZMnx">
-          <node concept="3Fmcul" id="3slbD0C6J1N" role="3FoqZy">
-            <node concept="3clFbS" id="3slbD0C6J1O" role="2VODD2">
+        <node concept="fWXJ_" id="5vhcTL2KCg8" role="3EZMnx">
+          <node concept="3Fmcul" id="5vhcTL2KCga" role="3FoqZy">
+            <node concept="3clFbS" id="5vhcTL2KCgc" role="2VODD2">
               <node concept="3clFbF" id="3slbD0C6J1P" role="3cqZAp">
                 <node concept="2OqwBi" id="3slbD0C6J1Q" role="3clFbG">
                   <node concept="2ShNRf" id="3slbD0C6J1R" role="2Oq$k0">
@@ -1462,9 +1466,9 @@
           <node concept="VPM3Z" id="2TTzVZwoCl$" role="3F10Kt">
             <property role="VOm3f" value="false" />
           </node>
-          <node concept="3gTLQM" id="CPtprWMDC2" role="3EZMnx">
-            <node concept="3Fmcul" id="CPtprWMDC3" role="3FoqZy">
-              <node concept="3clFbS" id="CPtprWMDC4" role="2VODD2">
+          <node concept="fWXJ_" id="5vhcTL2KRBr" role="3EZMnx">
+            <node concept="3Fmcul" id="5vhcTL2KRBt" role="3FoqZy">
+              <node concept="3clFbS" id="5vhcTL2KRBv" role="2VODD2">
                 <node concept="3clFbF" id="CPtprWNthc" role="3cqZAp">
                   <node concept="2OqwBi" id="CPtprWNwcK" role="3clFbG">
                     <node concept="2ShNRf" id="CPtprWNthd" role="2Oq$k0">
@@ -1522,9 +1526,9 @@
               </node>
             </node>
           </node>
-          <node concept="3gTLQM" id="7S_3HdEVzRr" role="3EZMnx">
-            <node concept="3Fmcul" id="7S_3HdEVzRs" role="3FoqZy">
-              <node concept="3clFbS" id="7S_3HdEVzRt" role="2VODD2">
+          <node concept="fWXJ_" id="5vhcTL2L5ou" role="3EZMnx">
+            <node concept="3Fmcul" id="5vhcTL2L5ow" role="3FoqZy">
+              <node concept="3clFbS" id="5vhcTL2L5oy" role="2VODD2">
                 <node concept="3clFbF" id="7S_3HdEVzRu" role="3cqZAp">
                   <node concept="2OqwBi" id="7S_3HdEVzRv" role="3clFbG">
                     <node concept="2ShNRf" id="7S_3HdEVzRw" role="2Oq$k0">
@@ -1613,54 +1617,49 @@
           </node>
         </node>
         <node concept="3XFhqQ" id="7S_3HdEVHc9" role="3EZMnx" />
-        <node concept="3EZMnI" id="2TTzVZwoCn4" role="3EZMnx">
-          <node concept="VPM3Z" id="2TTzVZwoCn5" role="3F10Kt">
-            <property role="VOm3f" value="false" />
-          </node>
-          <node concept="3gTLQM" id="CPtprWNHEy" role="3EZMnx">
-            <node concept="3Fmcul" id="CPtprWNHEz" role="3FoqZy">
-              <node concept="3clFbS" id="CPtprWNHE$" role="2VODD2">
-                <node concept="3clFbF" id="CPtprWNHE_" role="3cqZAp">
-                  <node concept="2OqwBi" id="CPtprWNHEA" role="3clFbG">
-                    <node concept="2ShNRf" id="CPtprWNHEB" role="2Oq$k0">
-                      <node concept="YeOm9" id="CPtprWNHEC" role="2ShVmc">
-                        <node concept="1Y3b0j" id="CPtprWNHED" role="YeSDq">
-                          <property role="2bfB8j" value="true" />
-                          <ref role="1Y3XeK" to="r4b4:CPtprWNoFw" resolve="UtilButton" />
-                          <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
-                          <node concept="3Tm1VV" id="CPtprWNHEE" role="1B3o_S" />
-                          <node concept="3clFb_" id="CPtprWNHEF" role="jymVt">
-                            <property role="TrG5h" value="perform" />
-                            <property role="1EzhhJ" value="false" />
-                            <node concept="3cqZAl" id="CPtprWNHEG" role="3clF45" />
-                            <node concept="3Tm1VV" id="CPtprWNHEH" role="1B3o_S" />
-                            <node concept="37vLTG" id="CPtprWNHEI" role="3clF46">
-                              <property role="TrG5h" value="n" />
-                              <node concept="3Tqbb2" id="CPtprWNHEJ" role="1tU5fm" />
-                            </node>
-                            <node concept="3clFbS" id="CPtprWNHEK" role="3clF47">
-                              <node concept="3clFbJ" id="CPtprWNHEL" role="3cqZAp">
-                                <node concept="3clFbS" id="CPtprWNHEM" role="3clFbx">
-                                  <node concept="3clFbF" id="CPtprWNHEN" role="3cqZAp">
-                                    <node concept="2OqwBi" id="CPtprWNHFr" role="3clFbG">
-                                      <node concept="2OqwBi" id="CPtprWNHEP" role="2Oq$k0">
-                                        <node concept="pncrf" id="CPtprWNHEQ" role="2Oq$k0" />
-                                        <node concept="YCak7" id="CPtprWNHF5" role="2OqNvi" />
-                                      </node>
-                                      <node concept="HtI8k" id="CPtprWNHFx" role="2OqNvi">
-                                        <node concept="37vLTw" id="CPtprWNHFz" role="HtI8F">
-                                          <ref role="3cqZAo" node="CPtprWNHEI" resolve="n" />
-                                        </node>
+        <node concept="fWXJ_" id="5vhcTL2LkpP" role="3EZMnx">
+          <node concept="3Fmcul" id="5vhcTL2LkpR" role="3FoqZy">
+            <node concept="3clFbS" id="5vhcTL2LkpT" role="2VODD2">
+              <node concept="3clFbF" id="CPtprWNHE_" role="3cqZAp">
+                <node concept="2OqwBi" id="CPtprWNHEA" role="3clFbG">
+                  <node concept="2ShNRf" id="CPtprWNHEB" role="2Oq$k0">
+                    <node concept="YeOm9" id="CPtprWNHEC" role="2ShVmc">
+                      <node concept="1Y3b0j" id="CPtprWNHED" role="YeSDq">
+                        <property role="2bfB8j" value="true" />
+                        <ref role="1Y3XeK" to="r4b4:CPtprWNoFw" resolve="UtilButton" />
+                        <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
+                        <node concept="3Tm1VV" id="CPtprWNHEE" role="1B3o_S" />
+                        <node concept="3clFb_" id="CPtprWNHEF" role="jymVt">
+                          <property role="TrG5h" value="perform" />
+                          <property role="1EzhhJ" value="false" />
+                          <node concept="3cqZAl" id="CPtprWNHEG" role="3clF45" />
+                          <node concept="3Tm1VV" id="CPtprWNHEH" role="1B3o_S" />
+                          <node concept="37vLTG" id="CPtprWNHEI" role="3clF46">
+                            <property role="TrG5h" value="n" />
+                            <node concept="3Tqbb2" id="CPtprWNHEJ" role="1tU5fm" />
+                          </node>
+                          <node concept="3clFbS" id="CPtprWNHEK" role="3clF47">
+                            <node concept="3clFbJ" id="CPtprWNHEL" role="3cqZAp">
+                              <node concept="3clFbS" id="CPtprWNHEM" role="3clFbx">
+                                <node concept="3clFbF" id="CPtprWNHEN" role="3cqZAp">
+                                  <node concept="2OqwBi" id="CPtprWNHFr" role="3clFbG">
+                                    <node concept="2OqwBi" id="CPtprWNHEP" role="2Oq$k0">
+                                      <node concept="pncrf" id="CPtprWNHEQ" role="2Oq$k0" />
+                                      <node concept="YCak7" id="CPtprWNHF5" role="2OqNvi" />
+                                    </node>
+                                    <node concept="HtI8k" id="CPtprWNHFx" role="2OqNvi">
+                                      <node concept="37vLTw" id="CPtprWNHFz" role="HtI8F">
+                                        <ref role="3cqZAo" node="CPtprWNHEI" resolve="n" />
                                       </node>
                                     </node>
                                   </node>
                                 </node>
-                                <node concept="3y3z36" id="CPtprWNHEU" role="3clFbw">
-                                  <node concept="10Nm6u" id="CPtprWNHEV" role="3uHU7w" />
-                                  <node concept="2OqwBi" id="CPtprWNHEW" role="3uHU7B">
-                                    <node concept="pncrf" id="CPtprWNHEX" role="2Oq$k0" />
-                                    <node concept="YCak7" id="CPtprWNHF3" role="2OqNvi" />
-                                  </node>
+                              </node>
+                              <node concept="3y3z36" id="CPtprWNHEU" role="3clFbw">
+                                <node concept="10Nm6u" id="CPtprWNHEV" role="3uHU7w" />
+                                <node concept="2OqwBi" id="CPtprWNHEW" role="3uHU7B">
+                                  <node concept="pncrf" id="CPtprWNHEX" role="2Oq$k0" />
+                                  <node concept="YCak7" id="CPtprWNHF3" role="2OqNvi" />
                                 </node>
                               </node>
                             </node>
@@ -1668,78 +1667,72 @@
                         </node>
                       </node>
                     </node>
-                    <node concept="liA8E" id="CPtprWNHEZ" role="2OqNvi">
-                      <ref role="37wK5l" to="r4b4:CPtprWNBIs" resolve="createDownButton" />
-                      <node concept="pncrf" id="CPtprWNHF0" role="37wK5m" />
-                    </node>
+                  </node>
+                  <node concept="liA8E" id="CPtprWNHEZ" role="2OqNvi">
+                    <ref role="37wK5l" to="r4b4:CPtprWNBIs" resolve="createDownButton" />
+                    <node concept="pncrf" id="CPtprWNHF0" role="37wK5m" />
                   </node>
                 </node>
               </node>
             </node>
           </node>
-          <node concept="l2Vlx" id="2TTzVZwoCn7" role="2iSdaV" />
-          <node concept="pkWqt" id="2TTzVZwoCn8" role="pqm2j">
-            <node concept="3clFbS" id="2TTzVZwoCn9" role="2VODD2">
-              <node concept="3clFbF" id="2TTzVZwoCna" role="3cqZAp">
-                <node concept="3y3z36" id="2TTzVZwoCnW" role="3clFbG">
-                  <node concept="10Nm6u" id="2TTzVZwoCnZ" role="3uHU7w" />
-                  <node concept="2OqwBi" id="2TTzVZwoCnw" role="3uHU7B">
-                    <node concept="pncrf" id="2TTzVZwoCnb" role="2Oq$k0" />
-                    <node concept="YCak7" id="2TTzVZwoCnA" role="2OqNvi" />
+          <node concept="pkWqt" id="5vhcTL2LlZr" role="pqm2j">
+            <node concept="3clFbS" id="5vhcTL2LlZs" role="2VODD2">
+              <node concept="3clFbF" id="5vhcTL2LmhK" role="3cqZAp">
+                <node concept="3y3z36" id="5vhcTL2LmhM" role="3clFbG">
+                  <node concept="10Nm6u" id="5vhcTL2LmhN" role="3uHU7w" />
+                  <node concept="2OqwBi" id="5vhcTL2LmhO" role="3uHU7B">
+                    <node concept="pncrf" id="5vhcTL2LmhP" role="2Oq$k0" />
+                    <node concept="YCak7" id="5vhcTL2LmhQ" role="2OqNvi" />
                   </node>
                 </node>
               </node>
             </node>
           </node>
         </node>
-        <node concept="3EZMnI" id="2TTzVZwoCo9" role="3EZMnx">
-          <node concept="VPM3Z" id="2TTzVZwoCoa" role="3F10Kt">
-            <property role="VOm3f" value="false" />
-          </node>
-          <node concept="3gTLQM" id="7S_3HdEVzOF" role="3EZMnx">
-            <node concept="3Fmcul" id="7S_3HdEVzOG" role="3FoqZy">
-              <node concept="3clFbS" id="7S_3HdEVzOH" role="2VODD2">
-                <node concept="3clFbF" id="7S_3HdEVzOI" role="3cqZAp">
-                  <node concept="2OqwBi" id="7S_3HdEVzOJ" role="3clFbG">
-                    <node concept="2ShNRf" id="7S_3HdEVzOK" role="2Oq$k0">
-                      <node concept="YeOm9" id="7S_3HdEVzOL" role="2ShVmc">
-                        <node concept="1Y3b0j" id="7S_3HdEVzOM" role="YeSDq">
-                          <property role="2bfB8j" value="true" />
-                          <ref role="1Y3XeK" to="r4b4:CPtprWNoFw" resolve="UtilButton" />
-                          <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
-                          <node concept="3Tm1VV" id="7S_3HdEVzON" role="1B3o_S" />
-                          <node concept="3clFb_" id="7S_3HdEVzOO" role="jymVt">
-                            <property role="TrG5h" value="perform" />
-                            <property role="1EzhhJ" value="false" />
-                            <node concept="3cqZAl" id="7S_3HdEVzOP" role="3clF45" />
-                            <node concept="3Tm1VV" id="7S_3HdEVzOQ" role="1B3o_S" />
-                            <node concept="37vLTG" id="7S_3HdEVzOR" role="3clF46">
-                              <property role="TrG5h" value="n" />
-                              <node concept="3Tqbb2" id="7S_3HdEVzOS" role="1tU5fm" />
-                            </node>
-                            <node concept="3clFbS" id="7S_3HdEVzOT" role="3clF47">
-                              <node concept="3clFbJ" id="7S_3HdEVzOU" role="3cqZAp">
-                                <node concept="3clFbS" id="7S_3HdEVzOV" role="3clFbx">
-                                  <node concept="3clFbF" id="7S_3HdEVzS2" role="3cqZAp">
-                                    <node concept="2OqwBi" id="7S_3HdEVzSO" role="3clFbG">
-                                      <node concept="2OqwBi" id="7S_3HdEVzSo" role="2Oq$k0">
-                                        <node concept="pncrf" id="7S_3HdEVzS3" role="2Oq$k0" />
-                                        <node concept="1mfA1w" id="7S_3HdEVzSu" role="2OqNvi" />
-                                      </node>
-                                      <node concept="HtI8k" id="7S_3HdEVzSU" role="2OqNvi">
-                                        <node concept="37vLTw" id="7S_3HdEVzSW" role="HtI8F">
-                                          <ref role="3cqZAo" node="7S_3HdEVzOR" resolve="n" />
-                                        </node>
+        <node concept="fWXJ_" id="5vhcTL2Lw$N" role="3EZMnx">
+          <node concept="3Fmcul" id="5vhcTL2Lw$P" role="3FoqZy">
+            <node concept="3clFbS" id="5vhcTL2Lw$R" role="2VODD2">
+              <node concept="3clFbF" id="7S_3HdEVzOI" role="3cqZAp">
+                <node concept="2OqwBi" id="7S_3HdEVzOJ" role="3clFbG">
+                  <node concept="2ShNRf" id="7S_3HdEVzOK" role="2Oq$k0">
+                    <node concept="YeOm9" id="7S_3HdEVzOL" role="2ShVmc">
+                      <node concept="1Y3b0j" id="7S_3HdEVzOM" role="YeSDq">
+                        <property role="2bfB8j" value="true" />
+                        <ref role="1Y3XeK" to="r4b4:CPtprWNoFw" resolve="UtilButton" />
+                        <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
+                        <node concept="3Tm1VV" id="7S_3HdEVzON" role="1B3o_S" />
+                        <node concept="3clFb_" id="7S_3HdEVzOO" role="jymVt">
+                          <property role="TrG5h" value="perform" />
+                          <property role="1EzhhJ" value="false" />
+                          <node concept="3cqZAl" id="7S_3HdEVzOP" role="3clF45" />
+                          <node concept="3Tm1VV" id="7S_3HdEVzOQ" role="1B3o_S" />
+                          <node concept="37vLTG" id="7S_3HdEVzOR" role="3clF46">
+                            <property role="TrG5h" value="n" />
+                            <node concept="3Tqbb2" id="7S_3HdEVzOS" role="1tU5fm" />
+                          </node>
+                          <node concept="3clFbS" id="7S_3HdEVzOT" role="3clF47">
+                            <node concept="3clFbJ" id="7S_3HdEVzOU" role="3cqZAp">
+                              <node concept="3clFbS" id="7S_3HdEVzOV" role="3clFbx">
+                                <node concept="3clFbF" id="7S_3HdEVzS2" role="3cqZAp">
+                                  <node concept="2OqwBi" id="7S_3HdEVzSO" role="3clFbG">
+                                    <node concept="2OqwBi" id="7S_3HdEVzSo" role="2Oq$k0">
+                                      <node concept="pncrf" id="7S_3HdEVzS3" role="2Oq$k0" />
+                                      <node concept="1mfA1w" id="7S_3HdEVzSu" role="2OqNvi" />
+                                    </node>
+                                    <node concept="HtI8k" id="7S_3HdEVzSU" role="2OqNvi">
+                                      <node concept="37vLTw" id="7S_3HdEVzSW" role="HtI8F">
+                                        <ref role="3cqZAo" node="7S_3HdEVzOR" resolve="n" />
                                       </node>
                                     </node>
                                   </node>
                                 </node>
-                                <node concept="3y3z36" id="7S_3HdEVzP3" role="3clFbw">
-                                  <node concept="10Nm6u" id="7S_3HdEVzP4" role="3uHU7w" />
-                                  <node concept="2OqwBi" id="7S_3HdEVzP5" role="3uHU7B">
-                                    <node concept="pncrf" id="7S_3HdEVzP6" role="2Oq$k0" />
-                                    <node concept="1mfA1w" id="7S_3HdEVzS0" role="2OqNvi" />
-                                  </node>
+                              </node>
+                              <node concept="3y3z36" id="7S_3HdEVzP3" role="3clFbw">
+                                <node concept="10Nm6u" id="7S_3HdEVzP4" role="3uHU7w" />
+                                <node concept="2OqwBi" id="7S_3HdEVzP5" role="3uHU7B">
+                                  <node concept="pncrf" id="7S_3HdEVzP6" role="2Oq$k0" />
+                                  <node concept="1mfA1w" id="7S_3HdEVzS0" role="2OqNvi" />
                                 </node>
                               </node>
                             </node>
@@ -1747,18 +1740,17 @@
                         </node>
                       </node>
                     </node>
-                    <node concept="liA8E" id="7S_3HdEVzP8" role="2OqNvi">
-                      <ref role="37wK5l" to="r4b4:CPtprWNBIA" resolve="createLeftButton" />
-                      <node concept="pncrf" id="7S_3HdEVzP9" role="37wK5m" />
-                    </node>
+                  </node>
+                  <node concept="liA8E" id="7S_3HdEVzP8" role="2OqNvi">
+                    <ref role="37wK5l" to="r4b4:CPtprWNBIA" resolve="createLeftButton" />
+                    <node concept="pncrf" id="7S_3HdEVzP9" role="37wK5m" />
                   </node>
                 </node>
               </node>
             </node>
           </node>
-          <node concept="l2Vlx" id="2TTzVZwoCoc" role="2iSdaV" />
-          <node concept="pkWqt" id="2TTzVZwoCol" role="pqm2j">
-            <node concept="3clFbS" id="2TTzVZwoCom" role="2VODD2">
+          <node concept="pkWqt" id="5vhcTL2LD2J" role="pqm2j">
+            <node concept="3clFbS" id="5vhcTL2LD2K" role="2VODD2">
               <node concept="3clFbF" id="2TTzVZwoCon" role="3cqZAp">
                 <node concept="1Wc70l" id="2TTzVZwoIrD" role="3clFbG">
                   <node concept="2OqwBi" id="2TTzVZwoIs1" role="3uHU7w">

--- a/code/languages/com.mbeddr.cc/languages/com.mbeddr.cc.requirements/requirements.mpl
+++ b/code/languages/com.mbeddr.cc/languages/com.mbeddr.cc.requirements/requirements.mpl
@@ -145,6 +145,7 @@
     <language slang="l:b83431fe-5c8f-40bc-8a36-65e25f4dd253:jetbrains.mps.lang.textGen" version="1" />
     <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
     <language slang="l:7a5dda62-9140-4668-ab76-d5ed1746f2b2:jetbrains.mps.lang.typesystem" version="5" />
+    <language slang="l:62971cbe-fd2f-4135-b001-ee6cb7a74436:nl.f1re.mps.editor.swing" version="0" />
   </languageVersions>
   <dependencyVersions>
     <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />

--- a/code/languages/com.mbeddr.core/languages/com.mbeddr.core.statements/languageModels/typesystem.mps
+++ b/code/languages/com.mbeddr.core/languages/com.mbeddr.core.statements/languageModels/typesystem.mps
@@ -2,7 +2,7 @@
 <model ref="r:a7e7800a-15b6-4c02-ae4d-6b40a48c7370(com.mbeddr.core.statements.typesystem)">
   <persistence version="9" />
   <languages>
-    <use id="17566462-d837-4552-874c-64e45c10778a" name="com.mbeddr.mpsutil.compare.pattern" version="0" />
+    <use id="17566462-d837-4552-874c-64e45c10778a" name="de.itemis.mps.compare.pattern" version="0" />
     <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="12" />
     <use id="774bf8a0-62e5-41e1-af63-f4812e60e48b" name="jetbrains.mps.baseLanguage.checkedDots" version="0" />
     <devkit ref="00000000-0000-4000-0000-1de82b3a4936(jetbrains.mps.devkit.aspect.typesystem)" />

--- a/code/languages/com.mbeddr.core/languages/com.mbeddr.core.statements/statements.mpl
+++ b/code/languages/com.mbeddr.core/languages/com.mbeddr.core.statements/statements.mpl
@@ -29,11 +29,11 @@
     <language slang="l:63e0e566-5131-447e-90e3-12ea330e1a00:com.mbeddr.mpsutil.blutil" version="3" />
     <language slang="l:935bff03-e393-4547-a3a2-60335e0cad25:com.mbeddr.mpsutil.ccmenu" version="-1" />
     <language slang="l:f92af8d7-1fae-4067-8109-17acf80f8e58:com.mbeddr.mpsutil.ccmenu.reftarget" version="-1" />
-    <language slang="l:17566462-d837-4552-874c-64e45c10778a:com.mbeddr.mpsutil.compare.pattern" version="0" />
     <language slang="l:9d69e719-78c8-4286-90db-fb19c107d049:com.mbeddr.mpsutil.grammarcells" version="2" />
     <language slang="l:b4f35ed8-45af-4efa-abe4-00ac26956e69:com.mbeddr.mpsutil.grammarcells.runtimelang" version="0" />
     <language slang="l:b92f861d-0184-446d-b88b-6dcf0e070241:com.mbeddr.mpsutil.intentions" version="0" />
     <language slang="l:47f075a6-558e-4640-a606-7ce0236c8023:com.mbeddr.mpsutil.interpreter" version="1" />
+    <language slang="l:17566462-d837-4552-874c-64e45c10778a:de.itemis.mps.compare.pattern" version="0" />
     <language slang="l:f89904fb-9486-43a1-865e-5ad0375a8a88:de.itemis.mps.editor.bool" version="0" />
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
     <language slang="l:774bf8a0-62e5-41e1-af63-f4812e60e48b:jetbrains.mps.baseLanguage.checkedDots" version="0" />

--- a/code/platform/com.mbeddr.doc/languages/com.mbeddr.doc/doc.mpl
+++ b/code/platform/com.mbeddr.doc/languages/com.mbeddr.doc/doc.mpl
@@ -244,6 +244,7 @@
     <language slang="l:7a5dda62-9140-4668-ab76-d5ed1746f2b2:jetbrains.mps.lang.typesystem" version="5" />
     <language slang="l:696c1165-4a59-463b-bc5d-902caab85dd0:jetbrains.mps.make.facet" version="0" />
     <language slang="l:95f8a3e6-f994-4ca0-a65e-763c9bae2d3b:jetbrains.mps.make.script" version="0" />
+    <language slang="l:62971cbe-fd2f-4135-b001-ee6cb7a74436:nl.f1re.mps.editor.swing" version="0" />
   </languageVersions>
   <dependencyVersions>
     <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />

--- a/code/platform/com.mbeddr.doc/languages/com.mbeddr.doc/languageModels/editor.mps
+++ b/code/platform/com.mbeddr.doc/languages/com.mbeddr.doc/languageModels/editor.mps
@@ -21,6 +21,7 @@
     <use id="774bf8a0-62e5-41e1-af63-f4812e60e48b" name="jetbrains.mps.baseLanguage.checkedDots" version="0" />
     <use id="9d69e719-78c8-4286-90db-fb19c107d049" name="com.mbeddr.mpsutil.grammarcells" version="2" />
     <use id="443f4c36-fcf5-4eb6-9500-8d06ed259e3e" name="jetbrains.mps.baseLanguage.classifiers" version="0" />
+    <use id="62971cbe-fd2f-4135-b001-ee6cb7a74436" name="nl.f1re.mps.editor.swing" version="0" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
@@ -663,6 +664,13 @@
     </language>
     <language id="774bf8a0-62e5-41e1-af63-f4812e60e48b" name="jetbrains.mps.baseLanguage.checkedDots">
       <concept id="4079382982702596667" name="jetbrains.mps.baseLanguage.checkedDots.structure.CheckedDotExpression" flags="nn" index="2EnYce" />
+    </language>
+    <language id="62971cbe-fd2f-4135-b001-ee6cb7a74436" name="nl.f1re.mps.editor.swing">
+      <concept id="8659612544244790000" name="nl.f1re.mps.editor.swing.structure.QueryFunction_String" flags="ig" index="05MPa" />
+      <concept id="8659612544247522174" name="nl.f1re.mps.editor.swing.structure.ConceptFunctionParameter_component" flags="ng" index="0jJN4" />
+      <concept id="8659612544238797919" name="nl.f1re.mps.editor.swing.structure.CellModel_CustomJComponent" flags="sg" stub="8659612544238937882" index="fWXJ_">
+        <child id="8659612544238938786" name="toStringFunction" index="fNvko" />
+      </concept>
     </language>
     <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
       <concept id="2524418899405758586" name="jetbrains.mps.baseLanguage.closures.structure.InferredClosureParameterDeclaration" flags="ig" index="gl6BB" />
@@ -1813,93 +1821,106 @@
             </node>
           </node>
         </node>
-        <node concept="3gTLQM" id="7$0InQiLgVT" role="3EZMnx">
-          <node concept="3Fmcul" id="7$0InQiLgVV" role="3FoqZy">
-            <node concept="3clFbS" id="7$0InQiLgVX" role="2VODD2">
-              <node concept="3cpWs8" id="1zJYO2NWkJr" role="3cqZAp">
-                <node concept="3cpWsn" id="1zJYO2NWkJs" role="3cpWs9">
-                  <property role="TrG5h" value="component" />
-                  <node concept="3uibUv" id="1zJYO2NWkJt" role="1tU5fm">
-                    <ref role="3uigEE" to="exr9:~EditorComponent" resolve="EditorComponent" />
-                  </node>
-                  <node concept="10QFUN" id="1zJYO2NWlTO" role="33vP2m">
-                    <node concept="3uibUv" id="1zJYO2NWmfr" role="10QFUM">
-                      <ref role="3uigEE" to="exr9:~EditorComponent" resolve="EditorComponent" />
-                    </node>
-                    <node concept="2OqwBi" id="1zJYO2NWlj9" role="10QFUP">
-                      <node concept="1Q80Hx" id="1zJYO2NWl5J" role="2Oq$k0" />
-                      <node concept="liA8E" id="1zJYO2NWlPQ" role="2OqNvi">
-                        <ref role="37wK5l" to="cj4x:~EditorContext.getEditorComponent()" resolve="getEditorComponent" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="3clFbJ" id="7$0InQiLh29" role="3cqZAp">
-                <node concept="3clFbS" id="7$0InQiLh2a" role="3clFbx">
-                  <node concept="3cpWs6" id="7$0InQiLh2h" role="3cqZAp">
-                    <node concept="2ShNRf" id="7$0InQiLh2e" role="3cqZAk">
-                      <node concept="1pGfFk" id="7$0InQiLh2f" role="2ShVmc">
-                        <ref role="37wK5l" to="dxuu:~JLabel.&lt;init&gt;(java.lang.String)" resolve="JLabel" />
-                        <node concept="Xl_RD" id="7$0InQiLh2g" role="37wK5m">
-                          <property role="Xl_RC" value="Invalid Path" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="3fqX7Q" id="7$0InQiLh2j" role="3clFbw">
-                  <node concept="2OqwBi" id="7$0InQiLh2k" role="3fr31v">
-                    <node concept="2OqwBi" id="7$0InQiLh2l" role="2Oq$k0">
-                      <node concept="pncrf" id="7$0InQiLh2m" role="2Oq$k0" />
-                      <node concept="3TrEf2" id="7$0InQiLh2n" role="2OqNvi">
-                        <ref role="3Tt5mk" to="2c95:5yxqZJwzQtY" resolve="resource" />
-                      </node>
-                    </node>
-                    <node concept="2qgKlT" id="7$0InQiLh2o" role="2OqNvi">
-                      <ref role="37wK5l" to="4gky:5yxqZJwzQu4" resolve="isValidFile" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="9aQIb" id="7$0InQiLh2p" role="9aQIa">
-                  <node concept="3clFbS" id="7$0InQiLh2q" role="9aQI4">
-                    <node concept="3cpWs8" id="1zJYO2NW_cO" role="3cqZAp">
-                      <node concept="3cpWsn" id="1zJYO2NW_cP" role="3cpWs9">
-                        <property role="TrG5h" value="pane" />
-                        <property role="3TUv4t" value="true" />
-                        <node concept="3uibUv" id="1zJYO2NW$Uw" role="1tU5fm">
-                          <ref role="3uigEE" node="7$0InQiL72L" resolve="ImagePane" />
-                        </node>
-                        <node concept="2ShNRf" id="1zJYO2NW_cQ" role="33vP2m">
-                          <node concept="1pGfFk" id="1zJYO2NW_cR" role="2ShVmc">
-                            <ref role="37wK5l" node="7$0InQiL72S" resolve="ImagePane" />
-                            <node concept="2OqwBi" id="1zJYO2NW_cS" role="37wK5m">
-                              <node concept="2OqwBi" id="1zJYO2NW_cT" role="2Oq$k0">
-                                <node concept="pncrf" id="1zJYO2NW_cU" role="2Oq$k0" />
-                                <node concept="3TrEf2" id="1zJYO2NW_cV" role="2OqNvi">
-                                  <ref role="3Tt5mk" to="2c95:5yxqZJwzQtY" resolve="resource" />
+        <node concept="fWXJ_" id="5vhcTL2qHkd" role="3EZMnx">
+          <node concept="3Fmcul" id="5vhcTL2qHkf" role="3FoqZy">
+            <node concept="3clFbS" id="5vhcTL2qHkh" role="2VODD2">
+              <node concept="3clFbJ" id="5vhcTL2qLrt" role="3cqZAp">
+                <node concept="3clFbS" id="5vhcTL2qLru" role="3clFbx">
+                  <node concept="3cpWs6" id="5vhcTL2qLrv" role="3cqZAp">
+                    <node concept="2ShNRf" id="5vhcTL2qLrw" role="3cqZAk">
+                      <node concept="YeOm9" id="5vhcTL2qLrx" role="2ShVmc">
+                        <node concept="1Y3b0j" id="5vhcTL2qLry" role="YeSDq">
+                          <property role="2bfB8j" value="true" />
+                          <property role="373rjd" value="true" />
+                          <ref role="37wK5l" to="dxuu:~JLabel.&lt;init&gt;(java.lang.String)" resolve="JLabel" />
+                          <ref role="1Y3XeK" to="dxuu:~JLabel" resolve="JLabel" />
+                          <node concept="3Tm1VV" id="5vhcTL2qLrz" role="1B3o_S" />
+                          <node concept="Xl_RD" id="5vhcTL2qLr$" role="37wK5m">
+                            <property role="Xl_RC" value="Invalid Path" />
+                          </node>
+                          <node concept="3clFb_" id="5vhcTL2qLr_" role="jymVt">
+                            <property role="TrG5h" value="toString" />
+                            <node concept="3Tm1VV" id="5vhcTL2qLrA" role="1B3o_S" />
+                            <node concept="3uibUv" id="5vhcTL2qLrB" role="3clF45">
+                              <ref role="3uigEE" to="wyt6:~String" resolve="String" />
+                            </node>
+                            <node concept="3clFbS" id="5vhcTL2qLrC" role="3clF47">
+                              <node concept="3clFbF" id="5vhcTL2qLrD" role="3cqZAp">
+                                <node concept="1rXfSq" id="5vhcTL2qLrE" role="3clFbG">
+                                  <ref role="37wK5l" to="dxuu:~JLabel.getText()" resolve="getText" />
                                 </node>
                               </node>
-                              <node concept="2qgKlT" id="1zJYO2NW_cW" role="2OqNvi">
-                                <ref role="37wK5l" to="4gky:5yxqZJwzQzV" resolve="getEditTimeFileName" />
-                              </node>
                             </node>
-                            <node concept="3clFbT" id="1zJYO2NW_cX" role="37wK5m" />
+                            <node concept="2AHcQZ" id="5vhcTL2qLrF" role="2AJF6D">
+                              <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                            </node>
                           </node>
                         </node>
                       </node>
                     </node>
-                    <node concept="3cpWs6" id="7$0InQj202r" role="3cqZAp">
-                      <node concept="2OqwBi" id="7$0InQj1Yxm" role="3cqZAk">
-                        <node concept="37vLTw" id="1zJYO2NW_cY" role="2Oq$k0">
-                          <ref role="3cqZAo" node="1zJYO2NW_cP" resolve="pane" />
+                  </node>
+                </node>
+                <node concept="3fqX7Q" id="5vhcTL2qLrG" role="3clFbw">
+                  <node concept="2OqwBi" id="5vhcTL2qLrH" role="3fr31v">
+                    <node concept="2OqwBi" id="5vhcTL2qLrI" role="2Oq$k0">
+                      <node concept="pncrf" id="5vhcTL2qLrJ" role="2Oq$k0" />
+                      <node concept="3TrEf2" id="5vhcTL2qLrK" role="2OqNvi">
+                        <ref role="3Tt5mk" to="2c95:5yxqZJwzQtY" resolve="resource" />
+                      </node>
+                    </node>
+                    <node concept="2qgKlT" id="5vhcTL2qLrL" role="2OqNvi">
+                      <ref role="37wK5l" to="4gky:5yxqZJwzQu4" resolve="isValidFile" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="9aQIb" id="5vhcTL2qLrM" role="9aQIa">
+                  <node concept="3clFbS" id="5vhcTL2qLrN" role="9aQI4">
+                    <node concept="3cpWs8" id="5vhcTL2qLrO" role="3cqZAp">
+                      <node concept="3cpWsn" id="5vhcTL2qLrP" role="3cpWs9">
+                        <property role="TrG5h" value="pane" />
+                        <property role="3TUv4t" value="true" />
+                        <node concept="3uibUv" id="5vhcTL2qLrQ" role="1tU5fm">
+                          <ref role="3uigEE" node="7$0InQiL72L" resolve="ImagePane" />
                         </node>
-                        <node concept="liA8E" id="7$0InQj1ZrW" role="2OqNvi">
+                        <node concept="2ShNRf" id="5vhcTL2qLrR" role="33vP2m">
+                          <node concept="1pGfFk" id="5vhcTL2qLrS" role="2ShVmc">
+                            <ref role="37wK5l" node="7$0InQiL72S" resolve="ImagePane" />
+                            <node concept="2OqwBi" id="5vhcTL2qLrT" role="37wK5m">
+                              <node concept="2OqwBi" id="5vhcTL2qLrU" role="2Oq$k0">
+                                <node concept="pncrf" id="5vhcTL2qLrV" role="2Oq$k0" />
+                                <node concept="3TrEf2" id="5vhcTL2qLrW" role="2OqNvi">
+                                  <ref role="3Tt5mk" to="2c95:5yxqZJwzQtY" resolve="resource" />
+                                </node>
+                              </node>
+                              <node concept="2qgKlT" id="5vhcTL2qLrX" role="2OqNvi">
+                                <ref role="37wK5l" to="4gky:5yxqZJwzQzV" resolve="getEditTimeFileName" />
+                              </node>
+                            </node>
+                            <node concept="3clFbT" id="5vhcTL2qLrY" role="37wK5m" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3cpWs6" id="5vhcTL2qLrZ" role="3cqZAp">
+                      <node concept="2OqwBi" id="5vhcTL2qLs0" role="3cqZAk">
+                        <node concept="37vLTw" id="5vhcTL2qLs1" role="2Oq$k0">
+                          <ref role="3cqZAo" node="5vhcTL2qLrP" resolve="pane" />
+                        </node>
+                        <node concept="liA8E" id="5vhcTL2qLs2" role="2OqNvi">
                           <ref role="37wK5l" node="7$0InQj16ly" resolve="loadImage" />
                         </node>
                       </node>
                     </node>
                   </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="05MPa" id="5vhcTL2qMB5" role="fNvko">
+            <node concept="3clFbS" id="5vhcTL2qMB6" role="2VODD2">
+              <node concept="3clFbF" id="5vhcTL2qMIS" role="3cqZAp">
+                <node concept="Xl_RD" id="5vhcTL2qMIR" role="3clFbG">
+                  <property role="Xl_RC" value="image preview" />
                 </node>
               </node>
             </node>
@@ -3257,9 +3278,9 @@
         </node>
       </node>
       <node concept="2iRkQZ" id="5g63V59E0w2" role="2iSdaV" />
-      <node concept="3gTLQM" id="7$DvC4gUqv3" role="3EZMnx">
-        <node concept="3Fmcul" id="7$DvC4gUqv4" role="3FoqZy">
-          <node concept="3clFbS" id="7$DvC4gUqv5" role="2VODD2">
+      <node concept="fWXJ_" id="5vhcTL2NJrk" role="3EZMnx">
+        <node concept="3Fmcul" id="5vhcTL2NJrm" role="3FoqZy">
+          <node concept="3clFbS" id="5vhcTL2NJro" role="2VODD2">
             <node concept="3cpWs8" id="10GsATRFqtw" role="3cqZAp">
               <node concept="3cpWsn" id="10GsATRFqtx" role="3cpWs9">
                 <property role="TrG5h" value="area" />
@@ -3360,7 +3381,8 @@
                   <ref role="3uigEE" to="dxuu:~JScrollPane" resolve="JScrollPane" />
                 </node>
                 <node concept="2ShNRf" id="10GsATRFqpG" role="33vP2m">
-                  <node concept="1pGfFk" id="10GsATRFqpH" role="2ShVmc">
+                  <node concept="1pGfFk" id="5vhcTL2NOqC" role="2ShVmc">
+                    <property role="373rjd" value="true" />
                     <ref role="37wK5l" to="dxuu:~JScrollPane.&lt;init&gt;(java.awt.Component)" resolve="JScrollPane" />
                     <node concept="37vLTw" id="5Hxjapw9vfP" role="37wK5m">
                       <ref role="3cqZAo" node="10GsATRFqtx" resolve="area" />
@@ -3440,6 +3462,18 @@
             <node concept="3clFbF" id="5g63V59J95V" role="3cqZAp">
               <node concept="37vLTw" id="5g63V59J95T" role="3clFbG">
                 <ref role="3cqZAo" node="10GsATRFqpD" resolve="sp" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="05MPa" id="5vhcTL2NP$3" role="fNvko">
+          <node concept="3clFbS" id="5vhcTL2NP$4" role="2VODD2">
+            <node concept="3clFbF" id="5vhcTL2NQaI" role="3cqZAp">
+              <node concept="2OqwBi" id="5vhcTL2NR9d" role="3clFbG">
+                <node concept="pncrf" id="5vhcTL2NQaH" role="2Oq$k0" />
+                <node concept="3TrcHB" id="5vhcTL2NSJV" role="2OqNvi">
+                  <ref role="3TsBF5" to="2c95:7$DvC4gUq7E" resolve="text" />
+                </node>
               </node>
             </node>
           </node>
@@ -6087,14 +6121,15 @@
           <node concept="3F0ifn" id="4E5hYf6UMRT" role="3EZMnx">
             <property role="3F0ifm" value="" />
           </node>
-          <node concept="3gTLQM" id="4E5hYf6S9T7" role="3EZMnx">
-            <node concept="3Fmcul" id="4E5hYf6S9T8" role="3FoqZy">
-              <node concept="3clFbS" id="4E5hYf6S9T9" role="2VODD2">
+          <node concept="fWXJ_" id="5vhcTL2qV1o" role="3EZMnx">
+            <node concept="3Fmcul" id="5vhcTL2qV1q" role="3FoqZy">
+              <node concept="3clFbS" id="5vhcTL2qV1s" role="2VODD2">
                 <node concept="3clFbJ" id="7$0InQiRAlV" role="3cqZAp">
                   <node concept="3clFbS" id="7$0InQiRAlW" role="3clFbx">
                     <node concept="3cpWs6" id="7$0InQiRAm3" role="3cqZAp">
                       <node concept="2ShNRf" id="7$0InQiRAm0" role="3cqZAk">
-                        <node concept="1pGfFk" id="7$0InQiRAm1" role="2ShVmc">
+                        <node concept="1pGfFk" id="5vhcTL2r05a" role="2ShVmc">
+                          <property role="373rjd" value="true" />
                           <ref role="37wK5l" to="dxuu:~JLabel.&lt;init&gt;(java.lang.String)" resolve="JLabel" />
                           <node concept="Xl_RD" id="7$0InQiRAm2" role="37wK5m">
                             <property role="Xl_RC" value="Invalid Path" />
@@ -6145,6 +6180,15 @@
                         </node>
                       </node>
                     </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="05MPa" id="5vhcTL2r4yi" role="fNvko">
+              <node concept="3clFbS" id="5vhcTL2r4yj" role="2VODD2">
+                <node concept="3clFbF" id="5vhcTL2r1IW" role="3cqZAp">
+                  <node concept="Xl_RD" id="5vhcTL2r1IV" role="3clFbG">
+                    <property role="Xl_RC" value="image preview" />
                   </node>
                 </node>
               </node>
@@ -6485,9 +6529,9 @@
               </node>
             </node>
             <node concept="2iRfu4" id="5WYUu8H1IxK" role="2iSdaV" />
-            <node concept="3gTLQM" id="5WYUu8H1IxL" role="3EZMnx">
-              <node concept="3Fmcul" id="5WYUu8H1IxM" role="3FoqZy">
-                <node concept="3clFbS" id="5WYUu8H1IxN" role="2VODD2">
+            <node concept="fWXJ_" id="5vhcTL2NYRO" role="3EZMnx">
+              <node concept="3Fmcul" id="5vhcTL2NYRQ" role="3FoqZy">
+                <node concept="3clFbS" id="5vhcTL2NYRS" role="2VODD2">
                   <node concept="3cpWs8" id="5WYUu8H1IxO" role="3cqZAp">
                     <node concept="3cpWsn" id="5WYUu8H1IxP" role="3cpWs9">
                       <property role="TrG5h" value="text" />
@@ -6535,32 +6579,55 @@
                   </node>
                   <node concept="3clFbF" id="5WYUu8H1Iy7" role="3cqZAp">
                     <node concept="2ShNRf" id="5WYUu8H1Iy8" role="3clFbG">
-                      <node concept="1pGfFk" id="5WYUu8H1Iy9" role="2ShVmc">
-                        <ref role="37wK5l" to="dxuu:~JLabel.&lt;init&gt;(java.lang.String)" resolve="JLabel" />
-                        <node concept="3cpWs3" id="5WYUu8H1Iya" role="37wK5m">
-                          <node concept="3cpWs3" id="5WYUu8H1Iyb" role="3uHU7B">
-                            <node concept="2OqwBi" id="5WYUu8H1Iyc" role="3uHU7w">
-                              <node concept="37vLTw" id="5WYUu8H1Iyd" role="2Oq$k0">
-                                <ref role="3cqZAo" node="5WYUu8H1Iy0" resolve="replacedLineEndings" />
+                      <node concept="YeOm9" id="inTShjbBVk" role="2ShVmc">
+                        <node concept="1Y3b0j" id="inTShjbBVn" role="YeSDq">
+                          <property role="2bfB8j" value="true" />
+                          <property role="373rjd" value="true" />
+                          <ref role="37wK5l" to="dxuu:~JLabel.&lt;init&gt;(java.lang.String)" resolve="JLabel" />
+                          <ref role="1Y3XeK" to="dxuu:~JLabel" resolve="JLabel" />
+                          <node concept="3Tm1VV" id="inTShjbBVo" role="1B3o_S" />
+                          <node concept="3cpWs3" id="5WYUu8H1Iya" role="37wK5m">
+                            <node concept="3cpWs3" id="5WYUu8H1Iyb" role="3uHU7B">
+                              <node concept="2OqwBi" id="5WYUu8H1Iyc" role="3uHU7w">
+                                <node concept="37vLTw" id="5WYUu8H1Iyd" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="5WYUu8H1Iy0" resolve="replacedLineEndings" />
+                                </node>
+                                <node concept="liA8E" id="5WYUu8H1Iye" role="2OqNvi">
+                                  <ref role="37wK5l" to="wyt6:~String.replace(java.lang.CharSequence,java.lang.CharSequence)" resolve="replace" />
+                                  <node concept="Xl_RD" id="5WYUu8H1Iyf" role="37wK5m">
+                                    <property role="Xl_RC" value=" " />
+                                  </node>
+                                  <node concept="Xl_RD" id="5WYUu8H1Iyg" role="37wK5m">
+                                    <property role="Xl_RC" value="&amp;nbsp;" />
+                                  </node>
+                                </node>
                               </node>
-                              <node concept="liA8E" id="5WYUu8H1Iye" role="2OqNvi">
-                                <ref role="37wK5l" to="wyt6:~String.replace(java.lang.CharSequence,java.lang.CharSequence)" resolve="replace" />
-                                <node concept="Xl_RD" id="5WYUu8H1Iyf" role="37wK5m">
-                                  <property role="Xl_RC" value=" " />
-                                </node>
-                                <node concept="Xl_RD" id="5WYUu8H1Iyg" role="37wK5m">
-                                  <property role="Xl_RC" value="&amp;nbsp;" />
-                                </node>
+                              <node concept="Xl_RD" id="5WYUu8H1Iyh" role="3uHU7B">
+                                <property role="Xl_RC" value="&lt;html&gt;&lt;head&gt;&lt;style type='text/css'&gt;body{font-family:monospace}&lt;/style&gt;&lt;/head&gt;&lt;body&gt;" />
                               </node>
                             </node>
-                            <node concept="Xl_RD" id="5WYUu8H1Iyh" role="3uHU7B">
-                              <property role="Xl_RC" value="&lt;html&gt;&lt;head&gt;&lt;style type='text/css'&gt;body{font-family:monospace}&lt;/style&gt;&lt;/head&gt;&lt;body&gt;" />
+                            <node concept="Xl_RD" id="5WYUu8H1Iyi" role="3uHU7w">
+                              <property role="Xl_RC" value="&lt;/body&gt;&lt;/html&gt;" />
                             </node>
-                          </node>
-                          <node concept="Xl_RD" id="5WYUu8H1Iyi" role="3uHU7w">
-                            <property role="Xl_RC" value="&lt;/body&gt;&lt;/html&gt;" />
                           </node>
                         </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="05MPa" id="5vhcTL2O6KK" role="fNvko">
+                <node concept="3clFbS" id="5vhcTL2O6KL" role="2VODD2">
+                  <node concept="3clFbF" id="5vhcTL2O9EV" role="3cqZAp">
+                    <node concept="2OqwBi" id="5vhcTL2Ofnt" role="3clFbG">
+                      <node concept="0kSF2" id="5vhcTL2OcF2" role="2Oq$k0">
+                        <node concept="3uibUv" id="5vhcTL2OcF4" role="0kSFW">
+                          <ref role="3uigEE" to="dxuu:~JLabel" resolve="JLabel" />
+                        </node>
+                        <node concept="0jJN4" id="5vhcTL2O9EU" role="0kSFX" />
+                      </node>
+                      <node concept="liA8E" id="5vhcTL2Oi2K" role="2OqNvi">
+                        <ref role="37wK5l" to="dxuu:~JLabel.getText()" resolve="getText" />
                       </node>
                     </node>
                   </node>
@@ -7496,9 +7563,22 @@
           <node concept="1yz3lS" id="7yQnM2M$OAf" role="1yzFaX">
             <node concept="1QoScp" id="7yQnM2M$OJf" role="2wV5jI">
               <property role="1QpmdY" value="true" />
-              <node concept="3gTLQM" id="7yQnM2M$OJg" role="1QoS34">
-                <node concept="3Fmcul" id="7yQnM2M$OJh" role="3FoqZy">
-                  <node concept="3clFbS" id="7yQnM2M$OJi" role="2VODD2">
+              <node concept="pkWqt" id="7yQnM2M$OJt" role="3e4ffs">
+                <node concept="3clFbS" id="7yQnM2M$OJu" role="2VODD2">
+                  <node concept="3clFbF" id="7yQnM2M$OJv" role="3cqZAp">
+                    <node concept="2OqwBi" id="7yQnM2M$OJw" role="3clFbG">
+                      <node concept="GFMny" id="7yQnM2M$OJx" role="2Oq$k0" />
+                      <node concept="3TrcHB" id="7yQnM2M$OJy" role="2OqNvi">
+                        <ref role="3TsBF5" to="2c95:UZf0JknNZ8" resolve="renderInspector" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="r$x8Z" id="7yQnM2M$OJz" role="1QoVPY" />
+              <node concept="fWXJ_" id="5vhcTL2OqLZ" role="1QoS34">
+                <node concept="3Fmcul" id="5vhcTL2OqM1" role="3FoqZy">
+                  <node concept="3clFbS" id="5vhcTL2OqM3" role="2VODD2">
                     <node concept="3cpWs8" id="7yQnM2M$OJj" role="3cqZAp">
                       <node concept="3cpWsn" id="7yQnM2M$OJk" role="3cpWs9">
                         <property role="TrG5h" value="inspector" />
@@ -7537,20 +7617,34 @@
                     </node>
                   </node>
                 </node>
-              </node>
-              <node concept="pkWqt" id="7yQnM2M$OJt" role="3e4ffs">
-                <node concept="3clFbS" id="7yQnM2M$OJu" role="2VODD2">
-                  <node concept="3clFbF" id="7yQnM2M$OJv" role="3cqZAp">
-                    <node concept="2OqwBi" id="7yQnM2M$OJw" role="3clFbG">
-                      <node concept="GFMny" id="7yQnM2M$OJx" role="2Oq$k0" />
-                      <node concept="3TrcHB" id="7yQnM2M$OJy" role="2OqNvi">
-                        <ref role="3TsBF5" to="2c95:UZf0JknNZ8" resolve="renderInspector" />
+                <node concept="05MPa" id="5vhcTL2OupP" role="fNvko">
+                  <node concept="3clFbS" id="5vhcTL2OupQ" role="2VODD2">
+                    <node concept="3clFbF" id="5vhcTL2OwjA" role="3cqZAp">
+                      <node concept="2OqwBi" id="5vhcTL2OFAj" role="3clFbG">
+                        <node concept="2OqwBi" id="5vhcTL2OE43" role="2Oq$k0">
+                          <node concept="2OqwBi" id="5vhcTL2O$Ec" role="2Oq$k0">
+                            <node concept="0kSF2" id="5vhcTL2Oz14" role="2Oq$k0">
+                              <node concept="3uibUv" id="5vhcTL2Oz16" role="0kSFW">
+                                <ref role="3uigEE" to="zyr2:~InspectorEditorComponent" resolve="InspectorEditorComponent" />
+                              </node>
+                              <node concept="0jJN4" id="5vhcTL2Owj_" role="0kSFX" />
+                            </node>
+                            <node concept="liA8E" id="5vhcTL2ODtl" role="2OqNvi">
+                              <ref role="37wK5l" to="exr9:~EditorComponent.getRootCell()" resolve="getRootCell" />
+                            </node>
+                          </node>
+                          <node concept="liA8E" id="5vhcTL2OFc5" role="2OqNvi">
+                            <ref role="37wK5l" to="f4zo:~EditorCell.renderText()" resolve="renderText" />
+                          </node>
+                        </node>
+                        <node concept="liA8E" id="5vhcTL2OG3w" role="2OqNvi">
+                          <ref role="37wK5l" to="wyt6:~Object.toString()" resolve="toString" />
+                        </node>
                       </node>
                     </node>
                   </node>
                 </node>
               </node>
-              <node concept="r$x8Z" id="7yQnM2M$OJz" role="1QoVPY" />
             </node>
           </node>
         </node>
@@ -7962,48 +8056,6 @@
               <node concept="1yz3lS" id="7yQnM2MyQs5" role="1yzFaX">
                 <node concept="1QoScp" id="7yQnM2MyQHx" role="2wV5jI">
                   <property role="1QpmdY" value="true" />
-                  <node concept="3gTLQM" id="7yQnM2Mzq5q" role="1QoS34">
-                    <node concept="3Fmcul" id="7yQnM2Mzq5s" role="3FoqZy">
-                      <node concept="3clFbS" id="7yQnM2Mzq5u" role="2VODD2">
-                        <node concept="3cpWs8" id="7yQnM2MzquL" role="3cqZAp">
-                          <node concept="3cpWsn" id="7yQnM2MzquM" role="3cpWs9">
-                            <property role="TrG5h" value="inspector" />
-                            <node concept="3uibUv" id="7yQnM2MzquN" role="1tU5fm">
-                              <ref role="3uigEE" to="zyr2:~InspectorEditorComponent" resolve="InspectorEditorComponent" />
-                            </node>
-                            <node concept="2ShNRf" id="7yQnM2MzqA3" role="33vP2m">
-                              <node concept="1pGfFk" id="7yQnM2MztC$" role="2ShVmc">
-                                <property role="373rjd" value="true" />
-                                <ref role="37wK5l" to="zyr2:~InspectorEditorComponent.&lt;init&gt;(org.jetbrains.mps.openapi.module.SRepository)" resolve="InspectorEditorComponent" />
-                                <node concept="2OqwBi" id="7yQnM2MztYY" role="37wK5m">
-                                  <node concept="1Q80Hx" id="7yQnM2MztMY" role="2Oq$k0" />
-                                  <node concept="liA8E" id="7yQnM2MzucC" role="2OqNvi">
-                                    <ref role="37wK5l" to="cj4x:~EditorContext.getRepository()" resolve="getRepository" />
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="3clFbF" id="7yQnM2MCnSD" role="3cqZAp">
-                          <node concept="2OqwBi" id="7yQnM2MCoGW" role="3clFbG">
-                            <node concept="37vLTw" id="7yQnM2MCnSB" role="2Oq$k0">
-                              <ref role="3cqZAo" node="7yQnM2MzquM" resolve="inspector" />
-                            </node>
-                            <node concept="liA8E" id="7yQnM2MCpPy" role="2OqNvi">
-                              <ref role="37wK5l" to="exr9:~EditorComponent.editNode(org.jetbrains.mps.openapi.model.SNode)" resolve="editNode" />
-                              <node concept="pncrf" id="7yQnM2MCq3U" role="37wK5m" />
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="3clFbF" id="7yQnM2MzudR" role="3cqZAp">
-                          <node concept="37vLTw" id="7yQnM2MzudP" role="3clFbG">
-                            <ref role="3cqZAo" node="7yQnM2MzquM" resolve="inspector" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
                   <node concept="pkWqt" id="7yQnM2MyQH$" role="3e4ffs">
                     <node concept="3clFbS" id="7yQnM2MyQHA" role="2VODD2">
                       <node concept="3clFbF" id="7yQnM2MzoLx" role="3cqZAp">
@@ -8017,6 +8069,75 @@
                     </node>
                   </node>
                   <node concept="r$x8Z" id="7yQnM2Mzux5" role="1QoVPY" />
+                  <node concept="fWXJ_" id="5vhcTL2OSoC" role="1QoS34">
+                    <node concept="3Fmcul" id="5vhcTL2OSoD" role="3FoqZy">
+                      <node concept="3clFbS" id="5vhcTL2OSoE" role="2VODD2">
+                        <node concept="3cpWs8" id="5vhcTL2OSoF" role="3cqZAp">
+                          <node concept="3cpWsn" id="5vhcTL2OSoG" role="3cpWs9">
+                            <property role="TrG5h" value="inspector" />
+                            <node concept="3uibUv" id="5vhcTL2OSoH" role="1tU5fm">
+                              <ref role="3uigEE" to="zyr2:~InspectorEditorComponent" resolve="InspectorEditorComponent" />
+                            </node>
+                            <node concept="2ShNRf" id="5vhcTL2OSoI" role="33vP2m">
+                              <node concept="1pGfFk" id="5vhcTL2OSoJ" role="2ShVmc">
+                                <property role="373rjd" value="true" />
+                                <ref role="37wK5l" to="zyr2:~InspectorEditorComponent.&lt;init&gt;(org.jetbrains.mps.openapi.module.SRepository)" resolve="InspectorEditorComponent" />
+                                <node concept="2OqwBi" id="5vhcTL2OSoK" role="37wK5m">
+                                  <node concept="1Q80Hx" id="5vhcTL2OSoL" role="2Oq$k0" />
+                                  <node concept="liA8E" id="5vhcTL2OSoM" role="2OqNvi">
+                                    <ref role="37wK5l" to="cj4x:~EditorContext.getRepository()" resolve="getRepository" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3clFbF" id="5vhcTL2OSoN" role="3cqZAp">
+                          <node concept="2OqwBi" id="5vhcTL2OSoO" role="3clFbG">
+                            <node concept="37vLTw" id="5vhcTL2OSoP" role="2Oq$k0">
+                              <ref role="3cqZAo" node="5vhcTL2OSoG" resolve="inspector" />
+                            </node>
+                            <node concept="liA8E" id="5vhcTL2OSoQ" role="2OqNvi">
+                              <ref role="37wK5l" to="exr9:~EditorComponent.editNode(org.jetbrains.mps.openapi.model.SNode)" resolve="editNode" />
+                              <node concept="pncrf" id="5vhcTL2OSoR" role="37wK5m" />
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3clFbF" id="5vhcTL2OSoS" role="3cqZAp">
+                          <node concept="37vLTw" id="5vhcTL2OSoT" role="3clFbG">
+                            <ref role="3cqZAo" node="5vhcTL2OSoG" resolve="inspector" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="05MPa" id="5vhcTL2OSoU" role="fNvko">
+                      <node concept="3clFbS" id="5vhcTL2OSoV" role="2VODD2">
+                        <node concept="3clFbF" id="5vhcTL2OSoW" role="3cqZAp">
+                          <node concept="2OqwBi" id="5vhcTL2OSoX" role="3clFbG">
+                            <node concept="2OqwBi" id="5vhcTL2OSoY" role="2Oq$k0">
+                              <node concept="2OqwBi" id="5vhcTL2OSoZ" role="2Oq$k0">
+                                <node concept="0kSF2" id="5vhcTL2OSp0" role="2Oq$k0">
+                                  <node concept="3uibUv" id="5vhcTL2OSp1" role="0kSFW">
+                                    <ref role="3uigEE" to="zyr2:~InspectorEditorComponent" resolve="InspectorEditorComponent" />
+                                  </node>
+                                  <node concept="0jJN4" id="5vhcTL2OSp2" role="0kSFX" />
+                                </node>
+                                <node concept="liA8E" id="5vhcTL2OSp3" role="2OqNvi">
+                                  <ref role="37wK5l" to="exr9:~EditorComponent.getRootCell()" resolve="getRootCell" />
+                                </node>
+                              </node>
+                              <node concept="liA8E" id="5vhcTL2OSp4" role="2OqNvi">
+                                <ref role="37wK5l" to="f4zo:~EditorCell.renderText()" resolve="renderText" />
+                              </node>
+                            </node>
+                            <node concept="liA8E" id="5vhcTL2OSp5" role="2OqNvi">
+                              <ref role="37wK5l" to="wyt6:~Object.toString()" resolve="toString" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
                 </node>
               </node>
             </node>
@@ -8552,25 +8673,25 @@
             <node concept="2iRfu4" id="5MdJlx$Eugs" role="2iSdaV" />
           </node>
           <node concept="2iRkQZ" id="5MdJlx$EtWM" role="2iSdaV" />
-          <node concept="3gTLQM" id="1R2r3DPmM_L" role="3EZMnx">
-            <node concept="3Fmcul" id="1R2r3DPmM_R" role="3FoqZy">
-              <node concept="3clFbS" id="1R2r3DPmM_X" role="2VODD2">
-                <node concept="3cpWs8" id="1R2r3DPnfv9" role="3cqZAp">
-                  <node concept="3cpWsn" id="1R2r3DPnfva" role="3cpWs9">
+          <node concept="fWXJ_" id="5vhcTL2OYX5" role="3EZMnx">
+            <node concept="3Fmcul" id="5vhcTL2OYX7" role="3FoqZy">
+              <node concept="3clFbS" id="5vhcTL2OYX9" role="2VODD2">
+                <node concept="3cpWs8" id="5vhcTL2P0bj" role="3cqZAp">
+                  <node concept="3cpWsn" id="5vhcTL2P0bk" role="3cpWs9">
                     <property role="TrG5h" value="ideaProject" />
                     <property role="3TUv4t" value="true" />
-                    <node concept="3uibUv" id="1R2r3DPnfvb" role="1tU5fm">
+                    <node concept="3uibUv" id="5vhcTL2P0bl" role="1tU5fm">
                       <ref role="3uigEE" to="4nm9:~Project" resolve="Project" />
                     </node>
-                    <node concept="2YIFZM" id="1R2r3DPng86" role="33vP2m">
+                    <node concept="2YIFZM" id="5vhcTL2P0bm" role="33vP2m">
                       <ref role="37wK5l" to="alof:~ProjectHelper.toIdeaProject(jetbrains.mps.project.Project)" resolve="toIdeaProject" />
                       <ref role="1Pybhc" to="alof:~ProjectHelper" resolve="ProjectHelper" />
-                      <node concept="2YIFZM" id="1R2r3DPnghl" role="37wK5m">
+                      <node concept="2YIFZM" id="5vhcTL2P0bn" role="37wK5m">
                         <ref role="37wK5l" to="alof:~ProjectHelper.getProject(org.jetbrains.mps.openapi.module.SRepository)" resolve="getProject" />
                         <ref role="1Pybhc" to="alof:~ProjectHelper" resolve="ProjectHelper" />
-                        <node concept="2OqwBi" id="1R2r3DPngA6" role="37wK5m">
-                          <node concept="1Q80Hx" id="1R2r3DPnglT" role="2Oq$k0" />
-                          <node concept="liA8E" id="1R2r3DPngMi" role="2OqNvi">
+                        <node concept="2OqwBi" id="5vhcTL2P0bo" role="37wK5m">
+                          <node concept="1Q80Hx" id="5vhcTL2P0bp" role="2Oq$k0" />
+                          <node concept="liA8E" id="5vhcTL2P0bq" role="2OqNvi">
                             <ref role="37wK5l" to="cj4x:~EditorContext.getRepository()" resolve="getRepository" />
                           </node>
                         </node>
@@ -8578,104 +8699,104 @@
                     </node>
                   </node>
                 </node>
-                <node concept="3cpWs8" id="1R2r3DPmME9" role="3cqZAp">
-                  <node concept="3cpWsn" id="1R2r3DPmMEa" role="3cpWs9">
+                <node concept="3cpWs8" id="5vhcTL2P0br" role="3cqZAp">
+                  <node concept="3cpWsn" id="5vhcTL2P0bs" role="3cpWs9">
                     <property role="TrG5h" value="btn" />
-                    <node concept="3uibUv" id="1R2r3DPmMEb" role="1tU5fm">
+                    <node concept="3uibUv" id="5vhcTL2P0bt" role="1tU5fm">
                       <ref role="3uigEE" to="dxuu:~JButton" resolve="JButton" />
                     </node>
-                    <node concept="2ShNRf" id="1R2r3DPmMJX" role="33vP2m">
-                      <node concept="1pGfFk" id="1R2r3DPmNo3" role="2ShVmc">
+                    <node concept="2ShNRf" id="5vhcTL2P0bu" role="33vP2m">
+                      <node concept="1pGfFk" id="1UWjN7wfr2t" role="2ShVmc">
                         <property role="373rjd" value="true" />
                         <ref role="37wK5l" to="dxuu:~JButton.&lt;init&gt;(java.lang.String)" resolve="JButton" />
-                        <node concept="Xl_RD" id="1R2r3DPmNuO" role="37wK5m">
+                        <node concept="Xl_RD" id="5vhcTL2P0by" role="37wK5m">
                           <property role="Xl_RC" value="Open Visualization tool" />
                         </node>
                       </node>
                     </node>
                   </node>
                 </node>
-                <node concept="3clFbF" id="1R2r3DPmO4a" role="3cqZAp">
-                  <node concept="2OqwBi" id="1R2r3DPmOVV" role="3clFbG">
-                    <node concept="37vLTw" id="1R2r3DPmO48" role="2Oq$k0">
-                      <ref role="3cqZAo" node="1R2r3DPmMEa" resolve="btn" />
+                <node concept="3clFbF" id="5vhcTL2P0bE" role="3cqZAp">
+                  <node concept="2OqwBi" id="5vhcTL2P0bF" role="3clFbG">
+                    <node concept="37vLTw" id="5vhcTL2P0bG" role="2Oq$k0">
+                      <ref role="3cqZAo" node="5vhcTL2P0bs" resolve="btn" />
                     </node>
-                    <node concept="liA8E" id="1R2r3DPmPLF" role="2OqNvi">
+                    <node concept="liA8E" id="5vhcTL2P0bH" role="2OqNvi">
                       <ref role="37wK5l" to="dxuu:~JComponent.setOpaque(boolean)" resolve="setOpaque" />
-                      <node concept="3clFbT" id="1R2r3DPmPMz" role="37wK5m" />
+                      <node concept="3clFbT" id="5vhcTL2P0bI" role="37wK5m" />
                     </node>
                   </node>
                 </node>
-                <node concept="3clFbF" id="1R2r3DPmPVw" role="3cqZAp">
-                  <node concept="2OqwBi" id="1R2r3DPmPXD" role="3clFbG">
-                    <node concept="37vLTw" id="1R2r3DPmPVu" role="2Oq$k0">
-                      <ref role="3cqZAo" node="1R2r3DPmMEa" resolve="btn" />
+                <node concept="3clFbF" id="5vhcTL2P0bJ" role="3cqZAp">
+                  <node concept="2OqwBi" id="5vhcTL2P0bK" role="3clFbG">
+                    <node concept="37vLTw" id="5vhcTL2P0bL" role="2Oq$k0">
+                      <ref role="3cqZAo" node="5vhcTL2P0bs" resolve="btn" />
                     </node>
-                    <node concept="liA8E" id="1R2r3DPmQ7e" role="2OqNvi">
+                    <node concept="liA8E" id="5vhcTL2P0bM" role="2OqNvi">
                       <ref role="37wK5l" to="dxuu:~AbstractButton.addActionListener(java.awt.event.ActionListener)" resolve="addActionListener" />
-                      <node concept="2ShNRf" id="1R2r3DPmQ7G" role="37wK5m">
-                        <node concept="YeOm9" id="1R2r3DPmXYW" role="2ShVmc">
-                          <node concept="1Y3b0j" id="1R2r3DPmXYZ" role="YeSDq">
+                      <node concept="2ShNRf" id="5vhcTL2P0bN" role="37wK5m">
+                        <node concept="YeOm9" id="5vhcTL2P0bO" role="2ShVmc">
+                          <node concept="1Y3b0j" id="5vhcTL2P0bP" role="YeSDq">
                             <property role="2bfB8j" value="true" />
                             <property role="373rjd" value="true" />
                             <ref role="1Y3XeK" to="hyam:~ActionListener" resolve="ActionListener" />
                             <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
-                            <node concept="3Tm1VV" id="1R2r3DPmXZ0" role="1B3o_S" />
-                            <node concept="3clFb_" id="1R2r3DPmXZe" role="jymVt">
+                            <node concept="3Tm1VV" id="5vhcTL2P0bQ" role="1B3o_S" />
+                            <node concept="3clFb_" id="5vhcTL2P0bR" role="jymVt">
                               <property role="TrG5h" value="actionPerformed" />
-                              <node concept="3Tm1VV" id="1R2r3DPmXZf" role="1B3o_S" />
-                              <node concept="3cqZAl" id="1R2r3DPmXZh" role="3clF45" />
-                              <node concept="37vLTG" id="1R2r3DPmXZi" role="3clF46">
+                              <node concept="3Tm1VV" id="5vhcTL2P0bS" role="1B3o_S" />
+                              <node concept="3cqZAl" id="5vhcTL2P0bT" role="3clF45" />
+                              <node concept="37vLTG" id="5vhcTL2P0bU" role="3clF46">
                                 <property role="TrG5h" value="p1" />
-                                <node concept="3uibUv" id="1R2r3DPmXZj" role="1tU5fm">
+                                <node concept="3uibUv" id="5vhcTL2P0bV" role="1tU5fm">
                                   <ref role="3uigEE" to="hyam:~ActionEvent" resolve="ActionEvent" />
                                 </node>
                               </node>
-                              <node concept="3clFbS" id="1R2r3DPmXZk" role="3clF47">
-                                <node concept="1QHqEK" id="1R2r3DPniV9" role="3cqZAp">
-                                  <node concept="1QHqEC" id="1R2r3DPniVb" role="1QHqEI">
-                                    <node concept="3clFbS" id="1R2r3DPniVd" role="1bW5cS">
-                                      <node concept="3clFbF" id="1R2r3DPnlfx" role="3cqZAp">
-                                        <node concept="2OqwBi" id="1R2r3DPnlqE" role="3clFbG">
-                                          <node concept="liA8E" id="1R2r3DPnlEC" role="2OqNvi">
+                              <node concept="3clFbS" id="5vhcTL2P0bW" role="3clF47">
+                                <node concept="1QHqEK" id="5vhcTL2P0bX" role="3cqZAp">
+                                  <node concept="1QHqEC" id="5vhcTL2P0bY" role="1QHqEI">
+                                    <node concept="3clFbS" id="5vhcTL2P0bZ" role="1bW5cS">
+                                      <node concept="3clFbF" id="5vhcTL2P0c0" role="3cqZAp">
+                                        <node concept="2OqwBi" id="5vhcTL2P0c1" role="3clFbG">
+                                          <node concept="liA8E" id="5vhcTL2P0c2" role="2OqNvi">
                                             <ref role="37wK5l" to="71xd:~BaseTool.openTool(boolean)" resolve="openTool" />
-                                            <node concept="3clFbT" id="1R2r3DPnmta" role="37wK5m">
+                                            <node concept="3clFbT" id="5vhcTL2P0c3" role="37wK5m">
                                               <property role="3clFbU" value="true" />
                                             </node>
                                           </node>
-                                          <node concept="2OqwBi" id="1R2r3DPnhCu" role="2Oq$k0">
-                                            <node concept="37vLTw" id="1R2r3DPnh3J" role="2Oq$k0">
-                                              <ref role="3cqZAo" node="1R2r3DPnfva" resolve="ideaProject" />
+                                          <node concept="2OqwBi" id="5vhcTL2P0c4" role="2Oq$k0">
+                                            <node concept="37vLTw" id="5vhcTL2P0c5" role="2Oq$k0">
+                                              <ref role="3cqZAo" node="5vhcTL2P0bk" resolve="ideaProject" />
                                             </node>
-                                            <node concept="LR4U6" id="1R2r3DPni3C" role="2OqNvi">
+                                            <node concept="LR4U6" id="5vhcTL2P0c6" role="2OqNvi">
                                               <ref role="LR4U5" to="k4pk:1X6acCMyKUd" resolve="SVGViewer" />
                                             </node>
                                           </node>
                                         </node>
                                       </node>
-                                      <node concept="3clFbF" id="1R2r3DPno1r" role="3cqZAp">
-                                        <node concept="2OqwBi" id="1R2r3DPno4o" role="3clFbG">
-                                          <node concept="2XshWL" id="1R2r3DPnocH" role="2OqNvi">
+                                      <node concept="3clFbF" id="5vhcTL2P0c7" role="3cqZAp">
+                                        <node concept="2OqwBi" id="5vhcTL2P0c8" role="3clFbG">
+                                          <node concept="2XshWL" id="5vhcTL2P0c9" role="2OqNvi">
                                             <ref role="2WH_rO" to="k4pk:18ZQ$P85dt6" resolve="load" />
-                                            <node concept="pncrf" id="1R2r3DPnpeP" role="2XxRq1" />
-                                            <node concept="2OqwBi" id="1R2r3DPnwmP" role="2XxRq1">
-                                              <node concept="2OqwBi" id="1R2r3DPnvuU" role="2Oq$k0">
-                                                <node concept="2OqwBi" id="1R2r3DPnrMJ" role="2Oq$k0">
-                                                  <node concept="pncrf" id="1R2r3DPnruN" role="2Oq$k0" />
-                                                  <node concept="2qgKlT" id="1R2r3DPns$M" role="2OqNvi">
+                                            <node concept="pncrf" id="5vhcTL2P0ca" role="2XxRq1" />
+                                            <node concept="2OqwBi" id="5vhcTL2P0cb" role="2XxRq1">
+                                              <node concept="2OqwBi" id="5vhcTL2P0cc" role="2Oq$k0">
+                                                <node concept="2OqwBi" id="5vhcTL2P0cd" role="2Oq$k0">
+                                                  <node concept="pncrf" id="5vhcTL2P0ce" role="2Oq$k0" />
+                                                  <node concept="2qgKlT" id="5vhcTL2P0cf" role="2OqNvi">
                                                     <ref role="37wK5l" to="grvc:2N1CSrzPN_a" resolve="getCategories" />
                                                   </node>
                                                 </node>
-                                                <node concept="39bAoz" id="1R2r3DPnw0R" role="2OqNvi" />
+                                                <node concept="39bAoz" id="5vhcTL2P0cg" role="2OqNvi" />
                                               </node>
-                                              <node concept="1uHKPH" id="1R2r3DPnwSx" role="2OqNvi" />
+                                              <node concept="1uHKPH" id="5vhcTL2P0ch" role="2OqNvi" />
                                             </node>
                                           </node>
-                                          <node concept="2OqwBi" id="1R2r3DPocVf" role="2Oq$k0">
-                                            <node concept="37vLTw" id="1R2r3DPocVg" role="2Oq$k0">
-                                              <ref role="3cqZAo" node="1R2r3DPnfva" resolve="ideaProject" />
+                                          <node concept="2OqwBi" id="5vhcTL2P0ci" role="2Oq$k0">
+                                            <node concept="37vLTw" id="5vhcTL2P0cj" role="2Oq$k0">
+                                              <ref role="3cqZAo" node="5vhcTL2P0bk" resolve="ideaProject" />
                                             </node>
-                                            <node concept="LR4U6" id="1R2r3DPocVh" role="2OqNvi">
+                                            <node concept="LR4U6" id="5vhcTL2P0ck" role="2OqNvi">
                                               <ref role="LR4U5" to="k4pk:1X6acCMyKUd" resolve="SVGViewer" />
                                             </node>
                                           </node>
@@ -8683,15 +8804,15 @@
                                       </node>
                                     </node>
                                   </node>
-                                  <node concept="2OqwBi" id="1R2r3DPnjI7" role="ukAjM">
-                                    <node concept="1Q80Hx" id="1R2r3DPnjgg" role="2Oq$k0" />
-                                    <node concept="liA8E" id="1R2r3DPnjVb" role="2OqNvi">
+                                  <node concept="2OqwBi" id="5vhcTL2P0cl" role="ukAjM">
+                                    <node concept="1Q80Hx" id="5vhcTL2P0cm" role="2Oq$k0" />
+                                    <node concept="liA8E" id="5vhcTL2P0cn" role="2OqNvi">
                                       <ref role="37wK5l" to="cj4x:~EditorContext.getRepository()" resolve="getRepository" />
                                     </node>
                                   </node>
                                 </node>
                               </node>
-                              <node concept="2AHcQZ" id="1R2r3DPmXZm" role="2AJF6D">
+                              <node concept="2AHcQZ" id="5vhcTL2P0co" role="2AJF6D">
                                 <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
                               </node>
                             </node>
@@ -8701,9 +8822,9 @@
                     </node>
                   </node>
                 </node>
-                <node concept="3clFbF" id="1R2r3DPmPQW" role="3cqZAp">
-                  <node concept="37vLTw" id="1R2r3DPmPQU" role="3clFbG">
-                    <ref role="3cqZAo" node="1R2r3DPmMEa" resolve="btn" />
+                <node concept="3clFbF" id="5vhcTL2P0cp" role="3cqZAp">
+                  <node concept="37vLTw" id="5vhcTL2P0cq" role="3clFbG">
+                    <ref role="3cqZAo" node="5vhcTL2P0bs" resolve="btn" />
                   </node>
                 </node>
               </node>

--- a/code/platform/com.mbeddr.doc/languages/com.mbeddr.slides/com.mbeddr.slides.mpl
+++ b/code/platform/com.mbeddr.doc/languages/com.mbeddr.slides/com.mbeddr.slides.mpl
@@ -134,6 +134,7 @@
     <language slang="l:b83431fe-5c8f-40bc-8a36-65e25f4dd253:jetbrains.mps.lang.textGen" version="1" />
     <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
     <language slang="l:7a5dda62-9140-4668-ab76-d5ed1746f2b2:jetbrains.mps.lang.typesystem" version="5" />
+    <language slang="l:62971cbe-fd2f-4135-b001-ee6cb7a74436:nl.f1re.mps.editor.swing" version="0" />
   </languageVersions>
   <dependencyVersions>
     <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />

--- a/code/platform/com.mbeddr.doc/languages/com.mbeddr.slides/languageModels/editor.mps
+++ b/code/platform/com.mbeddr.doc/languages/com.mbeddr.slides/languageModels/editor.mps
@@ -64,7 +64,7 @@
       <concept id="1088013125922" name="jetbrains.mps.lang.editor.structure.CellModel_RefCell" flags="sg" stub="730538219795941030" index="1iCGBv">
         <child id="1088186146602" name="editorComponent" index="1sWHZn" />
       </concept>
-      <concept id="1381004262292414836" name="jetbrains.mps.lang.editor.structure.ICellStyle" flags="ng" index="1k5N5V">
+      <concept id="1381004262292414836" name="jetbrains.mps.lang.editor.structure.ICellStyle" flags="ngI" index="1k5N5V">
         <reference id="1381004262292426837" name="parentStyleClass" index="1k5W1q" />
       </concept>
       <concept id="3982520150125052579" name="jetbrains.mps.lang.editor.structure.QueryFunction_AttributeStyleParameter" flags="ig" index="3sjG9q" />
@@ -91,7 +91,7 @@
         <property id="1073389577007" name="text" index="3F0ifm" />
       </concept>
       <concept id="1073389658414" name="jetbrains.mps.lang.editor.structure.CellModel_Property" flags="sg" stub="730538219796134133" index="3F0A7n" />
-      <concept id="1219418625346" name="jetbrains.mps.lang.editor.structure.IStyleContainer" flags="ng" index="3F0Thp">
+      <concept id="1219418625346" name="jetbrains.mps.lang.editor.structure.IStyleContainer" flags="ngI" index="3F0Thp">
         <child id="1219418656006" name="styleItem" index="3F10Kt" />
       </concept>
       <concept id="1073389882823" name="jetbrains.mps.lang.editor.structure.CellModel_RefNode" flags="sg" stub="730538219795960754" index="3F1sOY" />
@@ -138,7 +138,7 @@
         <property id="1176718929932" name="isFinal" index="3TUv4t" />
         <child id="1068431790190" name="initializer" index="33vP2m" />
       </concept>
-      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ng" index="366HgL">
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ngI" index="366HgL">
         <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
       </concept>
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
@@ -183,7 +183,7 @@
       <concept id="1081516740877" name="jetbrains.mps.baseLanguage.structure.NotExpression" flags="nn" index="3fqX7Q">
         <child id="1081516765348" name="expression" index="3fr31v" />
       </concept>
-      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
@@ -204,7 +204,7 @@
         <child id="8276990574895933172" name="throwable" index="1zc67B" />
       </concept>
       <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
-      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ngI" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
       </concept>
       <concept id="5351203823916750322" name="jetbrains.mps.baseLanguage.structure.TryUniversalStatement" flags="nn" index="3J1_TO">
@@ -232,7 +232,7 @@
       <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
         <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
       </concept>
-      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
     </language>

--- a/code/platform/com.mbeddr.doc/languages/com.mbeddr.slides/languageModels/editor.mps
+++ b/code/platform/com.mbeddr.doc/languages/com.mbeddr.slides/languageModels/editor.mps
@@ -3,6 +3,7 @@
   <persistence version="9" />
   <languages>
     <use id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor" version="14" />
+    <use id="62971cbe-fd2f-4135-b001-ee6cb7a74436" name="nl.f1re.mps.editor.swing" version="0" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
@@ -63,7 +64,7 @@
       <concept id="1088013125922" name="jetbrains.mps.lang.editor.structure.CellModel_RefCell" flags="sg" stub="730538219795941030" index="1iCGBv">
         <child id="1088186146602" name="editorComponent" index="1sWHZn" />
       </concept>
-      <concept id="1381004262292414836" name="jetbrains.mps.lang.editor.structure.ICellStyle" flags="ngI" index="1k5N5V">
+      <concept id="1381004262292414836" name="jetbrains.mps.lang.editor.structure.ICellStyle" flags="ng" index="1k5N5V">
         <reference id="1381004262292426837" name="parentStyleClass" index="1k5W1q" />
       </concept>
       <concept id="3982520150125052579" name="jetbrains.mps.lang.editor.structure.QueryFunction_AttributeStyleParameter" flags="ig" index="3sjG9q" />
@@ -90,7 +91,7 @@
         <property id="1073389577007" name="text" index="3F0ifm" />
       </concept>
       <concept id="1073389658414" name="jetbrains.mps.lang.editor.structure.CellModel_Property" flags="sg" stub="730538219796134133" index="3F0A7n" />
-      <concept id="1219418625346" name="jetbrains.mps.lang.editor.structure.IStyleContainer" flags="ngI" index="3F0Thp">
+      <concept id="1219418625346" name="jetbrains.mps.lang.editor.structure.IStyleContainer" flags="ng" index="3F0Thp">
         <child id="1219418656006" name="styleItem" index="3F10Kt" />
       </concept>
       <concept id="1073389882823" name="jetbrains.mps.lang.editor.structure.CellModel_RefNode" flags="sg" stub="730538219795960754" index="3F1sOY" />
@@ -137,6 +138,9 @@
         <property id="1176718929932" name="isFinal" index="3TUv4t" />
         <child id="1068431790190" name="initializer" index="33vP2m" />
       </concept>
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ng" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
+      </concept>
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
@@ -156,7 +160,6 @@
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
-      <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
       <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
         <child id="1082485599094" name="ifFalseStatement" index="9aQIa" />
         <child id="1068580123160" name="condition" index="3clFbw" />
@@ -180,7 +183,7 @@
       <concept id="1081516740877" name="jetbrains.mps.baseLanguage.structure.NotExpression" flags="nn" index="3fqX7Q">
         <child id="1081516765348" name="expression" index="3fr31v" />
       </concept>
-      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
@@ -201,7 +204,7 @@
         <child id="8276990574895933172" name="throwable" index="1zc67B" />
       </concept>
       <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
-      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ngI" index="1B3ioH">
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
       </concept>
       <concept id="5351203823916750322" name="jetbrains.mps.baseLanguage.structure.TryUniversalStatement" flags="nn" index="3J1_TO">
@@ -212,6 +215,9 @@
       <concept id="1170345865475" name="jetbrains.mps.baseLanguage.structure.AnonymousClass" flags="ig" index="1Y3b0j">
         <reference id="1170346070688" name="classifier" index="1Y3XeK" />
       </concept>
+    </language>
+    <language id="62971cbe-fd2f-4135-b001-ee6cb7a74436" name="nl.f1re.mps.editor.swing">
+      <concept id="8659612544238797919" name="nl.f1re.mps.editor.swing.structure.CellModel_CustomJComponent" flags="sg" stub="8659612544238937882" index="fWXJ_" />
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
       <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
@@ -226,7 +232,7 @@
       <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
         <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
       </concept>
-      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
     </language>
@@ -474,179 +480,142 @@
           </node>
         </node>
       </node>
-      <node concept="3EZMnI" id="2PGidvqggYR" role="3EZMnx">
-        <node concept="VPM3Z" id="2PGidvqggYS" role="3F10Kt">
-          <property role="VOm3f" value="false" />
-        </node>
-        <node concept="2iRkQZ" id="2PGidvqggYU" role="2iSdaV" />
-        <node concept="pkWqt" id="2PGidvqggYV" role="pqm2j">
-          <node concept="3clFbS" id="2PGidvqggYW" role="2VODD2">
-            <node concept="3clFbF" id="2PGidvqggYX" role="3cqZAp">
-              <node concept="2OqwBi" id="2PGidvqggZj" role="3clFbG">
-                <node concept="pncrf" id="2PGidvqggYY" role="2Oq$k0" />
-                <node concept="3TrcHB" id="4IRvlq8d300" role="2OqNvi">
-                  <ref role="3TsBF5" to="apd:5yxqZJwzcbA" resolve="showImage" />
+      <node concept="fWXJ_" id="5vhcTL2t3iz" role="3EZMnx">
+        <node concept="3Fmcul" id="5vhcTL2t3i_" role="3FoqZy">
+          <node concept="3clFbS" id="5vhcTL2t3iB" role="2VODD2">
+            <node concept="3clFbJ" id="5yxqZJwzQDw" role="3cqZAp">
+              <node concept="3clFbS" id="5yxqZJwzQDx" role="3clFbx">
+                <node concept="3cpWs6" id="5yxqZJwz93G" role="3cqZAp">
+                  <node concept="2ShNRf" id="5yxqZJwz93D" role="3cqZAk">
+                    <node concept="1pGfFk" id="5vhcTL2tinn" role="2ShVmc">
+                      <property role="373rjd" value="true" />
+                      <ref role="37wK5l" to="dxuu:~JLabel.&lt;init&gt;(java.lang.String)" resolve="JLabel" />
+                      <node concept="Xl_RD" id="5yxqZJwz93K" role="37wK5m">
+                        <property role="Xl_RC" value="Invalid Path" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3fqX7Q" id="5yxqZJwzQD_" role="3clFbw">
+                <node concept="2OqwBi" id="5yxqZJwzQEo" role="3fr31v">
+                  <node concept="2OqwBi" id="5yxqZJwzQDW" role="2Oq$k0">
+                    <node concept="pncrf" id="5yxqZJwzQDB" role="2Oq$k0" />
+                    <node concept="3TrEf2" id="4IRvlq8d2ZW" role="2OqNvi">
+                      <ref role="3Tt5mk" to="apd:5yxqZJwzQtY" resolve="resource" />
+                    </node>
+                  </node>
+                  <node concept="2qgKlT" id="5yxqZJwzQEt" role="2OqNvi">
+                    <ref role="37wK5l" to="4gky:5yxqZJwzQu4" resolve="isValidFile" />
+                  </node>
+                </node>
+              </node>
+              <node concept="9aQIb" id="5yxqZJwzQEw" role="9aQIa">
+                <node concept="3clFbS" id="5yxqZJwzQEx" role="9aQI4">
+                  <node concept="3J1_TO" id="3RseghIdSP1" role="3cqZAp">
+                    <node concept="3clFbS" id="3RseghIdSP2" role="1zxBo7">
+                      <node concept="3cpWs8" id="3RseghIdPNB" role="3cqZAp">
+                        <node concept="3cpWsn" id="3RseghIdPNC" role="3cpWs9">
+                          <property role="TrG5h" value="imeg" />
+                          <node concept="3uibUv" id="3RseghIdPND" role="1tU5fm">
+                            <ref role="3uigEE" to="jan3:~BufferedImage" resolve="BufferedImage" />
+                          </node>
+                          <node concept="2YIFZM" id="3RseghIdPNE" role="33vP2m">
+                            <ref role="1Pybhc" to="oqcp:~ImageIO" resolve="ImageIO" />
+                            <ref role="37wK5l" to="oqcp:~ImageIO.read(java.io.File)" resolve="read" />
+                            <node concept="2ShNRf" id="3RseghIdPNF" role="37wK5m">
+                              <node concept="1pGfFk" id="3RseghIdPNG" role="2ShVmc">
+                                <ref role="37wK5l" to="guwi:~File.&lt;init&gt;(java.lang.String)" resolve="File" />
+                                <node concept="2OqwBi" id="3RseghIdPNH" role="37wK5m">
+                                  <node concept="2OqwBi" id="3RseghIdPNI" role="2Oq$k0">
+                                    <node concept="pncrf" id="3RseghIdPNJ" role="2Oq$k0" />
+                                    <node concept="3TrEf2" id="4IRvlq8d2ZY" role="2OqNvi">
+                                      <ref role="3Tt5mk" to="apd:5yxqZJwzQtY" resolve="resource" />
+                                    </node>
+                                  </node>
+                                  <node concept="2qgKlT" id="3RseghIdPNL" role="2OqNvi">
+                                    <ref role="37wK5l" to="4gky:5yxqZJwzQzV" resolve="getEditTimeFileName" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3cpWs6" id="5yxqZJwySE7" role="3cqZAp">
+                        <node concept="2ShNRf" id="5yxqZJwyQDd" role="3cqZAk">
+                          <node concept="1pGfFk" id="5vhcTL2tvxC" role="2ShVmc">
+                            <property role="373rjd" value="true" />
+                            <ref role="37wK5l" to="dxuu:~JLabel.&lt;init&gt;(javax.swing.Icon)" resolve="JLabel" />
+                            <node concept="2ShNRf" id="3RseghIdPNQ" role="37wK5m">
+                              <node concept="1pGfFk" id="3RseghIdPNS" role="2ShVmc">
+                                <ref role="37wK5l" to="dxuu:~ImageIcon.&lt;init&gt;(java.awt.Image)" resolve="ImageIcon" />
+                                <node concept="37vLTw" id="5Hxjapw9vhf" role="37wK5m">
+                                  <ref role="3cqZAo" node="3RseghIdPNC" resolve="imeg" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3uVAMA" id="3RseghIdSP4" role="1zxBo5">
+                      <node concept="XOnhg" id="3RseghIdSP5" role="1zc67B">
+                        <property role="3TUv4t" value="false" />
+                        <property role="TrG5h" value="ex" />
+                        <node concept="nSUau" id="bKsWirPy5Nd" role="1tU5fm">
+                          <node concept="3uibUv" id="3RseghIdSPe" role="nSUat">
+                            <ref role="3uigEE" to="guwi:~IOException" resolve="IOException" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbS" id="3RseghIdSP7" role="1zc67A">
+                        <node concept="3clFbF" id="3RseghIdSPg" role="3cqZAp">
+                          <node concept="2OqwBi" id="3RseghIdSPA" role="3clFbG">
+                            <node concept="37vLTw" id="5Hxjapw9v7w" role="2Oq$k0">
+                              <ref role="3cqZAo" node="3RseghIdSP5" resolve="ex" />
+                            </node>
+                            <node concept="liA8E" id="3RseghIdSPH" role="2OqNvi">
+                              <ref role="37wK5l" to="wyt6:~Throwable.printStackTrace()" resolve="printStackTrace" />
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3cpWs6" id="3RseghIdSPR" role="3cqZAp">
+                          <node concept="2ShNRf" id="3RseghIdSPO" role="3cqZAk">
+                            <node concept="1pGfFk" id="5vhcTL2tyi4" role="2ShVmc">
+                              <property role="373rjd" value="true" />
+                              <ref role="37wK5l" to="dxuu:~JLabel.&lt;init&gt;(java.lang.String)" resolve="JLabel" />
+                              <node concept="3cpWs3" id="3RseghIdSQe" role="37wK5m">
+                                <node concept="Xl_RD" id="3RseghIdSPQ" role="3uHU7B">
+                                  <property role="Xl_RC" value="Exception: " />
+                                </node>
+                                <node concept="2OqwBi" id="3RseghIdSQB" role="3uHU7w">
+                                  <node concept="37vLTw" id="5Hxjapw9vb7" role="2Oq$k0">
+                                    <ref role="3cqZAo" node="3RseghIdSP5" resolve="ex" />
+                                  </node>
+                                  <node concept="liA8E" id="3RseghIdSQI" role="2OqNvi">
+                                    <ref role="37wK5l" to="wyt6:~Throwable.getMessage()" resolve="getMessage" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
                 </node>
               </node>
             </node>
           </node>
         </node>
-        <node concept="3gTLQM" id="5yxqZJwyOSq" role="3EZMnx">
-          <node concept="3Fmcul" id="5yxqZJwyOSr" role="3FoqZy">
-            <node concept="3clFbS" id="5yxqZJwyOSs" role="2VODD2">
-              <node concept="3clFbJ" id="5yxqZJwzQDw" role="3cqZAp">
-                <node concept="3clFbS" id="5yxqZJwzQDx" role="3clFbx">
-                  <node concept="3cpWs8" id="5yxqZJwz93A" role="3cqZAp">
-                    <node concept="3cpWsn" id="5yxqZJwz93B" role="3cpWs9">
-                      <property role="TrG5h" value="l" />
-                      <node concept="3uibUv" id="5yxqZJwz93C" role="1tU5fm">
-                        <ref role="3uigEE" to="dxuu:~JLabel" resolve="JLabel" />
-                      </node>
-                      <node concept="2ShNRf" id="5yxqZJwz93D" role="33vP2m">
-                        <node concept="1pGfFk" id="5yxqZJwz93E" role="2ShVmc">
-                          <ref role="37wK5l" to="dxuu:~JLabel.&lt;init&gt;(java.lang.String)" resolve="JLabel" />
-                          <node concept="Xl_RD" id="5yxqZJwz93K" role="37wK5m">
-                            <property role="Xl_RC" value="Invalid Path" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="3cpWs6" id="5yxqZJwz93G" role="3cqZAp">
-                    <node concept="37vLTw" id="5Hxjapw9v9Z" role="3cqZAk">
-                      <ref role="3cqZAo" node="5yxqZJwz93B" resolve="l" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="3fqX7Q" id="5yxqZJwzQD_" role="3clFbw">
-                  <node concept="2OqwBi" id="5yxqZJwzQEo" role="3fr31v">
-                    <node concept="2OqwBi" id="5yxqZJwzQDW" role="2Oq$k0">
-                      <node concept="pncrf" id="5yxqZJwzQDB" role="2Oq$k0" />
-                      <node concept="3TrEf2" id="4IRvlq8d2ZW" role="2OqNvi">
-                        <ref role="3Tt5mk" to="apd:5yxqZJwzQtY" resolve="resource" />
-                      </node>
-                    </node>
-                    <node concept="2qgKlT" id="5yxqZJwzQEt" role="2OqNvi">
-                      <ref role="37wK5l" to="4gky:5yxqZJwzQu4" resolve="isValidFile" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="9aQIb" id="5yxqZJwzQEw" role="9aQIa">
-                  <node concept="3clFbS" id="5yxqZJwzQEx" role="9aQI4">
-                    <node concept="3J1_TO" id="3RseghIdSP1" role="3cqZAp">
-                      <node concept="3clFbS" id="3RseghIdSP2" role="1zxBo7">
-                        <node concept="3cpWs8" id="3RseghIdPNB" role="3cqZAp">
-                          <node concept="3cpWsn" id="3RseghIdPNC" role="3cpWs9">
-                            <property role="TrG5h" value="imeg" />
-                            <node concept="3uibUv" id="3RseghIdPND" role="1tU5fm">
-                              <ref role="3uigEE" to="jan3:~BufferedImage" resolve="BufferedImage" />
-                            </node>
-                            <node concept="2YIFZM" id="3RseghIdPNE" role="33vP2m">
-                              <ref role="1Pybhc" to="oqcp:~ImageIO" resolve="ImageIO" />
-                              <ref role="37wK5l" to="oqcp:~ImageIO.read(java.io.File)" resolve="read" />
-                              <node concept="2ShNRf" id="3RseghIdPNF" role="37wK5m">
-                                <node concept="1pGfFk" id="3RseghIdPNG" role="2ShVmc">
-                                  <ref role="37wK5l" to="guwi:~File.&lt;init&gt;(java.lang.String)" resolve="File" />
-                                  <node concept="2OqwBi" id="3RseghIdPNH" role="37wK5m">
-                                    <node concept="2OqwBi" id="3RseghIdPNI" role="2Oq$k0">
-                                      <node concept="pncrf" id="3RseghIdPNJ" role="2Oq$k0" />
-                                      <node concept="3TrEf2" id="4IRvlq8d2ZY" role="2OqNvi">
-                                        <ref role="3Tt5mk" to="apd:5yxqZJwzQtY" resolve="resource" />
-                                      </node>
-                                    </node>
-                                    <node concept="2qgKlT" id="3RseghIdPNL" role="2OqNvi">
-                                      <ref role="37wK5l" to="4gky:5yxqZJwzQzV" resolve="getEditTimeFileName" />
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="3cpWs8" id="5yxqZJwyQD9" role="3cqZAp">
-                          <node concept="3cpWsn" id="5yxqZJwyQDa" role="3cpWs9">
-                            <property role="TrG5h" value="l" />
-                            <node concept="3uibUv" id="5yxqZJwyQDb" role="1tU5fm">
-                              <ref role="3uigEE" to="dxuu:~JLabel" resolve="JLabel" />
-                            </node>
-                            <node concept="2ShNRf" id="5yxqZJwyQDd" role="33vP2m">
-                              <node concept="1pGfFk" id="5yxqZJwyQDe" role="2ShVmc">
-                                <ref role="37wK5l" to="dxuu:~JLabel.&lt;init&gt;(javax.swing.Icon)" resolve="JLabel" />
-                                <node concept="2ShNRf" id="3RseghIdPNQ" role="37wK5m">
-                                  <node concept="1pGfFk" id="3RseghIdPNS" role="2ShVmc">
-                                    <ref role="37wK5l" to="dxuu:~ImageIcon.&lt;init&gt;(java.awt.Image)" resolve="ImageIcon" />
-                                    <node concept="37vLTw" id="5Hxjapw9vhf" role="37wK5m">
-                                      <ref role="3cqZAo" node="3RseghIdPNC" resolve="imeg" />
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="3cpWs6" id="5yxqZJwySE7" role="3cqZAp">
-                          <node concept="37vLTw" id="5Hxjapw9v5M" role="3cqZAk">
-                            <ref role="3cqZAo" node="5yxqZJwyQDa" resolve="l" />
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="3uVAMA" id="3RseghIdSP4" role="1zxBo5">
-                        <node concept="XOnhg" id="3RseghIdSP5" role="1zc67B">
-                          <property role="3TUv4t" value="false" />
-                          <property role="TrG5h" value="ex" />
-                          <node concept="nSUau" id="bKsWirPy5Nd" role="1tU5fm">
-                            <node concept="3uibUv" id="3RseghIdSPe" role="nSUat">
-                              <ref role="3uigEE" to="guwi:~IOException" resolve="IOException" />
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="3clFbS" id="3RseghIdSP7" role="1zc67A">
-                          <node concept="3clFbF" id="3RseghIdSPg" role="3cqZAp">
-                            <node concept="2OqwBi" id="3RseghIdSPA" role="3clFbG">
-                              <node concept="37vLTw" id="5Hxjapw9v7w" role="2Oq$k0">
-                                <ref role="3cqZAo" node="3RseghIdSP5" resolve="ex" />
-                              </node>
-                              <node concept="liA8E" id="3RseghIdSPH" role="2OqNvi">
-                                <ref role="37wK5l" to="wyt6:~Throwable.printStackTrace()" resolve="printStackTrace" />
-                              </node>
-                            </node>
-                          </node>
-                          <node concept="3cpWs8" id="3RseghIdSPL" role="3cqZAp">
-                            <node concept="3cpWsn" id="3RseghIdSPM" role="3cpWs9">
-                              <property role="TrG5h" value="l" />
-                              <node concept="3uibUv" id="3RseghIdSPN" role="1tU5fm">
-                                <ref role="3uigEE" to="dxuu:~JLabel" resolve="JLabel" />
-                              </node>
-                              <node concept="2ShNRf" id="3RseghIdSPO" role="33vP2m">
-                                <node concept="1pGfFk" id="3RseghIdSPP" role="2ShVmc">
-                                  <ref role="37wK5l" to="dxuu:~JLabel.&lt;init&gt;(java.lang.String)" resolve="JLabel" />
-                                  <node concept="3cpWs3" id="3RseghIdSQe" role="37wK5m">
-                                    <node concept="Xl_RD" id="3RseghIdSPQ" role="3uHU7B">
-                                      <property role="Xl_RC" value="Exception: " />
-                                    </node>
-                                    <node concept="2OqwBi" id="3RseghIdSQB" role="3uHU7w">
-                                      <node concept="37vLTw" id="5Hxjapw9vb7" role="2Oq$k0">
-                                        <ref role="3cqZAo" node="3RseghIdSP5" resolve="ex" />
-                                      </node>
-                                      <node concept="liA8E" id="3RseghIdSQI" role="2OqNvi">
-                                        <ref role="37wK5l" to="wyt6:~Throwable.getMessage()" resolve="getMessage" />
-                                      </node>
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                          <node concept="3cpWs6" id="3RseghIdSPR" role="3cqZAp">
-                            <node concept="37vLTw" id="5Hxjapw9vdU" role="3cqZAk">
-                              <ref role="3cqZAo" node="3RseghIdSPM" resolve="l" />
-                            </node>
-                          </node>
-                          <node concept="3clFbH" id="3RseghIdSPJ" role="3cqZAp" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
+        <node concept="pkWqt" id="5vhcTL2t7sL" role="pqm2j">
+          <node concept="3clFbS" id="5vhcTL2t7sM" role="2VODD2">
+            <node concept="3clFbF" id="2PGidvqggYX" role="3cqZAp">
+              <node concept="2OqwBi" id="2PGidvqggZj" role="3clFbG">
+                <node concept="pncrf" id="2PGidvqggYY" role="2Oq$k0" />
+                <node concept="3TrcHB" id="4IRvlq8d300" role="2OqNvi">
+                  <ref role="3TsBF5" to="apd:5yxqZJwzcbA" resolve="showImage" />
                 </node>
               </node>
             </node>

--- a/code/platform/com.mbeddr.mpsutil/languages/com.mbeddr.core.base/com.mbeddr.core.base.mpl
+++ b/code/platform/com.mbeddr.mpsutil/languages/com.mbeddr.core.base/com.mbeddr.core.base.mpl
@@ -111,6 +111,7 @@
     <dependency reexport="false">f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)</dependency>
     <dependency reexport="false">9e24fcdc-a232-4d24-8c95-1f525946191a(com.mbeddr.core.base.pluginSolution)</dependency>
     <dependency reexport="false">39983771-4e9b-401b-a1a9-1da6c777c843(MPS.ThirdParty)</dependency>
+    <dependency reexport="false">df7a5caa-3be8-43f2-a870-f5474c3bcdb5(nl.f1re.mps.editor.swing.runtime)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:63e0e566-5131-447e-90e3-12ea330e1a00:com.mbeddr.mpsutil.blutil" version="3" />
@@ -178,6 +179,7 @@
     <language slang="l:7a5dda62-9140-4668-ab76-d5ed1746f2b2:jetbrains.mps.lang.typesystem" version="5" />
     <language slang="l:c9d137c4-3259-44f8-80ff-33ab2b506ee4:jetbrains.mps.lang.util.order" version="0" />
     <language slang="l:696c1165-4a59-463b-bc5d-902caab85dd0:jetbrains.mps.make.facet" version="0" />
+    <language slang="l:62971cbe-fd2f-4135-b001-ee6cb7a74436:nl.f1re.mps.editor.swing" version="0" />
   </languageVersions>
   <dependencyVersions>
     <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
@@ -224,6 +226,7 @@
     <module reference="7866978e-a0f0-4cc7-81bc-4d213d9375e1(jetbrains.mps.lang.smodel)" version="1" />
     <module reference="c72da2b9-7cce-4447-8389-f407dc1158b7(jetbrains.mps.lang.structure)" version="0" />
     <module reference="9ded098b-ad6a-4657-bfd9-48636cfe8bc3(jetbrains.mps.lang.traceable)" version="0" />
+    <module reference="df7a5caa-3be8-43f2-a870-f5474c3bcdb5(nl.f1re.mps.editor.swing.runtime)" version="0" />
     <module reference="b0f8641f-bd77-4421-8425-30d9088a82f7(org.apache.commons)" version="0" />
   </dependencyVersions>
   <extendedLanguages>

--- a/code/platform/com.mbeddr.mpsutil/languages/com.mbeddr.core.base/models/editor.mps
+++ b/code/platform/com.mbeddr.mpsutil/languages/com.mbeddr.core.base/models/editor.mps
@@ -95,7 +95,7 @@
       <concept id="1402906326895675325" name="jetbrains.mps.lang.editor.structure.CellActionMap_FunctionParm_selectedNode" flags="nn" index="0IXxy" />
       <concept id="5991739802479784074" name="jetbrains.mps.lang.editor.structure.MenuTypeNamed" flags="ng" index="22hDWg" />
       <concept id="5991739802479784073" name="jetbrains.mps.lang.editor.structure.MenuTypeDefault" flags="ng" index="22hDWj" />
-      <concept id="2000375450116454183" name="jetbrains.mps.lang.editor.structure.ISubstituteMenu" flags="ng" index="22mbnS">
+      <concept id="2000375450116454183" name="jetbrains.mps.lang.editor.structure.ISubstituteMenu" flags="ngI" index="22mbnS">
         <child id="414384289274416996" name="parts" index="3ft7WO" />
       </concept>
       <concept id="2000375450116423800" name="jetbrains.mps.lang.editor.structure.SubstituteMenu" flags="ng" index="22mcaB" />
@@ -213,10 +213,10 @@
       <concept id="1164996492011" name="jetbrains.mps.lang.editor.structure.CellMenuPart_ReferentPrimary" flags="ng" index="ZcVJ$">
         <child id="6918029743851332884" name="matchingText" index="1NQq9M" />
       </concept>
-      <concept id="1630016958697718209" name="jetbrains.mps.lang.editor.structure.IMenuReference_Default" flags="ng" index="2Z_bC8">
+      <concept id="1630016958697718209" name="jetbrains.mps.lang.editor.structure.IMenuReference_Default" flags="ngI" index="2Z_bC8">
         <reference id="1630016958698373342" name="concept" index="2ZyFGn" />
       </concept>
-      <concept id="1630016958697344083" name="jetbrains.mps.lang.editor.structure.IMenu_Concept" flags="ng" index="2ZABuq">
+      <concept id="1630016958697344083" name="jetbrains.mps.lang.editor.structure.IMenu_Concept" flags="ngI" index="2ZABuq">
         <reference id="6591946374543067572" name="conceptDeclaration" index="aqKnT" />
         <child id="5991739802479788259" name="type" index="22hAXT" />
       </concept>
@@ -273,7 +273,7 @@
       <concept id="7597241200646296617" name="jetbrains.mps.lang.editor.structure.NavigatableNodeStyleClassItem" flags="ln" index="3k4GqR">
         <child id="7597241200646296618" name="functionNode" index="3k4GqO" />
       </concept>
-      <concept id="1381004262292414836" name="jetbrains.mps.lang.editor.structure.ICellStyle" flags="ng" index="1k5N5V">
+      <concept id="1381004262292414836" name="jetbrains.mps.lang.editor.structure.ICellStyle" flags="ngI" index="1k5N5V">
         <reference id="1381004262292426837" name="parentStyleClass" index="1k5W1q" />
       </concept>
       <concept id="1236262245656" name="jetbrains.mps.lang.editor.structure.MatchingLabelStyleClassItem" flags="ln" index="3mYdg7">
@@ -327,7 +327,7 @@
         <property id="1073389577007" name="text" index="3F0ifm" />
       </concept>
       <concept id="1073389658414" name="jetbrains.mps.lang.editor.structure.CellModel_Property" flags="sg" stub="730538219796134133" index="3F0A7n" />
-      <concept id="1219418625346" name="jetbrains.mps.lang.editor.structure.IStyleContainer" flags="ng" index="3F0Thp">
+      <concept id="1219418625346" name="jetbrains.mps.lang.editor.structure.IStyleContainer" flags="ngI" index="3F0Thp">
         <child id="1219418656006" name="styleItem" index="3F10Kt" />
       </concept>
       <concept id="1073389882823" name="jetbrains.mps.lang.editor.structure.CellModel_RefNode" flags="sg" stub="730538219795960754" index="3F1sOY">
@@ -338,7 +338,7 @@
         <child id="1182233390675" name="filter" index="12AuX0" />
       </concept>
       <concept id="1176474535556" name="jetbrains.mps.lang.editor.structure.QueryFunction_JComponent" flags="in" index="3Fmcul" />
-      <concept id="843003353410421268" name="jetbrains.mps.lang.editor.structure.IOutputConceptTransformationMenuPart" flags="ng" index="1FNN41">
+      <concept id="843003353410421268" name="jetbrains.mps.lang.editor.structure.IOutputConceptTransformationMenuPart" flags="ngI" index="1FNN41">
         <child id="843003353410424960" name="outputConceptReference" index="1FNMel" />
       </concept>
       <concept id="843003353410421233" name="jetbrains.mps.lang.editor.structure.OptionalConceptReference" flags="ng" index="1FNNb$">
@@ -352,7 +352,7 @@
         <child id="1225900141900" name="modelAccessor" index="1HlULh" />
       </concept>
       <concept id="5624877018226900666" name="jetbrains.mps.lang.editor.structure.TransformationMenu" flags="ng" index="3ICUPy" />
-      <concept id="5624877018228267058" name="jetbrains.mps.lang.editor.structure.ITransformationMenu" flags="ng" index="3INCJE">
+      <concept id="5624877018228267058" name="jetbrains.mps.lang.editor.structure.ITransformationMenu" flags="ngI" index="3INCJE">
         <child id="1638911550608572412" name="sections" index="IW6Ez" />
       </concept>
       <concept id="6918029743850363447" name="jetbrains.mps.lang.editor.structure.ConceptFunctionParameter_targetNode" flags="ng" index="1NM5Ph" />
@@ -429,7 +429,7 @@
       <concept id="1188207840427" name="jetbrains.mps.baseLanguage.structure.AnnotationInstance" flags="nn" index="2AHcQZ">
         <reference id="1188208074048" name="annotation" index="2AI5Lk" />
       </concept>
-      <concept id="1188208481402" name="jetbrains.mps.baseLanguage.structure.HasAnnotation" flags="ng" index="2AJDlI">
+      <concept id="1188208481402" name="jetbrains.mps.baseLanguage.structure.HasAnnotation" flags="ngI" index="2AJDlI">
         <child id="1188208488637" name="annotation" index="2AJF6D" />
       </concept>
       <concept id="1095950406618" name="jetbrains.mps.baseLanguage.structure.DivExpression" flags="nn" index="FJ1c_" />
@@ -499,7 +499,7 @@
         <property id="1176718929932" name="isFinal" index="3TUv4t" />
         <child id="1068431790190" name="initializer" index="33vP2m" />
       </concept>
-      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ng" index="366HgL">
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ngI" index="366HgL">
         <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
       </concept>
       <concept id="1092119917967" name="jetbrains.mps.baseLanguage.structure.MulExpression" flags="nn" index="17qRlL" />
@@ -574,7 +574,7 @@
       <concept id="1160998861373" name="jetbrains.mps.baseLanguage.structure.AssertStatement" flags="nn" index="1gVbGN">
         <child id="1160998896846" name="condition" index="1gVkn0" />
       </concept>
-      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
         <child id="4972241301747169160" name="typeArgument" index="3PaCim" />
@@ -606,7 +606,7 @@
       </concept>
       <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
       <concept id="1081855346303" name="jetbrains.mps.baseLanguage.structure.BreakStatement" flags="nn" index="3zACq4" />
-      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ngI" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
       </concept>
       <concept id="1144230876926" name="jetbrains.mps.baseLanguage.structure.AbstractForStatement" flags="nn" index="1DupvO">
@@ -660,9 +660,9 @@
       <concept id="4079382982702596667" name="jetbrains.mps.baseLanguage.checkedDots.structure.CheckedDotExpression" flags="nn" index="2EnYce" />
     </language>
     <language id="62971cbe-fd2f-4135-b001-ee6cb7a74436" name="nl.f1re.mps.editor.swing">
-      <concept id="8659612544244102551" name="nl.f1re.mps.editor.swing.structure.QueryFunction_Style" flags="ig" index="00ECH" />
+      <concept id="8659612544244102551" name="nl.f1re.mps.editor.swing.structure.QueryFunction_Font" flags="ig" index="00ECH" />
       <concept id="8659612544238797919" name="nl.f1re.mps.editor.swing.structure.CellModel_CustomJComponent" flags="sg" stub="8659612544238937882" index="fWXJ_">
-        <child id="8659612544244095634" name="styleFunction" index="00CkC" />
+        <child id="8659612544244095634" name="fontFunction" index="00CkC" />
       </concept>
     </language>
     <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
@@ -807,7 +807,7 @@
         <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
         <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
       </concept>
-      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
       <concept id="709746936026466394" name="jetbrains.mps.lang.core.structure.ChildAttribute" flags="ng" index="3VBwX9">
@@ -1730,7 +1730,7 @@
                       </node>
                     </node>
                     <node concept="2AHcQZ" id="inTShiWUFY" role="2AJF6D">
-                      <ref role="2AI5Lk" to="wyt6:~Override" />
+                      <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
                     </node>
                   </node>
                 </node>
@@ -2069,7 +2069,7 @@
                       </node>
                     </node>
                     <node concept="2AHcQZ" id="inTShiXcMC" role="2AJF6D">
-                      <ref role="2AI5Lk" to="wyt6:~Override" />
+                      <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
                     </node>
                   </node>
                 </node>

--- a/code/platform/com.mbeddr.mpsutil/languages/com.mbeddr.core.base/models/editor.mps
+++ b/code/platform/com.mbeddr.mpsutil/languages/com.mbeddr.core.base/models/editor.mps
@@ -20,6 +20,7 @@
     <use id="1919c723-b60b-4592-9318-9ce96d91da44" name="de.itemis.mps.editor.celllayout" version="-1" />
     <use id="982eb8df-2c96-4bd7-9963-11712ea622e5" name="jetbrains.mps.lang.resources" version="-1" />
     <use id="b1ab8c10-c118-4755-bf2a-cebab35cf533" name="jetbrains.mps.lang.editor.tooltips" version="0" />
+    <use id="62971cbe-fd2f-4135-b001-ee6cb7a74436" name="nl.f1re.mps.editor.swing" version="0" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
@@ -76,6 +77,8 @@
     <import index="tpen" ref="r:00000000-0000-4000-0000-011c895902c3(jetbrains.mps.baseLanguage.editor)" />
     <import index="z2i8" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.icons(MPS.IDEA/)" />
     <import index="muut" ref="63e0e566-5131-447e-90e3-12ea330e1a00/r:7b6c196f-8133-489b-a5b2-6ed29b884e93(com.mbeddr.mpsutil.blutil/com.mbeddr.mpsutil.blutil.editor)" />
+    <import index="hhnx" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.editor.runtime(MPS.Editor/)" />
+    <import index="clc5" ref="r:f3c60842-0867-4098-adfc-0827d66d9af8(nl.f1re.mps.editor.swing.runtime)" />
   </imports>
   <registry>
     <language id="b8bb702e-43ed-4090-a902-d180d3e5f292" name="de.slisson.mps.conditionalEditor">
@@ -92,7 +95,7 @@
       <concept id="1402906326895675325" name="jetbrains.mps.lang.editor.structure.CellActionMap_FunctionParm_selectedNode" flags="nn" index="0IXxy" />
       <concept id="5991739802479784074" name="jetbrains.mps.lang.editor.structure.MenuTypeNamed" flags="ng" index="22hDWg" />
       <concept id="5991739802479784073" name="jetbrains.mps.lang.editor.structure.MenuTypeDefault" flags="ng" index="22hDWj" />
-      <concept id="2000375450116454183" name="jetbrains.mps.lang.editor.structure.ISubstituteMenu" flags="ngI" index="22mbnS">
+      <concept id="2000375450116454183" name="jetbrains.mps.lang.editor.structure.ISubstituteMenu" flags="ng" index="22mbnS">
         <child id="414384289274416996" name="parts" index="3ft7WO" />
       </concept>
       <concept id="2000375450116423800" name="jetbrains.mps.lang.editor.structure.SubstituteMenu" flags="ng" index="22mcaB" />
@@ -210,10 +213,10 @@
       <concept id="1164996492011" name="jetbrains.mps.lang.editor.structure.CellMenuPart_ReferentPrimary" flags="ng" index="ZcVJ$">
         <child id="6918029743851332884" name="matchingText" index="1NQq9M" />
       </concept>
-      <concept id="1630016958697718209" name="jetbrains.mps.lang.editor.structure.IMenuReference_Default" flags="ngI" index="2Z_bC8">
+      <concept id="1630016958697718209" name="jetbrains.mps.lang.editor.structure.IMenuReference_Default" flags="ng" index="2Z_bC8">
         <reference id="1630016958698373342" name="concept" index="2ZyFGn" />
       </concept>
-      <concept id="1630016958697344083" name="jetbrains.mps.lang.editor.structure.IMenu_Concept" flags="ngI" index="2ZABuq">
+      <concept id="1630016958697344083" name="jetbrains.mps.lang.editor.structure.IMenu_Concept" flags="ng" index="2ZABuq">
         <reference id="6591946374543067572" name="conceptDeclaration" index="aqKnT" />
         <child id="5991739802479788259" name="type" index="22hAXT" />
       </concept>
@@ -270,7 +273,7 @@
       <concept id="7597241200646296617" name="jetbrains.mps.lang.editor.structure.NavigatableNodeStyleClassItem" flags="ln" index="3k4GqR">
         <child id="7597241200646296618" name="functionNode" index="3k4GqO" />
       </concept>
-      <concept id="1381004262292414836" name="jetbrains.mps.lang.editor.structure.ICellStyle" flags="ngI" index="1k5N5V">
+      <concept id="1381004262292414836" name="jetbrains.mps.lang.editor.structure.ICellStyle" flags="ng" index="1k5N5V">
         <reference id="1381004262292426837" name="parentStyleClass" index="1k5W1q" />
       </concept>
       <concept id="1236262245656" name="jetbrains.mps.lang.editor.structure.MatchingLabelStyleClassItem" flags="ln" index="3mYdg7">
@@ -324,7 +327,7 @@
         <property id="1073389577007" name="text" index="3F0ifm" />
       </concept>
       <concept id="1073389658414" name="jetbrains.mps.lang.editor.structure.CellModel_Property" flags="sg" stub="730538219796134133" index="3F0A7n" />
-      <concept id="1219418625346" name="jetbrains.mps.lang.editor.structure.IStyleContainer" flags="ngI" index="3F0Thp">
+      <concept id="1219418625346" name="jetbrains.mps.lang.editor.structure.IStyleContainer" flags="ng" index="3F0Thp">
         <child id="1219418656006" name="styleItem" index="3F10Kt" />
       </concept>
       <concept id="1073389882823" name="jetbrains.mps.lang.editor.structure.CellModel_RefNode" flags="sg" stub="730538219795960754" index="3F1sOY">
@@ -335,7 +338,7 @@
         <child id="1182233390675" name="filter" index="12AuX0" />
       </concept>
       <concept id="1176474535556" name="jetbrains.mps.lang.editor.structure.QueryFunction_JComponent" flags="in" index="3Fmcul" />
-      <concept id="843003353410421268" name="jetbrains.mps.lang.editor.structure.IOutputConceptTransformationMenuPart" flags="ngI" index="1FNN41">
+      <concept id="843003353410421268" name="jetbrains.mps.lang.editor.structure.IOutputConceptTransformationMenuPart" flags="ng" index="1FNN41">
         <child id="843003353410424960" name="outputConceptReference" index="1FNMel" />
       </concept>
       <concept id="843003353410421233" name="jetbrains.mps.lang.editor.structure.OptionalConceptReference" flags="ng" index="1FNNb$">
@@ -349,7 +352,7 @@
         <child id="1225900141900" name="modelAccessor" index="1HlULh" />
       </concept>
       <concept id="5624877018226900666" name="jetbrains.mps.lang.editor.structure.TransformationMenu" flags="ng" index="3ICUPy" />
-      <concept id="5624877018228267058" name="jetbrains.mps.lang.editor.structure.ITransformationMenu" flags="ngI" index="3INCJE">
+      <concept id="5624877018228267058" name="jetbrains.mps.lang.editor.structure.ITransformationMenu" flags="ng" index="3INCJE">
         <child id="1638911550608572412" name="sections" index="IW6Ez" />
       </concept>
       <concept id="6918029743850363447" name="jetbrains.mps.lang.editor.structure.ConceptFunctionParameter_targetNode" flags="ng" index="1NM5Ph" />
@@ -420,10 +423,13 @@
       <concept id="1076505808687" name="jetbrains.mps.baseLanguage.structure.WhileStatement" flags="nn" index="2$JKZl">
         <child id="1076505808688" name="condition" index="2$JKZa" />
       </concept>
+      <concept id="1239714755177" name="jetbrains.mps.baseLanguage.structure.AbstractUnaryNumberOperation" flags="nn" index="2$Kvd9">
+        <child id="1239714902950" name="expression" index="2$L3a6" />
+      </concept>
       <concept id="1188207840427" name="jetbrains.mps.baseLanguage.structure.AnnotationInstance" flags="nn" index="2AHcQZ">
         <reference id="1188208074048" name="annotation" index="2AI5Lk" />
       </concept>
-      <concept id="1188208481402" name="jetbrains.mps.baseLanguage.structure.HasAnnotation" flags="ngI" index="2AJDlI">
+      <concept id="1188208481402" name="jetbrains.mps.baseLanguage.structure.HasAnnotation" flags="ng" index="2AJDlI">
         <child id="1188208488637" name="annotation" index="2AJF6D" />
       </concept>
       <concept id="1095950406618" name="jetbrains.mps.baseLanguage.structure.DivExpression" flags="nn" index="FJ1c_" />
@@ -493,6 +499,9 @@
         <property id="1176718929932" name="isFinal" index="3TUv4t" />
         <child id="1068431790190" name="initializer" index="33vP2m" />
       </concept>
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ng" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
+      </concept>
       <concept id="1092119917967" name="jetbrains.mps.baseLanguage.structure.MulExpression" flags="nn" index="17qRlL" />
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
@@ -558,13 +567,14 @@
       <concept id="1079359253375" name="jetbrains.mps.baseLanguage.structure.ParenthesizedExpression" flags="nn" index="1eOMI4">
         <child id="1079359253376" name="expression" index="1eOMHV" />
       </concept>
+      <concept id="1081506773034" name="jetbrains.mps.baseLanguage.structure.LessThanExpression" flags="nn" index="3eOVzh" />
       <concept id="1081516740877" name="jetbrains.mps.baseLanguage.structure.NotExpression" flags="nn" index="3fqX7Q">
         <child id="1081516765348" name="expression" index="3fr31v" />
       </concept>
       <concept id="1160998861373" name="jetbrains.mps.baseLanguage.structure.AssertStatement" flags="nn" index="1gVbGN">
         <child id="1160998896846" name="condition" index="1gVkn0" />
       </concept>
-      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
         <child id="4972241301747169160" name="typeArgument" index="3PaCim" />
@@ -586,6 +596,7 @@
         <child id="1081773367579" name="rightExpression" index="3uHU7w" />
         <child id="1081773367580" name="leftExpression" index="3uHU7B" />
       </concept>
+      <concept id="1214918800624" name="jetbrains.mps.baseLanguage.structure.PostfixIncrementExpression" flags="nn" index="3uNrnE" />
       <concept id="3093926081414150598" name="jetbrains.mps.baseLanguage.structure.MultipleCatchClause" flags="ng" index="3uVAMA">
         <child id="8276990574895933173" name="catchBody" index="1zc67A" />
         <child id="8276990574895933172" name="throwable" index="1zc67B" />
@@ -595,13 +606,25 @@
       </concept>
       <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
       <concept id="1081855346303" name="jetbrains.mps.baseLanguage.structure.BreakStatement" flags="nn" index="3zACq4" />
-      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ngI" index="1B3ioH">
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
+      </concept>
+      <concept id="1144230876926" name="jetbrains.mps.baseLanguage.structure.AbstractForStatement" flags="nn" index="1DupvO">
+        <child id="1144230900587" name="variable" index="1Duv9x" />
+      </concept>
+      <concept id="1144231330558" name="jetbrains.mps.baseLanguage.structure.ForStatement" flags="nn" index="1Dw8fO">
+        <child id="1144231399730" name="condition" index="1Dwp0S" />
+        <child id="1144231408325" name="iteration" index="1Dwrff" />
       </concept>
       <concept id="5351203823916750322" name="jetbrains.mps.baseLanguage.structure.TryUniversalStatement" flags="nn" index="3J1_TO">
         <child id="8276990574886367510" name="catchClause" index="1zxBo5" />
         <child id="8276990574886367509" name="finallyClause" index="1zxBo6" />
         <child id="8276990574886367508" name="body" index="1zxBo7" />
+      </concept>
+      <concept id="1163668896201" name="jetbrains.mps.baseLanguage.structure.TernaryOperatorExpression" flags="nn" index="3K4zz7">
+        <child id="1163668914799" name="condition" index="3K4Cdx" />
+        <child id="1163668922816" name="ifTrue" index="3K4E3e" />
+        <child id="1163668934364" name="ifFalse" index="3K4GZi" />
       </concept>
       <concept id="1163670490218" name="jetbrains.mps.baseLanguage.structure.SwitchStatement" flags="nn" index="3KaCP$">
         <child id="1163670592366" name="defaultBlock" index="3Kb1Dw" />
@@ -613,9 +636,6 @@
         <child id="1163670683720" name="body" index="3Kbo56" />
       </concept>
       <concept id="3066917033203108594" name="jetbrains.mps.baseLanguage.structure.LocalInstanceMethodCall" flags="nn" index="3P9mCS" />
-      <concept id="1221737317277" name="jetbrains.mps.baseLanguage.structure.StaticInitializer" flags="lg" index="1Pe0a1">
-        <child id="1221737317278" name="statementList" index="1Pe0a2" />
-      </concept>
       <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="nn" index="3SKdUt">
         <child id="8356039341262087992" name="line" index="1aUNEU" />
       </concept>
@@ -638,6 +658,12 @@
     </language>
     <language id="774bf8a0-62e5-41e1-af63-f4812e60e48b" name="jetbrains.mps.baseLanguage.checkedDots">
       <concept id="4079382982702596667" name="jetbrains.mps.baseLanguage.checkedDots.structure.CheckedDotExpression" flags="nn" index="2EnYce" />
+    </language>
+    <language id="62971cbe-fd2f-4135-b001-ee6cb7a74436" name="nl.f1re.mps.editor.swing">
+      <concept id="8659612544244102551" name="nl.f1re.mps.editor.swing.structure.QueryFunction_Style" flags="ig" index="00ECH" />
+      <concept id="8659612544238797919" name="nl.f1re.mps.editor.swing.structure.CellModel_CustomJComponent" flags="sg" stub="8659612544238937882" index="fWXJ_">
+        <child id="8659612544244095634" name="styleFunction" index="00CkC" />
+      </concept>
     </language>
     <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
       <concept id="2524418899405758586" name="jetbrains.mps.baseLanguage.closures.structure.InferredClosureParameterDeclaration" flags="ig" index="gl6BB" />
@@ -781,7 +807,7 @@
         <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
         <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
       </concept>
-      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
       <concept id="709746936026466394" name="jetbrains.mps.lang.core.structure.ChildAttribute" flags="ng" index="3VBwX9">
@@ -1684,6 +1710,29 @@
                       </node>
                     </node>
                   </node>
+                  <node concept="3clFb_" id="inTShiWUFS" role="jymVt">
+                    <property role="TrG5h" value="renderText" />
+                    <node concept="3Tm1VV" id="inTShiWUFT" role="1B3o_S" />
+                    <node concept="3uibUv" id="inTShiWUFV" role="3clF45">
+                      <ref role="3uigEE" to="cj4x:~TextBuilder" resolve="TextBuilder" />
+                    </node>
+                    <node concept="3clFbS" id="inTShiWUFX" role="3clF47">
+                      <node concept="3clFbF" id="inTShiWYWZ" role="3cqZAp">
+                        <node concept="2ShNRf" id="inTShiWYWX" role="3clFbG">
+                          <node concept="1pGfFk" id="inTShiX9lD" role="2ShVmc">
+                            <property role="373rjd" value="true" />
+                            <ref role="37wK5l" to="hhnx:~TextBuilderImpl.&lt;init&gt;(java.lang.String)" resolve="TextBuilderImpl" />
+                            <node concept="Xl_RD" id="inTShiXaSi" role="37wK5m">
+                              <property role="Xl_RC" value="]" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="2AHcQZ" id="inTShiWUFY" role="2AJF6D">
+                      <ref role="2AI5Lk" to="wyt6:~Override" />
+                    </node>
+                  </node>
                 </node>
               </node>
             </node>
@@ -1998,6 +2047,29 @@
                           <property role="3clFbU" value="true" />
                         </node>
                       </node>
+                    </node>
+                  </node>
+                  <node concept="3clFb_" id="inTShiXcMw" role="jymVt">
+                    <property role="TrG5h" value="renderText" />
+                    <node concept="3Tm1VV" id="inTShiXcMx" role="1B3o_S" />
+                    <node concept="3uibUv" id="inTShiXcMy" role="3clF45">
+                      <ref role="3uigEE" to="cj4x:~TextBuilder" resolve="TextBuilder" />
+                    </node>
+                    <node concept="3clFbS" id="inTShiXcMz" role="3clF47">
+                      <node concept="3clFbF" id="inTShiXcM$" role="3cqZAp">
+                        <node concept="2ShNRf" id="inTShiXcM_" role="3clFbG">
+                          <node concept="1pGfFk" id="inTShiXcMA" role="2ShVmc">
+                            <property role="373rjd" value="true" />
+                            <ref role="37wK5l" to="hhnx:~TextBuilderImpl.&lt;init&gt;(java.lang.String)" resolve="TextBuilderImpl" />
+                            <node concept="Xl_RD" id="inTShiXcMB" role="37wK5m">
+                              <property role="Xl_RC" value="[" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="2AHcQZ" id="inTShiXcMC" role="2AJF6D">
+                      <ref role="2AI5Lk" to="wyt6:~Override" />
                     </node>
                   </node>
                 </node>
@@ -3346,6 +3418,183 @@
                       <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
                     </node>
                   </node>
+                  <node concept="2tJIrI" id="inTShiXraq" role="jymVt" />
+                  <node concept="3clFb_" id="7d0q5VH9zS5" role="jymVt">
+                    <property role="1EzhhJ" value="false" />
+                    <property role="TrG5h" value="renderText" />
+                    <property role="DiZV1" value="false" />
+                    <property role="od$2w" value="false" />
+                    <node concept="3Tm1VV" id="7d0q5VH9zS6" role="1B3o_S" />
+                    <node concept="3uibUv" id="7d0q5VH9zS7" role="3clF45">
+                      <ref role="3uigEE" to="cj4x:~TextBuilder" resolve="TextBuilder" />
+                    </node>
+                    <node concept="3clFbS" id="7d0q5VH9zS8" role="3clF47">
+                      <node concept="3cpWs8" id="10diQy0mxks" role="3cqZAp">
+                        <node concept="3cpWsn" id="10diQy0mxkr" role="3cpWs9">
+                          <property role="TrG5h" value="settings" />
+                          <node concept="3uibUv" id="10diQy0mxkt" role="1tU5fm">
+                            <ref role="3uigEE" to="exr9:~EditorSettings" resolve="EditorSettings" />
+                          </node>
+                          <node concept="2YIFZM" id="10diQy0mxY7" role="33vP2m">
+                            <ref role="1Pybhc" to="exr9:~EditorSettings" resolve="EditorSettings" />
+                            <ref role="37wK5l" to="exr9:~EditorSettings.getInstance()" resolve="getInstance" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3cpWs8" id="10diQy0mHsb" role="3cqZAp">
+                        <node concept="3cpWsn" id="10diQy0mHsc" role="3cpWs9">
+                          <property role="TrG5h" value="editorComponentSettings" />
+                          <node concept="3uibUv" id="10diQy0mGZP" role="1tU5fm">
+                            <ref role="3uigEE" to="cj4x:~EditorComponentSettings" resolve="EditorComponentSettings" />
+                          </node>
+                          <node concept="2OqwBi" id="10diQy0mHsd" role="33vP2m">
+                            <node concept="1rXfSq" id="10diQy0mHse" role="2Oq$k0">
+                              <ref role="37wK5l" to="g51k:~EditorCell_Basic.getEditorComponent()" resolve="getEditorComponent" />
+                            </node>
+                            <node concept="liA8E" id="10diQy0mHsf" role="2OqNvi">
+                              <ref role="37wK5l" to="cj4x:~EditorComponent.getEditorComponentSettings()" resolve="getEditorComponentSettings" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3cpWs8" id="10diQy0mRiS" role="3cqZAp">
+                        <node concept="3cpWsn" id="10diQy0mRiT" role="3cpWs9">
+                          <property role="TrG5h" value="fontMetrics" />
+                          <node concept="3uibUv" id="10diQy0mQT_" role="1tU5fm">
+                            <ref role="3uigEE" to="f4zo:~EditorFontMetrics" resolve="EditorFontMetrics" />
+                          </node>
+                          <node concept="2OqwBi" id="10diQy0mRiU" role="33vP2m">
+                            <node concept="37vLTw" id="10diQy0mRiV" role="2Oq$k0">
+                              <ref role="3cqZAo" node="10diQy0mHsc" resolve="editorComponentSettings" />
+                            </node>
+                            <node concept="liA8E" id="10diQy0mRiW" role="2OqNvi">
+                              <ref role="37wK5l" to="f4zo:~EditorFontMetricsProvider.getFontMetrics(java.lang.String,int,int)" resolve="getFontMetrics" />
+                              <node concept="2OqwBi" id="10diQy0mRiX" role="37wK5m">
+                                <node concept="37vLTw" id="10diQy0mRiY" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="10diQy0mxkr" resolve="settings" />
+                                </node>
+                                <node concept="liA8E" id="10diQy0mRiZ" role="2OqNvi">
+                                  <ref role="37wK5l" to="exr9:~EditorSettings.getFontFamily()" resolve="getFontFamily" />
+                                </node>
+                              </node>
+                              <node concept="10M0yZ" id="10diQy0mRj0" role="37wK5m">
+                                <ref role="3cqZAo" to="z60i:~Font.PLAIN" resolve="PLAIN" />
+                                <ref role="1PxDUh" to="z60i:~Font" resolve="Font" />
+                              </node>
+                              <node concept="2OqwBi" id="10diQy0mRj1" role="37wK5m">
+                                <node concept="37vLTw" id="10diQy0mRj2" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="10diQy0mHsc" resolve="editorComponentSettings" />
+                                </node>
+                                <node concept="liA8E" id="10diQy0mRj3" role="2OqNvi">
+                                  <ref role="37wK5l" to="cj4x:~EditorComponentSettings.getFontSize()" resolve="getFontSize" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3cpWs8" id="10diQy0lnXf" role="3cqZAp">
+                        <node concept="3cpWsn" id="10diQy0lnXg" role="3cpWs9">
+                          <property role="TrG5h" value="heightOfOneDash" />
+                          <node concept="10Oyi0" id="10diQy0lnXh" role="1tU5fm" />
+                          <node concept="2OqwBi" id="10diQy0mUcq" role="33vP2m">
+                            <node concept="37vLTw" id="10diQy0mT_B" role="2Oq$k0">
+                              <ref role="3cqZAo" node="10diQy0mRiT" resolve="fontMetrics" />
+                            </node>
+                            <node concept="liA8E" id="10diQy0mUXf" role="2OqNvi">
+                              <ref role="37wK5l" to="f4zo:~EditorFontMetrics.getHeight()" resolve="getHeight" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbH" id="10diQy0mtgp" role="3cqZAp" />
+                      <node concept="3cpWs8" id="10diQy0luMT" role="3cqZAp">
+                        <node concept="3cpWsn" id="10diQy0luMU" role="3cpWs9">
+                          <property role="TrG5h" value="builder" />
+                          <node concept="3uibUv" id="10diQy0luMV" role="1tU5fm">
+                            <ref role="3uigEE" to="cj4x:~TextBuilder" resolve="TextBuilder" />
+                          </node>
+                          <node concept="2ShNRf" id="10diQy0lw_b" role="33vP2m">
+                            <node concept="1pGfFk" id="10diQy0lx$d" role="2ShVmc">
+                              <property role="373rjd" value="true" />
+                              <ref role="37wK5l" to="hhnx:~TextBuilderImpl.&lt;init&gt;()" resolve="TextBuilderImpl" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3cpWs8" id="10diQy0lnXp" role="3cqZAp">
+                        <node concept="3cpWsn" id="10diQy0lnXq" role="3cpWs9">
+                          <property role="TrG5h" value="numberOfDashes" />
+                          <node concept="10Oyi0" id="10diQy0lnXr" role="1tU5fm" />
+                          <node concept="FJ1c_" id="10diQy0lnXs" role="33vP2m">
+                            <node concept="37vLTw" id="10diQy0lnXt" role="3uHU7w">
+                              <ref role="3cqZAo" node="10diQy0lnXg" resolve="heightOfOneDash" />
+                            </node>
+                            <node concept="2OqwBi" id="10diQy0miNB" role="3uHU7B">
+                              <node concept="1rXfSq" id="10diQy0lnXu" role="2Oq$k0">
+                                <ref role="37wK5l" to="g51k:~EditorCell_Basic.getParent()" resolve="getParent" />
+                              </node>
+                              <node concept="liA8E" id="10diQy0mkDD" role="2OqNvi">
+                                <ref role="37wK5l" to="g51k:~EditorCell_Basic.getHeight()" resolve="getHeight" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="1Dw8fO" id="10diQy0lz3I" role="3cqZAp">
+                        <node concept="3clFbS" id="10diQy0lz3K" role="2LFqv$">
+                          <node concept="3clFbF" id="10diQy0lJHX" role="3cqZAp">
+                            <node concept="2OqwBi" id="10diQy0lKka" role="3clFbG">
+                              <node concept="37vLTw" id="10diQy0lJHV" role="2Oq$k0">
+                                <ref role="3cqZAo" node="10diQy0luMU" resolve="builder" />
+                              </node>
+                              <node concept="liA8E" id="10diQy0lKZ9" role="2OqNvi">
+                                <ref role="37wK5l" to="cj4x:~TextBuilder.appendToTheBottom(jetbrains.mps.openapi.editor.TextBuilder)" resolve="appendToTheBottom" />
+                                <node concept="2ShNRf" id="10diQy0lLKP" role="37wK5m">
+                                  <node concept="1pGfFk" id="10diQy0lMBr" role="2ShVmc">
+                                    <property role="373rjd" value="true" />
+                                    <ref role="37wK5l" to="hhnx:~TextBuilderImpl.&lt;init&gt;(java.lang.String)" resolve="TextBuilderImpl" />
+                                    <node concept="Xl_RD" id="10diQy0lNgy" role="37wK5m">
+                                      <property role="Xl_RC" value="|" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3cpWsn" id="10diQy0lz3L" role="1Duv9x">
+                          <property role="TrG5h" value="i" />
+                          <node concept="10Oyi0" id="10diQy0lzA3" role="1tU5fm" />
+                          <node concept="3cmrfG" id="10diQy0l_q4" role="33vP2m">
+                            <property role="3cmrfH" value="0" />
+                          </node>
+                        </node>
+                        <node concept="3eOVzh" id="10diQy0lGqq" role="1Dwp0S">
+                          <node concept="37vLTw" id="10diQy0lIaP" role="3uHU7w">
+                            <ref role="3cqZAo" node="10diQy0lnXq" resolve="numberOfDashes" />
+                          </node>
+                          <node concept="37vLTw" id="10diQy0lDd5" role="3uHU7B">
+                            <ref role="3cqZAo" node="10diQy0lz3L" resolve="i" />
+                          </node>
+                        </node>
+                        <node concept="3uNrnE" id="10diQy0lJ5Q" role="1Dwrff">
+                          <node concept="37vLTw" id="10diQy0lJ5S" role="2$L3a6">
+                            <ref role="3cqZAo" node="10diQy0lz3L" resolve="i" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbF" id="10diQy0lOt1" role="3cqZAp">
+                        <node concept="37vLTw" id="10diQy0lOsZ" role="3clFbG">
+                          <ref role="3cqZAo" node="10diQy0luMU" resolve="builder" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="2AHcQZ" id="7d0q5VH9zSd" role="2AJF6D">
+                      <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                    </node>
+                  </node>
+                  <node concept="2tJIrI" id="inTShiXrar" role="jymVt" />
                 </node>
               </node>
             </node>
@@ -3595,39 +3844,53 @@
         </node>
       </node>
       <node concept="3EZMnI" id="3greo4ND__5" role="3EZMnx">
-        <node concept="3gTLQM" id="3greo4NDQG6" role="3EZMnx">
-          <node concept="3Fmcul" id="3greo4NDQG7" role="3FoqZy">
-            <node concept="3clFbS" id="3greo4NDQG8" role="2VODD2">
-              <node concept="3clFbF" id="3greo4NDQG9" role="3cqZAp">
-                <node concept="2OqwBi" id="3greo4NDQIq" role="3clFbG">
-                  <node concept="2ShNRf" id="3greo4NDQGa" role="2Oq$k0">
-                    <node concept="YeOm9" id="3greo4NDQGc" role="2ShVmc">
-                      <node concept="1Y3b0j" id="3greo4NDQGd" role="YeSDq">
+        <node concept="VPM3Z" id="3greo4ND__6" role="3F10Kt">
+          <property role="VOm3f" value="false" />
+        </node>
+        <node concept="l2Vlx" id="3greo4ND__8" role="2iSdaV" />
+        <node concept="pkWqt" id="3greo4ND__9" role="pqm2j">
+          <node concept="3clFbS" id="3greo4ND__a" role="2VODD2">
+            <node concept="3clFbF" id="3greo4ND__b" role="3cqZAp">
+              <node concept="2YIFZM" id="3greo4ND__e" role="3clFbG">
+                <ref role="37wK5l" to="hwgx:3slbD0C6STN" resolve="showButtons" />
+                <ref role="1Pybhc" to="hwgx:3slbD0C6STH" resolve="EditorButtonHelper" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="fWXJ_" id="5vhcTL2G5lY" role="3EZMnx">
+          <node concept="3Fmcul" id="5vhcTL2G5m0" role="3FoqZy">
+            <node concept="3clFbS" id="5vhcTL2G5m2" role="2VODD2">
+              <node concept="3clFbF" id="5vhcTL2G81L" role="3cqZAp">
+                <node concept="2OqwBi" id="5vhcTL2G81M" role="3clFbG">
+                  <node concept="2ShNRf" id="5vhcTL2G81N" role="2Oq$k0">
+                    <node concept="YeOm9" id="5vhcTL2G81O" role="2ShVmc">
+                      <node concept="1Y3b0j" id="5vhcTL2G81P" role="YeSDq">
                         <property role="2bfB8j" value="true" />
                         <ref role="1Y3XeK" node="3slbD0C7Kn7" resolve="CommandButton" />
                         <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
-                        <node concept="3Tm1VV" id="3greo4NDQGe" role="1B3o_S" />
-                        <node concept="3clFb_" id="3greo4NDQGf" role="jymVt">
+                        <node concept="3Tm1VV" id="5vhcTL2G81Q" role="1B3o_S" />
+                        <node concept="3clFb_" id="5vhcTL2G81R" role="jymVt">
                           <property role="TrG5h" value="perform" />
                           <property role="1EzhhJ" value="false" />
-                          <node concept="3cqZAl" id="3greo4NDQGg" role="3clF45" />
-                          <node concept="3Tm1VV" id="3greo4NDQGh" role="1B3o_S" />
-                          <node concept="37vLTG" id="3greo4NDQGi" role="3clF46">
+                          <node concept="3cqZAl" id="5vhcTL2G81S" role="3clF45" />
+                          <node concept="3Tm1VV" id="5vhcTL2G81T" role="1B3o_S" />
+                          <node concept="37vLTG" id="5vhcTL2G81U" role="3clF46">
                             <property role="TrG5h" value="n" />
-                            <node concept="3Tqbb2" id="3greo4NDQGj" role="1tU5fm" />
+                            <node concept="3Tqbb2" id="5vhcTL2G81V" role="1tU5fm" />
                           </node>
-                          <node concept="3clFbS" id="3greo4NDQGk" role="3clF47">
-                            <node concept="3clFbF" id="3greo4NDQGl" role="3cqZAp">
-                              <node concept="2OqwBi" id="3greo4NDQHr" role="3clFbG">
-                                <node concept="1PxgMI" id="3greo4NDQH5" role="2Oq$k0">
-                                  <node concept="37vLTw" id="3greo4NDQGm" role="1m5AlR">
-                                    <ref role="3cqZAo" node="3greo4NDQGi" resolve="n" />
+                          <node concept="3clFbS" id="5vhcTL2G81W" role="3clF47">
+                            <node concept="3clFbF" id="5vhcTL2G81X" role="3cqZAp">
+                              <node concept="2OqwBi" id="5vhcTL2G81Y" role="3clFbG">
+                                <node concept="1PxgMI" id="5vhcTL2G81Z" role="2Oq$k0">
+                                  <node concept="37vLTw" id="5vhcTL2G820" role="1m5AlR">
+                                    <ref role="3cqZAo" node="5vhcTL2G81U" resolve="n" />
                                   </node>
-                                  <node concept="chp4Y" id="79i$vAY5P5K" role="3oSUPX">
+                                  <node concept="chp4Y" id="5vhcTL2G821" role="3oSUPX">
                                     <ref role="cht4Q" to="vs0r:K292flwCEW" resolve="Assessment" />
                                   </node>
                                 </node>
-                                <node concept="2qgKlT" id="3greo4NDQI4" role="2OqNvi">
+                                <node concept="2qgKlT" id="5vhcTL2G822" role="2OqNvi">
                                   <ref role="37wK5l" to="hwgx:3jNX2XuLy_p" resolve="update" />
                                 </node>
                               </node>
@@ -3637,10 +3900,10 @@
                       </node>
                     </node>
                   </node>
-                  <node concept="liA8E" id="3greo4NDQIw" role="2OqNvi">
+                  <node concept="liA8E" id="5vhcTL2G823" role="2OqNvi">
                     <ref role="37wK5l" node="3slbD0C7Kn8" resolve="create" />
-                    <node concept="pncrf" id="3greo4NDQIx" role="37wK5m" />
-                    <node concept="Xl_RD" id="3greo4NDQIH" role="37wK5m">
+                    <node concept="pncrf" id="5vhcTL2G824" role="37wK5m" />
+                    <node concept="Xl_RD" id="5vhcTL2G825" role="37wK5m">
                       <property role="Xl_RC" value="Update" />
                     </node>
                   </node>
@@ -3648,10 +3911,20 @@
               </node>
             </node>
           </node>
+          <node concept="00ECH" id="5vhcTL2GS4w" role="00CkC">
+            <node concept="3clFbS" id="5vhcTL2GS4x" role="2VODD2">
+              <node concept="3clFbF" id="1UWjN7wdtSN" role="3cqZAp">
+                <node concept="2YIFZM" id="1UWjN7wdtZQ" role="3clFbG">
+                  <ref role="37wK5l" to="clc5:2j3rMbEPupR" resolve="verySmall" />
+                  <ref role="1Pybhc" to="clc5:5YyBAPlVDQl" resolve="FontHelper" />
+                </node>
+              </node>
+            </node>
+          </node>
         </node>
-        <node concept="3gTLQM" id="3greo4NDQIW" role="3EZMnx">
-          <node concept="3Fmcul" id="3greo4NDQIX" role="3FoqZy">
-            <node concept="3clFbS" id="3greo4NDQIY" role="2VODD2">
+        <node concept="fWXJ_" id="5vhcTL2JNdU" role="3EZMnx">
+          <node concept="3Fmcul" id="5vhcTL2JNdW" role="3FoqZy">
+            <node concept="3clFbS" id="5vhcTL2JNdY" role="2VODD2">
               <node concept="3clFbF" id="3greo4NDQIZ" role="3cqZAp">
                 <node concept="2OqwBi" id="3greo4NDQJ0" role="3clFbG">
                   <node concept="2ShNRf" id="3greo4NDQJ1" role="2Oq$k0">
@@ -3702,17 +3975,13 @@
               </node>
             </node>
           </node>
-        </node>
-        <node concept="VPM3Z" id="3greo4ND__6" role="3F10Kt">
-          <property role="VOm3f" value="false" />
-        </node>
-        <node concept="l2Vlx" id="3greo4ND__8" role="2iSdaV" />
-        <node concept="pkWqt" id="3greo4ND__9" role="pqm2j">
-          <node concept="3clFbS" id="3greo4ND__a" role="2VODD2">
-            <node concept="3clFbF" id="3greo4ND__b" role="3cqZAp">
-              <node concept="2YIFZM" id="3greo4ND__e" role="3clFbG">
-                <ref role="37wK5l" to="hwgx:3slbD0C6STN" resolve="showButtons" />
-                <ref role="1Pybhc" to="hwgx:3slbD0C6STH" resolve="EditorButtonHelper" />
+          <node concept="00ECH" id="1UWjN7wdwcf" role="00CkC">
+            <node concept="3clFbS" id="1UWjN7wdwcg" role="2VODD2">
+              <node concept="3clFbF" id="1UWjN7wdx0p" role="3cqZAp">
+                <node concept="2YIFZM" id="1UWjN7wdx4C" role="3clFbG">
+                  <ref role="37wK5l" to="clc5:2j3rMbEPupR" resolve="verySmall" />
+                  <ref role="1Pybhc" to="clc5:5YyBAPlVDQl" resolve="FontHelper" />
+                </node>
               </node>
             </node>
           </node>
@@ -4860,18 +5129,6 @@
         </node>
       </node>
     </node>
-    <node concept="Wx3nA" id="CPtprWM32t" role="jymVt">
-      <property role="TrG5h" value="font" />
-      <node concept="3Tm6S6" id="CPtprWM32u" role="1B3o_S" />
-      <node concept="3uibUv" id="CPtprWM32C" role="1tU5fm">
-        <ref role="3uigEE" to="z60i:~Font" resolve="Font" />
-      </node>
-    </node>
-    <node concept="Wx3nA" id="CPtprWM33$" role="jymVt">
-      <property role="TrG5h" value="fontSize" />
-      <node concept="3Tm6S6" id="CPtprWM33_" role="1B3o_S" />
-      <node concept="10Oyi0" id="CPtprWM33B" role="1tU5fm" />
-    </node>
     <node concept="312cEg" id="7v73aKirf4p" role="jymVt">
       <property role="TrG5h" value="buttonHeight" />
       <node concept="3Tm6S6" id="7v73aKirf4q" role="1B3o_S" />
@@ -4908,25 +5165,7 @@
               <node concept="37vLTw" id="CPtprWMDBY" role="37wK5m">
                 <ref role="3cqZAo" node="3slbD0C7Kn9" resolve="n" />
               </node>
-              <node concept="2OqwBi" id="CPtprWMDBP" role="37wK5m">
-                <node concept="37vLTw" id="CPtprWMDBw" role="2Oq$k0">
-                  <ref role="3cqZAo" node="3slbD0C7Knb" resolve="label" />
-                </node>
-                <node concept="liA8E" id="CPtprWMDBV" role="2OqNvi">
-                  <ref role="37wK5l" to="wyt6:~String.length()" resolve="length" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="CPtprWMC3m" role="3cqZAp">
-          <node concept="2OqwBi" id="CPtprWMC3G" role="3clFbG">
-            <node concept="37vLTw" id="5HxjapwgHoe" role="2Oq$k0">
-              <ref role="3cqZAo" node="CPtprWMC3f" resolve="l" />
-            </node>
-            <node concept="liA8E" id="CPtprWMC3M" role="2OqNvi">
-              <ref role="37wK5l" to="dxuu:~JLabel.setText(java.lang.String)" resolve="setText" />
-              <node concept="37vLTw" id="CPtprWMC3N" role="37wK5m">
+              <node concept="37vLTw" id="CPtprWMDBw" role="37wK5m">
                 <ref role="3cqZAo" node="3slbD0C7Knb" resolve="label" />
               </node>
             </node>
@@ -4984,25 +5223,7 @@
               <node concept="37vLTw" id="7v73aKiqUWp" role="37wK5m">
                 <ref role="3cqZAo" node="7v73aKiqUWe" resolve="n" />
               </node>
-              <node concept="2OqwBi" id="7v73aKiqUWq" role="37wK5m">
-                <node concept="37vLTw" id="7v73aKiqUWr" role="2Oq$k0">
-                  <ref role="3cqZAo" node="7v73aKiqUWg" resolve="label" />
-                </node>
-                <node concept="liA8E" id="7v73aKiqUWs" role="2OqNvi">
-                  <ref role="37wK5l" to="wyt6:~String.length()" resolve="length" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="7v73aKiqUWt" role="3cqZAp">
-          <node concept="2OqwBi" id="7v73aKiqUWu" role="3clFbG">
-            <node concept="37vLTw" id="7v73aKiqUWv" role="2Oq$k0">
-              <ref role="3cqZAo" node="7v73aKiqUWm" resolve="l" />
-            </node>
-            <node concept="liA8E" id="7v73aKiqUWw" role="2OqNvi">
-              <ref role="37wK5l" to="dxuu:~JLabel.setText(java.lang.String)" resolve="setText" />
-              <node concept="37vLTw" id="7v73aKiqUWx" role="37wK5m">
+              <node concept="37vLTw" id="7v73aKiqUWr" role="37wK5m">
                 <ref role="3cqZAo" node="7v73aKiqUWg" resolve="label" />
               </node>
             </node>
@@ -5045,9 +5266,7 @@
               <node concept="37vLTw" id="CPtprWMDBZ" role="37wK5m">
                 <ref role="3cqZAo" node="CPtprWMDAO" resolve="n" />
               </node>
-              <node concept="3cmrfG" id="CPtprWMDC0" role="37wK5m">
-                <property role="3cmrfH" value="1" />
-              </node>
+              <node concept="10Nm6u" id="inTShj2Wac" role="37wK5m" />
             </node>
           </node>
         </node>
@@ -5083,11 +5302,52 @@
         <property role="3TUv4t" value="true" />
         <node concept="3Tqbb2" id="CPtprWMC0R" role="1tU5fm" />
       </node>
-      <node concept="37vLTG" id="CPtprWMDBr" role="3clF46">
-        <property role="TrG5h" value="lengthInLetters" />
-        <node concept="10Oyi0" id="CPtprWMDBt" role="1tU5fm" />
-      </node>
       <node concept="3clFbS" id="CPtprWMC0S" role="3clF47">
+        <node concept="3cpWs8" id="inTShj2gJ5" role="3cqZAp">
+          <node concept="3cpWsn" id="inTShj2gJ8" role="3cpWs9">
+            <property role="TrG5h" value="lengthInLetters" />
+            <node concept="10Oyi0" id="CPtprWMDBt" role="1tU5fm" />
+            <node concept="3K4zz7" id="inTShj2$do" role="33vP2m">
+              <node concept="3cmrfG" id="inTShj2_N$" role="3K4GZi">
+                <property role="3cmrfH" value="1" />
+              </node>
+              <node concept="3y3z36" id="inTShj2wTy" role="3K4Cdx">
+                <node concept="10Nm6u" id="inTShj2ySe" role="3uHU7w" />
+                <node concept="37vLTw" id="inTShj2ulj" role="3uHU7B">
+                  <ref role="3cqZAo" node="inTShj2bWq" resolve="text" />
+                </node>
+              </node>
+              <node concept="2OqwBi" id="inTShj2kF6" role="3K4E3e">
+                <node concept="37vLTw" id="inTShj2iut" role="2Oq$k0">
+                  <ref role="3cqZAo" node="inTShj2bWq" resolve="text" />
+                </node>
+                <node concept="liA8E" id="inTShj2mLo" role="2OqNvi">
+                  <ref role="37wK5l" to="wyt6:~String.length()" resolve="length" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="5vhcTL2IAGT" role="3cqZAp">
+          <node concept="3cpWsn" id="5vhcTL2IAGW" role="3cpWs9">
+            <property role="TrG5h" value="fontSize" />
+            <node concept="10Oyi0" id="5vhcTL2IAGR" role="1tU5fm" />
+            <node concept="2OqwBi" id="1UWjN7wek8p" role="33vP2m">
+              <node concept="2OqwBi" id="1UWjN7wehBi" role="2Oq$k0">
+                <node concept="2YIFZM" id="1UWjN7wegrD" role="2Oq$k0">
+                  <ref role="37wK5l" to="clc5:2j3rMbEPupR" resolve="verySmall" />
+                  <ref role="1Pybhc" to="clc5:5YyBAPlVDQl" resolve="FontHelper" />
+                </node>
+                <node concept="liA8E" id="1UWjN7weiUe" role="2OqNvi">
+                  <ref role="37wK5l" to="g1qu:~JBFont.asBold()" resolve="asBold" />
+                </node>
+              </node>
+              <node concept="liA8E" id="1UWjN7welcS" role="2OqNvi">
+                <ref role="37wK5l" to="g1qu:~JBFont.getSize()" resolve="getSize" />
+              </node>
+            </node>
+          </node>
+        </node>
         <node concept="3cpWs8" id="CPtprWMC0T" role="3cqZAp">
           <node concept="3cpWsn" id="CPtprWMC0J" role="3cpWs9">
             <property role="TrG5h" value="height" />
@@ -5100,7 +5360,7 @@
                 </node>
               </node>
               <node concept="37vLTw" id="CPtprWMC0X" role="3uHU7B">
-                <ref role="3cqZAo" node="CPtprWM33$" resolve="fontSize" />
+                <ref role="3cqZAo" node="5vhcTL2IAGW" resolve="fontSize" />
               </node>
             </node>
           </node>
@@ -5113,8 +5373,42 @@
               <ref role="3uigEE" to="dxuu:~JLabel" resolve="JLabel" />
             </node>
             <node concept="2ShNRf" id="CPtprWMC10" role="33vP2m">
-              <node concept="1pGfFk" id="CPtprWMC11" role="2ShVmc">
-                <ref role="37wK5l" to="dxuu:~JLabel.&lt;init&gt;()" resolve="JLabel" />
+              <node concept="YeOm9" id="inTShj2XZg" role="2ShVmc">
+                <node concept="1Y3b0j" id="inTShj2XZj" role="YeSDq">
+                  <property role="2bfB8j" value="true" />
+                  <property role="373rjd" value="true" />
+                  <ref role="37wK5l" to="dxuu:~JLabel.&lt;init&gt;()" resolve="JLabel" />
+                  <ref role="1Y3XeK" to="dxuu:~JLabel" resolve="JLabel" />
+                  <node concept="3Tm1VV" id="inTShj2XZk" role="1B3o_S" />
+                  <node concept="3clFb_" id="inTShj3jZO" role="jymVt">
+                    <property role="TrG5h" value="toString" />
+                    <node concept="3Tm1VV" id="inTShj3jZP" role="1B3o_S" />
+                    <node concept="3uibUv" id="inTShj3jZR" role="3clF45">
+                      <ref role="3uigEE" to="wyt6:~String" resolve="String" />
+                    </node>
+                    <node concept="3clFbS" id="inTShj3k00" role="3clF47">
+                      <node concept="3clFbF" id="inTShj33ui" role="3cqZAp">
+                        <node concept="3K4zz7" id="inTShj3bTG" role="3clFbG">
+                          <node concept="37vLTw" id="inTShj3doo" role="3K4E3e">
+                            <ref role="3cqZAo" node="inTShj2bWq" resolve="text" />
+                          </node>
+                          <node concept="Xl_RD" id="inTShj3fN5" role="3K4GZi">
+                            <property role="Xl_RC" value="" />
+                          </node>
+                          <node concept="2OqwBi" id="inTShj37tv" role="3K4Cdx">
+                            <node concept="37vLTw" id="inTShj33uh" role="2Oq$k0">
+                              <ref role="3cqZAo" node="inTShj2bWq" resolve="text" />
+                            </node>
+                            <node concept="17RvpY" id="inTShj398L" role="2OqNvi" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="2AHcQZ" id="inTShj3k01" role="2AJF6D">
+                      <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                    </node>
+                  </node>
+                </node>
               </node>
             </node>
           </node>
@@ -5150,7 +5444,7 @@
                 <property role="3cmrfH" value="5" />
               </node>
               <node concept="37vLTw" id="CPtprWMC1g" role="3uHU7B">
-                <ref role="3cqZAo" node="CPtprWM33$" resolve="fontSize" />
+                <ref role="3cqZAo" node="5vhcTL2IAGW" resolve="fontSize" />
               </node>
             </node>
           </node>
@@ -5171,7 +5465,7 @@
                     </node>
                     <node concept="17qRlL" id="CPtprWMC1p" role="3uHU7w">
                       <node concept="37vLTw" id="CPtprWMDBu" role="3uHU7w">
-                        <ref role="3cqZAo" node="CPtprWMDBr" resolve="lengthInLetters" />
+                        <ref role="3cqZAo" node="inTShj2gJ8" resolve="lengthInLetters" />
                       </node>
                       <node concept="37vLTw" id="CPtprWMC1t" role="3uHU7B">
                         <ref role="3cqZAo" node="CPtprWMC0K" resolve="factor" />
@@ -5258,19 +5552,6 @@
               <ref role="37wK5l" to="dxuu:~JComponent.setOpaque(boolean)" resolve="setOpaque" />
               <node concept="3clFbT" id="CPtprWMC1U" role="37wK5m">
                 <property role="3clFbU" value="true" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="CPtprWMC1V" role="3cqZAp">
-          <node concept="2OqwBi" id="CPtprWMC1W" role="3clFbG">
-            <node concept="37vLTw" id="5HxjapweqAz" role="2Oq$k0">
-              <ref role="3cqZAo" node="CPtprWMC0I" resolve="l" />
-            </node>
-            <node concept="liA8E" id="CPtprWMC1Y" role="2OqNvi">
-              <ref role="37wK5l" to="dxuu:~JComponent.setFont(java.awt.Font)" resolve="setFont" />
-              <node concept="37vLTw" id="CPtprWMC1Z" role="37wK5m">
-                <ref role="3cqZAo" node="CPtprWM32t" resolve="font" />
               </node>
             </node>
           </node>
@@ -5528,10 +5809,42 @@
           </node>
         </node>
         <node concept="3clFbH" id="7F1rX5GHYpk" role="3cqZAp" />
+        <node concept="3clFbJ" id="inTShj2C$w" role="3cqZAp">
+          <node concept="3clFbS" id="inTShj2C$y" role="3clFbx">
+            <node concept="3clFbF" id="inTShj2J3s" role="3cqZAp">
+              <node concept="2OqwBi" id="inTShj2Ljd" role="3clFbG">
+                <node concept="37vLTw" id="inTShj2J3q" role="2Oq$k0">
+                  <ref role="3cqZAo" node="CPtprWMC0I" resolve="l" />
+                </node>
+                <node concept="liA8E" id="inTShj2Onu" role="2OqNvi">
+                  <ref role="37wK5l" to="dxuu:~JLabel.setText(java.lang.String)" resolve="setText" />
+                  <node concept="37vLTw" id="inTShj2PCU" role="37wK5m">
+                    <ref role="3cqZAo" node="inTShj2bWq" resolve="text" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="inTShj2FSj" role="3clFbw">
+            <node concept="37vLTw" id="inTShj2DER" role="2Oq$k0">
+              <ref role="3cqZAo" node="inTShj2bWq" resolve="text" />
+            </node>
+            <node concept="17RvpY" id="inTShj2HR6" role="2OqNvi" />
+          </node>
+        </node>
+        <node concept="3clFbH" id="inTShj2Axs" role="3cqZAp" />
         <node concept="3cpWs6" id="CPtprWMC37" role="3cqZAp">
           <node concept="37vLTw" id="5HxjapwgGV8" role="3cqZAk">
             <ref role="3cqZAo" node="CPtprWMC0I" resolve="l" />
           </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="inTShj2bWq" role="3clF46">
+        <property role="TrG5h" value="text" />
+        <property role="3TUv4t" value="true" />
+        <node concept="17QB3L" id="inTShj2dqK" role="1tU5fm" />
+        <node concept="2AHcQZ" id="inTShj2qUi" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
         </node>
       </node>
     </node>
@@ -5545,70 +5858,6 @@
       <node concept="37vLTG" id="3slbD0C7KnK" role="3clF46">
         <property role="TrG5h" value="n" />
         <node concept="3Tqbb2" id="3slbD0C7KnL" role="1tU5fm" />
-      </node>
-    </node>
-    <node concept="2tJIrI" id="7F1rX5GHHRJ" role="jymVt" />
-    <node concept="1Pe0a1" id="CPtprWM32M" role="jymVt">
-      <node concept="3clFbS" id="CPtprWM32N" role="1Pe0a2">
-        <node concept="3cpWs8" id="CPtprWM32O" role="3cqZAp">
-          <node concept="3cpWsn" id="CPtprWM32P" role="3cpWs9">
-            <property role="TrG5h" value="ei" />
-            <node concept="3uibUv" id="CPtprWM32Q" role="1tU5fm">
-              <ref role="3uigEE" to="exr9:~EditorSettings" resolve="EditorSettings" />
-            </node>
-            <node concept="2YIFZM" id="CPtprWM32R" role="33vP2m">
-              <ref role="1Pybhc" to="exr9:~EditorSettings" resolve="EditorSettings" />
-              <ref role="37wK5l" to="exr9:~EditorSettings.getInstance()" resolve="getInstance" />
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="CPtprWM33D" role="3cqZAp">
-          <node concept="37vLTI" id="CPtprWM33Z" role="3clFbG">
-            <node concept="37vLTw" id="CPtprWM33E" role="37vLTJ">
-              <ref role="3cqZAo" node="CPtprWM33$" resolve="fontSize" />
-            </node>
-            <node concept="3cpWsd" id="CPtprWM32V" role="37vLTx">
-              <node concept="3cmrfG" id="CPtprWM32W" role="3uHU7w">
-                <property role="3cmrfH" value="5" />
-              </node>
-              <node concept="2OqwBi" id="CPtprWM32X" role="3uHU7B">
-                <node concept="37vLTw" id="CPtprWM32Y" role="2Oq$k0">
-                  <ref role="3cqZAo" node="CPtprWM32P" resolve="ei" />
-                </node>
-                <node concept="liA8E" id="CPtprWM32Z" role="2OqNvi">
-                  <ref role="37wK5l" to="exr9:~EditorSettings.getFontSize()" resolve="getFontSize" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="CPtprWM33b" role="3cqZAp">
-          <node concept="37vLTI" id="CPtprWM33x" role="3clFbG">
-            <node concept="37vLTw" id="CPtprWM33c" role="37vLTJ">
-              <ref role="3cqZAo" node="CPtprWM32t" resolve="font" />
-            </node>
-            <node concept="2ShNRf" id="CPtprWM333" role="37vLTx">
-              <node concept="1pGfFk" id="CPtprWM334" role="2ShVmc">
-                <ref role="37wK5l" to="z60i:~Font.&lt;init&gt;(java.lang.String,int,int)" resolve="Font" />
-                <node concept="2OqwBi" id="CPtprWM335" role="37wK5m">
-                  <node concept="37vLTw" id="5HxjapwgHaJ" role="2Oq$k0">
-                    <ref role="3cqZAo" node="CPtprWM32P" resolve="ei" />
-                  </node>
-                  <node concept="liA8E" id="CPtprWM337" role="2OqNvi">
-                    <ref role="37wK5l" to="exr9:~EditorSettings.getFontFamily()" resolve="getFontFamily" />
-                  </node>
-                </node>
-                <node concept="10M0yZ" id="CPtprWM338" role="37wK5m">
-                  <ref role="3cqZAo" to="z60i:~Font.BOLD" resolve="BOLD" />
-                  <ref role="1PxDUh" to="z60i:~Font" resolve="Font" />
-                </node>
-                <node concept="37vLTw" id="CPtprWM342" role="37wK5m">
-                  <ref role="3cqZAo" node="CPtprWM33$" resolve="fontSize" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
       </node>
     </node>
   </node>
@@ -5757,9 +6006,7 @@
               <node concept="37vLTw" id="CPtprWNpey" role="37wK5m">
                 <ref role="3cqZAo" node="CPtprWNpe7" resolve="n" />
               </node>
-              <node concept="3cmrfG" id="CPtprWNpez" role="37wK5m">
-                <property role="3cmrfH" value="1" />
-              </node>
+              <node concept="10Nm6u" id="inTShj46Bl" role="37wK5m" />
             </node>
           </node>
         </node>
@@ -6353,6 +6600,38 @@
                       </node>
                     </node>
                     <node concept="2AHcQZ" id="2ka6MWOx8Lg" role="2AJF6D">
+                      <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                    </node>
+                  </node>
+                  <node concept="2tJIrI" id="inTShiY$RD" role="jymVt" />
+                  <node concept="3clFb_" id="inTShiY$cM" role="jymVt">
+                    <property role="1EzhhJ" value="false" />
+                    <property role="TrG5h" value="renderText" />
+                    <property role="DiZV1" value="false" />
+                    <property role="od$2w" value="false" />
+                    <node concept="3Tm1VV" id="inTShiY$cN" role="1B3o_S" />
+                    <node concept="3uibUv" id="inTShiY$cO" role="3clF45">
+                      <ref role="3uigEE" to="cj4x:~TextBuilder" resolve="TextBuilder" />
+                    </node>
+                    <node concept="3clFbS" id="inTShiY$cP" role="3clF47">
+                      <node concept="3clFbF" id="inTShiY$cQ" role="3cqZAp">
+                        <node concept="2ShNRf" id="inTShiY$cR" role="3clFbG">
+                          <node concept="1pGfFk" id="inTShiY$cS" role="2ShVmc">
+                            <property role="373rjd" value="true" />
+                            <ref role="37wK5l" to="hhnx:~TextBuilderImpl.&lt;init&gt;(java.lang.String)" resolve="TextBuilderImpl" />
+                            <node concept="3cpWs3" id="inTShiYFid" role="37wK5m">
+                              <node concept="Xl_RD" id="inTShiYHd2" role="3uHU7w">
+                                <property role="Xl_RC" value="%" />
+                              </node>
+                              <node concept="37vLTw" id="inTShiYAZY" role="3uHU7B">
+                                <ref role="3cqZAo" node="2ka6MWOx8ZT" resolve="percentage" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="2AHcQZ" id="inTShiY$cU" role="2AJF6D">
                       <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
                     </node>
                   </node>
@@ -9611,6 +9890,33 @@
                       </node>
                     </node>
                     <node concept="2AHcQZ" id="2iRSkE4DJ4y" role="2AJF6D">
+                      <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                    </node>
+                  </node>
+                  <node concept="2tJIrI" id="inTShiYub2" role="jymVt" />
+                  <node concept="3clFb_" id="inTShiYruE" role="jymVt">
+                    <property role="1EzhhJ" value="false" />
+                    <property role="TrG5h" value="renderText" />
+                    <property role="DiZV1" value="false" />
+                    <property role="od$2w" value="false" />
+                    <node concept="3Tm1VV" id="inTShiYruF" role="1B3o_S" />
+                    <node concept="3uibUv" id="inTShiYruG" role="3clF45">
+                      <ref role="3uigEE" to="cj4x:~TextBuilder" resolve="TextBuilder" />
+                    </node>
+                    <node concept="3clFbS" id="inTShiYruH" role="3clF47">
+                      <node concept="3clFbF" id="inTShiYvBf" role="3cqZAp">
+                        <node concept="2ShNRf" id="inTShiYrvf" role="3clFbG">
+                          <node concept="1pGfFk" id="inTShiYrvg" role="2ShVmc">
+                            <property role="373rjd" value="true" />
+                            <ref role="37wK5l" to="hhnx:~TextBuilderImpl.&lt;init&gt;(java.lang.String)" resolve="TextBuilderImpl" />
+                            <node concept="Xl_RD" id="inTShiYwwy" role="37wK5m">
+                              <property role="Xl_RC" value="+" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="2AHcQZ" id="inTShiYrvG" role="2AJF6D">
                       <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
                     </node>
                   </node>
@@ -13389,6 +13695,182 @@
                       <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
                     </node>
                   </node>
+                  <node concept="2tJIrI" id="inTShiYm6v" role="jymVt" />
+                  <node concept="3clFb_" id="inTShiYi_A" role="jymVt">
+                    <property role="1EzhhJ" value="false" />
+                    <property role="TrG5h" value="renderText" />
+                    <property role="DiZV1" value="false" />
+                    <property role="od$2w" value="false" />
+                    <node concept="3Tm1VV" id="inTShiYi_B" role="1B3o_S" />
+                    <node concept="3uibUv" id="inTShiYi_C" role="3clF45">
+                      <ref role="3uigEE" to="cj4x:~TextBuilder" resolve="TextBuilder" />
+                    </node>
+                    <node concept="3clFbS" id="inTShiYi_D" role="3clF47">
+                      <node concept="3cpWs8" id="inTShiYi_E" role="3cqZAp">
+                        <node concept="3cpWsn" id="inTShiYi_F" role="3cpWs9">
+                          <property role="TrG5h" value="settings" />
+                          <node concept="3uibUv" id="inTShiYi_G" role="1tU5fm">
+                            <ref role="3uigEE" to="exr9:~EditorSettings" resolve="EditorSettings" />
+                          </node>
+                          <node concept="2YIFZM" id="inTShiYi_H" role="33vP2m">
+                            <ref role="1Pybhc" to="exr9:~EditorSettings" resolve="EditorSettings" />
+                            <ref role="37wK5l" to="exr9:~EditorSettings.getInstance()" resolve="getInstance" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3cpWs8" id="inTShiYi_I" role="3cqZAp">
+                        <node concept="3cpWsn" id="inTShiYi_J" role="3cpWs9">
+                          <property role="TrG5h" value="editorComponentSettings" />
+                          <node concept="3uibUv" id="inTShiYi_K" role="1tU5fm">
+                            <ref role="3uigEE" to="cj4x:~EditorComponentSettings" resolve="EditorComponentSettings" />
+                          </node>
+                          <node concept="2OqwBi" id="inTShiYi_L" role="33vP2m">
+                            <node concept="1rXfSq" id="inTShiYi_M" role="2Oq$k0">
+                              <ref role="37wK5l" to="g51k:~EditorCell_Basic.getEditorComponent()" resolve="getEditorComponent" />
+                            </node>
+                            <node concept="liA8E" id="inTShiYi_N" role="2OqNvi">
+                              <ref role="37wK5l" to="cj4x:~EditorComponent.getEditorComponentSettings()" resolve="getEditorComponentSettings" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3cpWs8" id="inTShiYi_O" role="3cqZAp">
+                        <node concept="3cpWsn" id="inTShiYi_P" role="3cpWs9">
+                          <property role="TrG5h" value="fontMetrics" />
+                          <node concept="3uibUv" id="inTShiYi_Q" role="1tU5fm">
+                            <ref role="3uigEE" to="f4zo:~EditorFontMetrics" resolve="EditorFontMetrics" />
+                          </node>
+                          <node concept="2OqwBi" id="inTShiYi_R" role="33vP2m">
+                            <node concept="37vLTw" id="inTShiYi_S" role="2Oq$k0">
+                              <ref role="3cqZAo" node="inTShiYi_J" resolve="editorComponentSettings" />
+                            </node>
+                            <node concept="liA8E" id="inTShiYi_T" role="2OqNvi">
+                              <ref role="37wK5l" to="f4zo:~EditorFontMetricsProvider.getFontMetrics(java.lang.String,int,int)" resolve="getFontMetrics" />
+                              <node concept="2OqwBi" id="inTShiYi_U" role="37wK5m">
+                                <node concept="37vLTw" id="inTShiYi_V" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="inTShiYi_F" resolve="settings" />
+                                </node>
+                                <node concept="liA8E" id="inTShiYi_W" role="2OqNvi">
+                                  <ref role="37wK5l" to="exr9:~EditorSettings.getFontFamily()" resolve="getFontFamily" />
+                                </node>
+                              </node>
+                              <node concept="10M0yZ" id="inTShiYi_X" role="37wK5m">
+                                <ref role="3cqZAo" to="z60i:~Font.PLAIN" resolve="PLAIN" />
+                                <ref role="1PxDUh" to="z60i:~Font" resolve="Font" />
+                              </node>
+                              <node concept="2OqwBi" id="inTShiYi_Y" role="37wK5m">
+                                <node concept="37vLTw" id="inTShiYi_Z" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="inTShiYi_J" resolve="editorComponentSettings" />
+                                </node>
+                                <node concept="liA8E" id="inTShiYiA0" role="2OqNvi">
+                                  <ref role="37wK5l" to="cj4x:~EditorComponentSettings.getFontSize()" resolve="getFontSize" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3cpWs8" id="inTShiYiA1" role="3cqZAp">
+                        <node concept="3cpWsn" id="inTShiYiA2" role="3cpWs9">
+                          <property role="TrG5h" value="heightOfOneDash" />
+                          <node concept="10Oyi0" id="inTShiYiA3" role="1tU5fm" />
+                          <node concept="2OqwBi" id="inTShiYiA4" role="33vP2m">
+                            <node concept="37vLTw" id="inTShiYiA5" role="2Oq$k0">
+                              <ref role="3cqZAo" node="inTShiYi_P" resolve="fontMetrics" />
+                            </node>
+                            <node concept="liA8E" id="inTShiYiA6" role="2OqNvi">
+                              <ref role="37wK5l" to="f4zo:~EditorFontMetrics.getHeight()" resolve="getHeight" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbH" id="inTShiYiA7" role="3cqZAp" />
+                      <node concept="3cpWs8" id="inTShiYiA8" role="3cqZAp">
+                        <node concept="3cpWsn" id="inTShiYiA9" role="3cpWs9">
+                          <property role="TrG5h" value="builder" />
+                          <node concept="3uibUv" id="inTShiYiAa" role="1tU5fm">
+                            <ref role="3uigEE" to="cj4x:~TextBuilder" resolve="TextBuilder" />
+                          </node>
+                          <node concept="2ShNRf" id="inTShiYiAb" role="33vP2m">
+                            <node concept="1pGfFk" id="inTShiYiAc" role="2ShVmc">
+                              <property role="373rjd" value="true" />
+                              <ref role="37wK5l" to="hhnx:~TextBuilderImpl.&lt;init&gt;()" resolve="TextBuilderImpl" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3cpWs8" id="inTShiYiAd" role="3cqZAp">
+                        <node concept="3cpWsn" id="inTShiYiAe" role="3cpWs9">
+                          <property role="TrG5h" value="numberOfDashes" />
+                          <node concept="10Oyi0" id="inTShiYiAf" role="1tU5fm" />
+                          <node concept="FJ1c_" id="inTShiYiAg" role="33vP2m">
+                            <node concept="37vLTw" id="inTShiYiAh" role="3uHU7w">
+                              <ref role="3cqZAo" node="inTShiYiA2" resolve="heightOfOneDash" />
+                            </node>
+                            <node concept="2OqwBi" id="inTShiYiAi" role="3uHU7B">
+                              <node concept="1rXfSq" id="inTShiYiAj" role="2Oq$k0">
+                                <ref role="37wK5l" to="g51k:~EditorCell_Basic.getParent()" resolve="getParent" />
+                              </node>
+                              <node concept="liA8E" id="inTShiYiAk" role="2OqNvi">
+                                <ref role="37wK5l" to="g51k:~EditorCell_Basic.getHeight()" resolve="getHeight" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="1Dw8fO" id="inTShiYiAl" role="3cqZAp">
+                        <node concept="3clFbS" id="inTShiYiAm" role="2LFqv$">
+                          <node concept="3clFbF" id="inTShiYiAn" role="3cqZAp">
+                            <node concept="2OqwBi" id="inTShiYiAo" role="3clFbG">
+                              <node concept="37vLTw" id="inTShiYiAp" role="2Oq$k0">
+                                <ref role="3cqZAo" node="inTShiYiA9" resolve="builder" />
+                              </node>
+                              <node concept="liA8E" id="inTShiYiAq" role="2OqNvi">
+                                <ref role="37wK5l" to="cj4x:~TextBuilder.appendToTheBottom(jetbrains.mps.openapi.editor.TextBuilder)" resolve="appendToTheBottom" />
+                                <node concept="2ShNRf" id="inTShiYiAr" role="37wK5m">
+                                  <node concept="1pGfFk" id="inTShiYiAs" role="2ShVmc">
+                                    <property role="373rjd" value="true" />
+                                    <ref role="37wK5l" to="hhnx:~TextBuilderImpl.&lt;init&gt;(java.lang.String)" resolve="TextBuilderImpl" />
+                                    <node concept="Xl_RD" id="inTShiYiAt" role="37wK5m">
+                                      <property role="Xl_RC" value="|" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3cpWsn" id="inTShiYiAu" role="1Duv9x">
+                          <property role="TrG5h" value="i" />
+                          <node concept="10Oyi0" id="inTShiYiAv" role="1tU5fm" />
+                          <node concept="3cmrfG" id="inTShiYiAw" role="33vP2m">
+                            <property role="3cmrfH" value="0" />
+                          </node>
+                        </node>
+                        <node concept="3eOVzh" id="inTShiYiAx" role="1Dwp0S">
+                          <node concept="37vLTw" id="inTShiYiAy" role="3uHU7w">
+                            <ref role="3cqZAo" node="inTShiYiAe" resolve="numberOfDashes" />
+                          </node>
+                          <node concept="37vLTw" id="inTShiYiAz" role="3uHU7B">
+                            <ref role="3cqZAo" node="inTShiYiAu" resolve="i" />
+                          </node>
+                        </node>
+                        <node concept="3uNrnE" id="inTShiYiA$" role="1Dwrff">
+                          <node concept="37vLTw" id="inTShiYiA_" role="2$L3a6">
+                            <ref role="3cqZAo" node="inTShiYiAu" resolve="i" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbF" id="inTShiYiAA" role="3cqZAp">
+                        <node concept="37vLTw" id="inTShiYiAB" role="3clFbG">
+                          <ref role="3cqZAo" node="inTShiYiA9" resolve="builder" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="2AHcQZ" id="inTShiYiAC" role="2AJF6D">
+                      <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                    </node>
+                  </node>
                 </node>
               </node>
             </node>
@@ -13731,6 +14213,33 @@
                       </node>
                     </node>
                     <node concept="2AHcQZ" id="56eyDwNvPp8" role="2AJF6D">
+                      <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                    </node>
+                  </node>
+                  <node concept="2tJIrI" id="inTShiYNmu" role="jymVt" />
+                  <node concept="3clFb_" id="inTShiYMAW" role="jymVt">
+                    <property role="1EzhhJ" value="false" />
+                    <property role="TrG5h" value="renderText" />
+                    <property role="DiZV1" value="false" />
+                    <property role="od$2w" value="false" />
+                    <node concept="3Tm1VV" id="inTShiYMAX" role="1B3o_S" />
+                    <node concept="3uibUv" id="inTShiYMAY" role="3clF45">
+                      <ref role="3uigEE" to="cj4x:~TextBuilder" resolve="TextBuilder" />
+                    </node>
+                    <node concept="3clFbS" id="inTShiYMAZ" role="3clF47">
+                      <node concept="3clFbF" id="inTShiYMB0" role="3cqZAp">
+                        <node concept="2ShNRf" id="inTShiYMB1" role="3clFbG">
+                          <node concept="1pGfFk" id="inTShiYMB2" role="2ShVmc">
+                            <property role="373rjd" value="true" />
+                            <ref role="37wK5l" to="hhnx:~TextBuilderImpl.&lt;init&gt;(java.lang.String)" resolve="TextBuilderImpl" />
+                            <node concept="Xl_RD" id="inTShiYMB3" role="37wK5m">
+                              <property role="Xl_RC" value="|" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="2AHcQZ" id="inTShiYMB4" role="2AJF6D">
                       <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
                     </node>
                   </node>

--- a/code/platform/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.asynccell.sandbox/com.mbeddr.mpsutil.asynccell.sandbox.mpl
+++ b/code/platform/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.asynccell.sandbox/com.mbeddr.mpsutil.asynccell.sandbox.mpl
@@ -48,6 +48,7 @@
     <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
     <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
     <language slang="l:7a5dda62-9140-4668-ab76-d5ed1746f2b2:jetbrains.mps.lang.typesystem" version="5" />
+    <language slang="l:62971cbe-fd2f-4135-b001-ee6cb7a74436:nl.f1re.mps.editor.swing" version="0" />
   </languageVersions>
   <dependencyVersions>
     <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />

--- a/code/platform/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.asynccell.sandbox/models/editor.mps
+++ b/code/platform/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.asynccell.sandbox/models/editor.mps
@@ -53,7 +53,7 @@
       <concept id="1073389577006" name="jetbrains.mps.lang.editor.structure.CellModel_Constant" flags="sn" stub="3610246225209162225" index="3F0ifn">
         <property id="1073389577007" name="text" index="3F0ifm" />
       </concept>
-      <concept id="1219418625346" name="jetbrains.mps.lang.editor.structure.IStyleContainer" flags="ng" index="3F0Thp">
+      <concept id="1219418625346" name="jetbrains.mps.lang.editor.structure.IStyleContainer" flags="ngI" index="3F0Thp">
         <child id="1219418656006" name="styleItem" index="3F10Kt" />
       </concept>
       <concept id="1176474535556" name="jetbrains.mps.lang.editor.structure.QueryFunction_JComponent" flags="in" index="3Fmcul" />
@@ -88,7 +88,7 @@
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <child id="1068431790190" name="initializer" index="33vP2m" />
       </concept>
-      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ng" index="366HgL">
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ngI" index="366HgL">
         <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
       </concept>
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
@@ -131,7 +131,7 @@
       </concept>
       <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
       <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
-      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
@@ -143,7 +143,7 @@
       <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
         <reference id="1107535924139" name="classifier" index="3uigEE" />
       </concept>
-      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ngI" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
       </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
@@ -164,7 +164,7 @@
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
-      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
     </language>

--- a/code/platform/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.asynccell.sandbox/models/editor.mps
+++ b/code/platform/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.asynccell.sandbox/models/editor.mps
@@ -4,6 +4,7 @@
   <languages>
     <use id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor" version="14" />
     <use id="774bf8a0-62e5-41e1-af63-f4812e60e48b" name="jetbrains.mps.baseLanguage.checkedDots" version="-1" />
+    <use id="62971cbe-fd2f-4135-b001-ee6cb7a74436" name="nl.f1re.mps.editor.swing" version="0" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
@@ -14,6 +15,7 @@
     <import index="hox0" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.style(MPS.Editor/)" />
     <import index="cj4x" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor(MPS.Editor/)" />
     <import index="f4zo" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.cells(MPS.Editor/)" />
+    <import index="z60i" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt(JDK/)" />
     <import index="9aj0" ref="r:22cab18f-2fbb-4efb-b2e4-0123510ed1db(com.mbeddr.mpsutil.asynccell.sandbox.structure)" implicit="true" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
   </imports>
@@ -51,7 +53,7 @@
       <concept id="1073389577006" name="jetbrains.mps.lang.editor.structure.CellModel_Constant" flags="sn" stub="3610246225209162225" index="3F0ifn">
         <property id="1073389577007" name="text" index="3F0ifm" />
       </concept>
-      <concept id="1219418625346" name="jetbrains.mps.lang.editor.structure.IStyleContainer" flags="ngI" index="3F0Thp">
+      <concept id="1219418625346" name="jetbrains.mps.lang.editor.structure.IStyleContainer" flags="ng" index="3F0Thp">
         <child id="1219418656006" name="styleItem" index="3F10Kt" />
       </concept>
       <concept id="1176474535556" name="jetbrains.mps.lang.editor.structure.QueryFunction_JComponent" flags="in" index="3Fmcul" />
@@ -85,6 +87,9 @@
       <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ng" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
       </concept>
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
@@ -126,7 +131,7 @@
       </concept>
       <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
       <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
-      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
@@ -138,7 +143,7 @@
       <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
         <reference id="1107535924139" name="classifier" index="3uigEE" />
       </concept>
-      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ngI" index="1B3ioH">
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
       </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
@@ -149,6 +154,9 @@
     <language id="774bf8a0-62e5-41e1-af63-f4812e60e48b" name="jetbrains.mps.baseLanguage.checkedDots">
       <concept id="4079382982702596667" name="jetbrains.mps.baseLanguage.checkedDots.structure.CheckedDotExpression" flags="nn" index="2EnYce" />
     </language>
+    <language id="62971cbe-fd2f-4135-b001-ee6cb7a74436" name="nl.f1re.mps.editor.swing">
+      <concept id="8659612544238797919" name="nl.f1re.mps.editor.swing.structure.CellModel_CustomJComponent" flags="sg" stub="8659612544238937882" index="fWXJ_" />
+    </language>
     <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
       <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
         <child id="1199569906740" name="parameter" index="1bW2Oz" />
@@ -156,7 +164,7 @@
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
-      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
     </language>
@@ -168,9 +176,9 @@
         <node concept="VPM3Z" id="17HIJlL0f2u" role="3F10Kt">
           <property role="VOm3f" value="false" />
         </node>
-        <node concept="3gTLQM" id="17HIJlKZMgt" role="3EZMnx">
-          <node concept="3Fmcul" id="17HIJlKZMgv" role="3FoqZy">
-            <node concept="3clFbS" id="17HIJlKZMgx" role="2VODD2">
+        <node concept="fWXJ_" id="5vhcTL2u3Tj" role="3EZMnx">
+          <node concept="3Fmcul" id="5vhcTL2u3Tl" role="3FoqZy">
+            <node concept="3clFbS" id="5vhcTL2u3Tn" role="2VODD2">
               <node concept="3cpWs8" id="17HIJlKZU70" role="3cqZAp">
                 <node concept="3cpWsn" id="17HIJlKZU71" role="3cpWs9">
                   <property role="TrG5h" value="button" />
@@ -178,7 +186,8 @@
                     <ref role="3uigEE" to="dxuu:~JButton" resolve="JButton" />
                   </node>
                   <node concept="2ShNRf" id="17HIJlKZU72" role="33vP2m">
-                    <node concept="1pGfFk" id="17HIJlKZU73" role="2ShVmc">
+                    <node concept="1pGfFk" id="5vhcTL2uloQ" role="2ShVmc">
+                      <property role="373rjd" value="true" />
                       <ref role="37wK5l" to="dxuu:~JButton.&lt;init&gt;(java.lang.String)" resolve="JButton" />
                       <node concept="Xl_RD" id="17HIJlKZU74" role="37wK5m">
                         <property role="Xl_RC" value="Start 5s calculation" />
@@ -245,9 +254,9 @@
             </node>
           </node>
         </node>
-        <node concept="3gTLQM" id="2YOONxNRDtn" role="3EZMnx">
-          <node concept="3Fmcul" id="2YOONxNRDto" role="3FoqZy">
-            <node concept="3clFbS" id="2YOONxNRDtp" role="2VODD2">
+        <node concept="fWXJ_" id="5vhcTL2u7zb" role="3EZMnx">
+          <node concept="3Fmcul" id="5vhcTL2u7zd" role="3FoqZy">
+            <node concept="3clFbS" id="5vhcTL2u7zf" role="2VODD2">
               <node concept="3cpWs8" id="2YOONxNRDtq" role="3cqZAp">
                 <node concept="3cpWsn" id="2YOONxNRDtr" role="3cpWs9">
                   <property role="TrG5h" value="button" />
@@ -255,7 +264,8 @@
                     <ref role="3uigEE" to="dxuu:~JButton" resolve="JButton" />
                   </node>
                   <node concept="2ShNRf" id="2YOONxNRDtt" role="33vP2m">
-                    <node concept="1pGfFk" id="2YOONxNRDtu" role="2ShVmc">
+                    <node concept="1pGfFk" id="5vhcTL2uuAs" role="2ShVmc">
+                      <property role="373rjd" value="true" />
                       <ref role="37wK5l" to="dxuu:~JButton.&lt;init&gt;(java.lang.String)" resolve="JButton" />
                       <node concept="Xl_RD" id="2YOONxNRDtv" role="37wK5m">
                         <property role="Xl_RC" value="Throw Exception in 5s" />
@@ -333,9 +343,10 @@
             <property role="VOm3f" value="false" />
           </node>
         </node>
-        <node concept="3gTLQM" id="2u$73V9r4d6" role="3EZMnx">
-          <node concept="3Fmcul" id="2u$73V9r4d7" role="3FoqZy">
-            <node concept="3clFbS" id="2u$73V9r4d8" role="2VODD2">
+        <node concept="2iRfu4" id="17HIJlL0f2x" role="2iSdaV" />
+        <node concept="fWXJ_" id="5vhcTL2uaB7" role="3EZMnx">
+          <node concept="3Fmcul" id="5vhcTL2uaB9" role="3FoqZy">
+            <node concept="3clFbS" id="5vhcTL2uaBb" role="2VODD2">
               <node concept="3cpWs8" id="2u$73V9r4d9" role="3cqZAp">
                 <node concept="3cpWsn" id="2u$73V9r4da" role="3cpWs9">
                   <property role="TrG5h" value="button" />
@@ -343,7 +354,8 @@
                     <ref role="3uigEE" to="dxuu:~JButton" resolve="JButton" />
                   </node>
                   <node concept="2ShNRf" id="2u$73V9r4dc" role="33vP2m">
-                    <node concept="1pGfFk" id="2u$73V9r4dd" role="2ShVmc">
+                    <node concept="1pGfFk" id="5vhcTL2uB7r" role="2ShVmc">
+                      <property role="373rjd" value="true" />
                       <ref role="37wK5l" to="dxuu:~JButton.&lt;init&gt;(java.lang.String)" resolve="JButton" />
                       <node concept="Xl_RD" id="2u$73V9r4de" role="37wK5m">
                         <property role="Xl_RC" value="Set to calculating" />
@@ -421,9 +433,9 @@
             </node>
           </node>
         </node>
-        <node concept="3gTLQM" id="2u$73V9r4Bq" role="3EZMnx">
-          <node concept="3Fmcul" id="2u$73V9r4Br" role="3FoqZy">
-            <node concept="3clFbS" id="2u$73V9r4Bs" role="2VODD2">
+        <node concept="fWXJ_" id="5vhcTL2uezJ" role="3EZMnx">
+          <node concept="3Fmcul" id="5vhcTL2uezL" role="3FoqZy">
+            <node concept="3clFbS" id="5vhcTL2uezN" role="2VODD2">
               <node concept="3cpWs8" id="2u$73V9r4Bt" role="3cqZAp">
                 <node concept="3cpWsn" id="2u$73V9r4Bu" role="3cpWs9">
                   <property role="TrG5h" value="button" />
@@ -431,7 +443,8 @@
                     <ref role="3uigEE" to="dxuu:~JButton" resolve="JButton" />
                   </node>
                   <node concept="2ShNRf" id="2u$73V9r4Bw" role="33vP2m">
-                    <node concept="1pGfFk" id="2u$73V9r4Bx" role="2ShVmc">
+                    <node concept="1pGfFk" id="5vhcTL2uPjA" role="2ShVmc">
+                      <property role="373rjd" value="true" />
                       <ref role="37wK5l" to="dxuu:~JButton.&lt;init&gt;(java.lang.String)" resolve="JButton" />
                       <node concept="Xl_RD" id="2u$73V9r4By" role="37wK5m">
                         <property role="Xl_RC" value="Set to \&quot;my result\&quot;" />
@@ -511,7 +524,6 @@
             </node>
           </node>
         </node>
-        <node concept="2iRfu4" id="17HIJlL0f2x" role="2iSdaV" />
       </node>
       <node concept="gc7cB" id="17HIJlL001o" role="3EZMnx">
         <node concept="2SqB2G" id="3Wx3Ow9bTSR" role="2SqHTX">

--- a/code/platform/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.bldoc/languageModels/editor.mps
+++ b/code/platform/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.bldoc/languageModels/editor.mps
@@ -14,7 +14,9 @@
     <import index="exr9" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor(MPS.Editor/)" />
     <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
     <import index="f4zo" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.cells(MPS.Editor/)" />
+    <import index="hhnx" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.editor.runtime(MPS.Editor/)" />
     <import index="s9ok" ref="r:cd485f95-5a84-4e95-8a53-480ef712b00a(com.mbeddr.mpsutil.bldoc.structure)" implicit="true" />
+    <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
   </imports>
   <registry>
@@ -86,6 +88,12 @@
       </concept>
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
       <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="nn" index="2tJIrI" />
+      <concept id="1188207840427" name="jetbrains.mps.baseLanguage.structure.AnnotationInstance" flags="nn" index="2AHcQZ">
+        <reference id="1188208074048" name="annotation" index="2AI5Lk" />
+      </concept>
+      <concept id="1188208481402" name="jetbrains.mps.baseLanguage.structure.HasAnnotation" flags="ngI" index="2AJDlI">
+        <child id="1188208488637" name="annotation" index="2AJF6D" />
+      </concept>
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
@@ -128,6 +136,9 @@
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <property id="1176718929932" name="isFinal" index="3TUv4t" />
         <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ngI" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
       </concept>
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
@@ -590,6 +601,32 @@
                       </node>
                     </node>
                   </node>
+                  <node concept="3clFb_" id="inTShiYMAW" role="jymVt">
+                    <property role="1EzhhJ" value="false" />
+                    <property role="TrG5h" value="renderText" />
+                    <property role="DiZV1" value="false" />
+                    <property role="od$2w" value="false" />
+                    <node concept="3Tm1VV" id="inTShiYMAX" role="1B3o_S" />
+                    <node concept="3uibUv" id="inTShiYMAY" role="3clF45">
+                      <ref role="3uigEE" to="cj4x:~TextBuilder" resolve="TextBuilder" />
+                    </node>
+                    <node concept="3clFbS" id="inTShiYMAZ" role="3clF47">
+                      <node concept="3clFbF" id="inTShiYMB0" role="3cqZAp">
+                        <node concept="2ShNRf" id="inTShiYMB1" role="3clFbG">
+                          <node concept="1pGfFk" id="inTShiYMB2" role="2ShVmc">
+                            <property role="373rjd" value="true" />
+                            <ref role="37wK5l" to="hhnx:~TextBuilderImpl.&lt;init&gt;(java.lang.String)" resolve="TextBuilderImpl" />
+                            <node concept="Xl_RD" id="inTShiYMB3" role="37wK5m">
+                              <property role="Xl_RC" value="]" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="2AHcQZ" id="inTShiYMB4" role="2AJF6D">
+                      <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                    </node>
+                  </node>
                 </node>
               </node>
             </node>
@@ -907,6 +944,32 @@
                           <property role="3clFbU" value="true" />
                         </node>
                       </node>
+                    </node>
+                  </node>
+                  <node concept="3clFb_" id="inTShiZHG5" role="jymVt">
+                    <property role="1EzhhJ" value="false" />
+                    <property role="TrG5h" value="renderText" />
+                    <property role="DiZV1" value="false" />
+                    <property role="od$2w" value="false" />
+                    <node concept="3Tm1VV" id="inTShiZHG6" role="1B3o_S" />
+                    <node concept="3uibUv" id="inTShiZHG7" role="3clF45">
+                      <ref role="3uigEE" to="cj4x:~TextBuilder" resolve="TextBuilder" />
+                    </node>
+                    <node concept="3clFbS" id="inTShiZHG8" role="3clF47">
+                      <node concept="3clFbF" id="inTShiZHG9" role="3cqZAp">
+                        <node concept="2ShNRf" id="inTShiZHGa" role="3clFbG">
+                          <node concept="1pGfFk" id="inTShiZHGb" role="2ShVmc">
+                            <property role="373rjd" value="true" />
+                            <ref role="37wK5l" to="hhnx:~TextBuilderImpl.&lt;init&gt;(java.lang.String)" resolve="TextBuilderImpl" />
+                            <node concept="Xl_RD" id="inTShiZHGc" role="37wK5m">
+                              <property role="Xl_RC" value="[" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="2AHcQZ" id="inTShiZHGd" role="2AJF6D">
+                      <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
                     </node>
                   </node>
                 </node>

--- a/code/platform/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.conceptdiagram/com.mbeddr.mpsutil.conceptdiagram.mpl
+++ b/code/platform/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.conceptdiagram/com.mbeddr.mpsutil.conceptdiagram.mpl
@@ -72,6 +72,7 @@
     <language slang="l:7a5dda62-9140-4668-ab76-d5ed1746f2b2:jetbrains.mps.lang.typesystem" version="5" />
     <language slang="l:c9d137c4-3259-44f8-80ff-33ab2b506ee4:jetbrains.mps.lang.util.order" version="0" />
     <language slang="l:696c1165-4a59-463b-bc5d-902caab85dd0:jetbrains.mps.make.facet" version="0" />
+    <language slang="l:62971cbe-fd2f-4135-b001-ee6cb7a74436:nl.f1re.mps.editor.swing" version="0" />
   </languageVersions>
   <dependencyVersions>
     <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />

--- a/code/platform/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.conceptdiagram/languageModels/editor.mps
+++ b/code/platform/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.conceptdiagram/languageModels/editor.mps
@@ -8,6 +8,7 @@
     <use id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections" version="2" />
     <use id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor" version="14" />
     <use id="63650c59-16c8-498a-99c8-005c7ee9515d" name="jetbrains.mps.lang.access" version="0" />
+    <use id="62971cbe-fd2f-4135-b001-ee6cb7a74436" name="nl.f1re.mps.editor.swing" version="0" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
@@ -329,6 +330,9 @@
     </language>
     <language id="774bf8a0-62e5-41e1-af63-f4812e60e48b" name="jetbrains.mps.baseLanguage.checkedDots">
       <concept id="4079382982702596667" name="jetbrains.mps.baseLanguage.checkedDots.structure.CheckedDotExpression" flags="nn" index="2EnYce" />
+    </language>
+    <language id="62971cbe-fd2f-4135-b001-ee6cb7a74436" name="nl.f1re.mps.editor.swing">
+      <concept id="8659612544238797919" name="nl.f1re.mps.editor.swing.structure.CellModel_CustomJComponent" flags="sg" stub="8659612544238937882" index="fWXJ_" />
     </language>
     <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
       <concept id="2524418899405758586" name="jetbrains.mps.baseLanguage.closures.structure.InferredClosureParameterDeclaration" flags="ig" index="gl6BB" />
@@ -5020,9 +5024,24 @@
         <node concept="2iRfu4" id="1FnP66Z9mTb" role="2iSdaV" />
         <node concept="3EZMnI" id="1FnP66Z5iNH" role="3EZMnx">
           <node concept="2iRfu4" id="1FnP66Z5iNI" role="2iSdaV" />
-          <node concept="3gTLQM" id="1RYCYRTU8cT" role="3EZMnx">
-            <node concept="3Fmcul" id="1RYCYRTU8cV" role="3FoqZy">
-              <node concept="3clFbS" id="1RYCYRTU8cX" role="2VODD2">
+          <node concept="pkWqt" id="1FnP66Z7dCm" role="pqm2j">
+            <node concept="3clFbS" id="1FnP66Z7dCn" role="2VODD2">
+              <node concept="3clFbF" id="1FnP66Z7e67" role="3cqZAp">
+                <node concept="2OqwBi" id="1FnP66Z7hc_" role="3clFbG">
+                  <node concept="2OqwBi" id="1FnP66Z7ej2" role="2Oq$k0">
+                    <node concept="pncrf" id="1FnP66Z7e66" role="2Oq$k0" />
+                    <node concept="3Tsc0h" id="1FnP66Z7eG6" role="2OqNvi">
+                      <ref role="3TtcxE" to="45ke:7APyAbMnxWJ" resolve="languagesInScope" />
+                    </node>
+                  </node>
+                  <node concept="3GX2aA" id="1FnP66Z7j7U" role="2OqNvi" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="fWXJ_" id="5vhcTL2vUw$" role="3EZMnx">
+            <node concept="3Fmcul" id="5vhcTL2vUwA" role="3FoqZy">
+              <node concept="3clFbS" id="5vhcTL2vUwC" role="2VODD2">
                 <node concept="3cpWs8" id="1RYCYRTUbyK" role="3cqZAp">
                   <node concept="3cpWsn" id="1RYCYRTUbyL" role="3cpWs9">
                     <property role="TrG5h" value="autoFillBtn" />
@@ -5030,24 +5049,13 @@
                       <ref role="3uigEE" to="dxuu:~JButton" resolve="JButton" />
                     </node>
                     <node concept="2ShNRf" id="1RYCYRTUbEm" role="33vP2m">
-                      <node concept="1pGfFk" id="1RYCYRTUcJD" role="2ShVmc">
+                      <node concept="1pGfFk" id="5vhcTL2w5J4" role="2ShVmc">
                         <property role="373rjd" value="true" />
                         <ref role="37wK5l" to="dxuu:~JButton.&lt;init&gt;(java.lang.String)" resolve="JButton" />
                         <node concept="Xl_RD" id="1RYCYRTUd8X" role="37wK5m">
                           <property role="Xl_RC" value="Populate" />
                         </node>
                       </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="3clFbF" id="1FnP66YTszj" role="3cqZAp">
-                  <node concept="2OqwBi" id="1FnP66YTtjN" role="3clFbG">
-                    <node concept="37vLTw" id="1FnP66YTszh" role="2Oq$k0">
-                      <ref role="3cqZAo" node="1RYCYRTUbyL" resolve="autoFillBtn" />
-                    </node>
-                    <node concept="liA8E" id="1FnP66YTuaZ" role="2OqNvi">
-                      <ref role="37wK5l" to="dxuu:~JComponent.setOpaque(boolean)" resolve="setOpaque" />
-                      <node concept="3clFbT" id="1FnP66YTFbq" role="37wK5m" />
                     </node>
                   </node>
                 </node>
@@ -5131,9 +5139,9 @@
               </node>
             </node>
           </node>
-          <node concept="3gTLQM" id="1FnP66Z5jCS" role="3EZMnx">
-            <node concept="3Fmcul" id="1FnP66Z5jCT" role="3FoqZy">
-              <node concept="3clFbS" id="1FnP66Z5jCU" role="2VODD2">
+          <node concept="fWXJ_" id="5vhcTL2vW_c" role="3EZMnx">
+            <node concept="3Fmcul" id="5vhcTL2vW_e" role="3FoqZy">
+              <node concept="3clFbS" id="5vhcTL2vW_g" role="2VODD2">
                 <node concept="3cpWs8" id="1FnP66Z5jCV" role="3cqZAp">
                   <node concept="3cpWsn" id="1FnP66Z5jCW" role="3cpWs9">
                     <property role="TrG5h" value="autoFillBtn" />
@@ -5141,24 +5149,13 @@
                       <ref role="3uigEE" to="dxuu:~JButton" resolve="JButton" />
                     </node>
                     <node concept="2ShNRf" id="1FnP66Z5jCY" role="33vP2m">
-                      <node concept="1pGfFk" id="1FnP66Z5jCZ" role="2ShVmc">
+                      <node concept="1pGfFk" id="5vhcTL2wqbE" role="2ShVmc">
                         <property role="373rjd" value="true" />
                         <ref role="37wK5l" to="dxuu:~JButton.&lt;init&gt;(java.lang.String)" resolve="JButton" />
                         <node concept="Xl_RD" id="1FnP66Z5jD0" role="37wK5m">
                           <property role="Xl_RC" value="Populate (ignore deprecated nodes)" />
                         </node>
                       </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="3clFbF" id="1FnP66Z5jD1" role="3cqZAp">
-                  <node concept="2OqwBi" id="1FnP66Z5jD2" role="3clFbG">
-                    <node concept="37vLTw" id="1FnP66Z5jD3" role="2Oq$k0">
-                      <ref role="3cqZAo" node="1FnP66Z5jCW" resolve="autoFillBtn" />
-                    </node>
-                    <node concept="liA8E" id="1FnP66Z5jD4" role="2OqNvi">
-                      <ref role="37wK5l" to="dxuu:~JComponent.setOpaque(boolean)" resolve="setOpaque" />
-                      <node concept="3clFbT" id="1FnP66Z5jD5" role="37wK5m" />
                     </node>
                   </node>
                 </node>
@@ -5244,25 +5241,10 @@
               </node>
             </node>
           </node>
-          <node concept="pkWqt" id="1FnP66Z7dCm" role="pqm2j">
-            <node concept="3clFbS" id="1FnP66Z7dCn" role="2VODD2">
-              <node concept="3clFbF" id="1FnP66Z7e67" role="3cqZAp">
-                <node concept="2OqwBi" id="1FnP66Z7hc_" role="3clFbG">
-                  <node concept="2OqwBi" id="1FnP66Z7ej2" role="2Oq$k0">
-                    <node concept="pncrf" id="1FnP66Z7e66" role="2Oq$k0" />
-                    <node concept="3Tsc0h" id="1FnP66Z7eG6" role="2OqNvi">
-                      <ref role="3TtcxE" to="45ke:7APyAbMnxWJ" resolve="languagesInScope" />
-                    </node>
-                  </node>
-                  <node concept="3GX2aA" id="1FnP66Z7j7U" role="2OqNvi" />
-                </node>
-              </node>
-            </node>
-          </node>
         </node>
-        <node concept="3gTLQM" id="1FnP66Z8qWU" role="3EZMnx">
-          <node concept="3Fmcul" id="1FnP66Z8qWV" role="3FoqZy">
-            <node concept="3clFbS" id="1FnP66Z8qWW" role="2VODD2">
+        <node concept="fWXJ_" id="5vhcTL2wD0v" role="3EZMnx">
+          <node concept="3Fmcul" id="5vhcTL2wD0x" role="3FoqZy">
+            <node concept="3clFbS" id="5vhcTL2wD0z" role="2VODD2">
               <node concept="3cpWs8" id="1FnP66Z8qWX" role="3cqZAp">
                 <node concept="3cpWsn" id="1FnP66Z8qWY" role="3cpWs9">
                   <property role="TrG5h" value="autoFillBtn" />
@@ -5270,24 +5252,13 @@
                     <ref role="3uigEE" to="dxuu:~JButton" resolve="JButton" />
                   </node>
                   <node concept="2ShNRf" id="1FnP66Z8qX0" role="33vP2m">
-                    <node concept="1pGfFk" id="1FnP66Z8qX1" role="2ShVmc">
+                    <node concept="1pGfFk" id="5vhcTL2wUdf" role="2ShVmc">
                       <property role="373rjd" value="true" />
                       <ref role="37wK5l" to="dxuu:~JButton.&lt;init&gt;(java.lang.String)" resolve="JButton" />
                       <node concept="Xl_RD" id="1FnP66Z8qX2" role="37wK5m">
                         <property role="Xl_RC" value="Clear" />
                       </node>
                     </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="3clFbF" id="1FnP66Z8qX3" role="3cqZAp">
-                <node concept="2OqwBi" id="1FnP66Z8qX4" role="3clFbG">
-                  <node concept="37vLTw" id="1FnP66Z8qX5" role="2Oq$k0">
-                    <ref role="3cqZAo" node="1FnP66Z8qWY" resolve="autoFillBtn" />
-                  </node>
-                  <node concept="liA8E" id="1FnP66Z8qX6" role="2OqNvi">
-                    <ref role="37wK5l" to="dxuu:~JComponent.setOpaque(boolean)" resolve="setOpaque" />
-                    <node concept="3clFbT" id="1FnP66Z8qX7" role="37wK5m" />
                   </node>
                 </node>
               </node>

--- a/code/platform/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.ecoreimporter.testing/com.mbeddr.mpsutil.ecore.testing.mpl
+++ b/code/platform/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.ecoreimporter.testing/com.mbeddr.mpsutil.ecore.testing.mpl
@@ -27,7 +27,7 @@
       <dependencies>
         <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
         <dependency reexport="false">d3a0fd26-445a-466c-900e-10444ddfed52(com.mbeddr.mpsutil.filepicker)</dependency>
-        <dependency reexport="false">c6420b75-4569-420d-aaf7-9bc590ad7b2a(com.mbeddr.mpsutil.comparator)</dependency>
+        <dependency reexport="false">c6420b75-4569-420d-aaf7-9bc590ad7b2a(de.itemis.mps.comparator)</dependency>
         <dependency reexport="false">53f72aed-03c9-433e-8bca-b0a0c1ec0c31(com.mbeddr.mpsutil.ecore.testing.runtime)</dependency>
       </dependencies>
       <languageVersions>
@@ -53,11 +53,11 @@
         <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
         <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
         <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
-        <module reference="c6420b75-4569-420d-aaf7-9bc590ad7b2a(com.mbeddr.mpsutil.comparator)" version="0" />
         <module reference="d08b2078-ada5-40fa-a3c5-d721088dc626(com.mbeddr.mpsutil.ecore.testing)" version="0" />
         <module reference="00dec2d4-ad3a-4958-9b82-2bad74f80c8b(com.mbeddr.mpsutil.ecore.testing#494571880817442454)" version="0" />
         <module reference="53f72aed-03c9-433e-8bca-b0a0c1ec0c31(com.mbeddr.mpsutil.ecore.testing.runtime)" version="0" />
         <module reference="d3a0fd26-445a-466c-900e-10444ddfed52(com.mbeddr.mpsutil.filepicker)" version="0" />
+        <module reference="c6420b75-4569-420d-aaf7-9bc590ad7b2a(de.itemis.mps.comparator)" version="0" />
         <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
         <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
         <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />

--- a/code/platform/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.editingGuide.execution.lang/com.mbeddr.mpsutil.editingGuide.execution.lang.mpl
+++ b/code/platform/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.editingGuide.execution.lang/com.mbeddr.mpsutil.editingGuide.execution.lang.mpl
@@ -56,6 +56,7 @@
     <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
     <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
     <language slang="l:7a5dda62-9140-4668-ab76-d5ed1746f2b2:jetbrains.mps.lang.typesystem" version="5" />
+    <language slang="l:62971cbe-fd2f-4135-b001-ee6cb7a74436:nl.f1re.mps.editor.swing" version="0" />
   </languageVersions>
   <dependencyVersions>
     <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />

--- a/code/platform/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.editingGuide.execution.lang/models/editor.mps
+++ b/code/platform/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.editingGuide.execution.lang/models/editor.mps
@@ -89,7 +89,7 @@
       <concept id="1225456267680" name="jetbrains.mps.lang.editor.structure.RGBColor" flags="ng" index="1iSF2X">
         <property id="1225456424731" name="value" index="1iTho6" />
       </concept>
-      <concept id="1381004262292414836" name="jetbrains.mps.lang.editor.structure.ICellStyle" flags="ng" index="1k5N5V">
+      <concept id="1381004262292414836" name="jetbrains.mps.lang.editor.structure.ICellStyle" flags="ngI" index="1k5N5V">
         <reference id="1381004262292426837" name="parentStyleClass" index="1k5W1q" />
       </concept>
       <concept id="1223387125302" name="jetbrains.mps.lang.editor.structure.QueryFunction_Boolean" flags="in" index="3nzxsE" />
@@ -114,7 +114,7 @@
         <property id="1073389577007" name="text" index="3F0ifm" />
       </concept>
       <concept id="1073389658414" name="jetbrains.mps.lang.editor.structure.CellModel_Property" flags="sg" stub="730538219796134133" index="3F0A7n" />
-      <concept id="1219418625346" name="jetbrains.mps.lang.editor.structure.IStyleContainer" flags="ng" index="3F0Thp">
+      <concept id="1219418625346" name="jetbrains.mps.lang.editor.structure.IStyleContainer" flags="ngI" index="3F0Thp">
         <child id="1219418656006" name="styleItem" index="3F10Kt" />
       </concept>
       <concept id="1073389882823" name="jetbrains.mps.lang.editor.structure.CellModel_RefNode" flags="sg" stub="730538219795960754" index="3F1sOY" />
@@ -156,7 +156,7 @@
       <concept id="1188207840427" name="jetbrains.mps.baseLanguage.structure.AnnotationInstance" flags="nn" index="2AHcQZ">
         <reference id="1188208074048" name="annotation" index="2AI5Lk" />
       </concept>
-      <concept id="1188208481402" name="jetbrains.mps.baseLanguage.structure.HasAnnotation" flags="ng" index="2AJDlI">
+      <concept id="1188208481402" name="jetbrains.mps.baseLanguage.structure.HasAnnotation" flags="ngI" index="2AJDlI">
         <child id="1188208488637" name="annotation" index="2AJF6D" />
       </concept>
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
@@ -199,7 +199,7 @@
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <child id="1068431790190" name="initializer" index="33vP2m" />
       </concept>
-      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ng" index="366HgL">
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ngI" index="366HgL">
         <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
       </concept>
       <concept id="1092119917967" name="jetbrains.mps.baseLanguage.structure.MulExpression" flags="nn" index="17qRlL" />
@@ -267,7 +267,7 @@
       <concept id="1081516740877" name="jetbrains.mps.baseLanguage.structure.NotExpression" flags="nn" index="3fqX7Q">
         <child id="1081516765348" name="expression" index="3fr31v" />
       </concept>
-      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
@@ -285,7 +285,7 @@
         <child id="1081773367580" name="leftExpression" index="3uHU7B" />
       </concept>
       <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
-      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ngI" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
       </concept>
       <concept id="3066917033203108594" name="jetbrains.mps.baseLanguage.structure.LocalInstanceMethodCall" flags="nn" index="3P9mCS" />
@@ -393,7 +393,7 @@
         <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
         <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
       </concept>
-      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
     </language>

--- a/code/platform/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.editingGuide.execution.lang/models/editor.mps
+++ b/code/platform/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.editingGuide.execution.lang/models/editor.mps
@@ -10,6 +10,7 @@
     <use id="1919c723-b60b-4592-9318-9ce96d91da44" name="de.itemis.mps.editor.celllayout" version="0" />
     <use id="31c91def-a131-41a1-9018-102874f49a12" name="de.slisson.mps.editor.multiline" version="0" />
     <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="12" />
+    <use id="62971cbe-fd2f-4135-b001-ee6cb7a74436" name="nl.f1re.mps.editor.swing" version="0" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
@@ -26,9 +27,10 @@
     <import index="g51k" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor.cells(MPS.Editor/)" />
     <import index="mc8f" ref="r:02240f59-d215-4642-b459-56f9f2ccb58d(de.itemis.mps.editor.celllayout.runtime.cells)" />
     <import index="kz9k" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.navigation(MPS.Editor/)" />
+    <import index="hhnx" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.editor.runtime(MPS.Editor/)" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
-    <import index="l4gp" ref="r:a2db9c62-2dcd-4812-bc5f-0468bbf0b1c1(com.mbeddr.mpsutil.editingGuide.behavior)" implicit="true" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
+    <import index="l4gp" ref="r:a2db9c62-2dcd-4812-bc5f-0468bbf0b1c1(com.mbeddr.mpsutil.editingGuide.behavior)" implicit="true" />
   </imports>
   <registry>
     <language id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor">
@@ -77,9 +79,6 @@
       <concept id="1233758997495" name="jetbrains.mps.lang.editor.structure.PunctuationLeftStyleClassItem" flags="ln" index="11L4FC" />
       <concept id="1233759184865" name="jetbrains.mps.lang.editor.structure.PunctuationRightStyleClassItem" flags="ln" index="11LMrY" />
       <concept id="3383245079137382180" name="jetbrains.mps.lang.editor.structure.StyleClass" flags="ig" index="14StLt" />
-      <concept id="1235999440492" name="jetbrains.mps.lang.editor.structure.HorizontalAlign" flags="ln" index="37jFXN">
-        <property id="1235999920262" name="align" index="37lx6p" />
-      </concept>
       <concept id="1221057094638" name="jetbrains.mps.lang.editor.structure.QueryFunction_Integer" flags="in" index="1cFabM" />
       <concept id="1103016434866" name="jetbrains.mps.lang.editor.structure.CellModel_JComponent" flags="sg" stub="8104358048506731196" index="3gTLQM">
         <child id="1176475119347" name="componentProvider" index="3FoqZy" />
@@ -90,7 +89,7 @@
       <concept id="1225456267680" name="jetbrains.mps.lang.editor.structure.RGBColor" flags="ng" index="1iSF2X">
         <property id="1225456424731" name="value" index="1iTho6" />
       </concept>
-      <concept id="1381004262292414836" name="jetbrains.mps.lang.editor.structure.ICellStyle" flags="ngI" index="1k5N5V">
+      <concept id="1381004262292414836" name="jetbrains.mps.lang.editor.structure.ICellStyle" flags="ng" index="1k5N5V">
         <reference id="1381004262292426837" name="parentStyleClass" index="1k5W1q" />
       </concept>
       <concept id="1223387125302" name="jetbrains.mps.lang.editor.structure.QueryFunction_Boolean" flags="in" index="3nzxsE" />
@@ -115,7 +114,7 @@
         <property id="1073389577007" name="text" index="3F0ifm" />
       </concept>
       <concept id="1073389658414" name="jetbrains.mps.lang.editor.structure.CellModel_Property" flags="sg" stub="730538219796134133" index="3F0A7n" />
-      <concept id="1219418625346" name="jetbrains.mps.lang.editor.structure.IStyleContainer" flags="ngI" index="3F0Thp">
+      <concept id="1219418625346" name="jetbrains.mps.lang.editor.structure.IStyleContainer" flags="ng" index="3F0Thp">
         <child id="1219418656006" name="styleItem" index="3F10Kt" />
       </concept>
       <concept id="1073389882823" name="jetbrains.mps.lang.editor.structure.CellModel_RefNode" flags="sg" stub="730538219795960754" index="3F1sOY" />
@@ -157,7 +156,7 @@
       <concept id="1188207840427" name="jetbrains.mps.baseLanguage.structure.AnnotationInstance" flags="nn" index="2AHcQZ">
         <reference id="1188208074048" name="annotation" index="2AI5Lk" />
       </concept>
-      <concept id="1188208481402" name="jetbrains.mps.baseLanguage.structure.HasAnnotation" flags="ngI" index="2AJDlI">
+      <concept id="1188208481402" name="jetbrains.mps.baseLanguage.structure.HasAnnotation" flags="ng" index="2AJDlI">
         <child id="1188208488637" name="annotation" index="2AJF6D" />
       </concept>
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
@@ -199,6 +198,9 @@
       </concept>
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ng" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
       </concept>
       <concept id="1092119917967" name="jetbrains.mps.baseLanguage.structure.MulExpression" flags="nn" index="17qRlL" />
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
@@ -265,12 +267,13 @@
       <concept id="1081516740877" name="jetbrains.mps.baseLanguage.structure.NotExpression" flags="nn" index="3fqX7Q">
         <child id="1081516765348" name="expression" index="3fr31v" />
       </concept>
-      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
       <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk" />
       <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
+        <property id="521412098689998745" name="nonStatic" index="2bfB8j" />
         <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
       </concept>
       <concept id="7812454656619025412" name="jetbrains.mps.baseLanguage.structure.LocalMethodCall" flags="nn" index="1rXfSq" />
@@ -282,7 +285,7 @@
         <child id="1081773367580" name="leftExpression" index="3uHU7B" />
       </concept>
       <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
-      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ngI" index="1B3ioH">
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
       </concept>
       <concept id="3066917033203108594" name="jetbrains.mps.baseLanguage.structure.LocalInstanceMethodCall" flags="nn" index="3P9mCS" />
@@ -307,6 +310,9 @@
     </language>
     <language id="774bf8a0-62e5-41e1-af63-f4812e60e48b" name="jetbrains.mps.baseLanguage.checkedDots">
       <concept id="4079382982702596667" name="jetbrains.mps.baseLanguage.checkedDots.structure.CheckedDotExpression" flags="nn" index="2EnYce" />
+    </language>
+    <language id="62971cbe-fd2f-4135-b001-ee6cb7a74436" name="nl.f1re.mps.editor.swing">
+      <concept id="8659612544238797919" name="nl.f1re.mps.editor.swing.structure.CellModel_CustomJComponent" flags="sg" stub="8659612544238937882" index="fWXJ_" />
     </language>
     <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
       <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
@@ -387,7 +393,7 @@
         <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
         <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
       </concept>
-      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
     </language>
@@ -706,9 +712,9 @@
             <node concept="2iRfu4" id="7FOIhAt67tG" role="2iSdaV" />
             <node concept="3EZMnI" id="7lgjy2PT7d$" role="3EZMnx">
               <node concept="2iRfu4" id="7lgjy2PT7dA" role="2iSdaV" />
-              <node concept="3gTLQM" id="7lgjy2PT7dB" role="3EZMnx">
-                <node concept="3Fmcul" id="7lgjy2PT7dC" role="3FoqZy">
-                  <node concept="3clFbS" id="7lgjy2PT7dD" role="2VODD2">
+              <node concept="fWXJ_" id="5vhcTL2ySaY" role="3EZMnx">
+                <node concept="3Fmcul" id="5vhcTL2ySb0" role="3FoqZy">
+                  <node concept="3clFbS" id="5vhcTL2ySb2" role="2VODD2">
                     <node concept="3cpWs8" id="57DYivDUoNY" role="3cqZAp">
                       <node concept="3cpWsn" id="57DYivDUoO1" role="3cpWs9">
                         <property role="TrG5h" value="previousExecutor" />
@@ -739,10 +745,33 @@
                           <ref role="3uigEE" to="dxuu:~JButton" resolve="JButton" />
                         </node>
                         <node concept="2ShNRf" id="7lgjy2PT7dH" role="33vP2m">
-                          <node concept="1pGfFk" id="7lgjy2PT7dI" role="2ShVmc">
-                            <ref role="37wK5l" to="dxuu:~JButton.&lt;init&gt;(java.lang.String)" resolve="JButton" />
-                            <node concept="Xl_RD" id="7lgjy2PT7dJ" role="37wK5m">
-                              <property role="Xl_RC" value="Go Back" />
+                          <node concept="YeOm9" id="inTShjfgZ8" role="2ShVmc">
+                            <node concept="1Y3b0j" id="inTShjfgZb" role="YeSDq">
+                              <property role="2bfB8j" value="true" />
+                              <property role="373rjd" value="true" />
+                              <ref role="37wK5l" to="dxuu:~JButton.&lt;init&gt;(java.lang.String)" resolve="JButton" />
+                              <ref role="1Y3XeK" to="dxuu:~JButton" resolve="JButton" />
+                              <node concept="3clFb_" id="inTShjfi4i" role="jymVt">
+                                <property role="TrG5h" value="toString" />
+                                <node concept="3Tm1VV" id="inTShjfi4j" role="1B3o_S" />
+                                <node concept="3uibUv" id="inTShjfi4k" role="3clF45">
+                                  <ref role="3uigEE" to="wyt6:~String" resolve="String" />
+                                </node>
+                                <node concept="3clFbS" id="inTShjfi4l" role="3clF47">
+                                  <node concept="3clFbF" id="inTShjfi4m" role="3cqZAp">
+                                    <node concept="1rXfSq" id="inTShjfi4n" role="3clFbG">
+                                      <ref role="37wK5l" to="dxuu:~AbstractButton.getText()" resolve="getText" />
+                                    </node>
+                                  </node>
+                                </node>
+                                <node concept="2AHcQZ" id="inTShjfi4o" role="2AJF6D">
+                                  <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                                </node>
+                              </node>
+                              <node concept="3Tm1VV" id="inTShjfgZc" role="1B3o_S" />
+                              <node concept="Xl_RD" id="7lgjy2PT7dJ" role="37wK5m">
+                                <property role="Xl_RC" value="Go Back" />
+                              </node>
                             </node>
                           </node>
                         </node>
@@ -1051,9 +1080,9 @@
                 </node>
               </node>
               <node concept="3XFhqQ" id="7FOIhAt4Yrw" role="3EZMnx" />
-              <node concept="3gTLQM" id="icy2A0JpOG" role="3EZMnx">
-                <node concept="3Fmcul" id="icy2A0JpOH" role="3FoqZy">
-                  <node concept="3clFbS" id="icy2A0JpOI" role="2VODD2">
+              <node concept="fWXJ_" id="5vhcTL2z2P5" role="3EZMnx">
+                <node concept="3Fmcul" id="5vhcTL2z2P7" role="3FoqZy">
+                  <node concept="3clFbS" id="5vhcTL2z2P9" role="2VODD2">
                     <node concept="3cpWs8" id="icy2A0JpOJ" role="3cqZAp">
                       <node concept="3cpWsn" id="icy2A0JpOK" role="3cpWs9">
                         <property role="TrG5h" value="ex" />
@@ -1283,7 +1312,8 @@
                           <ref role="3uigEE" to="dxuu:~JButton" resolve="JButton" />
                         </node>
                         <node concept="2ShNRf" id="icy2A0JpPe" role="33vP2m">
-                          <node concept="1pGfFk" id="icy2A0JpPf" role="2ShVmc">
+                          <node concept="1pGfFk" id="5vhcTL2z9Vi" role="2ShVmc">
+                            <property role="373rjd" value="true" />
                             <ref role="37wK5l" to="dxuu:~JButton.&lt;init&gt;(java.lang.String)" resolve="JButton" />
                             <node concept="37vLTw" id="DBaqrEYxjZ" role="37wK5m">
                               <ref role="3cqZAo" node="DBaqrEYsHN" resolve="buttonText" />
@@ -1442,9 +1472,6 @@
                     </node>
                   </node>
                 </node>
-                <node concept="37jFXN" id="icy2A0JpPQ" role="3F10Kt">
-                  <property role="37lx6p" value="hZ7kOz9/RIGHT" />
-                </node>
               </node>
             </node>
           </node>
@@ -1573,9 +1600,9 @@
             <property role="3F0ifm" value="You are done with this exercise." />
           </node>
           <node concept="3F0ifn" id="47lXHjomsQ0" role="3EZMnx" />
-          <node concept="3gTLQM" id="47lXHjomsQc" role="3EZMnx">
-            <node concept="3Fmcul" id="47lXHjomsQd" role="3FoqZy">
-              <node concept="3clFbS" id="47lXHjomsQe" role="2VODD2">
+          <node concept="fWXJ_" id="5vhcTL2yCwZ" role="3EZMnx">
+            <node concept="3Fmcul" id="5vhcTL2yCx1" role="3FoqZy">
+              <node concept="3clFbS" id="5vhcTL2yCx3" role="2VODD2">
                 <node concept="3cpWs8" id="47lXHjomsQf" role="3cqZAp">
                   <node concept="3cpWsn" id="47lXHjomsQg" role="3cpWs9">
                     <property role="TrG5h" value="button" />
@@ -1583,7 +1610,8 @@
                       <ref role="3uigEE" to="dxuu:~JButton" resolve="JButton" />
                     </node>
                     <node concept="2ShNRf" id="47lXHjomsQi" role="33vP2m">
-                      <node concept="1pGfFk" id="47lXHjomsQj" role="2ShVmc">
+                      <node concept="1pGfFk" id="5vhcTL2yJYs" role="2ShVmc">
+                        <property role="373rjd" value="true" />
                         <ref role="37wK5l" to="dxuu:~JButton.&lt;init&gt;(java.lang.String)" resolve="JButton" />
                         <node concept="Xl_RD" id="47lXHjomsQk" role="37wK5m">
                           <property role="Xl_RC" value="Go Back" />
@@ -2648,6 +2676,32 @@
                       </node>
                     </node>
                     <node concept="2AHcQZ" id="1LnB5xduXK0" role="2AJF6D">
+                      <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                    </node>
+                  </node>
+                  <node concept="3clFb_" id="inTShiYMAW" role="jymVt">
+                    <property role="1EzhhJ" value="false" />
+                    <property role="TrG5h" value="renderText" />
+                    <property role="DiZV1" value="false" />
+                    <property role="od$2w" value="false" />
+                    <node concept="3Tm1VV" id="inTShiYMAX" role="1B3o_S" />
+                    <node concept="3uibUv" id="inTShiYMAY" role="3clF45">
+                      <ref role="3uigEE" to="cj4x:~TextBuilder" resolve="TextBuilder" />
+                    </node>
+                    <node concept="3clFbS" id="inTShiYMAZ" role="3clF47">
+                      <node concept="3clFbF" id="inTShiYMB0" role="3cqZAp">
+                        <node concept="2ShNRf" id="inTShiYMB1" role="3clFbG">
+                          <node concept="1pGfFk" id="inTShiYMB2" role="2ShVmc">
+                            <property role="373rjd" value="true" />
+                            <ref role="37wK5l" to="hhnx:~TextBuilderImpl.&lt;init&gt;(java.lang.String)" resolve="TextBuilderImpl" />
+                            <node concept="Xl_RD" id="inTShiYMB3" role="37wK5m">
+                              <property role="Xl_RC" value="|" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="2AHcQZ" id="inTShiYMB4" role="2AJF6D">
                       <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
                     </node>
                   </node>

--- a/code/platform/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.editingGuide/com.mbeddr.mpsutil.editingGuide.mpl
+++ b/code/platform/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.editingGuide/com.mbeddr.mpsutil.editingGuide.mpl
@@ -123,6 +123,7 @@
     <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
     <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
     <language slang="l:7a5dda62-9140-4668-ab76-d5ed1746f2b2:jetbrains.mps.lang.typesystem" version="5" />
+    <language slang="l:62971cbe-fd2f-4135-b001-ee6cb7a74436:nl.f1re.mps.editor.swing" version="0" />
   </languageVersions>
   <dependencyVersions>
     <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />

--- a/code/platform/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.editingGuide/models/editor.mps
+++ b/code/platform/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.editingGuide/models/editor.mps
@@ -7,6 +7,7 @@
     <use id="28f9e497-3b42-4291-aeba-0a1039153ab1" name="jetbrains.mps.lang.plugin" version="6" />
     <use id="04e1f940-330e-483b-9a6a-1648b396a81c" name="com.mbeddr.mpsutil.hyperlink" version="-1" />
     <use id="63650c59-16c8-498a-99c8-005c7ee9515d" name="jetbrains.mps.lang.access" version="-1" />
+    <use id="62971cbe-fd2f-4135-b001-ee6cb7a74436" name="nl.f1re.mps.editor.swing" version="0" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
@@ -239,6 +240,12 @@
         <child id="8974276187400348171" name="commandClosureLiteral" index="1QHqEI" />
       </concept>
       <concept id="8974276187400348177" name="jetbrains.mps.lang.access.structure.ExecuteCommandStatement" flags="nn" index="1QHqEO" />
+    </language>
+    <language id="62971cbe-fd2f-4135-b001-ee6cb7a74436" name="nl.f1re.mps.editor.swing">
+      <concept id="8659612544244790000" name="nl.f1re.mps.editor.swing.structure.QueryFunction_String" flags="ig" index="05MPa" />
+      <concept id="8659612544238797919" name="nl.f1re.mps.editor.swing.structure.CellModel_CustomJComponent" flags="sg" stub="8659612544238937882" index="fWXJ_">
+        <child id="8659612544238938786" name="toStringFunction" index="fNvko" />
+      </concept>
     </language>
     <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
       <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
@@ -1346,9 +1353,9 @@
       <node concept="3F0A7n" id="2Sndli4jFQe" role="3EZMnx">
         <ref role="1NtTu8" to="1oap:Ib_Fk7zNeV" resolve="file" />
       </node>
-      <node concept="3gTLQM" id="Ib_Fk7zNg6" role="3EZMnx">
-        <node concept="3Fmcul" id="Ib_Fk7zNg7" role="3FoqZy">
-          <node concept="3clFbS" id="Ib_Fk7zNg8" role="2VODD2">
+      <node concept="fWXJ_" id="5vhcTL2QWNC" role="3EZMnx">
+        <node concept="3Fmcul" id="5vhcTL2QWNE" role="3FoqZy">
+          <node concept="3clFbS" id="5vhcTL2QWNG" role="2VODD2">
             <node concept="3cpWs6" id="Ib_Fk7zNg9" role="3cqZAp">
               <node concept="2YIFZM" id="AN0tL0jRgr" role="3cqZAk">
                 <ref role="1Pybhc" to="7a0s:6UDbxo8i0QW" resolve="EditorUtil" />
@@ -1359,6 +1366,15 @@
                   <ref role="355D3u" to="1oap:Ib_Fk7zNeV" resolve="file" />
                 </node>
                 <node concept="1Q80Hx" id="AN0tL0jRgu" role="37wK5m" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="05MPa" id="5vhcTL2R0QH" role="fNvko">
+          <node concept="3clFbS" id="5vhcTL2R0QI" role="2VODD2">
+            <node concept="3clFbF" id="5vhcTL2R0V3" role="3cqZAp">
+              <node concept="Xl_RD" id="5vhcTL2R0V2" role="3clFbG">
+                <property role="Xl_RC" value="" />
               </node>
             </node>
           </node>

--- a/code/platform/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.editor.displayControl.sandbox/com.mbeddr.mpsutil.editor.displayControl.sandbox.mpl
+++ b/code/platform/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.editor.displayControl.sandbox/com.mbeddr.mpsutil.editor.displayControl.sandbox.mpl
@@ -47,6 +47,7 @@
     <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
     <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
     <language slang="l:7a5dda62-9140-4668-ab76-d5ed1746f2b2:jetbrains.mps.lang.typesystem" version="5" />
+    <language slang="l:62971cbe-fd2f-4135-b001-ee6cb7a74436:nl.f1re.mps.editor.swing" version="0" />
   </languageVersions>
   <dependencyVersions>
     <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />

--- a/code/platform/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.editor.displayControl.sandbox/models/com.mbeddr.mpsutil.editor.displayControl.sandbox.editor.mps
+++ b/code/platform/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.editor.displayControl.sandbox/models/com.mbeddr.mpsutil.editor.displayControl.sandbox.editor.mps
@@ -47,7 +47,7 @@
         <property id="1073389577007" name="text" index="3F0ifm" />
       </concept>
       <concept id="1073389658414" name="jetbrains.mps.lang.editor.structure.CellModel_Property" flags="sg" stub="730538219796134133" index="3F0A7n" />
-      <concept id="1219418625346" name="jetbrains.mps.lang.editor.structure.IStyleContainer" flags="ng" index="3F0Thp">
+      <concept id="1219418625346" name="jetbrains.mps.lang.editor.structure.IStyleContainer" flags="ngI" index="3F0Thp">
         <child id="1219418656006" name="styleItem" index="3F10Kt" />
       </concept>
       <concept id="1176474535556" name="jetbrains.mps.lang.editor.structure.QueryFunction_JComponent" flags="in" index="3Fmcul" />
@@ -61,7 +61,7 @@
       <concept id="1188207840427" name="jetbrains.mps.baseLanguage.structure.AnnotationInstance" flags="nn" index="2AHcQZ">
         <reference id="1188208074048" name="annotation" index="2AI5Lk" />
       </concept>
-      <concept id="1188208481402" name="jetbrains.mps.baseLanguage.structure.HasAnnotation" flags="ng" index="2AJDlI">
+      <concept id="1188208481402" name="jetbrains.mps.baseLanguage.structure.HasAnnotation" flags="ngI" index="2AJDlI">
         <child id="1188208488637" name="annotation" index="2AJF6D" />
       </concept>
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
@@ -83,7 +83,7 @@
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <child id="1068431790190" name="initializer" index="33vP2m" />
       </concept>
-      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ng" index="366HgL">
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ngI" index="366HgL">
         <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
       </concept>
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
@@ -113,7 +113,7 @@
       </concept>
       <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
       <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
-      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
@@ -125,7 +125,7 @@
       <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
         <reference id="1107535924139" name="classifier" index="3uigEE" />
       </concept>
-      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ngI" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
       </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
@@ -140,7 +140,7 @@
       <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
-      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
     </language>

--- a/code/platform/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.editor.displayControl.sandbox/models/com.mbeddr.mpsutil.editor.displayControl.sandbox.editor.mps
+++ b/code/platform/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.editor.displayControl.sandbox/models/com.mbeddr.mpsutil.editor.displayControl.sandbox.editor.mps
@@ -4,6 +4,7 @@
   <languages>
     <use id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor" version="14" />
     <use id="aee9cad2-acd4-4608-aef2-0004f6a1cdbd" name="jetbrains.mps.lang.actions" version="4" />
+    <use id="62971cbe-fd2f-4135-b001-ee6cb7a74436" name="nl.f1re.mps.editor.swing" version="0" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
@@ -46,7 +47,7 @@
         <property id="1073389577007" name="text" index="3F0ifm" />
       </concept>
       <concept id="1073389658414" name="jetbrains.mps.lang.editor.structure.CellModel_Property" flags="sg" stub="730538219796134133" index="3F0A7n" />
-      <concept id="1219418625346" name="jetbrains.mps.lang.editor.structure.IStyleContainer" flags="ngI" index="3F0Thp">
+      <concept id="1219418625346" name="jetbrains.mps.lang.editor.structure.IStyleContainer" flags="ng" index="3F0Thp">
         <child id="1219418656006" name="styleItem" index="3F10Kt" />
       </concept>
       <concept id="1176474535556" name="jetbrains.mps.lang.editor.structure.QueryFunction_JComponent" flags="in" index="3Fmcul" />
@@ -60,7 +61,7 @@
       <concept id="1188207840427" name="jetbrains.mps.baseLanguage.structure.AnnotationInstance" flags="nn" index="2AHcQZ">
         <reference id="1188208074048" name="annotation" index="2AI5Lk" />
       </concept>
-      <concept id="1188208481402" name="jetbrains.mps.baseLanguage.structure.HasAnnotation" flags="ngI" index="2AJDlI">
+      <concept id="1188208481402" name="jetbrains.mps.baseLanguage.structure.HasAnnotation" flags="ng" index="2AJDlI">
         <child id="1188208488637" name="annotation" index="2AJF6D" />
       </concept>
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
@@ -81,6 +82,9 @@
       </concept>
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ng" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
       </concept>
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
@@ -109,7 +113,7 @@
       </concept>
       <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
       <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
-      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
@@ -121,7 +125,7 @@
       <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
         <reference id="1107535924139" name="classifier" index="3uigEE" />
       </concept>
-      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ngI" index="1B3ioH">
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
       </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
@@ -129,11 +133,14 @@
         <reference id="1170346070688" name="classifier" index="1Y3XeK" />
       </concept>
     </language>
+    <language id="62971cbe-fd2f-4135-b001-ee6cb7a74436" name="nl.f1re.mps.editor.swing">
+      <concept id="8659612544238797919" name="nl.f1re.mps.editor.swing.structure.CellModel_CustomJComponent" flags="sg" stub="8659612544238937882" index="fWXJ_" />
+    </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
       <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
-      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
     </language>
@@ -177,9 +184,9 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
-      <node concept="3gTLQM" id="3Ol24iiTPXS" role="3EZMnx">
-        <node concept="3Fmcul" id="3Ol24iiTPXU" role="3FoqZy">
-          <node concept="3clFbS" id="3Ol24iiTPXW" role="2VODD2">
+      <node concept="fWXJ_" id="5vhcTL2zTLI" role="3EZMnx">
+        <node concept="3Fmcul" id="5vhcTL2zTLK" role="3FoqZy">
+          <node concept="3clFbS" id="5vhcTL2zTLM" role="2VODD2">
             <node concept="3cpWs8" id="3Ol24iiU3_X" role="3cqZAp">
               <node concept="3cpWsn" id="3Ol24iiU3_Y" role="3cpWs9">
                 <property role="TrG5h" value="refresh" />
@@ -187,7 +194,8 @@
                   <ref role="3uigEE" to="dxuu:~JButton" resolve="JButton" />
                 </node>
                 <node concept="2ShNRf" id="3Ol24iiU3B8" role="33vP2m">
-                  <node concept="1pGfFk" id="3Ol24iiU99A" role="2ShVmc">
+                  <node concept="1pGfFk" id="5vhcTL2zZxp" role="2ShVmc">
+                    <property role="373rjd" value="true" />
                     <ref role="37wK5l" to="dxuu:~JButton.&lt;init&gt;(java.lang.String)" resolve="JButton" />
                     <node concept="Xl_RD" id="3Ol24iiUCiy" role="37wK5m">
                       <property role="Xl_RC" value="Refresh" />

--- a/code/platform/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.jfreechart.sandboxlang/com.mbeddr.mpsutil.jfreechart.sandboxlang.mpl
+++ b/code/platform/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.jfreechart.sandboxlang/com.mbeddr.mpsutil.jfreechart.sandboxlang.mpl
@@ -49,6 +49,7 @@
     <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
     <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
     <language slang="l:7a5dda62-9140-4668-ab76-d5ed1746f2b2:jetbrains.mps.lang.typesystem" version="5" />
+    <language slang="l:62971cbe-fd2f-4135-b001-ee6cb7a74436:nl.f1re.mps.editor.swing" version="0" />
   </languageVersions>
   <dependencyVersions>
     <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />

--- a/code/platform/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.jfreechart.sandboxlang/models/editor.mps
+++ b/code/platform/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.jfreechart.sandboxlang/models/editor.mps
@@ -59,7 +59,7 @@
         <property id="1073389577007" name="text" index="3F0ifm" />
       </concept>
       <concept id="1073389658414" name="jetbrains.mps.lang.editor.structure.CellModel_Property" flags="sg" stub="730538219796134133" index="3F0A7n" />
-      <concept id="1219418625346" name="jetbrains.mps.lang.editor.structure.IStyleContainer" flags="ng" index="3F0Thp">
+      <concept id="1219418625346" name="jetbrains.mps.lang.editor.structure.IStyleContainer" flags="ngI" index="3F0Thp">
         <child id="1219418656006" name="styleItem" index="3F10Kt" />
       </concept>
       <concept id="1073390211982" name="jetbrains.mps.lang.editor.structure.CellModel_RefNodeList" flags="sg" stub="2794558372793454595" index="3F2HdR" />
@@ -96,7 +96,7 @@
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <child id="1068431790190" name="initializer" index="33vP2m" />
       </concept>
-      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ng" index="366HgL">
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ngI" index="366HgL">
         <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
       </concept>
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
@@ -127,7 +127,7 @@
       </concept>
       <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
       <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
-      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
@@ -139,7 +139,7 @@
       <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
         <reference id="1107535924139" name="classifier" index="3uigEE" />
       </concept>
-      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ngI" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
       </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
@@ -170,7 +170,7 @@
       <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
-      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
     </language>

--- a/code/platform/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.jfreechart.sandboxlang/models/editor.mps
+++ b/code/platform/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.jfreechart.sandboxlang/models/editor.mps
@@ -4,6 +4,7 @@
   <languages>
     <use id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor" version="14" />
     <use id="63650c59-16c8-498a-99c8-005c7ee9515d" name="jetbrains.mps.lang.access" version="0" />
+    <use id="62971cbe-fd2f-4135-b001-ee6cb7a74436" name="nl.f1re.mps.editor.swing" version="0" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
@@ -58,7 +59,7 @@
         <property id="1073389577007" name="text" index="3F0ifm" />
       </concept>
       <concept id="1073389658414" name="jetbrains.mps.lang.editor.structure.CellModel_Property" flags="sg" stub="730538219796134133" index="3F0A7n" />
-      <concept id="1219418625346" name="jetbrains.mps.lang.editor.structure.IStyleContainer" flags="ngI" index="3F0Thp">
+      <concept id="1219418625346" name="jetbrains.mps.lang.editor.structure.IStyleContainer" flags="ng" index="3F0Thp">
         <child id="1219418656006" name="styleItem" index="3F10Kt" />
       </concept>
       <concept id="1073390211982" name="jetbrains.mps.lang.editor.structure.CellModel_RefNodeList" flags="sg" stub="2794558372793454595" index="3F2HdR" />
@@ -95,6 +96,9 @@
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <child id="1068431790190" name="initializer" index="33vP2m" />
       </concept>
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ng" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
+      </concept>
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
@@ -123,7 +127,7 @@
       </concept>
       <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
       <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
-      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
@@ -135,7 +139,7 @@
       <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
         <reference id="1107535924139" name="classifier" index="3uigEE" />
       </concept>
-      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ngI" index="1B3ioH">
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
       </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
@@ -151,6 +155,12 @@
       </concept>
       <concept id="8974276187400348181" name="jetbrains.mps.lang.access.structure.ExecuteLightweightCommandStatement" flags="nn" index="1QHqEK" />
     </language>
+    <language id="62971cbe-fd2f-4135-b001-ee6cb7a74436" name="nl.f1re.mps.editor.swing">
+      <concept id="8659612544244790000" name="nl.f1re.mps.editor.swing.structure.QueryFunction_String" flags="ig" index="05MPa" />
+      <concept id="8659612544238797919" name="nl.f1re.mps.editor.swing.structure.CellModel_CustomJComponent" flags="sg" stub="8659612544238937882" index="fWXJ_">
+        <child id="8659612544238938786" name="toStringFunction" index="fNvko" />
+      </concept>
+    </language>
     <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
       <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
         <child id="1199569916463" name="body" index="1bW5cS" />
@@ -160,7 +170,7 @@
       <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
-      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
     </language>
@@ -249,9 +259,9 @@
           <property role="VOm3f" value="false" />
         </node>
       </node>
-      <node concept="3gTLQM" id="7uOgiT9t5r" role="3EZMnx">
-        <node concept="3Fmcul" id="7uOgiT9t5t" role="3FoqZy">
-          <node concept="3clFbS" id="7uOgiT9t5v" role="2VODD2">
+      <node concept="fWXJ_" id="5vhcTL2$zaT" role="3EZMnx">
+        <node concept="3Fmcul" id="5vhcTL2$zaV" role="3FoqZy">
+          <node concept="3clFbS" id="5vhcTL2$zaX" role="2VODD2">
             <node concept="3cpWs8" id="7uOgiT9urn" role="3cqZAp">
               <node concept="3cpWsn" id="7uOgiT9uro" role="3cpWs9">
                 <property role="TrG5h" value="panel" />
@@ -259,7 +269,8 @@
                   <ref role="3uigEE" to="k6nw:~ChartPanel" resolve="ChartPanel" />
                 </node>
                 <node concept="2ShNRf" id="7uOgiT9urp" role="33vP2m">
-                  <node concept="1pGfFk" id="7uOgiT9urq" role="2ShVmc">
+                  <node concept="1pGfFk" id="5vhcTL2$Kds" role="2ShVmc">
+                    <property role="373rjd" value="true" />
                     <ref role="37wK5l" to="k6nw:~ChartPanel.&lt;init&gt;(org.jfree.chart.JFreeChart)" resolve="ChartPanel" />
                     <node concept="2OqwBi" id="7uOgiT9N7J" role="37wK5m">
                       <node concept="pncrf" id="7uOgiT9MZm" role="2Oq$k0" />
@@ -296,6 +307,15 @@
             </node>
           </node>
         </node>
+        <node concept="05MPa" id="5vhcTL2$KY2" role="fNvko">
+          <node concept="3clFbS" id="5vhcTL2$KY3" role="2VODD2">
+            <node concept="3clFbF" id="5vhcTL2$KY8" role="3cqZAp">
+              <node concept="Xl_RD" id="5vhcTL2$KY7" role="3clFbG">
+                <property role="Xl_RC" value="chart" />
+              </node>
+            </node>
+          </node>
+        </node>
       </node>
       <node concept="3F0ifn" id="7uOgiT9i5X" role="3EZMnx">
         <node concept="ljvvj" id="7uOgiT9i5Y" role="3F10Kt">
@@ -311,9 +331,9 @@
           <property role="VOm3f" value="false" />
         </node>
       </node>
-      <node concept="3gTLQM" id="7uOgiT9P_C" role="3EZMnx">
-        <node concept="3Fmcul" id="7uOgiT9P_E" role="3FoqZy">
-          <node concept="3clFbS" id="7uOgiT9P_G" role="2VODD2">
+      <node concept="fWXJ_" id="5vhcTL2$NIC" role="3EZMnx">
+        <node concept="3Fmcul" id="5vhcTL2$NIE" role="3FoqZy">
+          <node concept="3clFbS" id="5vhcTL2$NIG" role="2VODD2">
             <node concept="3cpWs8" id="7uOgiT9Qx_" role="3cqZAp">
               <node concept="3cpWsn" id="7uOgiT9QxA" role="3cpWs9">
                 <property role="TrG5h" value="button" />
@@ -321,7 +341,8 @@
                   <ref role="3uigEE" to="dxuu:~JButton" resolve="JButton" />
                 </node>
                 <node concept="2ShNRf" id="7uOgiT9QxB" role="33vP2m">
-                  <node concept="1pGfFk" id="7uOgiT9QxC" role="2ShVmc">
+                  <node concept="1pGfFk" id="5vhcTL2$SFZ" role="2ShVmc">
+                    <property role="373rjd" value="true" />
                     <ref role="37wK5l" to="dxuu:~JButton.&lt;init&gt;(java.lang.String)" resolve="JButton" />
                     <node concept="Xl_RD" id="7uOgiT9QxD" role="37wK5m">
                       <property role="Xl_RC" value="Show in Tool Window" />

--- a/code/platform/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.review/com.mbeddr.mpsutil.review.mpl
+++ b/code/platform/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.review/com.mbeddr.mpsutil.review.mpl
@@ -82,6 +82,7 @@
   <languageVersions>
     <language slang="l:b92f861d-0184-446d-b88b-6dcf0e070241:com.mbeddr.mpsutil.intentions" version="0" />
     <language slang="l:f89904fb-9486-43a1-865e-5ad0375a8a88:de.itemis.mps.editor.bool" version="0" />
+    <language slang="l:1919c723-b60b-4592-9318-9ce96d91da44:de.itemis.mps.editor.celllayout" version="0" />
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
     <language slang="l:443f4c36-fcf5-4eb6-9500-8d06ed259e3e:jetbrains.mps.baseLanguage.classifiers" version="0" />
     <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />

--- a/code/platform/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.review/languageModels/editor.mps
+++ b/code/platform/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.review/languageModels/editor.mps
@@ -4,6 +4,7 @@
   <languages>
     <use id="f89904fb-9486-43a1-865e-5ad0375a8a88" name="de.itemis.mps.editor.bool" version="0" />
     <use id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor" version="14" />
+    <use id="1919c723-b60b-4592-9318-9ce96d91da44" name="de.itemis.mps.editor.celllayout" version="0" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
@@ -321,6 +322,7 @@
               <property role="nf9zW" value="260" />
             </node>
           </node>
+          <node concept="2iRkQZ" id="7KO_iaDZdU" role="2iSdaV" />
           <node concept="gc7cB" id="7KO_iaIKHH" role="3EZMnx">
             <node concept="3VJUX4" id="7KO_iaIKHJ" role="3YsKMw">
               <node concept="3clFbS" id="7KO_iaIKHL" role="2VODD2">
@@ -524,7 +526,6 @@
               </node>
             </node>
           </node>
-          <node concept="2iRkQZ" id="7KO_iaDZdU" role="2iSdaV" />
         </node>
         <node concept="3EZMnI" id="7KO_iaKeAM" role="3EZMnx">
           <node concept="VPM3Z" id="7KO_iaKeAO" role="3F10Kt">

--- a/code/platform/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.uniquenames/com.mbeddr.mpsutil.uniquenames.mpl
+++ b/code/platform/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.uniquenames/com.mbeddr.mpsutil.uniquenames.mpl
@@ -57,6 +57,7 @@
     <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
     <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
     <language slang="l:7a5dda62-9140-4668-ab76-d5ed1746f2b2:jetbrains.mps.lang.typesystem" version="5" />
+    <language slang="l:62971cbe-fd2f-4135-b001-ee6cb7a74436:nl.f1re.mps.editor.swing" version="0" />
   </languageVersions>
   <dependencyVersions>
     <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />

--- a/code/platform/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.uniquenames/languageModels/editor.mps
+++ b/code/platform/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.uniquenames/languageModels/editor.mps
@@ -9,6 +9,7 @@
     <use id="c0080a47-7e37-4558-bee9-9ae18e690549" name="jetbrains.mps.lang.extension" version="2" />
     <use id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor" version="14" />
     <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="12" />
+    <use id="62971cbe-fd2f-4135-b001-ee6cb7a74436" name="nl.f1re.mps.editor.swing" version="0" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
@@ -363,6 +364,12 @@
         <reference id="6626851894249712469" name="extensionPoint" index="2O5UnU" />
       </concept>
       <concept id="3175313036448560967" name="jetbrains.mps.lang.extension.structure.GetExtensionObjectsOperation" flags="nn" index="SfwO_" />
+    </language>
+    <language id="62971cbe-fd2f-4135-b001-ee6cb7a74436" name="nl.f1re.mps.editor.swing">
+      <concept id="8659612544244790000" name="nl.f1re.mps.editor.swing.structure.QueryFunction_String" flags="ig" index="05MPa" />
+      <concept id="8659612544238797919" name="nl.f1re.mps.editor.swing.structure.CellModel_CustomJComponent" flags="sg" stub="8659612544238937882" index="fWXJ_">
+        <child id="8659612544238938786" name="toStringFunction" index="fNvko" />
+      </concept>
     </language>
     <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
       <concept id="2524418899405758586" name="jetbrains.mps.baseLanguage.closures.structure.InferredClosureParameterDeclaration" flags="ig" index="gl6BB" />
@@ -3027,9 +3034,9 @@
           <ref role="1k5W1q" to="tpen:hgVSdfU" resolve="StringLiteral" />
           <ref role="1NtTu8" to="tpce:gSMwhzt" resolve="iconPath" />
         </node>
-        <node concept="3gTLQM" id="gSMKOBU" role="3EZMnx">
-          <node concept="3Fmcul" id="h7Gq5ai" role="3FoqZy">
-            <node concept="3clFbS" id="h7Gq5aj" role="2VODD2">
+        <node concept="fWXJ_" id="5vhcTL2RH9M" role="3EZMnx">
+          <node concept="3Fmcul" id="5vhcTL2RH9O" role="3FoqZy">
+            <node concept="3clFbS" id="5vhcTL2RH9Q" role="2VODD2">
               <node concept="3cpWs6" id="h7GrovA" role="3cqZAp">
                 <node concept="2YIFZM" id="4oSomgtvHf2" role="3cqZAk">
                   <ref role="37wK5l" to="7a0s:6UDbxo8i0Rf" resolve="createSelectIconButton" />
@@ -3043,6 +3050,15 @@
                   <node concept="3clFbT" id="4oSomgtvHf5" role="37wK5m">
                     <property role="3clFbU" value="true" />
                   </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="05MPa" id="5vhcTL2RJLk" role="fNvko">
+            <node concept="3clFbS" id="5vhcTL2RJLl" role="2VODD2">
+              <node concept="3clFbF" id="5vhcTL2RKac" role="3cqZAp">
+                <node concept="Xl_RD" id="5vhcTL2RKab" role="3clFbG">
+                  <property role="Xl_RC" value="" />
                 </node>
               </node>
             </node>

--- a/code/platform/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.collections.runtime/com.mbeddr.mpsutil.collections.runtime.msd
+++ b/code/platform/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.collections.runtime/com.mbeddr.mpsutil.collections.runtime.msd
@@ -16,7 +16,7 @@
     <dependency reexport="false">498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)</dependency>
     <dependency reexport="true">ecfb9949-7433-4db5-85de-0f84d172e4ce(de.q60.mps.collections.libs)</dependency>
     <dependency reexport="false">6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)</dependency>
-    <dependency reexport="false">c6420b75-4569-420d-aaf7-9bc590ad7b2a(com.mbeddr.mpsutil.comparator)</dependency>
+    <dependency reexport="false">c6420b75-4569-420d-aaf7-9bc590ad7b2a(de.itemis.mps.comparator)</dependency>
     <dependency reexport="false">9a4afe51-f114-4595-b5df-048ce3c596be(jetbrains.mps.runtime)</dependency>
     <dependency reexport="false">f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)</dependency>
   </dependencies>
@@ -38,7 +38,7 @@
     <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
     <module reference="3f2dbc2e-ad41-470f-b5f1-2869513d2b58(com.mbeddr.mpsutil.collections.runtime)" version="0" />
-    <module reference="c6420b75-4569-420d-aaf7-9bc590ad7b2a(com.mbeddr.mpsutil.comparator)" version="0" />
+    <module reference="c6420b75-4569-420d-aaf7-9bc590ad7b2a(de.itemis.mps.comparator)" version="0" />
     <module reference="ecfb9949-7433-4db5-85de-0f84d172e4ce(de.q60.mps.collections.libs)" version="0" />
     <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
     <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />

--- a/code/platform/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.ecore.testing.runtime/com.mbeddr.mpsutil.ecore.testing.runtime.msd
+++ b/code/platform/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.ecore.testing.runtime/com.mbeddr.mpsutil.ecore.testing.runtime.msd
@@ -12,7 +12,7 @@
   </facets>
   <dependencies>
     <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
-    <dependency reexport="false">c6420b75-4569-420d-aaf7-9bc590ad7b2a(com.mbeddr.mpsutil.comparator)</dependency>
+    <dependency reexport="false">c6420b75-4569-420d-aaf7-9bc590ad7b2a(de.itemis.mps.comparator)</dependency>
     <dependency reexport="false">c72da2b9-7cce-4447-8389-f407dc1158b7(jetbrains.mps.lang.structure)</dependency>
     <dependency reexport="false">3852b093-b918-413a-91e0-ba454bb21921(com.mbeddr.mpsutil.ecore.runtime)</dependency>
     <dependency reexport="false">8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)</dependency>
@@ -34,10 +34,10 @@
     <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
     <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
-    <module reference="c6420b75-4569-420d-aaf7-9bc590ad7b2a(com.mbeddr.mpsutil.comparator)" version="0" />
     <module reference="3852b093-b918-413a-91e0-ba454bb21921(com.mbeddr.mpsutil.ecore.runtime)" version="0" />
     <module reference="822a7acd-f487-45f5-bbb9-1ce595a1705f(com.mbeddr.mpsutil.ecore.stubs)" version="0" />
     <module reference="53f72aed-03c9-433e-8bca-b0a0c1ec0c31(com.mbeddr.mpsutil.ecore.testing.runtime)" version="0" />
+    <module reference="c6420b75-4569-420d-aaf7-9bc590ad7b2a(de.itemis.mps.comparator)" version="0" />
     <module reference="ecfb9949-7433-4db5-85de-0f84d172e4ce(de.q60.mps.collections.libs)" version="0" />
     <module reference="d936855b-48da-4812-a8a0-2bfddd633ac5(jetbrains.mps.lang.behavior.api)" version="0" />
     <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />

--- a/code/platform/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.ecore.testing.runtime/models/com/mbeddr/mpsutil/ecore/testing/runtime/main.mps
+++ b/code/platform/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.ecore.testing.runtime/models/com/mbeddr/mpsutil/ecore/testing/runtime/main.mps
@@ -9,7 +9,7 @@
   </languages>
   <imports>
     <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
-    <import index="mqum" ref="r:ec874b45-e888-42e6-995a-a298cefdff55(com.mbeddr.mpsutil.comparator.code)" />
+    <import index="mqum" ref="r:ec874b45-e888-42e6-995a-a298cefdff55(de.itemis.mps.comparator.code)" />
     <import index="tpce" ref="r:00000000-0000-4000-0000-011c89590292(jetbrains.mps.lang.structure.structure)" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" />

--- a/code/platform/com.mbeddr.mpsutil/tests/test.com.mbeddr.mpsutil.ecore.metaModelImport/test.com.mbeddr.mpsutil.ecore.metaModelImport.msd
+++ b/code/platform/com.mbeddr.mpsutil/tests/test.com.mbeddr.mpsutil.ecore.metaModelImport/test.com.mbeddr.mpsutil.ecore.metaModelImport.msd
@@ -14,7 +14,7 @@
   <dependencies>
     <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
     <dependency reexport="false">ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)</dependency>
-    <dependency reexport="true">c6420b75-4569-420d-aaf7-9bc590ad7b2a(com.mbeddr.mpsutil.comparator)</dependency>
+    <dependency reexport="true">c6420b75-4569-420d-aaf7-9bc590ad7b2a(de.itemis.mps.comparator)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:77948de3-6ef9-452d-b392-d01403e4086f:com.mbeddr.mpsutil.ecore" version="0" />
@@ -60,7 +60,7 @@
     <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
     <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
-    <module reference="c6420b75-4569-420d-aaf7-9bc590ad7b2a(com.mbeddr.mpsutil.comparator)" version="0" />
+    <module reference="c6420b75-4569-420d-aaf7-9bc590ad7b2a(de.itemis.mps.comparator)" version="0" />
     <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
     <module reference="5da3f266-d744-4554-a337-854f76f37e5f(test.com.mbeddr.mpsutil.ecore.metaModelImport)" version="0" />
   </dependencyVersions>

--- a/code/platform/com.mbeddr.mpsutil/tests/tests.com.mbeddr.mpsutil.json/models/tests.com.mbeddr.mpsutil.json.tests@tests.mps
+++ b/code/platform/com.mbeddr.mpsutil/tests/tests.com.mbeddr.mpsutil.json/models/tests.com.mbeddr.mpsutil.json.tests@tests.mps
@@ -5,7 +5,7 @@
     <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="6" />
     <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="1" />
     <use id="b5c0bb04-c583-4b2a-a66e-1eab92d33c68" name="com.mbeddr.mpsutil.json" version="0" />
-    <use id="f47b95d4-5e73-4c04-9204-18076950153b" name="com.mbeddr.mpsutil.compare" version="0" />
+    <use id="f47b95d4-5e73-4c04-9204-18076950153b" name="de.itemis.mps.compare" version="0" />
     <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
     <use id="c7fb639f-be78-4307-89b0-b5959c3fa8c8" name="jetbrains.mps.lang.text" version="0" />
     <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="12" />
@@ -127,8 +127,8 @@
         <child id="4342692121161094142" name="object" index="3YXoi7" />
       </concept>
     </language>
-    <language id="f47b95d4-5e73-4c04-9204-18076950153b" name="com.mbeddr.mpsutil.compare">
-      <concept id="756135271275943220" name="com.mbeddr.mpsutil.compare.structure.AssertNodeEquals" flags="ng" index="3GXo0L" />
+    <language id="f47b95d4-5e73-4c04-9204-18076950153b" name="de.itemis.mps.compare">
+      <concept id="756135271275943220" name="de.itemis.mps.compare.structure.AssertNodeEquals" flags="ng" index="3GXo0L" />
     </language>
     <language id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest">
       <concept id="8427750732757990717" name="jetbrains.mps.baseLanguage.unitTest.structure.BinaryAssert" flags="nn" index="3tpDYu">

--- a/code/platform/com.mbeddr.mpsutil/tests/tests.com.mbeddr.mpsutil.json/tests.com.mbeddr.mpsutil.json.msd
+++ b/code/platform/com.mbeddr.mpsutil/tests/tests.com.mbeddr.mpsutil.json/tests.com.mbeddr.mpsutil.json.msd
@@ -18,8 +18,8 @@
     <dependency reexport="false">39983771-4e9b-401b-a1a9-1da6c777c843(MPS.ThirdParty)</dependency>
   </dependencies>
   <languageVersions>
-    <language slang="l:f47b95d4-5e73-4c04-9204-18076950153b:com.mbeddr.mpsutil.compare" version="0" />
     <language slang="l:b5c0bb04-c583-4b2a-a66e-1eab92d33c68:com.mbeddr.mpsutil.json" version="0" />
+    <language slang="l:f47b95d4-5e73-4c04-9204-18076950153b:de.itemis.mps.compare" version="0" />
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
     <language slang="l:443f4c36-fcf5-4eb6-9500-8d06ed259e3e:jetbrains.mps.baseLanguage.classifiers" version="0" />
     <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />

--- a/code/platform/com.mbeddr.platform.build/solutions/com.mbeddr.platform.tests.build/models/com.mbeddr.platform.tests.build.mps
+++ b/code/platform/com.mbeddr.platform.build/solutions/com.mbeddr.platform.tests.build/models/com.mbeddr.platform.tests.build.mps
@@ -1565,7 +1565,7 @@
         <node concept="1SiIV0" id="2SeJqc6Ohp2" role="3bR37C">
           <node concept="3bR9La" id="2SeJqc6Ohp3" role="1SiIV1">
             <property role="3bR36h" value="true" />
-            <ref role="3bR37D" to="90a9:77YfcvOLBqQ" resolve="com.mbeddr.mpsutil.comparator" />
+            <ref role="3bR37D" to="90a9:77YfcvOLBqQ" resolve="de.itemis.mps.comparator" />
           </node>
         </node>
         <node concept="398BVA" id="bHMJKhDAXY" role="3LF7KH">

--- a/code/platform/com.mbeddr.platform.build/solutions/com.mbeddr.platform/models/com/mbeddr/platform/build.mps
+++ b/code/platform/com.mbeddr.platform.build/solutions/com.mbeddr.platform/models/com/mbeddr/platform/build.mps
@@ -2117,7 +2117,7 @@
           </node>
           <node concept="1SiIV0" id="vOGyTeLW36" role="3bR37C">
             <node concept="3bR9La" id="vOGyTeLW37" role="1SiIV1">
-              <ref role="3bR37D" to="90a9:77YfcvOLBqQ" resolve="com.mbeddr.mpsutil.comparator" />
+              <ref role="3bR37D" to="90a9:77YfcvOLBqQ" resolve="de.itemis.mps.comparator" />
             </node>
           </node>
           <node concept="1SiIV0" id="vOGyTeLW38" role="3bR37C">
@@ -2218,7 +2218,7 @@
         </node>
         <node concept="1SiIV0" id="vOGyTeLV80" role="3bR37C">
           <node concept="3bR9La" id="vOGyTeLV81" role="1SiIV1">
-            <ref role="3bR37D" to="90a9:77YfcvOLBqQ" resolve="com.mbeddr.mpsutil.comparator" />
+            <ref role="3bR37D" to="90a9:77YfcvOLBqQ" resolve="de.itemis.mps.comparator" />
           </node>
         </node>
         <node concept="1SiIV0" id="vOGyTeLV82" role="3bR37C">
@@ -18828,7 +18828,7 @@
         </node>
         <node concept="1SiIV0" id="4JmsWjEr2hh" role="3bR37C">
           <node concept="3bR9La" id="4JmsWjEr2hi" role="1SiIV1">
-            <ref role="3bR37D" to="90a9:77YfcvOLBqQ" resolve="com.mbeddr.mpsutil.comparator" />
+            <ref role="3bR37D" to="90a9:77YfcvOLBqQ" resolve="de.itemis.mps.comparator" />
           </node>
         </node>
         <node concept="1SiIV0" id="4JmsWjEr2hj" role="3bR37C">

--- a/code/platform/com.mbeddr.platform.build/solutions/com.mbeddr.platform/models/com/mbeddr/platform/build.mps
+++ b/code/platform/com.mbeddr.platform.build/solutions/com.mbeddr.platform/models/com/mbeddr/platform/build.mps
@@ -13926,6 +13926,11 @@
             <ref role="3bR37D" to="90a9:3$A0JaN5bpX" resolve="MPS.ThirdParty" />
           </node>
         </node>
+        <node concept="1SiIV0" id="5vhcTL2KfrF" role="3bR37C">
+          <node concept="3bR9La" id="5vhcTL2KfrG" role="1SiIV1">
+            <ref role="3bR37D" to="90a9:7wH7VDRXrTO" resolve="nl.f1re.mps.editor.swing.runtime" />
+          </node>
+        </node>
       </node>
     </node>
     <node concept="2G$12M" id="7Nsh5Tc2mTg" role="3989C9">


### PR DESCRIPTION
I am talking about the feature that you can press ctrl/cmd + c and ctrl/cmd +v to paste nodes from the editor to the clipboard or a normal text file.