### PR TITLE
fix: actionsfilter classloading issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is _loosely_ based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). The project does _not_ follow
 Semantic Versioning and the changes are simply documented in reverse chronological order, grouped by calendar month.
 
+# August 2025
+
+## com.mbeddr.mpsutil.actionsfilter
+
+- Classloading issues fixed.
+
 # July 2025
 
 ## com.mbeddr.core.base

--- a/code/platform/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.actionsfilter.ideaplugin/com.mbeddr.mpsutil.actionsfilter.ideaplugin.msd
+++ b/code/platform/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.actionsfilter.ideaplugin/com.mbeddr.mpsutil.actionsfilter.ideaplugin.msd
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <solution name="com.mbeddr.mpsutil.actionsfilter.ideaplugin" uuid="c091aa8e-adbb-460a-b99f-e1a7f2242121" moduleVersion="0">
   <models>
-    <modelRoot type="default" contentPath="${module}">
+    <modelRoot contentPath="${module}" type="default">
       <sourceRoot location="models" />
     </modelRoot>
   </models>
   <facets>
-    <facet type="java" compile="mps" classes="mps" ext="no">
+    <facet type="java" compile="mps" classes="provided" ext="no">
       <classes generated="true" path="${module}/classes_gen" />
     </facet>
   </facets>

--- a/code/platform/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.actionsfilter.runtime/com.mbeddr.mpsutil.actionsfilter.runtime.msd
+++ b/code/platform/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.actionsfilter.runtime/com.mbeddr.mpsutil.actionsfilter.runtime.msd
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <solution name="com.mbeddr.mpsutil.actionsfilter.runtime" uuid="436eb984-d162-4543-a347-2601ff5bb2a0" moduleVersion="0">
   <models>
-    <modelRoot type="default" contentPath="${module}">
+    <modelRoot contentPath="${module}" type="default">
       <sourceRoot location="models" />
     </modelRoot>
   </models>
   <facets>
-    <facet type="java" compile="mps" classes="mps" ext="yes">
+    <facet type="java" compile="mps" classes="provided" ext="yes">
       <classes generated="true" path="${module}/classes_gen" />
     </facet>
   </facets>

--- a/code/platform/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.actionsfilter.runtime/models/com/mbeddr/mpsutil/actionsfilter/runtime.mps
+++ b/code/platform/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.actionsfilter.runtime/models/com/mbeddr/mpsutil/actionsfilter/runtime.mps
@@ -6327,6 +6327,7 @@
                     <node concept="3Tm1VV" id="ABVPOa63Co" role="1B3o_S" />
                     <node concept="3cqZAl" id="ABVPOa63Cp" role="3clF45" />
                   </node>
+                  <node concept="2tJIrI" id="4jzGNE_n8_g" role="jymVt" />
                   <node concept="1bVj0M" id="wr$kYdIWsS" role="37wK5m">
                     <node concept="3clFbS" id="wr$kYdIWt0" role="1bW5cS">
                       <node concept="3clFbF" id="wr$kYdJ5FH" role="3cqZAp">
@@ -6339,6 +6340,27 @@
                   <node concept="10M0yZ" id="5ISq_XC4Qnu" role="37wK5m">
                     <ref role="3cqZAo" to="z2i8:~AllIcons$General.Add" resolve="Add" />
                     <ref role="1PxDUh" to="z2i8:~AllIcons$General" resolve="AllIcons.General" />
+                  </node>
+                  <node concept="3clFb_" id="4jzGNE_lnME" role="jymVt">
+                    <property role="TrG5h" value="getActionUpdateThread" />
+                    <node concept="3Tm1VV" id="4jzGNE_lnMF" role="1B3o_S" />
+                    <node concept="2AHcQZ" id="4jzGNE_lnMH" role="2AJF6D">
+                      <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+                    </node>
+                    <node concept="3uibUv" id="4jzGNE_lnMI" role="3clF45">
+                      <ref role="3uigEE" to="qkt:~ActionUpdateThread" resolve="ActionUpdateThread" />
+                    </node>
+                    <node concept="3clFbS" id="4jzGNE_lnMK" role="3clF47">
+                      <node concept="3clFbF" id="4jzGNE_mfrJ" role="3cqZAp">
+                        <node concept="Rm8GO" id="4jzGNE_mlOA" role="3clFbG">
+                          <ref role="Rm8GQ" to="qkt:~ActionUpdateThread.EDT" resolve="EDT" />
+                          <ref role="1Px2BO" to="qkt:~ActionUpdateThread" resolve="ActionUpdateThread" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="2AHcQZ" id="4jzGNE_lnML" role="2AJF6D">
+                      <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                    </node>
                   </node>
                 </node>
               </node>
@@ -6404,6 +6426,28 @@
                     </node>
                     <node concept="3Tm1VV" id="ABVPOa63CD" role="1B3o_S" />
                     <node concept="3cqZAl" id="ABVPOa63CE" role="3clF45" />
+                  </node>
+                  <node concept="2tJIrI" id="4jzGNE_n3pj" role="jymVt" />
+                  <node concept="3clFb_" id="4jzGNE_mJcR" role="jymVt">
+                    <property role="TrG5h" value="getActionUpdateThread" />
+                    <node concept="3Tm1VV" id="4jzGNE_mJcS" role="1B3o_S" />
+                    <node concept="2AHcQZ" id="4jzGNE_mJcT" role="2AJF6D">
+                      <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+                    </node>
+                    <node concept="3uibUv" id="4jzGNE_mJcU" role="3clF45">
+                      <ref role="3uigEE" to="qkt:~ActionUpdateThread" resolve="ActionUpdateThread" />
+                    </node>
+                    <node concept="3clFbS" id="4jzGNE_mJcV" role="3clF47">
+                      <node concept="3clFbF" id="4jzGNE_mJcW" role="3cqZAp">
+                        <node concept="Rm8GO" id="4jzGNE_mJcX" role="3clFbG">
+                          <ref role="Rm8GQ" to="qkt:~ActionUpdateThread.EDT" resolve="EDT" />
+                          <ref role="1Px2BO" to="qkt:~ActionUpdateThread" resolve="ActionUpdateThread" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="2AHcQZ" id="4jzGNE_mJcY" role="2AJF6D">
+                      <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                    </node>
                   </node>
                   <node concept="2tJIrI" id="7bxyEIQZZhh" role="jymVt" />
                   <node concept="1bVj0M" id="3ifiSLucDJH" role="37wK5m">
@@ -6654,6 +6698,28 @@
                     <node concept="3Tm1VV" id="5ISq_XC77O2" role="1B3o_S" />
                     <node concept="3cqZAl" id="5ISq_XC77O3" role="3clF45" />
                   </node>
+                  <node concept="2tJIrI" id="4jzGNE_mUty" role="jymVt" />
+                  <node concept="3clFb_" id="4jzGNE_mR3C" role="jymVt">
+                    <property role="TrG5h" value="getActionUpdateThread" />
+                    <node concept="3Tm1VV" id="4jzGNE_mR3D" role="1B3o_S" />
+                    <node concept="2AHcQZ" id="4jzGNE_mR3E" role="2AJF6D">
+                      <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+                    </node>
+                    <node concept="3uibUv" id="4jzGNE_mR3F" role="3clF45">
+                      <ref role="3uigEE" to="qkt:~ActionUpdateThread" resolve="ActionUpdateThread" />
+                    </node>
+                    <node concept="3clFbS" id="4jzGNE_mR3G" role="3clF47">
+                      <node concept="3clFbF" id="4jzGNE_mR3H" role="3cqZAp">
+                        <node concept="Rm8GO" id="4jzGNE_mR3I" role="3clFbG">
+                          <ref role="Rm8GQ" to="qkt:~ActionUpdateThread.EDT" resolve="EDT" />
+                          <ref role="1Px2BO" to="qkt:~ActionUpdateThread" resolve="ActionUpdateThread" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="2AHcQZ" id="4jzGNE_mR3J" role="2AJF6D">
+                      <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                    </node>
+                  </node>
                   <node concept="2tJIrI" id="7bxyEIR1YWh" role="jymVt" />
                   <node concept="3clFb_" id="7bxyEIR1PQ1" role="jymVt">
                     <property role="TrG5h" value="update" />
@@ -6838,6 +6904,28 @@
                     </node>
                     <node concept="3Tm1VV" id="5ISq_XC8aP7" role="1B3o_S" />
                     <node concept="3cqZAl" id="5ISq_XC8aP8" role="3clF45" />
+                  </node>
+                  <node concept="2tJIrI" id="4jzGNE_noD2" role="jymVt" />
+                  <node concept="3clFb_" id="4jzGNE_nleM" role="jymVt">
+                    <property role="TrG5h" value="getActionUpdateThread" />
+                    <node concept="3Tm1VV" id="4jzGNE_nleN" role="1B3o_S" />
+                    <node concept="2AHcQZ" id="4jzGNE_nleO" role="2AJF6D">
+                      <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+                    </node>
+                    <node concept="3uibUv" id="4jzGNE_nleP" role="3clF45">
+                      <ref role="3uigEE" to="qkt:~ActionUpdateThread" resolve="ActionUpdateThread" />
+                    </node>
+                    <node concept="3clFbS" id="4jzGNE_nleQ" role="3clF47">
+                      <node concept="3clFbF" id="4jzGNE_nleR" role="3cqZAp">
+                        <node concept="Rm8GO" id="4jzGNE_nleS" role="3clFbG">
+                          <ref role="Rm8GQ" to="qkt:~ActionUpdateThread.EDT" resolve="EDT" />
+                          <ref role="1Px2BO" to="qkt:~ActionUpdateThread" resolve="ActionUpdateThread" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="2AHcQZ" id="4jzGNE_nleT" role="2AJF6D">
+                      <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                    </node>
                   </node>
                   <node concept="1bVj0M" id="3ifiSLud$cN" role="37wK5m">
                     <node concept="3clFbS" id="3ifiSLud$cV" role="1bW5cS">

--- a/code/platform/com.mbeddr.platform.build/solutions/com.mbeddr.platform/models/com/mbeddr/platform/build.mps
+++ b/code/platform/com.mbeddr.platform.build/solutions/com.mbeddr.platform/models/com/mbeddr/platform/build.mps
@@ -19185,15 +19185,18 @@
       </node>
       <node concept="m$_wl" id="4SMNYR2Zl4L" role="39821P">
         <ref role="m_rDy" node="4SMNYR2Zjo5" resolve="com.mbeddr.mpsutil.actionsfilter" />
-        <node concept="pUk6x" id="4SMNYR2Zl4M" role="pUk7w" />
+        <node concept="pUk6x" id="1MBa0SvgMP4" role="pUk7w" />
         <node concept="398223" id="4SMNYR2Zl4N" role="39821P">
+          <node concept="L2wRC" id="4SMNYR2Zl4Q" role="39821P">
+            <ref role="L2wRA" node="4SMNYR2ZktT" resolve="com.mbeddr.mpsutil.actionsfilter.runtime" />
+          </node>
+          <node concept="L2wRC" id="11HDj3hprs4" role="39821P">
+            <ref role="L2wRA" node="1LEJpHNG_EO" resolve="com.mbeddr.mpsutil.actionsfilter.ideaplugin" />
+          </node>
           <node concept="3_J27D" id="4SMNYR2Zl4O" role="Nbhlr">
             <node concept="3Mxwew" id="4SMNYR2Zl4P" role="3MwsjC">
               <property role="3MwjfP" value="lib" />
             </node>
-          </node>
-          <node concept="L2wRC" id="4SMNYR2Zl4Q" role="39821P">
-            <ref role="L2wRA" node="4SMNYR2ZktT" resolve="com.mbeddr.mpsutil.actionsfilter.runtime" />
           </node>
         </node>
       </node>


### PR DESCRIPTION
* Put the actionsfilter runtime and ideaplugin solutions under the lib/ folder in the plugin to make them accessible by IDEA. Fixes "com.intellij.diagnostic.PluginException: Cannot create extension (class=com.mbeddr.mpsutil.actionsfilter.ideaplugin.EnableActionFilterUpdates)".

* Change these solutions to use the provided (IDEA) classloader. Fixes ClassCastException due to classes being loaded by separate classloaders.