### PR TITLE
Fix navigation support deadlocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ Semantic Versioning and the changes are simply documented in reverse chronologic
 
 # October 2025
 
+## Multiple languages
+
+### Fixed
+
+- `jetbrains.mps.openapi.navigation.NavigationSupport - Replace with #getInstance(project) call` message is no longer
+  being logged (#3175).
+
+## com.mbeddr.mpsutil.hyperlink
+
+### Fixed
+
+- MPS no longer freezes when clicking on a link that opens another root node (#3180).
+
 ## com.mbeddr.mpsutil.actionsfilter
 
 ### Fixed

--- a/code/platform/com.mbeddr.mpsutil/languages/com.mbeddr.core.base/models/behavior.mps
+++ b/code/platform/com.mbeddr.mpsutil/languages/com.mbeddr.core.base/models/behavior.mps
@@ -436,6 +436,7 @@
       <concept id="1138411891628" name="jetbrains.mps.lang.smodel.structure.SNodeOperation" flags="nn" index="eCIE_">
         <child id="1144104376918" name="parameter" index="1xVPHs" />
       </concept>
+      <concept id="5045161044515397667" name="jetbrains.mps.lang.smodel.structure.Node_PointerOperation" flags="ng" index="iZEcu" />
       <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
       <concept id="1138661924179" name="jetbrains.mps.lang.smodel.structure.Property_SetOperation" flags="nn" index="tyxLq">
         <child id="1138662048170" name="value" index="tz02z" />
@@ -12009,25 +12010,40 @@
       <node concept="3clFbS" id="7NyyyjNKwp8" role="3clF47">
         <node concept="3clFbJ" id="2bPPn51N8zV" role="3cqZAp">
           <node concept="3clFbS" id="2bPPn51N8zY" role="3clFbx">
-            <node concept="3clFbF" id="7NyyyjNuC1u" role="3cqZAp">
-              <node concept="2OqwBi" id="7NyyyjNuC1w" role="3clFbG">
-                <node concept="2YIFZM" id="7NyyyjNuC1x" role="2Oq$k0">
-                  <ref role="1Pybhc" to="kz9k:~NavigationSupport" resolve="NavigationSupport" />
-                  <ref role="37wK5l" to="kz9k:~NavigationSupport.getInstance()" resolve="getInstance" />
+            <node concept="3clFbF" id="5mxmbv8TajE" role="3cqZAp">
+              <node concept="2OqwBi" id="5mxmbv8Tikc" role="3clFbG">
+                <node concept="2OqwBi" id="5mxmbv8ThqT" role="2Oq$k0">
+                  <node concept="2OqwBi" id="5mxmbv8TgzR" role="2Oq$k0">
+                    <node concept="2ShNRf" id="5mxmbv8TajA" role="2Oq$k0">
+                      <node concept="1pGfFk" id="5mxmbv8TfLq" role="2ShVmc">
+                        <property role="373rjd" value="true" />
+                        <ref role="37wK5l" to="kz9k:~EditorNavigator.&lt;init&gt;(jetbrains.mps.project.Project)" resolve="EditorNavigator" />
+                        <node concept="37vLTw" id="5mxmbv8TgoK" role="37wK5m">
+                          <ref role="3cqZAo" node="7NyyyjNKwAa" resolve="project" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="liA8E" id="5mxmbv8TgTb" role="2OqNvi">
+                      <ref role="37wK5l" to="kz9k:~EditorNavigator.shallFocus(boolean)" resolve="shallFocus" />
+                      <node concept="3clFbT" id="5mxmbv8Thd_" role="37wK5m">
+                        <property role="3clFbU" value="true" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="5mxmbv8ThO9" role="2OqNvi">
+                    <ref role="37wK5l" to="kz9k:~EditorNavigator.shallSelect(boolean)" resolve="shallSelect" />
+                    <node concept="3clFbT" id="5mxmbv8Tifd" role="37wK5m">
+                      <property role="3clFbU" value="true" />
+                    </node>
+                  </node>
                 </node>
-                <node concept="liA8E" id="7NyyyjNuC1y" role="2OqNvi">
-                  <ref role="37wK5l" to="kz9k:~NavigationSupport.openNode(jetbrains.mps.project.Project,org.jetbrains.mps.openapi.model.SNode,boolean,boolean)" resolve="openNode" />
-                  <node concept="37vLTw" id="1T2KDlwQTRx" role="37wK5m">
-                    <ref role="3cqZAo" node="7NyyyjNKwAa" resolve="project" />
-                  </node>
-                  <node concept="37vLTw" id="7NyyyjNKwQT" role="37wK5m">
-                    <ref role="3cqZAo" node="7NyyyjNKwv9" resolve="n" />
-                  </node>
-                  <node concept="3clFbT" id="7NyyyjNuC1_" role="37wK5m">
-                    <property role="3clFbU" value="true" />
-                  </node>
-                  <node concept="3clFbT" id="7NyyyjNuC1A" role="37wK5m">
-                    <property role="3clFbU" value="true" />
+                <node concept="liA8E" id="5mxmbv8TivU" role="2OqNvi">
+                  <ref role="37wK5l" to="kz9k:~EditorNavigator.open(org.jetbrains.mps.openapi.model.SNodeReference)" resolve="open" />
+                  <node concept="2OqwBi" id="5mxmbv8Tj3Y" role="37wK5m">
+                    <node concept="37vLTw" id="5mxmbv8TiOW" role="2Oq$k0">
+                      <ref role="3cqZAo" node="7NyyyjNKwv9" resolve="n" />
+                    </node>
+                    <node concept="iZEcu" id="5mxmbv8TjUe" role="2OqNvi" />
                   </node>
                 </node>
               </node>

--- a/code/platform/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.hyperlink.sandbox/models/editor.mps
+++ b/code/platform/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.hyperlink.sandbox/models/editor.mps
@@ -14,6 +14,7 @@
     <import index="ag3p" ref="04e1f940-330e-483b-9a6a-1648b396a81c/r:4f3facd2-2d6c-40e4-a229-cdeb0a5137d8(com.mbeddr.mpsutil.hyperlink/com.mbeddr.mpsutil.hyperlink.runtime)" />
     <import index="q861" ref="r:c7cdac2b-0c9c-4410-a65e-22bf20d39e5d(com.mbeddr.mpsutil.hyperlink.sandbox.structure)" implicit="true" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
+    <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
   </imports>
   <registry>
     <language id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor">
@@ -129,7 +130,19 @@
         <reference id="1170346070688" name="classifier" index="1Y3XeK" />
       </concept>
     </language>
+    <language id="446c26eb-2b7b-4bf0-9b35-f83fa582753e" name="jetbrains.mps.lang.modelapi">
+      <concept id="4733039728785194814" name="jetbrains.mps.lang.modelapi.structure.NamedNodeReference" flags="ng" index="ZC_QK">
+        <reference id="7256306938026143658" name="target" index="2aWVGs" />
+      </concept>
+    </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="7400021826774799413" name="jetbrains.mps.lang.smodel.structure.NodePointerExpression" flags="ng" index="2tJFMh">
+        <child id="7400021826774799510" name="ref" index="2tJFKM" />
+      </concept>
+      <concept id="4065387505485742749" name="jetbrains.mps.lang.smodel.structure.AbstractPointerResolveOperation" flags="ng" index="2yCiFS">
+        <child id="3648723375513868575" name="repositoryArg" index="Vysub" />
+      </concept>
+      <concept id="3648723375513868532" name="jetbrains.mps.lang.smodel.structure.NodePointer_ResolveOperation" flags="ng" index="Vyspw" />
       <concept id="1219352745532" name="jetbrains.mps.lang.smodel.structure.NodeRefExpression" flags="nn" index="3B5_sB">
         <reference id="1219352800908" name="referentNode" index="3B5MYn" />
       </concept>
@@ -464,7 +477,9 @@
                               </node>
                               <node concept="liA8E" id="1vOFPmHie0x" role="2OqNvi">
                                 <ref role="37wK5l" to="ag3p:5A_Zlt6y20F" resolve="openInBrowser" />
-                                <node concept="Xl_RD" id="1vOFPmHie0y" role="37wK5m" />
+                                <node concept="Xl_RD" id="1vOFPmHie0y" role="37wK5m">
+                                  <property role="Xl_RC" value="http://www.google.com" />
+                                </node>
                               </node>
                             </node>
                           </node>
@@ -674,6 +689,47 @@
         </node>
       </node>
       <node concept="3F0ifn" id="5YjCZTskOAg" role="3EZMnx" />
+      <node concept="3F0ifn" id="6JXRT2$OOeJ" role="3EZMnx">
+        <property role="3F0ifm" value="A URL link to another node" />
+        <node concept="3tD6jV" id="6JXRT2$OPgW" role="3F10Kt">
+          <ref role="3tD7wE" to="tj7y:3T8dS7TLUcl" resolve="hyperlink-style" />
+          <node concept="3sjG9q" id="6JXRT2$OPgX" role="3tD6jU">
+            <node concept="3clFbS" id="6JXRT2$OPgY" role="2VODD2">
+              <node concept="3clFbF" id="6JXRT2$OPgZ" role="3cqZAp">
+                <node concept="Rm8GO" id="6JXRT2$OPh0" role="3clFbG">
+                  <ref role="Rm8GQ" to="tj7y:3T8dS7U98jM" resolve="URL" />
+                  <ref role="1Px2BO" to="tj7y:3T8dS7U966b" resolve="HyperlinkStyle" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3tD6jV" id="6JXRT2$OPh1" role="3F10Kt">
+          <ref role="3tD7wE" to="tj7y:ojedFZ7Qi6" resolve="hyperlink-node" />
+          <node concept="3sjG9q" id="6JXRT2$OPh2" role="3tD6jU">
+            <node concept="3clFbS" id="6JXRT2$OPh3" role="2VODD2">
+              <node concept="3clFbF" id="6JXRT2$OPZz" role="3cqZAp">
+                <node concept="2OqwBi" id="6JXRT2$OQs3" role="3clFbG">
+                  <node concept="2tJFMh" id="6JXRT2$OPZt" role="2Oq$k0">
+                    <node concept="ZC_QK" id="6JXRT2$OQ9E" role="2tJFKM">
+                      <ref role="2aWVGs" to="tpck:gw2VY9q" resolve="BaseConcept" />
+                    </node>
+                  </node>
+                  <node concept="Vyspw" id="6JXRT2$OQO7" role="2OqNvi">
+                    <node concept="2OqwBi" id="6JXRT2$OR30" role="Vysub">
+                      <node concept="1Q80Hx" id="6JXRT2$OQSO" role="2Oq$k0" />
+                      <node concept="liA8E" id="6JXRT2$ORff" role="2OqNvi">
+                        <ref role="37wK5l" to="cj4x:~EditorContext.getRepository()" resolve="getRepository" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3F0ifn" id="6JXRT2$OOeI" role="3EZMnx" />
       <node concept="3F1sOY" id="5YjCZTskPiX" role="3EZMnx">
         <ref role="1NtTu8" to="q861:5YjCZTskODm" resolve="myChild" />
       </node>

--- a/code/platform/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.hyperlink/com.mbeddr.mpsutil.hyperlink.mpl
+++ b/code/platform/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.hyperlink/com.mbeddr.mpsutil.hyperlink.mpl
@@ -19,6 +19,7 @@
     <dependency reexport="false">498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)</dependency>
     <dependency reexport="false">742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)</dependency>
     <dependency reexport="false">8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)</dependency>
+    <dependency reexport="false">86441d7a-e194-42da-81a5-2161ec62a379(MPS.Workbench)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
@@ -64,6 +65,7 @@
     <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
     <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
+    <module reference="86441d7a-e194-42da-81a5-2161ec62a379(MPS.Workbench)" version="0" />
     <module reference="04e1f940-330e-483b-9a6a-1648b396a81c(com.mbeddr.mpsutil.hyperlink)" version="0" />
     <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
     <module reference="a9e4c532-c5f5-4bb7-99ef-42abb73bbb70(jetbrains.mps.lang.descriptor.aspects)" version="0" />

--- a/code/platform/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.hyperlink/languageModels/plugin.mps
+++ b/code/platform/com.mbeddr.mpsutil/languages/com.mbeddr.mpsutil.hyperlink/languageModels/plugin.mps
@@ -38,7 +38,11 @@
     <import index="z1c3" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.project(MPS.Core/)" />
     <import index="w1kc" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel(MPS.Core/)" />
     <import index="18ew" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.util(MPS.Core/)" />
-    <import index="z1c4" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.project(MPS.Platform/)" implicit="true" />
+    <import index="z1c4" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.project(MPS.Platform/)" />
+    <import index="3s15" ref="86441d7a-e194-42da-81a5-2161ec62a379/java:jetbrains.mps.workbench(MPS.Workbench/)" />
+    <import index="ddhc" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ide(MPS.IDEA/)" />
+    <import index="qq03" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.ide.actions(MPS.Platform/)" implicit="true" />
+    <import index="qkt" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.actionSystem(MPS.IDEA/)" implicit="true" />
   </imports>
   <registry>
     <language id="28f9e497-3b42-4291-aeba-0a1039153ab1" name="jetbrains.mps.lang.plugin">
@@ -224,7 +228,6 @@
         <child id="8974276187400348171" name="commandClosureLiteral" index="1QHqEI" />
       </concept>
       <concept id="8974276187400348181" name="jetbrains.mps.lang.access.structure.ExecuteLightweightCommandStatement" flags="nn" index="1QHqEK" />
-      <concept id="8974276187400348183" name="jetbrains.mps.lang.access.structure.ExecuteWriteActionStatement" flags="nn" index="1QHqEM" />
     </language>
     <language id="774bf8a0-62e5-41e1-af63-f4812e60e48b" name="jetbrains.mps.baseLanguage.checkedDots">
       <concept id="4079382982702596667" name="jetbrains.mps.baseLanguage.checkedDots.structure.CheckedDotExpression" flags="nn" index="2EnYce" />
@@ -256,6 +259,7 @@
       </concept>
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="5045161044515397667" name="jetbrains.mps.lang.smodel.structure.Node_PointerOperation" flags="ng" index="iZEcu" />
       <concept id="4497478346159780083" name="jetbrains.mps.lang.smodel.structure.LanguageRefExpression" flags="ng" index="pHN19">
         <child id="3542851458883491298" name="languageId" index="2V$M_3" />
       </concept>
@@ -1629,6 +1633,29 @@
         </node>
       </node>
       <node concept="3clFbS" id="80_psBUUou" role="3clF47">
+        <node concept="3cpWs8" id="5mxmbv91fXs" role="3cqZAp">
+          <node concept="3cpWsn" id="5mxmbv91fXt" role="3cpWs9">
+            <property role="TrG5h" value="editorComponent" />
+            <node concept="3uibUv" id="5mxmbv91ePM" role="1tU5fm">
+              <ref role="3uigEE" to="exr9:~EditorComponent" resolve="EditorComponent" />
+            </node>
+            <node concept="1rXfSq" id="5mxmbv91fXu" role="33vP2m">
+              <ref role="37wK5l" node="7RVr8_tU_PH" resolve="getEditorComponent" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="5mxmbv91ifG" role="3cqZAp">
+          <node concept="3clFbS" id="5mxmbv91ifI" role="3clFbx">
+            <node concept="3cpWs6" id="5mxmbv91nml" role="3cqZAp" />
+          </node>
+          <node concept="3clFbC" id="5mxmbv91lJE" role="3clFbw">
+            <node concept="10Nm6u" id="5mxmbv91lQ1" role="3uHU7w" />
+            <node concept="37vLTw" id="5mxmbv91kh9" role="3uHU7B">
+              <ref role="3cqZAo" node="5mxmbv91fXt" resolve="editorComponent" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="5mxmbv91oUu" role="3cqZAp" />
         <node concept="3cpWs8" id="80_psBV4F0" role="3cqZAp">
           <node concept="3cpWsn" id="80_psBV4EZ" role="3cpWs9">
             <property role="3TUv4t" value="false" />
@@ -1669,8 +1696,8 @@
                 <node concept="liA8E" id="80_psC6rF3" role="2OqNvi">
                   <ref role="37wK5l" to="exr9:~EditorComponent.getRootCell()" resolve="getRootCell" />
                 </node>
-                <node concept="1rXfSq" id="7RVr8_tUJmy" role="2Oq$k0">
-                  <ref role="37wK5l" node="7RVr8_tU_PH" resolve="getEditorComponent" />
+                <node concept="37vLTw" id="5mxmbv91fXw" role="2Oq$k0">
+                  <ref role="3cqZAo" node="5mxmbv91fXt" resolve="editorComponent" />
                 </node>
               </node>
               <node concept="liA8E" id="80_psC6n2T" role="2OqNvi">
@@ -1809,8 +1836,8 @@
                     <node concept="liA8E" id="4BxMnKBnIy4" role="2OqNvi">
                       <ref role="37wK5l" to="exr9:~EditorComponent.goByCurrentReference()" resolve="goByCurrentReference" />
                     </node>
-                    <node concept="1rXfSq" id="7RVr8_tUJyx" role="2Oq$k0">
-                      <ref role="37wK5l" node="7RVr8_tU_PH" resolve="getEditorComponent" />
+                    <node concept="37vLTw" id="5mxmbv91fXx" role="2Oq$k0">
+                      <ref role="3cqZAo" node="5mxmbv91fXt" resolve="editorComponent" />
                     </node>
                   </node>
                 </node>
@@ -1850,72 +1877,88 @@
                   </node>
                 </node>
                 <node concept="3clFbS" id="ojedFZ7Wdl" role="3eOfB_">
-                  <node concept="3cpWs8" id="ojedFZ8myx" role="3cqZAp">
-                    <node concept="3cpWsn" id="ojedFZ8myy" role="3cpWs9">
-                      <property role="TrG5h" value="editorContext" />
-                      <node concept="3uibUv" id="ojedFZ8myv" role="1tU5fm">
-                        <ref role="3uigEE" to="exr9:~EditorContext" resolve="EditorContext" />
-                      </node>
-                      <node concept="2OqwBi" id="ojedFZ8myz" role="33vP2m">
-                        <node concept="1rXfSq" id="ojedFZ8my$" role="2Oq$k0">
-                          <ref role="37wK5l" node="7RVr8_tU_PH" resolve="getEditorComponent" />
+                  <node concept="3cpWs8" id="5mxmbv91vXk" role="3cqZAp">
+                    <node concept="3cpWsn" id="5mxmbv91vXj" role="3cpWs9">
+                      <property role="TrG5h" value="mpsProject" />
+                      <node concept="2OqwBi" id="5mxmbv923nN" role="33vP2m">
+                        <node concept="10M0yZ" id="5mxmbv922nW" role="2Oq$k0">
+                          <ref role="3cqZAo" to="qq03:~MPSCommonDataKeys.MPS_PROJECT" resolve="MPS_PROJECT" />
+                          <ref role="1PxDUh" to="3s15:~MPSDataKeys" resolve="MPSDataKeys" />
                         </node>
-                        <node concept="liA8E" id="ojedFZ8my_" role="2OqNvi">
-                          <ref role="37wK5l" to="exr9:~EditorComponent.getEditorContext()" resolve="getEditorContext" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="1QHqEM" id="ojedFZ8f4M" role="3cqZAp">
-                    <node concept="1QHqEC" id="ojedFZ8f4N" role="1QHqEI">
-                      <node concept="3clFbS" id="ojedFZ8f4O" role="1bW5cS">
-                        <node concept="3clFbF" id="ojedFZ8luV" role="3cqZAp">
-                          <node concept="2OqwBi" id="ojedFZ8lEr" role="3clFbG">
-                            <node concept="2YIFZM" id="ojedFZ8lxL" role="2Oq$k0">
-                              <ref role="37wK5l" to="kz9k:~NavigationSupport.getInstance()" resolve="getInstance" />
-                              <ref role="1Pybhc" to="kz9k:~NavigationSupport" resolve="NavigationSupport" />
+                        <node concept="liA8E" id="5mxmbv92540" role="2OqNvi">
+                          <ref role="37wK5l" to="qkt:~DataKey.getData(com.intellij.openapi.actionSystem.DataContext)" resolve="getData" />
+                          <node concept="2OqwBi" id="5mxmbv92aVa" role="37wK5m">
+                            <node concept="2YIFZM" id="5mxmbv929Nl" role="2Oq$k0">
+                              <ref role="37wK5l" to="ddhc:~DataManager.getInstance()" resolve="getInstance" />
+                              <ref role="1Pybhc" to="ddhc:~DataManager" resolve="DataManager" />
                             </node>
-                            <node concept="liA8E" id="ojedFZ8lP1" role="2OqNvi">
-                              <ref role="37wK5l" to="kz9k:~NavigationSupport.openNode(jetbrains.mps.project.Project,org.jetbrains.mps.openapi.model.SNode,boolean,boolean)" resolve="openNode" />
-                              <node concept="2OqwBi" id="ojedFZ8nna" role="37wK5m">
-                                <node concept="2OqwBi" id="ojedFZ8mU1" role="2Oq$k0">
-                                  <node concept="37vLTw" id="ojedFZ8mFF" role="2Oq$k0">
-                                    <ref role="3cqZAo" node="ojedFZ8myy" resolve="editorContext" />
-                                  </node>
-                                  <node concept="liA8E" id="ojedFZ8nfU" role="2OqNvi">
-                                    <ref role="37wK5l" to="exr9:~EditorContext.getOperationContext()" resolve="getOperationContext" />
-                                  </node>
-                                </node>
-                                <node concept="liA8E" id="ojedFZ8nE$" role="2OqNvi">
-                                  <ref role="37wK5l" to="w1kc:~IOperationContext.getProject()" resolve="getProject" />
-                                </node>
-                              </node>
-                              <node concept="37vLTw" id="ojedFZ8nN7" role="37wK5m">
-                                <ref role="3cqZAo" node="ojedFZ7VMV" resolve="hyperlinkNode" />
-                              </node>
-                              <node concept="1rXfSq" id="6gZrhT93wFs" role="37wK5m">
-                                <ref role="37wK5l" node="6gZrhT93izx" resolve="getHyperLinkFocus" />
-                                <node concept="37vLTw" id="6gZrhT93wZC" role="37wK5m">
-                                  <ref role="3cqZAo" node="80_psBV9Cp" resolve="cellAtCursor" />
-                                </node>
-                              </node>
-                              <node concept="1rXfSq" id="6gZrhT93wMG" role="37wK5m">
-                                <ref role="37wK5l" node="6gZrhT93tHY" resolve="getHyperLinkSelect" />
-                                <node concept="37vLTw" id="6gZrhT93x4t" role="37wK5m">
-                                  <ref role="3cqZAo" node="80_psBV9Cp" resolve="cellAtCursor" />
-                                </node>
+                            <node concept="liA8E" id="5mxmbv92cRK" role="2OqNvi">
+                              <ref role="37wK5l" to="ddhc:~DataManager.getDataContext(java.awt.Component)" resolve="getDataContext" />
+                              <node concept="37vLTw" id="5mxmbv92eUw" role="37wK5m">
+                                <ref role="3cqZAo" node="5mxmbv91fXt" resolve="editorComponent" />
                               </node>
                             </node>
                           </node>
                         </node>
                       </node>
-                    </node>
-                    <node concept="2OqwBi" id="ojedFZ8l1O" role="ukAjM">
-                      <node concept="37vLTw" id="ojedFZ8myA" role="2Oq$k0">
-                        <ref role="3cqZAo" node="ojedFZ8myy" resolve="editorContext" />
+                      <node concept="3uibUv" id="5mxmbv92MXc" role="1tU5fm">
+                        <ref role="3uigEE" to="z1c4:~MPSProject" resolve="MPSProject" />
                       </node>
-                      <node concept="liA8E" id="ojedFZ8lgv" role="2OqNvi">
-                        <ref role="37wK5l" to="exr9:~EditorContext.getRepository()" resolve="getRepository" />
+                    </node>
+                  </node>
+                  <node concept="3clFbJ" id="5mxmbv92YuE" role="3cqZAp">
+                    <node concept="3clFbS" id="5mxmbv92YuG" role="3clFbx">
+                      <node concept="3cpWs6" id="5mxmbv932Kv" role="3cqZAp" />
+                    </node>
+                    <node concept="3clFbC" id="5mxmbv931b4" role="3clFbw">
+                      <node concept="10Nm6u" id="5mxmbv931hr" role="3uHU7w" />
+                      <node concept="37vLTw" id="5mxmbv92ZH6" role="3uHU7B">
+                        <ref role="3cqZAo" node="5mxmbv91vXj" resolve="mpsProject" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbH" id="5mxmbv9347W" role="3cqZAp" />
+                  <node concept="3clFbF" id="5mxmbv916B7" role="3cqZAp">
+                    <node concept="2OqwBi" id="5mxmbv92Aoe" role="3clFbG">
+                      <node concept="2OqwBi" id="5mxmbv92veH" role="2Oq$k0">
+                        <node concept="2OqwBi" id="5mxmbv92pkc" role="2Oq$k0">
+                          <node concept="2ShNRf" id="5mxmbv916B3" role="2Oq$k0">
+                            <node concept="1pGfFk" id="5mxmbv91alp" role="2ShVmc">
+                              <property role="373rjd" value="true" />
+                              <ref role="37wK5l" to="kz9k:~EditorNavigator.&lt;init&gt;(jetbrains.mps.project.Project)" resolve="EditorNavigator" />
+                              <node concept="37vLTw" id="5mxmbv92h19" role="37wK5m">
+                                <ref role="3cqZAo" node="5mxmbv91vXj" resolve="mpsProject" />
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="liA8E" id="5mxmbv92q_S" role="2OqNvi">
+                            <ref role="37wK5l" to="kz9k:~EditorNavigator.shallFocus(boolean)" resolve="shallFocus" />
+                            <node concept="1rXfSq" id="5mxmbv92rNL" role="37wK5m">
+                              <ref role="37wK5l" node="6gZrhT93izx" resolve="getHyperLinkFocus" />
+                              <node concept="37vLTw" id="5mxmbv92tPD" role="37wK5m">
+                                <ref role="3cqZAo" node="80_psBV9Cp" resolve="cellAtCursor" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="liA8E" id="5mxmbv92xOX" role="2OqNvi">
+                          <ref role="37wK5l" to="kz9k:~EditorNavigator.shallSelect(boolean)" resolve="shallSelect" />
+                          <node concept="1rXfSq" id="5mxmbv92zMl" role="37wK5m">
+                            <ref role="37wK5l" node="6gZrhT93tHY" resolve="getHyperLinkSelect" />
+                            <node concept="37vLTw" id="5mxmbv92_ej" role="37wK5m">
+                              <ref role="3cqZAo" node="80_psBV9Cp" resolve="cellAtCursor" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="liA8E" id="5mxmbv92CGN" role="2OqNvi">
+                        <ref role="37wK5l" to="kz9k:~EditorNavigator.open(org.jetbrains.mps.openapi.model.SNodeReference)" resolve="open" />
+                        <node concept="2OqwBi" id="5mxmbv92FbF" role="37wK5m">
+                          <node concept="37vLTw" id="5mxmbv92E9U" role="2Oq$k0">
+                            <ref role="3cqZAo" node="ojedFZ7VMV" resolve="hyperlinkNode" />
+                          </node>
+                          <node concept="iZEcu" id="5mxmbv92G0j" role="2OqNvi" />
+                        </node>
                       </node>
                     </node>
                   </node>

--- a/code/platform/com.mbeddr.mpsutil/solutions/com.mbeddr.core.base.pluginSolution/models/com/mbeddr/core/base/pluginSolution/plugin.mps
+++ b/code/platform/com.mbeddr.mpsutil/solutions/com.mbeddr.core.base.pluginSolution/models/com/mbeddr/core/base/pluginSolution/plugin.mps
@@ -582,7 +582,6 @@
         <child id="8974276187400348171" name="commandClosureLiteral" index="1QHqEI" />
       </concept>
       <concept id="8974276187400348181" name="jetbrains.mps.lang.access.structure.ExecuteLightweightCommandStatement" flags="nn" index="1QHqEK" />
-      <concept id="8974276187400348183" name="jetbrains.mps.lang.access.structure.ExecuteWriteActionStatement" flags="nn" index="1QHqEM" />
       <concept id="8974276187400348177" name="jetbrains.mps.lang.access.structure.ExecuteCommandStatement" flags="nn" index="1QHqEO" />
     </language>
     <language id="774bf8a0-62e5-41e1-af63-f4812e60e48b" name="jetbrains.mps.baseLanguage.checkedDots">
@@ -650,6 +649,7 @@
       <concept id="1138411891628" name="jetbrains.mps.lang.smodel.structure.SNodeOperation" flags="nn" index="eCIE_">
         <child id="1144104376918" name="parameter" index="1xVPHs" />
       </concept>
+      <concept id="5045161044515397667" name="jetbrains.mps.lang.smodel.structure.Node_PointerOperation" flags="ng" index="iZEcu" />
       <concept id="1140725362528" name="jetbrains.mps.lang.smodel.structure.Link_SetTargetOperation" flags="nn" index="2oxUTD">
         <child id="1140725362529" name="linkTarget" index="2oxUTC" />
       </concept>
@@ -10305,46 +10305,61 @@
             </node>
           </node>
           <node concept="3clFbS" id="1N2UgSJLMxL" role="3clFbx">
-            <node concept="3clFbF" id="1N2UgSJLMxM" role="3cqZAp">
-              <node concept="2OqwBi" id="1N2UgSJLMxN" role="3clFbG">
-                <node concept="2YIFZM" id="1N2UgSJLNbJ" role="2Oq$k0">
-                  <ref role="1Pybhc" to="kz9k:~NavigationSupport" resolve="NavigationSupport" />
-                  <ref role="37wK5l" to="kz9k:~NavigationSupport.getInstance()" resolve="getInstance" />
+            <node concept="3clFbF" id="5mxmbv8Tnx4" role="3cqZAp">
+              <node concept="2OqwBi" id="5mxmbv8TD_9" role="3clFbG">
+                <node concept="2ShNRf" id="5mxmbv8Tnx0" role="2Oq$k0">
+                  <node concept="1pGfFk" id="5mxmbv8T$q7" role="2ShVmc">
+                    <property role="373rjd" value="true" />
+                    <ref role="37wK5l" to="kz9k:~ProjectPaneNavigator.&lt;init&gt;(jetbrains.mps.project.Project)" resolve="ProjectPaneNavigator" />
+                    <node concept="37vLTw" id="5mxmbv8TCwi" role="37wK5m">
+                      <ref role="3cqZAo" node="Iviav3qo5" resolve="myProject" />
+                    </node>
+                  </node>
                 </node>
-                <node concept="liA8E" id="1N2UgSJLMxP" role="2OqNvi">
-                  <ref role="37wK5l" to="kz9k:~NavigationSupport.selectInTree(jetbrains.mps.project.Project,org.jetbrains.mps.openapi.model.SNode,boolean)" resolve="selectInTree" />
-                  <node concept="37vLTw" id="1N2UgSJLMxQ" role="37wK5m">
-                    <ref role="3cqZAo" node="Iviav3qo5" resolve="myProject" />
+                <node concept="liA8E" id="5mxmbv8TEtd" role="2OqNvi">
+                  <ref role="37wK5l" to="kz9k:~ProjectPaneNavigator.select(org.jetbrains.mps.openapi.model.SNodeReference)" resolve="select" />
+                  <node concept="2OqwBi" id="5mxmbv8TInD" role="37wK5m">
+                    <node concept="37vLTw" id="5mxmbv8TGJs" role="2Oq$k0">
+                      <ref role="3cqZAo" node="Iviav45kB" resolve="node" />
+                    </node>
+                    <node concept="liA8E" id="5mxmbv8TJtC" role="2OqNvi">
+                      <ref role="37wK5l" to="mhbf:~SNode.getReference()" resolve="getReference" />
+                    </node>
                   </node>
-                  <node concept="37vLTw" id="1N2UgSJLMxR" role="37wK5m">
-                    <ref role="3cqZAo" node="Iviav45kB" resolve="node" />
-                  </node>
-                  <node concept="3clFbT" id="1N2UgSJLMxS" role="37wK5m" />
                 </node>
               </node>
             </node>
           </node>
         </node>
         <node concept="3clFbH" id="Iviav4zwl" role="3cqZAp" />
-        <node concept="3clFbF" id="Iviav4CV9" role="3cqZAp">
-          <node concept="2OqwBi" id="Iviav4D1U" role="3clFbG">
-            <node concept="2YIFZM" id="Iviav4CWh" role="2Oq$k0">
-              <ref role="37wK5l" to="kz9k:~NavigationSupport.getInstance()" resolve="getInstance" />
-              <ref role="1Pybhc" to="kz9k:~NavigationSupport" resolve="NavigationSupport" />
+        <node concept="3clFbF" id="5mxmbv8TSE3" role="3cqZAp">
+          <node concept="2OqwBi" id="5mxmbv8Ulhk" role="3clFbG">
+            <node concept="2OqwBi" id="5mxmbv8Uik2" role="2Oq$k0">
+              <node concept="2ShNRf" id="5mxmbv8TSDZ" role="2Oq$k0">
+                <node concept="1pGfFk" id="5mxmbv8Udyy" role="2ShVmc">
+                  <property role="373rjd" value="true" />
+                  <ref role="37wK5l" to="kz9k:~EditorNavigator.&lt;init&gt;(jetbrains.mps.project.Project)" resolve="EditorNavigator" />
+                  <node concept="37vLTw" id="5mxmbv8UhaL" role="37wK5m">
+                    <ref role="3cqZAo" node="Iviav3qo5" resolve="myProject" />
+                  </node>
+                </node>
+              </node>
+              <node concept="liA8E" id="5mxmbv8Uj1W" role="2OqNvi">
+                <ref role="37wK5l" to="kz9k:~EditorNavigator.shallFocus(boolean)" resolve="shallFocus" />
+                <node concept="3clFbT" id="5mxmbv8UkpA" role="37wK5m">
+                  <property role="3clFbU" value="true" />
+                </node>
+              </node>
             </node>
-            <node concept="liA8E" id="Iviav4Eau" role="2OqNvi">
-              <ref role="37wK5l" to="kz9k:~NavigationSupport.openNode(jetbrains.mps.project.Project,org.jetbrains.mps.openapi.model.SNode,boolean,boolean)" resolve="openNode" />
-              <node concept="37vLTw" id="1T2KDlwRteX" role="37wK5m">
-                <ref role="3cqZAo" node="Iviav3qo5" resolve="myProject" />
-              </node>
-              <node concept="37vLTw" id="Iviav4FFr" role="37wK5m">
-                <ref role="3cqZAo" node="Iviav45kB" resolve="node" />
-              </node>
-              <node concept="3clFbT" id="Iviav4FIi" role="37wK5m">
-                <property role="3clFbU" value="true" />
-              </node>
-              <node concept="3clFbT" id="Iviav4FLf" role="37wK5m">
-                <property role="3clFbU" value="false" />
+            <node concept="liA8E" id="5mxmbv8UmMm" role="2OqNvi">
+              <ref role="37wK5l" to="kz9k:~EditorNavigator.open(org.jetbrains.mps.openapi.model.SNodeReference)" resolve="open" />
+              <node concept="2OqwBi" id="5mxmbv8UpQQ" role="37wK5m">
+                <node concept="37vLTw" id="5mxmbv8UpgP" role="2Oq$k0">
+                  <ref role="3cqZAo" node="Iviav45kB" resolve="node" />
+                </node>
+                <node concept="liA8E" id="5mxmbv8UqFY" role="2OqNvi">
+                  <ref role="37wK5l" to="mhbf:~SNode.getReference()" resolve="getReference" />
+                </node>
               </node>
             </node>
           </node>
@@ -15975,14 +15990,34 @@
                                   <node concept="3clFbS" id="2bPPn51YmqY" role="3clFbx">
                                     <node concept="3clFbJ" id="24fB7C4kTI4" role="3cqZAp">
                                       <node concept="3clFbS" id="24fB7C4kTI7" role="3clFbx">
-                                        <node concept="1QHqEM" id="7NyyyjNUySE" role="3cqZAp">
-                                          <node concept="1QHqEC" id="7NyyyjNUySG" role="1QHqEI">
-                                            <node concept="3clFbS" id="7NyyyjNUySI" role="1bW5cS">
-                                              <node concept="3cpWs8" id="9MiAwFl$dJ" role="3cqZAp">
-                                                <node concept="3cpWsn" id="9MiAwFl$dK" role="3cpWs9">
-                                                  <property role="TrG5h" value="programNode" />
-                                                  <node concept="3Tqbb2" id="9MiAwFl$dC" role="1tU5fm" />
-                                                  <node concept="2OqwBi" id="9MiAwFl$dL" role="33vP2m">
+                                        <node concept="3cpWs8" id="9MiAwFl$dJ" role="3cqZAp">
+                                          <node concept="3cpWsn" id="9MiAwFl$dK" role="3cpWs9">
+                                            <property role="TrG5h" value="programNode" />
+                                            <node concept="3Tqbb2" id="9MiAwFl$dC" role="1tU5fm" />
+                                          </node>
+                                        </node>
+                                        <node concept="3cpWs8" id="5mxmbv8Vp0x" role="3cqZAp">
+                                          <node concept="3cpWsn" id="5mxmbv8Vp0y" role="3cpWs9">
+                                            <property role="TrG5h" value="mpsProject" />
+                                            <node concept="3uibUv" id="5mxmbv8Vn20" role="1tU5fm">
+                                              <ref role="3uigEE" to="z1c3:~Project" resolve="Project" />
+                                            </node>
+                                            <node concept="2OqwBi" id="5mxmbv8Vp0z" role="33vP2m">
+                                              <node concept="2WthIp" id="5mxmbv8Vp0$" role="2Oq$k0">
+                                                <ref role="32nkFo" node="7Q6Q5uyvZ1G" resolve="GenericTreeTool" />
+                                              </node>
+                                              <node concept="2BZ7hE" id="5mxmbv8Vp0_" role="2OqNvi">
+                                                <ref role="2WH_rO" node="1yljmw4QRzD" resolve="project" />
+                                              </node>
+                                            </node>
+                                          </node>
+                                        </node>
+                                        <node concept="1QHqEK" id="5mxmbv8UFVW" role="3cqZAp">
+                                          <node concept="1QHqEC" id="5mxmbv8UFVY" role="1QHqEI">
+                                            <node concept="3clFbS" id="5mxmbv8UFW0" role="1bW5cS">
+                                              <node concept="3clFbF" id="5mxmbv8UPGf" role="3cqZAp">
+                                                <node concept="37vLTI" id="5mxmbv8UPGh" role="3clFbG">
+                                                  <node concept="2OqwBi" id="9MiAwFl$dL" role="37vLTx">
                                                     <node concept="1eOMI4" id="9MiAwFl$dM" role="2Oq$k0">
                                                       <node concept="10QFUN" id="9MiAwFl$dN" role="1eOMHV">
                                                         <node concept="37vLTw" id="9MiAwFl$dO" role="10QFUP">
@@ -15997,42 +16032,7 @@
                                                       <ref role="37wK5l" to="hwgx:7NyyyjNyzs8" resolve="getProgramNode" />
                                                     </node>
                                                   </node>
-                                                </node>
-                                              </node>
-                                              <node concept="3clFbJ" id="9MiAwFl$rH" role="3cqZAp">
-                                                <node concept="3clFbS" id="9MiAwFl$rK" role="3clFbx">
-                                                  <node concept="3clFbF" id="7NyyyjNuC1u" role="3cqZAp">
-                                                    <node concept="2OqwBi" id="7NyyyjNuC1w" role="3clFbG">
-                                                      <node concept="2YIFZM" id="7NyyyjNuC1x" role="2Oq$k0">
-                                                        <ref role="37wK5l" to="kz9k:~NavigationSupport.getInstance()" resolve="getInstance" />
-                                                        <ref role="1Pybhc" to="kz9k:~NavigationSupport" resolve="NavigationSupport" />
-                                                      </node>
-                                                      <node concept="liA8E" id="7NyyyjNuC1y" role="2OqNvi">
-                                                        <ref role="37wK5l" to="kz9k:~NavigationSupport.openNode(jetbrains.mps.project.Project,org.jetbrains.mps.openapi.model.SNode,boolean,boolean)" resolve="openNode" />
-                                                        <node concept="2OqwBi" id="7NyyyjNIhYm" role="37wK5m">
-                                                          <node concept="2WthIp" id="7NyyyjNIhYp" role="2Oq$k0">
-                                                            <ref role="32nkFo" node="7Q6Q5uyvZ1G" resolve="GenericTreeTool" />
-                                                          </node>
-                                                          <node concept="2BZ7hE" id="7NyyyjNIhYr" role="2OqNvi">
-                                                            <ref role="2WH_rO" node="1yljmw4QRzD" resolve="project" />
-                                                          </node>
-                                                        </node>
-                                                        <node concept="37vLTw" id="9MiAwFl$dR" role="37wK5m">
-                                                          <ref role="3cqZAo" node="9MiAwFl$dK" resolve="programNode" />
-                                                        </node>
-                                                        <node concept="3clFbT" id="7NyyyjNuC1_" role="37wK5m">
-                                                          <property role="3clFbU" value="true" />
-                                                        </node>
-                                                        <node concept="3clFbT" id="7NyyyjNuC1A" role="37wK5m">
-                                                          <property role="3clFbU" value="true" />
-                                                        </node>
-                                                      </node>
-                                                    </node>
-                                                  </node>
-                                                </node>
-                                                <node concept="3y3z36" id="9MiAwFl$_j" role="3clFbw">
-                                                  <node concept="10Nm6u" id="9MiAwFl$_z" role="3uHU7w" />
-                                                  <node concept="37vLTw" id="9MiAwFl$wi" role="3uHU7B">
+                                                  <node concept="37vLTw" id="5mxmbv8UPGl" role="37vLTJ">
                                                     <ref role="3cqZAo" node="9MiAwFl$dK" resolve="programNode" />
                                                   </node>
                                                 </node>
@@ -16040,16 +16040,59 @@
                                             </node>
                                           </node>
                                           <node concept="2OqwBi" id="3k8awrIlmm3" role="ukAjM">
-                                            <node concept="2OqwBi" id="3k8awrIliTH" role="2Oq$k0">
-                                              <node concept="2WthIp" id="3k8awrIliTK" role="2Oq$k0">
-                                                <ref role="32nkFo" node="7Q6Q5uyvZ1G" resolve="GenericTreeTool" />
-                                              </node>
-                                              <node concept="2BZ7hE" id="3k8awrIliTM" role="2OqNvi">
-                                                <ref role="2WH_rO" node="1yljmw4QRzD" resolve="project" />
-                                              </node>
+                                            <node concept="37vLTw" id="5mxmbv8Vp0A" role="2Oq$k0">
+                                              <ref role="3cqZAo" node="5mxmbv8Vp0y" resolve="mpsProject" />
                                             </node>
                                             <node concept="liA8E" id="3k8awrIloAz" role="2OqNvi">
                                               <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                                            </node>
+                                          </node>
+                                        </node>
+                                        <node concept="3clFbJ" id="9MiAwFl$rH" role="3cqZAp">
+                                          <node concept="3clFbS" id="9MiAwFl$rK" role="3clFbx">
+                                            <node concept="3clFbF" id="5mxmbv8V40C" role="3cqZAp">
+                                              <node concept="2OqwBi" id="5mxmbv8VKc_" role="3clFbG">
+                                                <node concept="2OqwBi" id="5mxmbv8VDYX" role="2Oq$k0">
+                                                  <node concept="2OqwBi" id="5mxmbv8Vwvh" role="2Oq$k0">
+                                                    <node concept="2ShNRf" id="5mxmbv8V40$" role="2Oq$k0">
+                                                      <node concept="1pGfFk" id="5mxmbv8VlBo" role="2ShVmc">
+                                                        <property role="373rjd" value="true" />
+                                                        <ref role="37wK5l" to="kz9k:~EditorNavigator.&lt;init&gt;(jetbrains.mps.project.Project)" resolve="EditorNavigator" />
+                                                        <node concept="37vLTw" id="5mxmbv8VuUE" role="37wK5m">
+                                                          <ref role="3cqZAo" node="5mxmbv8Vp0y" resolve="mpsProject" />
+                                                        </node>
+                                                      </node>
+                                                    </node>
+                                                    <node concept="liA8E" id="5mxmbv8VzGT" role="2OqNvi">
+                                                      <ref role="37wK5l" to="kz9k:~EditorNavigator.shallFocus(boolean)" resolve="shallFocus" />
+                                                      <node concept="3clFbT" id="5mxmbv8VAoX" role="37wK5m">
+                                                        <property role="3clFbU" value="true" />
+                                                      </node>
+                                                    </node>
+                                                  </node>
+                                                  <node concept="liA8E" id="5mxmbv8VFiP" role="2OqNvi">
+                                                    <ref role="37wK5l" to="kz9k:~EditorNavigator.shallSelect(boolean)" resolve="shallSelect" />
+                                                    <node concept="3clFbT" id="5mxmbv8VIuc" role="37wK5m">
+                                                      <property role="3clFbU" value="true" />
+                                                    </node>
+                                                  </node>
+                                                </node>
+                                                <node concept="liA8E" id="5mxmbv8VNGh" role="2OqNvi">
+                                                  <ref role="37wK5l" to="kz9k:~EditorNavigator.open(org.jetbrains.mps.openapi.model.SNodeReference)" resolve="open" />
+                                                  <node concept="2OqwBi" id="5mxmbv8VULd" role="37wK5m">
+                                                    <node concept="37vLTw" id="5mxmbv8VSTq" role="2Oq$k0">
+                                                      <ref role="3cqZAo" node="9MiAwFl$dK" resolve="programNode" />
+                                                    </node>
+                                                    <node concept="iZEcu" id="5mxmbv8VYL3" role="2OqNvi" />
+                                                  </node>
+                                                </node>
+                                              </node>
+                                            </node>
+                                          </node>
+                                          <node concept="3y3z36" id="9MiAwFl$_j" role="3clFbw">
+                                            <node concept="10Nm6u" id="9MiAwFl$_z" role="3uHU7w" />
+                                            <node concept="37vLTw" id="9MiAwFl$wi" role="3uHU7B">
+                                              <ref role="3cqZAo" node="9MiAwFl$dK" resolve="programNode" />
                                             </node>
                                           </node>
                                         </node>
@@ -16548,14 +16591,18 @@
                                             </node>
                                           </node>
                                           <node concept="3clFbS" id="9MiAwFNoYT" role="3clF47">
-                                            <node concept="1QHqEM" id="9MiAwFNsAY" role="3cqZAp">
-                                              <node concept="1QHqEC" id="9MiAwFNsAZ" role="1QHqEI">
-                                                <node concept="3clFbS" id="9MiAwFNsB0" role="1bW5cS">
-                                                  <node concept="3cpWs8" id="9MiAwFNsB1" role="3cqZAp">
-                                                    <node concept="3cpWsn" id="9MiAwFNsB2" role="3cpWs9">
-                                                      <property role="TrG5h" value="programNode" />
-                                                      <node concept="3Tqbb2" id="9MiAwFNsB3" role="1tU5fm" />
-                                                      <node concept="2OqwBi" id="9MiAwFNsB4" role="33vP2m">
+                                            <node concept="3cpWs8" id="9MiAwFNsB1" role="3cqZAp">
+                                              <node concept="3cpWsn" id="9MiAwFNsB2" role="3cpWs9">
+                                                <property role="TrG5h" value="programNode" />
+                                                <node concept="3Tqbb2" id="9MiAwFNsB3" role="1tU5fm" />
+                                              </node>
+                                            </node>
+                                            <node concept="1QHqEK" id="5mxmbv8Wlf8" role="3cqZAp">
+                                              <node concept="1QHqEC" id="5mxmbv8Wlfa" role="1QHqEI">
+                                                <node concept="3clFbS" id="5mxmbv8Wlfc" role="1bW5cS">
+                                                  <node concept="3clFbF" id="5mxmbv8WuoF" role="3cqZAp">
+                                                    <node concept="37vLTI" id="5mxmbv8WuoH" role="3clFbG">
+                                                      <node concept="2OqwBi" id="9MiAwFNsB4" role="37vLTx">
                                                         <node concept="1eOMI4" id="9MiAwFNsB5" role="2Oq$k0">
                                                           <node concept="10QFUN" id="9MiAwFNsB6" role="1eOMHV">
                                                             <node concept="37vLTw" id="9MiAwFNsB7" role="10QFUP">
@@ -16570,42 +16617,7 @@
                                                           <ref role="37wK5l" to="hwgx:7NyyyjNyzs8" resolve="getProgramNode" />
                                                         </node>
                                                       </node>
-                                                    </node>
-                                                  </node>
-                                                  <node concept="3clFbJ" id="9MiAwFNsBa" role="3cqZAp">
-                                                    <node concept="3clFbS" id="9MiAwFNsBb" role="3clFbx">
-                                                      <node concept="3clFbF" id="9MiAwFNsBc" role="3cqZAp">
-                                                        <node concept="2OqwBi" id="9MiAwFNsBd" role="3clFbG">
-                                                          <node concept="2YIFZM" id="9MiAwFNsBe" role="2Oq$k0">
-                                                            <ref role="1Pybhc" to="kz9k:~NavigationSupport" resolve="NavigationSupport" />
-                                                            <ref role="37wK5l" to="kz9k:~NavigationSupport.getInstance()" resolve="getInstance" />
-                                                          </node>
-                                                          <node concept="liA8E" id="9MiAwFNsBf" role="2OqNvi">
-                                                            <ref role="37wK5l" to="kz9k:~NavigationSupport.openNode(jetbrains.mps.project.Project,org.jetbrains.mps.openapi.model.SNode,boolean,boolean)" resolve="openNode" />
-                                                            <node concept="2OqwBi" id="1T2KDlwRmcm" role="37wK5m">
-                                                              <node concept="2WthIp" id="1T2KDlwRmcn" role="2Oq$k0">
-                                                                <ref role="32nkFo" node="7Q6Q5uyvZ1G" resolve="GenericTreeTool" />
-                                                              </node>
-                                                              <node concept="2BZ7hE" id="1T2KDlwRmco" role="2OqNvi">
-                                                                <ref role="2WH_rO" node="1yljmw4QRzD" resolve="project" />
-                                                              </node>
-                                                            </node>
-                                                            <node concept="37vLTw" id="9MiAwFNsBl" role="37wK5m">
-                                                              <ref role="3cqZAo" node="9MiAwFNsB2" resolve="programNode" />
-                                                            </node>
-                                                            <node concept="3clFbT" id="9MiAwFNsBm" role="37wK5m">
-                                                              <property role="3clFbU" value="true" />
-                                                            </node>
-                                                            <node concept="3clFbT" id="9MiAwFNsBn" role="37wK5m">
-                                                              <property role="3clFbU" value="true" />
-                                                            </node>
-                                                          </node>
-                                                        </node>
-                                                      </node>
-                                                    </node>
-                                                    <node concept="3y3z36" id="9MiAwFNsBo" role="3clFbw">
-                                                      <node concept="10Nm6u" id="9MiAwFNsBp" role="3uHU7w" />
-                                                      <node concept="37vLTw" id="9MiAwFNsBq" role="3uHU7B">
+                                                      <node concept="37vLTw" id="5mxmbv8WuoL" role="37vLTJ">
                                                         <ref role="3cqZAo" node="9MiAwFNsB2" resolve="programNode" />
                                                       </node>
                                                     </node>
@@ -16618,6 +16630,54 @@
                                                 </node>
                                                 <node concept="liA8E" id="3k8awrIlC4e" role="2OqNvi">
                                                   <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                                                </node>
+                                              </node>
+                                            </node>
+                                            <node concept="3clFbJ" id="9MiAwFNsBa" role="3cqZAp">
+                                              <node concept="3clFbS" id="9MiAwFNsBb" role="3clFbx">
+                                                <node concept="3clFbF" id="5mxmbv8WGcy" role="3cqZAp">
+                                                  <node concept="2OqwBi" id="5mxmbv8XlIs" role="3clFbG">
+                                                    <node concept="2OqwBi" id="5mxmbv8XaMS" role="2Oq$k0">
+                                                      <node concept="2OqwBi" id="5mxmbv8X2DF" role="2Oq$k0">
+                                                        <node concept="2ShNRf" id="5mxmbv8WGcu" role="2Oq$k0">
+                                                          <node concept="1pGfFk" id="5mxmbv8WSUM" role="2ShVmc">
+                                                            <property role="373rjd" value="true" />
+                                                            <ref role="37wK5l" to="kz9k:~EditorNavigator.&lt;init&gt;(jetbrains.mps.project.Project)" resolve="EditorNavigator" />
+                                                            <node concept="37vLTw" id="5mxmbv8WYRF" role="37wK5m">
+                                                              <ref role="3cqZAo" node="9MiAwFNoYR" resolve="project" />
+                                                            </node>
+                                                          </node>
+                                                        </node>
+                                                        <node concept="liA8E" id="5mxmbv8X5qH" role="2OqNvi">
+                                                          <ref role="37wK5l" to="kz9k:~EditorNavigator.shallFocus(boolean)" resolve="shallFocus" />
+                                                          <node concept="3clFbT" id="5mxmbv8X932" role="37wK5m">
+                                                            <property role="3clFbU" value="true" />
+                                                          </node>
+                                                        </node>
+                                                      </node>
+                                                      <node concept="liA8E" id="5mxmbv8XehY" role="2OqNvi">
+                                                        <ref role="37wK5l" to="kz9k:~EditorNavigator.shallSelect(boolean)" resolve="shallSelect" />
+                                                        <node concept="3clFbT" id="5mxmbv8Xipw" role="37wK5m">
+                                                          <property role="3clFbU" value="true" />
+                                                        </node>
+                                                      </node>
+                                                    </node>
+                                                    <node concept="liA8E" id="5mxmbv8Xo_F" role="2OqNvi">
+                                                      <ref role="37wK5l" to="kz9k:~EditorNavigator.open(org.jetbrains.mps.openapi.model.SNodeReference)" resolve="open" />
+                                                      <node concept="2OqwBi" id="5mxmbv8Xy6S" role="37wK5m">
+                                                        <node concept="37vLTw" id="5mxmbv8XvYp" role="2Oq$k0">
+                                                          <ref role="3cqZAo" node="9MiAwFNsB2" resolve="programNode" />
+                                                        </node>
+                                                        <node concept="iZEcu" id="5mxmbv8XzkC" role="2OqNvi" />
+                                                      </node>
+                                                    </node>
+                                                  </node>
+                                                </node>
+                                              </node>
+                                              <node concept="3y3z36" id="9MiAwFNsBo" role="3clFbw">
+                                                <node concept="10Nm6u" id="9MiAwFNsBp" role="3uHU7w" />
+                                                <node concept="37vLTw" id="9MiAwFNsBq" role="3uHU7B">
+                                                  <ref role="3cqZAo" node="9MiAwFNsB2" resolve="programNode" />
                                                 </node>
                                               </node>
                                             </node>
@@ -17359,7 +17419,7 @@
                               <ref role="3cqZAo" node="24fB7C4QyNR" resolve="menu" />
                             </node>
                             <node concept="liA8E" id="24fB7C4QyO5" role="2OqNvi">
-                              <ref role="37wK5l" to="dxuu:~JPopupMenu.show(java.awt.Component,int,int)" resolve="show" />
+                              <ref role="37wK5l" to="jkm4:~JBPopupMenu.show(java.awt.Component,int,int)" resolve="show" />
                               <node concept="2OqwBi" id="24fB7C4QyO6" role="37wK5m">
                                 <node concept="2WthIp" id="24fB7C4QyO7" role="2Oq$k0">
                                   <ref role="32nkFo" node="7Q6Q5uyvZ1G" resolve="GenericTreeTool" />

--- a/code/platform/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.editingGuide.execution/models/com/mbeddr/mpsutil/editingGuide/execution.mps
+++ b/code/platform/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.editingGuide.execution/models/com/mbeddr/mpsutil/editingGuide/execution.mps
@@ -82,6 +82,9 @@
         <property id="1176718929932" name="isFinal" index="3TUv4t" />
         <child id="1068431790190" name="initializer" index="33vP2m" />
       </concept>
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ngI" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
+      </concept>
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
@@ -220,6 +223,7 @@
       <concept id="1138411891628" name="jetbrains.mps.lang.smodel.structure.SNodeOperation" flags="nn" index="eCIE_">
         <child id="1144104376918" name="parameter" index="1xVPHs" />
       </concept>
+      <concept id="5045161044515397667" name="jetbrains.mps.lang.smodel.structure.Node_PointerOperation" flags="ng" index="iZEcu" />
       <concept id="4497478346159780083" name="jetbrains.mps.lang.smodel.structure.LanguageRefExpression" flags="ng" index="pHN19">
         <child id="3542851458883491298" name="languageId" index="2V$M_3" />
       </concept>
@@ -1312,114 +1316,6 @@
         </node>
       </node>
     </node>
-    <node concept="2tJIrI" id="44KFiKpmvX5" role="jymVt" />
-    <node concept="3clFb_" id="5h2rxDjY35n" role="jymVt">
-      <property role="TrG5h" value="getEditorComponent" />
-      <node concept="3uibUv" id="5h2rxDjY7cC" role="3clF45">
-        <ref role="3uigEE" to="exr9:~EditorComponent" resolve="EditorComponent" />
-      </node>
-      <node concept="3Tmbuc" id="5h2rxDjY3$D" role="1B3o_S" />
-      <node concept="3clFbS" id="5h2rxDjY35r" role="3clF47">
-        <node concept="3clFbJ" id="5h2rxDjXgbQ" role="3cqZAp">
-          <node concept="3clFbS" id="5h2rxDjXgbS" role="3clFbx">
-            <node concept="3cpWs8" id="5h2rxDjX631" role="3cqZAp">
-              <node concept="3cpWsn" id="5h2rxDjX632" role="3cpWs9">
-                <property role="TrG5h" value="editor" />
-                <node concept="3uibUv" id="5h2rxDjX633" role="1tU5fm">
-                  <ref role="3uigEE" to="cj4x:~Editor" resolve="Editor" />
-                </node>
-                <node concept="2OqwBi" id="5h2rxDjX634" role="33vP2m">
-                  <node concept="2YIFZM" id="5h2rxDjX635" role="2Oq$k0">
-                    <ref role="37wK5l" to="kz9k:~NavigationSupport.getInstance()" resolve="getInstance" />
-                    <ref role="1Pybhc" to="kz9k:~NavigationSupport" resolve="NavigationSupport" />
-                  </node>
-                  <node concept="liA8E" id="5h2rxDjX636" role="2OqNvi">
-                    <ref role="37wK5l" to="kz9k:~NavigationSupport.openNode(jetbrains.mps.project.Project,org.jetbrains.mps.openapi.model.SNode,boolean,boolean)" resolve="openNode" />
-                    <node concept="37vLTw" id="5h2rxDjX74W" role="37wK5m">
-                      <ref role="3cqZAo" node="5h2rxDjX6LC" resolve="myMpsProject" />
-                    </node>
-                    <node concept="1rXfSq" id="692bXAb6b7q" role="37wK5m">
-                      <ref role="37wK5l" node="692bXAb66ij" resolve="getSandboxExercise" />
-                    </node>
-                    <node concept="3clFbT" id="5h2rxDjX63a" role="37wK5m">
-                      <property role="3clFbU" value="true" />
-                    </node>
-                    <node concept="3clFbT" id="5h2rxDjX63b" role="37wK5m" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbF" id="5h2rxDjX7zl" role="3cqZAp">
-              <node concept="37vLTI" id="5h2rxDjX7zn" role="3clFbG">
-                <node concept="10QFUN" id="5h2rxDjX7wJ" role="37vLTx">
-                  <node concept="2OqwBi" id="5h2rxDjX7wK" role="10QFUP">
-                    <node concept="37vLTw" id="5h2rxDjX7wL" role="2Oq$k0">
-                      <ref role="3cqZAo" node="5h2rxDjX632" resolve="editor" />
-                    </node>
-                    <node concept="liA8E" id="5h2rxDjX7wM" role="2OqNvi">
-                      <ref role="37wK5l" to="cj4x:~Editor.getCurrentEditorComponent()" resolve="getCurrentEditorComponent" />
-                    </node>
-                  </node>
-                  <node concept="3uibUv" id="5h2rxDjX7wN" role="10QFUM">
-                    <ref role="3uigEE" to="exr9:~EditorComponent" resolve="EditorComponent" />
-                  </node>
-                </node>
-                <node concept="37vLTw" id="5h2rxDjX7zr" role="37vLTJ">
-                  <ref role="3cqZAo" node="5h2rxDjX7Cz" resolve="myEditorComponent" />
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbF" id="692bXAb5WNE" role="3cqZAp">
-              <node concept="2OqwBi" id="692bXAb5WU_" role="3clFbG">
-                <node concept="37vLTw" id="692bXAb5WNC" role="2Oq$k0">
-                  <ref role="3cqZAo" node="5h2rxDjX7Cz" resolve="myEditorComponent" />
-                </node>
-                <node concept="liA8E" id="692bXAb5Y1x" role="2OqNvi">
-                  <ref role="37wK5l" to="exr9:~EditorComponent.addDisposeListener(jetbrains.mps.nodeEditor.EditorComponent$EditorDisposeListener)" resolve="addDisposeListener" />
-                  <node concept="37vLTw" id="3$YAQZ4CAuR" role="37wK5m">
-                    <ref role="3cqZAo" node="3$YAQZ4C_3p" resolve="myEditorDisposeListener" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbF" id="4TMjSvbGFWw" role="3cqZAp">
-              <node concept="2OqwBi" id="4TMjSvbGHmd" role="3clFbG">
-                <node concept="2OqwBi" id="4TMjSvbGG9B" role="2Oq$k0">
-                  <node concept="37vLTw" id="4TMjSvbGFWu" role="2Oq$k0">
-                    <ref role="3cqZAo" node="5h2rxDjX7Cz" resolve="myEditorComponent" />
-                  </node>
-                  <node concept="liA8E" id="4TMjSvbGHgz" role="2OqNvi">
-                    <ref role="37wK5l" to="exr9:~EditorComponent.getSelectionManager()" resolve="getSelectionManager" />
-                  </node>
-                </node>
-                <node concept="liA8E" id="4TMjSvbGHpQ" role="2OqNvi">
-                  <ref role="37wK5l" to="lwvz:~SelectionManager.addSelectionListener(jetbrains.mps.openapi.editor.selection.SelectionListener)" resolve="addSelectionListener" />
-                  <node concept="37vLTw" id="3$YAQZ4CzrT" role="37wK5m">
-                    <ref role="3cqZAo" node="3$YAQZ4Cxvc" resolve="mySelectionListener" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbF" id="5h2rxDjXrN0" role="3cqZAp">
-              <node concept="1rXfSq" id="5h2rxDjXrMY" role="3clFbG">
-                <ref role="37wK5l" node="5h2rxDjXllI" resolve="initHints" />
-              </node>
-            </node>
-          </node>
-          <node concept="3clFbC" id="5h2rxDjXgl$" role="3clFbw">
-            <node concept="10Nm6u" id="5h2rxDjXgnl" role="3uHU7w" />
-            <node concept="37vLTw" id="5h2rxDjXgf4" role="3uHU7B">
-              <ref role="3cqZAo" node="5h2rxDjX7Cz" resolve="myEditorComponent" />
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="5h2rxDjY7HY" role="3cqZAp">
-          <node concept="37vLTw" id="5h2rxDjY7HW" role="3clFbG">
-            <ref role="3cqZAo" node="5h2rxDjX7Cz" resolve="myEditorComponent" />
-          </node>
-        </node>
-      </node>
-    </node>
     <node concept="2tJIrI" id="692bXAb65K5" role="jymVt" />
     <node concept="3clFb_" id="692bXAb66ij" role="jymVt">
       <property role="TrG5h" value="getSandboxExercise" />
@@ -2391,54 +2287,130 @@
           </node>
         </node>
         <node concept="3clFbH" id="1mj5sqT6PjF" role="3cqZAp" />
-        <node concept="3clFbF" id="4TMjSvbGkmI" role="3cqZAp">
-          <node concept="2OqwBi" id="4TMjSvbGkmK" role="3clFbG">
-            <node concept="1rXfSq" id="4TMjSvbGkmL" role="2Oq$k0">
-              <ref role="37wK5l" node="5h2rxDjY35n" resolve="getEditorComponent" />
+        <node concept="3clFbJ" id="5h2rxDjXgbQ" role="3cqZAp">
+          <node concept="3y3z36" id="5mxmbv90Ewd" role="3clFbw">
+            <node concept="37vLTw" id="5h2rxDjXgf4" role="3uHU7B">
+              <ref role="3cqZAo" node="5h2rxDjX7Cz" resolve="myEditorComponent" />
             </node>
-            <node concept="liA8E" id="4TMjSvbGkmM" role="2OqNvi">
-              <ref role="37wK5l" to="exr9:~EditorComponent.editNode(org.jetbrains.mps.openapi.model.SNode)" resolve="editNode" />
-              <node concept="37vLTw" id="1mj5sqT6tnC" role="37wK5m">
-                <ref role="3cqZAo" node="1mj5sqT6tnA" resolve="sandboxExercise" />
+            <node concept="10Nm6u" id="5h2rxDjXgnl" role="3uHU7w" />
+          </node>
+          <node concept="3clFbS" id="5mxmbv90lgx" role="3clFbx">
+            <node concept="3clFbF" id="5mxmbv90pBS" role="3cqZAp">
+              <node concept="2OqwBi" id="5mxmbv90tu1" role="3clFbG">
+                <node concept="37vLTw" id="5mxmbv90pBR" role="2Oq$k0">
+                  <ref role="3cqZAo" node="5h2rxDjX7Cz" resolve="myEditorComponent" />
+                </node>
+                <node concept="liA8E" id="5mxmbv90xM4" role="2OqNvi">
+                  <ref role="37wK5l" to="exr9:~EditorComponent.editNode(org.jetbrains.mps.openapi.model.SNode)" resolve="editNode" />
+                  <node concept="37vLTw" id="5mxmbv90AAQ" role="37wK5m">
+                    <ref role="3cqZAo" node="1mj5sqT6tnA" resolve="sandboxExercise" />
+                  </node>
+                </node>
               </node>
             </node>
           </node>
         </node>
-        <node concept="3clFbF" id="5M68p1G6Wgm" role="3cqZAp">
-          <node concept="2OqwBi" id="5M68p1G6Wxg" role="3clFbG">
-            <node concept="2YIFZM" id="5M68p1G6Wn_" role="2Oq$k0">
-              <ref role="37wK5l" to="kz9k:~NavigationSupport.getInstance()" resolve="getInstance" />
-              <ref role="1Pybhc" to="kz9k:~NavigationSupport" resolve="NavigationSupport" />
+        <node concept="3clFbH" id="5mxmbv90OFN" role="3cqZAp" />
+        <node concept="3clFbF" id="5mxmbv8YwdS" role="3cqZAp">
+          <node concept="2OqwBi" id="5mxmbv905l2" role="3clFbG">
+            <node concept="2OqwBi" id="5mxmbv8YQhE" role="2Oq$k0">
+              <node concept="2OqwBi" id="5mxmbv8YH1_" role="2Oq$k0">
+                <node concept="2ShNRf" id="5mxmbv8YwdO" role="2Oq$k0">
+                  <node concept="1pGfFk" id="5mxmbv8Y_FF" role="2ShVmc">
+                    <property role="373rjd" value="true" />
+                    <ref role="37wK5l" to="kz9k:~EditorNavigator.&lt;init&gt;(jetbrains.mps.project.Project)" resolve="EditorNavigator" />
+                    <node concept="37vLTw" id="5mxmbv8YDL2" role="37wK5m">
+                      <ref role="3cqZAo" node="5h2rxDjX6LC" resolve="myMpsProject" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="liA8E" id="5mxmbv8YJlY" role="2OqNvi">
+                  <ref role="37wK5l" to="kz9k:~EditorNavigator.shallFocus(boolean)" resolve="shallFocus" />
+                  <node concept="3clFbT" id="5mxmbv8YMpV" role="37wK5m">
+                    <property role="3clFbU" value="true" />
+                  </node>
+                </node>
+              </node>
+              <node concept="liA8E" id="5mxmbv8Z0wq" role="2OqNvi">
+                <ref role="37wK5l" to="kz9k:~EditorNavigator.onceEditorReady(java.util.function.BiConsumer)" resolve="onceEditorReady" />
+                <node concept="1bVj0M" id="5mxmbv8ZfG4" role="37wK5m">
+                  <node concept="gl6BB" id="5mxmbv8ZfGj" role="1bW2Oz">
+                    <property role="TrG5h" value="node" />
+                    <node concept="2jxLKc" id="5mxmbv8ZfGk" role="1tU5fm" />
+                  </node>
+                  <node concept="gl6BB" id="5mxmbv8ZfGX" role="1bW2Oz">
+                    <property role="TrG5h" value="editor" />
+                    <node concept="2jxLKc" id="5mxmbv8ZfGY" role="1tU5fm" />
+                  </node>
+                  <node concept="3clFbS" id="5mxmbv8ZfGZ" role="1bW5cS">
+                    <node concept="3clFbF" id="5h2rxDjX7zl" role="3cqZAp">
+                      <node concept="37vLTI" id="5h2rxDjX7zn" role="3clFbG">
+                        <node concept="10QFUN" id="5h2rxDjX7wJ" role="37vLTx">
+                          <node concept="2OqwBi" id="5h2rxDjX7wK" role="10QFUP">
+                            <node concept="37vLTw" id="5h2rxDjX7wL" role="2Oq$k0">
+                              <ref role="3cqZAo" node="5mxmbv8ZfGX" resolve="editor" />
+                            </node>
+                            <node concept="liA8E" id="5h2rxDjX7wM" role="2OqNvi">
+                              <ref role="37wK5l" to="cj4x:~Editor.getCurrentEditorComponent()" resolve="getCurrentEditorComponent" />
+                            </node>
+                          </node>
+                          <node concept="3uibUv" id="5h2rxDjX7wN" role="10QFUM">
+                            <ref role="3uigEE" to="exr9:~EditorComponent" resolve="EditorComponent" />
+                          </node>
+                        </node>
+                        <node concept="37vLTw" id="5h2rxDjX7zr" role="37vLTJ">
+                          <ref role="3cqZAo" node="5h2rxDjX7Cz" resolve="myEditorComponent" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbF" id="692bXAb5WNE" role="3cqZAp">
+                      <node concept="2OqwBi" id="692bXAb5WU_" role="3clFbG">
+                        <node concept="37vLTw" id="692bXAb5WNC" role="2Oq$k0">
+                          <ref role="3cqZAo" node="5h2rxDjX7Cz" resolve="myEditorComponent" />
+                        </node>
+                        <node concept="liA8E" id="692bXAb5Y1x" role="2OqNvi">
+                          <ref role="37wK5l" to="exr9:~EditorComponent.addDisposeListener(jetbrains.mps.nodeEditor.EditorComponent$EditorDisposeListener)" resolve="addDisposeListener" />
+                          <node concept="37vLTw" id="3$YAQZ4CAuR" role="37wK5m">
+                            <ref role="3cqZAo" node="3$YAQZ4C_3p" resolve="myEditorDisposeListener" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbF" id="4TMjSvbGFWw" role="3cqZAp">
+                      <node concept="2OqwBi" id="4TMjSvbGHmd" role="3clFbG">
+                        <node concept="2OqwBi" id="4TMjSvbGG9B" role="2Oq$k0">
+                          <node concept="37vLTw" id="4TMjSvbGFWu" role="2Oq$k0">
+                            <ref role="3cqZAo" node="5h2rxDjX7Cz" resolve="myEditorComponent" />
+                          </node>
+                          <node concept="liA8E" id="4TMjSvbGHgz" role="2OqNvi">
+                            <ref role="37wK5l" to="exr9:~EditorComponent.getSelectionManager()" resolve="getSelectionManager" />
+                          </node>
+                        </node>
+                        <node concept="liA8E" id="4TMjSvbGHpQ" role="2OqNvi">
+                          <ref role="37wK5l" to="lwvz:~SelectionManager.addSelectionListener(jetbrains.mps.openapi.editor.selection.SelectionListener)" resolve="addSelectionListener" />
+                          <node concept="37vLTw" id="3$YAQZ4CzrT" role="37wK5m">
+                            <ref role="3cqZAo" node="3$YAQZ4Cxvc" resolve="mySelectionListener" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbF" id="5h2rxDjXrN0" role="3cqZAp">
+                      <node concept="1rXfSq" id="5h2rxDjXrMY" role="3clFbG">
+                        <ref role="37wK5l" node="5h2rxDjXllI" resolve="initHints" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
             </node>
-            <node concept="liA8E" id="5M68p1G6WHg" role="2OqNvi">
-              <ref role="37wK5l" to="kz9k:~NavigationSupport.openNode(jetbrains.mps.project.Project,org.jetbrains.mps.openapi.model.SNode,boolean,boolean)" resolve="openNode" />
-              <node concept="37vLTw" id="5M68p1G6XNg" role="37wK5m">
-                <ref role="3cqZAo" node="5h2rxDjX6LC" resolve="myMpsProject" />
+            <node concept="liA8E" id="5mxmbv9083N" role="2OqNvi">
+              <ref role="37wK5l" to="kz9k:~EditorNavigator.open(org.jetbrains.mps.openapi.model.SNodeReference)" resolve="open" />
+              <node concept="2OqwBi" id="5mxmbv90evZ" role="37wK5m">
+                <node concept="37vLTw" id="5mxmbv90c$J" role="2Oq$k0">
+                  <ref role="3cqZAo" node="1mj5sqT6tnA" resolve="sandboxExercise" />
+                </node>
+                <node concept="iZEcu" id="5mxmbv90gWh" role="2OqNvi" />
               </node>
-              <node concept="37vLTw" id="1mj5sqT6tnD" role="37wK5m">
-                <ref role="3cqZAo" node="1mj5sqT6tnA" resolve="sandboxExercise" />
-              </node>
-              <node concept="3clFbT" id="5M68p1G6Zql" role="37wK5m">
-                <property role="3clFbU" value="true" />
-              </node>
-              <node concept="3clFbT" id="5M68p1G6Zy9" role="37wK5m">
-                <property role="3clFbU" value="false" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="3GvOzXgURkA" role="3cqZAp">
-          <node concept="2OqwBi" id="3GvOzXgUTsl" role="3clFbG">
-            <node concept="2OqwBi" id="3GvOzXgUS63" role="2Oq$k0">
-              <node concept="1rXfSq" id="3GvOzXgURk$" role="2Oq$k0">
-                <ref role="37wK5l" node="5h2rxDjY35n" resolve="getEditorComponent" />
-              </node>
-              <node concept="liA8E" id="3GvOzXgUTiv" role="2OqNvi">
-                <ref role="37wK5l" to="exr9:~EditorComponent.getEditorContext()" resolve="getEditorContext" />
-              </node>
-            </node>
-            <node concept="liA8E" id="3GvOzXgUTFd" role="2OqNvi">
-              <ref role="37wK5l" to="exr9:~EditorContext.getRepository()" resolve="getRepository" />
             </node>
           </node>
         </node>

--- a/code/platform/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.nodeaccess/models/com/mbeddr/mpsutil/nodeaccess/plugin.mps
+++ b/code/platform/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.nodeaccess/models/com/mbeddr/mpsutil/nodeaccess/plugin.mps
@@ -136,6 +136,9 @@
         <property id="1176718929932" name="isFinal" index="3TUv4t" />
         <child id="1068431790190" name="initializer" index="33vP2m" />
       </concept>
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ngI" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
+      </concept>
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
@@ -283,6 +286,7 @@
       <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
         <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
       </concept>
+      <concept id="5045161044515397667" name="jetbrains.mps.lang.smodel.structure.Node_PointerOperation" flags="ng" index="iZEcu" />
       <concept id="7453996997717780434" name="jetbrains.mps.lang.smodel.structure.Node_GetSConceptOperation" flags="nn" index="2yIwOk" />
       <concept id="2396822768958367367" name="jetbrains.mps.lang.smodel.structure.AbstractTypeCastExpression" flags="nn" index="$5XWr">
         <child id="6733348108486823193" name="leftExpression" index="1m5AlR" />
@@ -1023,25 +1027,40 @@
                         <node concept="3clFbH" id="4PqLM5kUh5N" role="3cqZAp" />
                         <node concept="3clFbJ" id="2N1CSrzKNQ4" role="3cqZAp">
                           <node concept="3clFbS" id="2N1CSrzKNQ5" role="3clFbx">
-                            <node concept="3clFbF" id="2N1CSrzKNQ6" role="3cqZAp">
-                              <node concept="2OqwBi" id="2N1CSrzKNQ7" role="3clFbG">
-                                <node concept="2YIFZM" id="2N1CSrzKNQ8" role="2Oq$k0">
-                                  <ref role="1Pybhc" to="kz9k:~NavigationSupport" resolve="NavigationSupport" />
-                                  <ref role="37wK5l" to="kz9k:~NavigationSupport.getInstance()" resolve="getInstance" />
+                            <node concept="3clFbF" id="5mxmbv93gIm" role="3cqZAp">
+                              <node concept="2OqwBi" id="5mxmbv93tlA" role="3clFbG">
+                                <node concept="2OqwBi" id="5mxmbv93qOT" role="2Oq$k0">
+                                  <node concept="2OqwBi" id="5mxmbv93nAo" role="2Oq$k0">
+                                    <node concept="2ShNRf" id="5mxmbv93gIi" role="2Oq$k0">
+                                      <node concept="1pGfFk" id="5mxmbv93l$u" role="2ShVmc">
+                                        <property role="373rjd" value="true" />
+                                        <ref role="37wK5l" to="kz9k:~EditorNavigator.&lt;init&gt;(jetbrains.mps.project.Project)" resolve="EditorNavigator" />
+                                        <node concept="37vLTw" id="5mxmbv93mNv" role="37wK5m">
+                                          <ref role="3cqZAo" node="602uc2JOA6c" resolve="fP" />
+                                        </node>
+                                      </node>
+                                    </node>
+                                    <node concept="liA8E" id="5mxmbv93prp" role="2OqNvi">
+                                      <ref role="37wK5l" to="kz9k:~EditorNavigator.shallFocus(boolean)" resolve="shallFocus" />
+                                      <node concept="3clFbT" id="5mxmbv93q7b" role="37wK5m">
+                                        <property role="3clFbU" value="true" />
+                                      </node>
+                                    </node>
+                                  </node>
+                                  <node concept="liA8E" id="5mxmbv93rzf" role="2OqNvi">
+                                    <ref role="37wK5l" to="kz9k:~EditorNavigator.shallSelect(boolean)" resolve="shallSelect" />
+                                    <node concept="3clFbT" id="5mxmbv93sft" role="37wK5m">
+                                      <property role="3clFbU" value="true" />
+                                    </node>
+                                  </node>
                                 </node>
-                                <node concept="liA8E" id="2N1CSrzKNQ9" role="2OqNvi">
-                                  <ref role="37wK5l" to="kz9k:~NavigationSupport.openNode(jetbrains.mps.project.Project,org.jetbrains.mps.openapi.model.SNode,boolean,boolean)" resolve="openNode" />
-                                  <node concept="37vLTw" id="1T2KDlwRAPO" role="37wK5m">
-                                    <ref role="3cqZAo" node="602uc2JOA6c" resolve="fP" />
-                                  </node>
-                                  <node concept="37vLTw" id="7CAL8BWtKc" role="37wK5m">
-                                    <ref role="3cqZAo" node="7CAL8BWo$s" resolve="resolveNode" />
-                                  </node>
-                                  <node concept="3clFbT" id="2N1CSrzKNQe" role="37wK5m">
-                                    <property role="3clFbU" value="true" />
-                                  </node>
-                                  <node concept="3clFbT" id="2N1CSrzKNQf" role="37wK5m">
-                                    <property role="3clFbU" value="true" />
+                                <node concept="liA8E" id="5mxmbv93ug5" role="2OqNvi">
+                                  <ref role="37wK5l" to="kz9k:~EditorNavigator.open(org.jetbrains.mps.openapi.model.SNodeReference)" resolve="open" />
+                                  <node concept="2OqwBi" id="5mxmbv93wtq" role="37wK5m">
+                                    <node concept="37vLTw" id="5mxmbv93vWt" role="2Oq$k0">
+                                      <ref role="3cqZAo" node="7CAL8BWo$s" resolve="resolveNode" />
+                                    </node>
+                                    <node concept="iZEcu" id="5mxmbv93xja" role="2OqNvi" />
                                   </node>
                                 </node>
                               </node>

--- a/code/platform/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.traceExplorer/models/com.mbeddr.mpsutil.traceExplorer.plugin.mps
+++ b/code/platform/com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.traceExplorer/models/com.mbeddr.mpsutil.traceExplorer.plugin.mps
@@ -364,7 +364,6 @@
         <child id="8974276187400348171" name="commandClosureLiteral" index="1QHqEI" />
       </concept>
       <concept id="8974276187400348181" name="jetbrains.mps.lang.access.structure.ExecuteLightweightCommandStatement" flags="nn" index="1QHqEK" />
-      <concept id="8974276187400348177" name="jetbrains.mps.lang.access.structure.ExecuteCommandStatement" flags="nn" index="1QHqEO" />
     </language>
     <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
       <concept id="2524418899405758586" name="jetbrains.mps.baseLanguage.closures.structure.InferredClosureParameterDeclaration" flags="ig" index="gl6BB" />
@@ -2205,7 +2204,7 @@
               <ref role="3cqZAo" node="5IR_boHPfLL" resolve="tree" />
             </node>
             <node concept="liA8E" id="5IR_boHPmJp" role="2OqNvi">
-              <ref role="37wK5l" to="dxuu:~JTree.setToggleClickCount(int)" resolve="setToggleClickCount" />
+              <ref role="37wK5l" to="2sud:~Tree.setToggleClickCount(int)" resolve="setToggleClickCount" />
               <node concept="3cmrfG" id="5IR_boHPmJq" role="37wK5m">
                 <property role="3cmrfH" value="-1" />
               </node>
@@ -5147,74 +5146,38 @@
               </node>
               <node concept="3clFbJ" id="3wJ9Qm1143W" role="3cqZAp">
                 <node concept="3clFbS" id="3wJ9Qm1143Y" role="3clFbx">
-                  <node concept="1QHqEO" id="3wJ9Qm1c3xO" role="3cqZAp">
-                    <node concept="1QHqEC" id="3wJ9Qm1c3xP" role="1QHqEI">
-                      <node concept="3clFbS" id="3wJ9Qm1c3xQ" role="1bW5cS">
-                        <node concept="3cpWs8" id="3wJ9Qm1c3xR" role="3cqZAp">
-                          <node concept="3cpWsn" id="3wJ9Qm1c3xS" role="3cpWs9">
-                            <property role="TrG5h" value="node" />
-                            <node concept="3uibUv" id="3wJ9Qm1c3xT" role="1tU5fm">
-                              <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
+                  <node concept="3clFbF" id="5mxmbv96Lnu" role="3cqZAp">
+                    <node concept="2OqwBi" id="5mxmbv99zIZ" role="3clFbG">
+                      <node concept="2OqwBi" id="5mxmbv98Kdy" role="2Oq$k0">
+                        <node concept="2OqwBi" id="5mxmbv9811w" role="2Oq$k0">
+                          <node concept="2ShNRf" id="5mxmbv96Lnq" role="2Oq$k0">
+                            <node concept="1pGfFk" id="5mxmbv97xX_" role="2ShVmc">
+                              <property role="373rjd" value="true" />
+                              <ref role="37wK5l" to="kz9k:~EditorNavigator.&lt;init&gt;(jetbrains.mps.project.Project)" resolve="EditorNavigator" />
+                              <node concept="37vLTw" id="5mxmbv97Tb2" role="37wK5m">
+                                <ref role="3cqZAo" node="2jSY3BO8rVn" resolve="project" />
+                              </node>
                             </node>
-                            <node concept="2OqwBi" id="3wJ9Qm1c3xU" role="33vP2m">
-                              <node concept="37vLTw" id="3EF07BwqnyA" role="2Oq$k0">
-                                <ref role="3cqZAo" node="3EF07Bwp96d" resolve="reference" />
-                              </node>
-                              <node concept="liA8E" id="3wJ9Qm1c3xW" role="2OqNvi">
-                                <ref role="37wK5l" to="mhbf:~SNodeReference.resolve(org.jetbrains.mps.openapi.module.SRepository)" resolve="resolve" />
-                                <node concept="2OqwBi" id="3wJ9Qm1c3xX" role="37wK5m">
-                                  <node concept="37vLTw" id="3wJ9Qm1c3xY" role="2Oq$k0">
-                                    <ref role="3cqZAo" node="2jSY3BO8rVn" resolve="project" />
-                                  </node>
-                                  <node concept="liA8E" id="3wJ9Qm1c3xZ" role="2OqNvi">
-                                    <ref role="37wK5l" to="z1c4:~Project.getRepository()" resolve="getRepository" />
-                                  </node>
-                                </node>
-                              </node>
+                          </node>
+                          <node concept="liA8E" id="5mxmbv98xV$" role="2OqNvi">
+                            <ref role="37wK5l" to="kz9k:~EditorNavigator.shallFocus(boolean)" resolve="shallFocus" />
+                            <node concept="3clFbT" id="5mxmbv98EEV" role="37wK5m">
+                              <property role="3clFbU" value="true" />
                             </node>
                           </node>
                         </node>
-                        <node concept="3clFbJ" id="3wJ9Qm29nGg" role="3cqZAp">
-                          <node concept="3clFbS" id="3wJ9Qm29nGi" role="3clFbx">
-                            <node concept="3clFbF" id="3wJ9Qm29Ks9" role="3cqZAp">
-                              <node concept="2OqwBi" id="3wJ9Qm1c3y3" role="3clFbG">
-                                <node concept="2YIFZM" id="3wJ9Qm1c3y4" role="2Oq$k0">
-                                  <ref role="1Pybhc" to="kz9k:~NavigationSupport" resolve="NavigationSupport" />
-                                  <ref role="37wK5l" to="kz9k:~NavigationSupport.getInstance()" resolve="getInstance" />
-                                </node>
-                                <node concept="liA8E" id="3wJ9Qm1c3y5" role="2OqNvi">
-                                  <ref role="37wK5l" to="kz9k:~NavigationSupport.openNode(jetbrains.mps.project.Project,org.jetbrains.mps.openapi.model.SNode,boolean,boolean)" resolve="openNode" />
-                                  <node concept="37vLTw" id="3wJ9Qm1c3y6" role="37wK5m">
-                                    <ref role="3cqZAo" node="2jSY3BO8rVn" resolve="project" />
-                                  </node>
-                                  <node concept="37vLTw" id="3wJ9Qm1c3y7" role="37wK5m">
-                                    <ref role="3cqZAo" node="3wJ9Qm1c3xS" resolve="node" />
-                                  </node>
-                                  <node concept="3clFbT" id="3wJ9Qm1c3y8" role="37wK5m">
-                                    <property role="3clFbU" value="true" />
-                                  </node>
-                                  <node concept="3clFbT" id="3wJ9Qm1c3y9" role="37wK5m">
-                                    <property role="3clFbU" value="true" />
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                          <node concept="3y3z36" id="3wJ9Qm29oxi" role="3clFbw">
-                            <node concept="10Nm6u" id="3wJ9Qm29p62" role="3uHU7w" />
-                            <node concept="37vLTw" id="3wJ9Qm29oi_" role="3uHU7B">
-                              <ref role="3cqZAo" node="3wJ9Qm1c3xS" resolve="node" />
-                            </node>
+                        <node concept="liA8E" id="5mxmbv99frA" role="2OqNvi">
+                          <ref role="37wK5l" to="kz9k:~EditorNavigator.shallSelect(boolean)" resolve="shallSelect" />
+                          <node concept="3clFbT" id="5mxmbv99ur0" role="37wK5m">
+                            <property role="3clFbU" value="true" />
                           </node>
                         </node>
                       </node>
-                    </node>
-                    <node concept="2OqwBi" id="3wJ9Qm1c3yo" role="ukAjM">
-                      <node concept="37vLTw" id="3wJ9Qm1c3yp" role="2Oq$k0">
-                        <ref role="3cqZAo" node="2jSY3BO8rVn" resolve="project" />
-                      </node>
-                      <node concept="liA8E" id="3wJ9Qm1c3yq" role="2OqNvi">
-                        <ref role="37wK5l" to="z1c4:~Project.getRepository()" resolve="getRepository" />
+                      <node concept="liA8E" id="5mxmbv99Buz" role="2OqNvi">
+                        <ref role="37wK5l" to="kz9k:~EditorNavigator.open(org.jetbrains.mps.openapi.model.SNodeReference)" resolve="open" />
+                        <node concept="37vLTw" id="5mxmbv99WhO" role="37wK5m">
+                          <ref role="3cqZAo" node="3EF07Bwp96d" resolve="reference" />
+                        </node>
                       </node>
                     </node>
                   </node>
@@ -8074,118 +8037,92 @@
     <node concept="3clFb_" id="6fyeJ0brdBQ" role="jymVt">
       <property role="TrG5h" value="selectFirstLeafCell" />
       <node concept="3clFbS" id="l9iXyRdj8f" role="3clF47">
-        <node concept="1QHqEO" id="l9iXyRe0OY" role="3cqZAp">
-          <node concept="1QHqEC" id="l9iXyRe0P0" role="1QHqEI">
-            <node concept="3clFbS" id="l9iXyRe0P2" role="1bW5cS">
-              <node concept="3cpWs8" id="l9iXyRdpa2" role="3cqZAp">
-                <node concept="3cpWsn" id="l9iXyRdpa3" role="3cpWs9">
-                  <property role="TrG5h" value="node" />
-                  <node concept="3uibUv" id="l9iXyRdpa4" role="1tU5fm">
-                    <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
-                  </node>
-                  <node concept="2OqwBi" id="l9iXyRdpa5" role="33vP2m">
-                    <node concept="37vLTw" id="l9iXyRdpa6" role="2Oq$k0">
-                      <ref role="3cqZAo" node="l9iXyRdowM" resolve="target" />
-                    </node>
-                    <node concept="liA8E" id="l9iXyRdpa7" role="2OqNvi">
-                      <ref role="37wK5l" to="mhbf:~SNodeReference.resolve(org.jetbrains.mps.openapi.module.SRepository)" resolve="resolve" />
-                      <node concept="2OqwBi" id="l9iXyRdpa8" role="37wK5m">
-                        <node concept="37vLTw" id="l9iXyRdpa9" role="2Oq$k0">
-                          <ref role="3cqZAo" node="l9iXyRdou9" resolve="project" />
-                        </node>
-                        <node concept="liA8E" id="l9iXyRdpaa" role="2OqNvi">
-                          <ref role="37wK5l" to="z1c4:~Project.getRepository()" resolve="getRepository" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="3clFbJ" id="49a8A6Fo85d" role="3cqZAp">
-                <node concept="3clFbS" id="49a8A6Fo85f" role="3clFbx">
-                  <node concept="3cpWs6" id="49a8A6FpHKW" role="3cqZAp" />
-                </node>
-                <node concept="3clFbC" id="49a8A6Fpvc1" role="3clFbw">
-                  <node concept="37vLTw" id="49a8A6ForLS" role="3uHU7B">
-                    <ref role="3cqZAo" node="l9iXyRdpa3" resolve="node" />
-                  </node>
-                  <node concept="10Nm6u" id="49a8A6FprOS" role="3uHU7w" />
-                </node>
-              </node>
-              <node concept="3cpWs8" id="l9iXyRdpab" role="3cqZAp">
-                <node concept="3cpWsn" id="l9iXyRdpac" role="3cpWs9">
-                  <property role="TrG5h" value="editor" />
-                  <node concept="3uibUv" id="l9iXyRdpad" role="1tU5fm">
-                    <ref role="3uigEE" to="cj4x:~Editor" resolve="Editor" />
-                  </node>
-                  <node concept="2OqwBi" id="l9iXyRdpae" role="33vP2m">
-                    <node concept="2YIFZM" id="l9iXyRdpaf" role="2Oq$k0">
-                      <ref role="1Pybhc" to="kz9k:~NavigationSupport" resolve="NavigationSupport" />
-                      <ref role="37wK5l" to="kz9k:~NavigationSupport.getInstance()" resolve="getInstance" />
-                    </node>
-                    <node concept="liA8E" id="l9iXyRdpag" role="2OqNvi">
-                      <ref role="37wK5l" to="kz9k:~NavigationSupport.openNode(jetbrains.mps.project.Project,org.jetbrains.mps.openapi.model.SNode,boolean,boolean)" resolve="openNode" />
-                      <node concept="37vLTw" id="l9iXyRdpah" role="37wK5m">
+        <node concept="3clFbF" id="5mxmbv9blxI" role="3cqZAp">
+          <node concept="2OqwBi" id="5mxmbv9gzvI" role="3clFbG">
+            <node concept="2OqwBi" id="5mxmbv9dmUK" role="2Oq$k0">
+              <node concept="2OqwBi" id="5mxmbv9d6ZG" role="2Oq$k0">
+                <node concept="2OqwBi" id="5mxmbv9cjR7" role="2Oq$k0">
+                  <node concept="2ShNRf" id="5mxmbv9blxE" role="2Oq$k0">
+                    <node concept="1pGfFk" id="5mxmbv9bRmp" role="2ShVmc">
+                      <property role="373rjd" value="true" />
+                      <ref role="37wK5l" to="kz9k:~EditorNavigator.&lt;init&gt;(jetbrains.mps.project.Project)" resolve="EditorNavigator" />
+                      <node concept="37vLTw" id="5mxmbv9c8y2" role="37wK5m">
                         <ref role="3cqZAo" node="l9iXyRdou9" resolve="project" />
                       </node>
-                      <node concept="37vLTw" id="l9iXyRdpai" role="37wK5m">
-                        <ref role="3cqZAo" node="l9iXyRdpa3" resolve="node" />
-                      </node>
-                      <node concept="3clFbT" id="l9iXyRdpaj" role="37wK5m">
-                        <property role="3clFbU" value="true" />
-                      </node>
-                      <node concept="3clFbT" id="l9iXyRdpak" role="37wK5m">
-                        <property role="3clFbU" value="true" />
-                      </node>
                     </node>
                   </node>
-                </node>
-              </node>
-              <node concept="3cpWs8" id="l9iXyRdpal" role="3cqZAp">
-                <node concept="3cpWsn" id="l9iXyRdpam" role="3cpWs9">
-                  <property role="TrG5h" value="editorComponent" />
-                  <node concept="3uibUv" id="l9iXyRdpan" role="1tU5fm">
-                    <ref role="3uigEE" to="cj4x:~EditorComponent" resolve="EditorComponent" />
-                  </node>
-                  <node concept="2OqwBi" id="l9iXyRdpao" role="33vP2m">
-                    <node concept="37vLTw" id="l9iXyRdpap" role="2Oq$k0">
-                      <ref role="3cqZAo" node="l9iXyRdpac" resolve="editor" />
-                    </node>
-                    <node concept="liA8E" id="l9iXyRdpaq" role="2OqNvi">
-                      <ref role="37wK5l" to="cj4x:~Editor.getCurrentEditorComponent()" resolve="getCurrentEditorComponent" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="3clFbF" id="l9iXyRdJRH" role="3cqZAp">
-                <node concept="2OqwBi" id="l9iXyRdMTg" role="3clFbG">
-                  <node concept="2OqwBi" id="l9iXyRdKCL" role="2Oq$k0">
-                    <node concept="37vLTw" id="l9iXyRdJRF" role="2Oq$k0">
-                      <ref role="3cqZAo" node="l9iXyRdpam" resolve="editorComponent" />
-                    </node>
-                    <node concept="liA8E" id="l9iXyRdKQZ" role="2OqNvi">
-                      <ref role="37wK5l" to="cj4x:~EditorComponent.getEditorContext()" resolve="getEditorContext" />
-                    </node>
-                  </node>
-                  <node concept="liA8E" id="l9iXyRdNx8" role="2OqNvi">
-                    <ref role="37wK5l" to="cj4x:~EditorContext.selectWRTFocusPolicy(org.jetbrains.mps.openapi.model.SNode,boolean)" resolve="selectWRTFocusPolicy" />
-                    <node concept="37vLTw" id="l9iXyRdOl0" role="37wK5m">
-                      <ref role="3cqZAo" node="l9iXyRdpa3" resolve="node" />
-                    </node>
-                    <node concept="3clFbT" id="l9iXyRdQ5h" role="37wK5m">
+                  <node concept="liA8E" id="5mxmbv9cOhV" role="2OqNvi">
+                    <ref role="37wK5l" to="kz9k:~EditorNavigator.shallSelect(boolean)" resolve="shallSelect" />
+                    <node concept="3clFbT" id="5mxmbv9d1Rx" role="37wK5m">
                       <property role="3clFbU" value="true" />
                     </node>
                   </node>
                 </node>
+                <node concept="liA8E" id="5mxmbv9daI_" role="2OqNvi">
+                  <ref role="37wK5l" to="kz9k:~EditorNavigator.shallFocus(boolean)" resolve="shallFocus" />
+                  <node concept="3clFbT" id="5mxmbv9djtJ" role="37wK5m">
+                    <property role="3clFbU" value="true" />
+                  </node>
+                </node>
+              </node>
+              <node concept="liA8E" id="5mxmbv9dPpa" role="2OqNvi">
+                <ref role="37wK5l" to="kz9k:~EditorNavigator.onceEditorReady(java.util.function.BiConsumer)" resolve="onceEditorReady" />
+                <node concept="1bVj0M" id="5mxmbv9e5lh" role="37wK5m">
+                  <node concept="gl6BB" id="5mxmbv9e5lw" role="1bW2Oz">
+                    <property role="TrG5h" value="node" />
+                    <node concept="2jxLKc" id="5mxmbv9e5lx" role="1tU5fm" />
+                  </node>
+                  <node concept="gl6BB" id="5mxmbv9e5qw" role="1bW2Oz">
+                    <property role="TrG5h" value="editor" />
+                    <node concept="2jxLKc" id="5mxmbv9e5qx" role="1tU5fm" />
+                  </node>
+                  <node concept="3clFbS" id="5mxmbv9e5qy" role="1bW5cS">
+                    <node concept="3cpWs8" id="l9iXyRdpal" role="3cqZAp">
+                      <node concept="3cpWsn" id="l9iXyRdpam" role="3cpWs9">
+                        <property role="TrG5h" value="editorComponent" />
+                        <node concept="3uibUv" id="l9iXyRdpan" role="1tU5fm">
+                          <ref role="3uigEE" to="cj4x:~EditorComponent" resolve="EditorComponent" />
+                        </node>
+                        <node concept="2OqwBi" id="l9iXyRdpao" role="33vP2m">
+                          <node concept="37vLTw" id="l9iXyRdpap" role="2Oq$k0">
+                            <ref role="3cqZAo" node="5mxmbv9e5qw" resolve="editor" />
+                          </node>
+                          <node concept="liA8E" id="l9iXyRdpaq" role="2OqNvi">
+                            <ref role="37wK5l" to="cj4x:~Editor.getCurrentEditorComponent()" resolve="getCurrentEditorComponent" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbF" id="l9iXyRdJRH" role="3cqZAp">
+                      <node concept="2OqwBi" id="l9iXyRdMTg" role="3clFbG">
+                        <node concept="2OqwBi" id="l9iXyRdKCL" role="2Oq$k0">
+                          <node concept="37vLTw" id="l9iXyRdJRF" role="2Oq$k0">
+                            <ref role="3cqZAo" node="l9iXyRdpam" resolve="editorComponent" />
+                          </node>
+                          <node concept="liA8E" id="l9iXyRdKQZ" role="2OqNvi">
+                            <ref role="37wK5l" to="cj4x:~EditorComponent.getEditorContext()" resolve="getEditorContext" />
+                          </node>
+                        </node>
+                        <node concept="liA8E" id="l9iXyRdNx8" role="2OqNvi">
+                          <ref role="37wK5l" to="cj4x:~EditorContext.selectWRTFocusPolicy(org.jetbrains.mps.openapi.model.SNode,boolean)" resolve="selectWRTFocusPolicy" />
+                          <node concept="37vLTw" id="l9iXyRdOl0" role="37wK5m">
+                            <ref role="3cqZAo" node="5mxmbv9e5lw" resolve="node" />
+                          </node>
+                          <node concept="3clFbT" id="l9iXyRdQ5h" role="37wK5m">
+                            <property role="3clFbU" value="true" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
               </node>
             </node>
-          </node>
-          <node concept="2OqwBi" id="l9iXyRe0Xj" role="ukAjM">
-            <node concept="37vLTw" id="l9iXyRe0Xk" role="2Oq$k0">
-              <ref role="3cqZAo" node="l9iXyRdou9" resolve="project" />
-            </node>
-            <node concept="liA8E" id="l9iXyRe0Xl" role="2OqNvi">
-              <ref role="37wK5l" to="z1c4:~Project.getRepository()" resolve="getRepository" />
+            <node concept="liA8E" id="5mxmbv9gGEe" role="2OqNvi">
+              <ref role="37wK5l" to="kz9k:~EditorNavigator.open(org.jetbrains.mps.openapi.model.SNodeReference)" resolve="open" />
+              <node concept="37vLTw" id="5mxmbv9gMeY" role="37wK5m">
+                <ref role="3cqZAo" node="l9iXyRdowM" resolve="target" />
+              </node>
             </node>
           </node>
         </node>

--- a/code/platform/com.mbeddr.platform.build/solutions/com.mbeddr.platform/models/com/mbeddr/platform/build.mps
+++ b/code/platform/com.mbeddr.platform.build/solutions/com.mbeddr.platform/models/com/mbeddr/platform/build.mps
@@ -4939,6 +4939,11 @@
             <ref role="3bR37D" to="ffeo:1H905DlDUSw" resolve="MPS.OpenAPI" />
           </node>
         </node>
+        <node concept="1SiIV0" id="5mxmbv9isD_" role="3bR37C">
+          <node concept="3bR9La" id="5mxmbv9isDA" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:2eDSGe9d1q1" resolve="MPS.Workbench" />
+          </node>
+        </node>
       </node>
       <node concept="1E1JtD" id="5WYUu8HaT_t" role="2G$12L">
         <property role="BnDLt" value="true" />


### PR DESCRIPTION
Migrate all usages of NavigationSupport to EditorNavigator (and one
usage to ProjectNavigator which is a similar helper class for locating
the node in the logical view).

NavigationSupport was often being used from a write lock, in 2025.1 this
leads to a deadlock. EditorNavigator presents a better API: it can be
called without holding a read/write lock and it accepts node references
instead of nodes.

Testing:

- hyperlink: open DummyConcept node in the
  com.mbeddr.mpsutil.hyperlink.sandbox.sandbox.manualTest model, click
  on 'A URL link to another node', MPS should not freeze.

Fixes #3175, fixes #3180.