### PR TITLE
build: com.mbeddr.mpsutil.plantuml: replaced old httpsupport with correct one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Semantic Versioning and the changes are simply documented in reverse chronologic
 # September 2025
 
 - The POM file of the mbeddr platform now includes bundled dependencies with 'provided' scope.
+- replaced plugin dependency `com.mbeddr.mpsutil.httpsupport` with `jetbrains.mps.ide.httpsupport`.
 
 ## com.mbeddr.mpsutil.actionsfilter
 

--- a/code/platform/com.mbeddr.platform.build/solutions/com.mbeddr.platform/models/com/mbeddr/platform/build.mps
+++ b/code/platform/com.mbeddr.platform.build/solutions/com.mbeddr.platform/models/com/mbeddr/platform/build.mps
@@ -2610,11 +2610,11 @@
         <property role="2iUeEt" value="mbeddr" />
         <property role="2iUeEu" value="http://mbeddr.com" />
       </node>
-      <node concept="m$_yC" id="4FMvhZvbzb3" role="m$_yJ">
-        <ref role="m$_y1" node="3lZeU8ehrPx" resolve="com.mbeddr.mpsutil.httpsupport" />
-      </node>
       <node concept="m$_yC" id="gz2HgGliyx" role="m$_yJ">
         <ref role="m$_y1" to="90a9:6bkzxtWP$OT" resolve="de.itemis.stubs.batik" />
+      </node>
+      <node concept="m$_yC" id="eIGgKQmmOH" role="m$_yJ">
+        <ref role="m$_y1" to="ffeo:5xhjlkpPhJu" resolve="jetbrains.mps.ide.httpsupport" />
       </node>
     </node>
     <node concept="2G$12M" id="4VgGsUqP22z" role="3989C9">


### PR DESCRIPTION
We had still an outdated plugin dependency to  `com.mbeddr.mpsutil.httpsupport`. I replaced it with `jetbrains.mps.ide.httpsupport`.