### PR TITLE
Update MPS-extensions version to 2025.1.3465.b8e2c14

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ ext.mpsMajor = "2025.1"
 ext.mpsBuild = "2025.1"
 
 //MPS-extensions version
-ext.mpsExtensionsVersion = "2025.1.3460.1d2fff5"
+ext.mpsExtensionsVersion = "2025.1.3465.b8e2c14"
 
 ext.artifactsDir = new File(rootDir, 'artifacts')
 


### PR DESCRIPTION
Renovate does not update the version automatically, probably because it treats it as unstable due to letter 'b' in the commit hash.