### PR TITLE
mbeddr.doc: Fix embed model content as text #3100

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Semantic Versioning and the changes are simply documented in reverse chronologic
 
 # August 2025
 
+## com.mbeddr.doc
+
+- Embed model context as text fixed.
+
 ## com.mbeddr.mpsutil.actionsfilter
 
 - Classloading issues fixed.

--- a/code/platform/com.mbeddr.doc/languages/com.mbeddr.doc/doc.mpl
+++ b/code/platform/com.mbeddr.doc/languages/com.mbeddr.doc/doc.mpl
@@ -33,6 +33,7 @@
         <dependency reexport="false">9e24fcdc-a232-4d24-8c95-1f525946191a(com.mbeddr.core.base.pluginSolution)</dependency>
         <dependency reexport="false">d3a0fd26-445a-466c-900e-10444ddfed52(com.mbeddr.mpsutil.filepicker)</dependency>
         <dependency reexport="false" scope="design">fc4584d6-365c-4ceb-b660-b2c91933024d(jetbrains.mps.lang.test#1210261198005)</dependency>
+        <dependency reexport="false">34e84b8f-afa8-4364-abcd-a279fddddbe7(jetbrains.mps.editor.runtime)</dependency>
       </dependencies>
       <languageVersions>
         <language slang="l:d4280a54-f6df-4383-aa41-d1b2bffa7eb1:com.mbeddr.core.base" version="6" />
@@ -92,6 +93,7 @@
         <module reference="83888646-71ce-4f1c-9c53-c54016f6ad4f(jetbrains.mps.baseLanguage.collections)" version="0" />
         <module reference="daafa647-f1f7-4b0b-b096-69cd7c8408c0(jetbrains.mps.baseLanguage.regexp)" version="0" />
         <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
+        <module reference="34e84b8f-afa8-4364-abcd-a279fddddbe7(jetbrains.mps.editor.runtime)" version="0" />
         <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
         <module reference="d936855b-48da-4812-a8a0-2bfddd633ac5(jetbrains.mps.lang.behavior.api)" version="0" />
         <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />

--- a/code/platform/com.mbeddr.doc/languages/com.mbeddr.doc/generator/template/com/mbeddr/doc/generator/template/main@generator.mps
+++ b/code/platform/com.mbeddr.doc/languages/com.mbeddr.doc/generator/template/com/mbeddr/doc/generator/template/main@generator.mps
@@ -37,6 +37,12 @@
     <import index="w1kc" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel(MPS.Core/)" />
     <import index="1ctc" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util.stream(JDK/)" />
     <import index="82uw" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util.function(JDK/)" />
+    <import index="dxuu" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:javax.swing(JDK/)" />
+    <import index="7a0s" ref="r:2af017c2-293f-4ebb-99f3-81e353b3d6e6(jetbrains.mps.editor.runtime)" />
+    <import index="cj4x" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor(MPS.Editor/)" />
+    <import index="exr9" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor(MPS.Editor/)" />
+    <import index="f4zo" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.cells(MPS.Editor/)" />
+    <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" />
   </imports>
   <registry>
     <language id="13744753-c81f-424a-9c1b-cf8943bf4e86" name="jetbrains.mps.lang.sharedConcepts">
@@ -790,12 +796,172 @@
             <property role="2qtEX9" value="text" />
             <node concept="3zFVjK" id="41AlOFgmdy2" role="3zH0cK">
               <node concept="3clFbS" id="41AlOFgmdy3" role="2VODD2">
-                <node concept="3clFbF" id="41AlOFgmdy9" role="3cqZAp">
-                  <node concept="2OqwBi" id="41AlOFgmdy4" role="3clFbG">
-                    <node concept="3TrcHB" id="41AlOFgmdy7" role="2OqNvi">
-                      <ref role="3TsBF5" to="2c95:627_yy34G1j" resolve="text" />
+                <node concept="3cpWs8" id="6YFu3Sal1KD" role="3cqZAp">
+                  <node concept="3cpWsn" id="6YFu3Sal1KG" role="3cpWs9">
+                    <property role="TrG5h" value="returnValue" />
+                    <node concept="17QB3L" id="6YFu3Sal1KB" role="1tU5fm" />
+                    <node concept="Xl_RD" id="3PypAgiX1gP" role="33vP2m">
+                      <property role="Xl_RC" value="" />
                     </node>
-                    <node concept="30H73N" id="41AlOFgmdy8" role="2Oq$k0" />
+                  </node>
+                </node>
+                <node concept="3cpWs8" id="33OwfkaNVVU" role="3cqZAp">
+                  <node concept="3cpWsn" id="33OwfkaNVVV" role="3cpWs9">
+                    <property role="TrG5h" value="repository" />
+                    <node concept="3uibUv" id="33OwfkaNVVW" role="1tU5fm">
+                      <ref role="3uigEE" to="lui2:~SRepository" resolve="SRepository" />
+                    </node>
+                    <node concept="2OqwBi" id="33OwfkaNYQg" role="33vP2m">
+                      <node concept="liA8E" id="33OwfkaNZHD" role="2OqNvi">
+                        <ref role="37wK5l" to="mhbf:~SModel.getRepository()" resolve="getRepository" />
+                      </node>
+                      <node concept="2JrnkZ" id="33OwfkaNYQp" role="2Oq$k0">
+                        <node concept="2OqwBi" id="33OwfkaNXTe" role="2JrQYb">
+                          <node concept="1iwH7S" id="33OwfkaNXfx" role="2Oq$k0" />
+                          <node concept="1st3f0" id="33OwfkaNYrt" role="2OqNvi" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3cpWs8" id="33OwfkaO1jf" role="3cqZAp">
+                  <node concept="3cpWsn" id="33OwfkaO1jg" role="3cpWs9">
+                    <property role="TrG5h" value="originalNode" />
+                    <node concept="3Tqbb2" id="1JF$bG_vH3D" role="1tU5fm">
+                      <ref role="ehGHo" to="2c95:627_yy34G1i" resolve="ModelContentAsTextParagraph" />
+                    </node>
+                    <node concept="10QFUN" id="1JF$bG_vKmz" role="33vP2m">
+                      <node concept="2OqwBi" id="33OwfkaO3iR" role="10QFUP">
+                        <node concept="1iwH7S" id="33OwfkaO2TE" role="2Oq$k0" />
+                        <node concept="12$id9" id="33OwfkaO48l" role="2OqNvi">
+                          <node concept="30H73N" id="33OwfkaO4Gx" role="12$y8L" />
+                        </node>
+                      </node>
+                      <node concept="3Tqbb2" id="1JF$bG_vKm$" role="10QFUM">
+                        <ref role="ehGHo" to="2c95:627_yy34G1i" resolve="ModelContentAsTextParagraph" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3J1_TO" id="33OwfkaO88Z" role="3cqZAp">
+                  <node concept="3uVAMA" id="33OwfkaOKE7" role="1zxBo5">
+                    <node concept="XOnhg" id="33OwfkaOKE8" role="1zc67B">
+                      <property role="TrG5h" value="e" />
+                      <node concept="nSUau" id="33OwfkaOKE9" role="1tU5fm">
+                        <node concept="3uibUv" id="33OwfkaOLfW" role="nSUat">
+                          <ref role="3uigEE" to="wyt6:~Exception" resolve="Exception" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbS" id="33OwfkaOKEa" role="1zc67A">
+                      <node concept="YS8fn" id="33OwfkaOMKO" role="3cqZAp">
+                        <node concept="2ShNRf" id="33OwfkaON58" role="YScLw">
+                          <node concept="1pGfFk" id="33OwfkaORja" role="2ShVmc">
+                            <property role="373rjd" value="true" />
+                            <ref role="37wK5l" to="wyt6:~RuntimeException.&lt;init&gt;(java.lang.Throwable)" resolve="RuntimeException" />
+                            <node concept="37vLTw" id="33OwfkaOScl" role="37wK5m">
+                              <ref role="3cqZAo" node="33OwfkaOKE8" resolve="e" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbS" id="33OwfkaO891" role="1zxBo7">
+                    <node concept="3clFbF" id="33OwfkaO9bU" role="3cqZAp">
+                      <node concept="2YIFZM" id="33OwfkaO9IE" role="3clFbG">
+                        <ref role="37wK5l" to="dxuu:~SwingUtilities.invokeAndWait(java.lang.Runnable)" resolve="invokeAndWait" />
+                        <ref role="1Pybhc" to="dxuu:~SwingUtilities" resolve="SwingUtilities" />
+                        <node concept="1bVj0M" id="33OwfkaOaLt" role="37wK5m">
+                          <node concept="3clFbS" id="33OwfkaOaLw" role="1bW5cS">
+                            <node concept="3clFbF" id="pG4hB4dUxW" role="3cqZAp">
+                              <node concept="2OqwBi" id="pG4hB4dXCk" role="3clFbG">
+                                <node concept="2OqwBi" id="pG4hB4dV2$" role="2Oq$k0">
+                                  <node concept="37vLTw" id="pG4hB4dUxU" role="2Oq$k0">
+                                    <ref role="3cqZAo" node="33OwfkaNVVV" resolve="repository" />
+                                  </node>
+                                  <node concept="liA8E" id="pG4hB4dWu8" role="2OqNvi">
+                                    <ref role="37wK5l" to="lui2:~SRepository.getModelAccess()" resolve="getModelAccess" />
+                                  </node>
+                                </node>
+                                <node concept="liA8E" id="pG4hB4dYmt" role="2OqNvi">
+                                  <ref role="37wK5l" to="lui2:~ModelAccess.runReadAction(java.lang.Runnable)" resolve="runReadAction" />
+                                  <node concept="1bVj0M" id="pG4hB4e0O5" role="37wK5m">
+                                    <node concept="3clFbS" id="pG4hB4e0O8" role="1bW5cS">
+                                      <node concept="3cpWs8" id="3PypAgiThJA" role="3cqZAp">
+                                        <node concept="3cpWsn" id="3PypAgiThJB" role="3cpWs9">
+                                          <property role="TrG5h" value="component" />
+                                          <node concept="3uibUv" id="3PypAgiThJC" role="1tU5fm">
+                                            <ref role="3uigEE" to="7a0s:6qGpHl7IHpK" resolve="HeadlessEditorComponent" />
+                                          </node>
+                                          <node concept="2ShNRf" id="3PypAgiTnEi" role="33vP2m">
+                                            <node concept="1pGfFk" id="3PypAgiT$Th" role="2ShVmc">
+                                              <property role="373rjd" value="true" />
+                                              <ref role="37wK5l" to="7a0s:2iNJDZP2RE6" resolve="HeadlessEditorComponent" />
+                                              <node concept="37vLTw" id="3PypAgiT_OR" role="37wK5m">
+                                                <ref role="3cqZAo" node="33OwfkaNVVV" resolve="repository" />
+                                              </node>
+                                            </node>
+                                          </node>
+                                        </node>
+                                      </node>
+                                      <node concept="3clFbF" id="3PypAgiTC1q" role="3cqZAp">
+                                        <node concept="2OqwBi" id="3PypAgiTEa1" role="3clFbG">
+                                          <node concept="37vLTw" id="3PypAgiTC1o" role="2Oq$k0">
+                                            <ref role="3cqZAo" node="3PypAgiThJB" resolve="component" />
+                                          </node>
+                                          <node concept="liA8E" id="3PypAgiTI2x" role="2OqNvi">
+                                            <ref role="37wK5l" to="exr9:~EditorComponent.editNode(org.jetbrains.mps.openapi.model.SNode)" resolve="editNode" />
+                                            <node concept="2OqwBi" id="pG4hB4ddru" role="37wK5m">
+                                              <node concept="37vLTw" id="3PypAgjaZuE" role="2Oq$k0">
+                                                <ref role="3cqZAo" node="33OwfkaO1jg" resolve="originalNode" />
+                                              </node>
+                                              <node concept="2qgKlT" id="pG4hB4dfod" role="2OqNvi">
+                                                <ref role="37wK5l" to="4gky:627_yy34GnC" resolve="targetNode" />
+                                              </node>
+                                            </node>
+                                          </node>
+                                        </node>
+                                      </node>
+                                      <node concept="3clFbF" id="3PypAgiTO$q" role="3cqZAp">
+                                        <node concept="37vLTI" id="3PypAgiTPnX" role="3clFbG">
+                                          <node concept="2OqwBi" id="3PypAgiWaDi" role="37vLTx">
+                                            <node concept="2OqwBi" id="3PypAgiTY0S" role="2Oq$k0">
+                                              <node concept="2OqwBi" id="3PypAgiTS9k" role="2Oq$k0">
+                                                <node concept="37vLTw" id="3PypAgiTQky" role="2Oq$k0">
+                                                  <ref role="3cqZAo" node="3PypAgiThJB" resolve="component" />
+                                                </node>
+                                                <node concept="liA8E" id="3PypAgiTXkz" role="2OqNvi">
+                                                  <ref role="37wK5l" to="exr9:~EditorComponent.getRootCell()" resolve="getRootCell" />
+                                                </node>
+                                              </node>
+                                              <node concept="liA8E" id="3PypAgiTZBl" role="2OqNvi">
+                                                <ref role="37wK5l" to="f4zo:~EditorCell.renderText()" resolve="renderText" />
+                                              </node>
+                                            </node>
+                                            <node concept="liA8E" id="3PypAgiWcff" role="2OqNvi">
+                                              <ref role="37wK5l" to="cj4x:~TextBuilder.getText()" resolve="getText" />
+                                            </node>
+                                          </node>
+                                          <node concept="37vLTw" id="3PypAgiW9GD" role="37vLTJ">
+                                            <ref role="3cqZAo" node="6YFu3Sal1KG" resolve="returnValue" />
+                                          </node>
+                                        </node>
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3cpWs6" id="33OwfkaOXVr" role="3cqZAp">
+                  <node concept="37vLTw" id="33OwfkaOYR1" role="3cqZAk">
+                    <ref role="3cqZAo" node="6YFu3Sal1KG" resolve="returnValue" />
                   </node>
                 </node>
               </node>


### PR DESCRIPTION
This PR tackels the ticket #3100 
I implemented the functionality to render the text of the linked node of a ModelContentAsTextParagraph directly in the generator. After this change a user no longer needs to update the text property with the intention "Update Model Content Text".

I'm not sure if the intention UpdateCodeText is still needed/wanted. If some project leads confirms this, I will add a commit to delete it directly.
