### PR TITLE
com.mbeddr.doc: add null checks for accessing the documentation generation folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is _loosely_ based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). The project does _not_ follow
 Semantic Versioning and the changes are simply documented in reverse chronological order, grouped by calendar month.
 
+# October 2025
+
+## com.mbeddr.doc
+
+- Null checks for accessing the documentation generation folder were added so that the documentation won't be generated for places where it is not possible (e.g. the console model).
+
 # September 2025
 
 - The POM file of the mbeddr platform now includes bundled dependencies with 'provided' scope, including the

--- a/code/platform/com.mbeddr.doc/languages/com.mbeddr.doc/generator/template/com/mbeddr/doc/generator/template/main@generator.mps
+++ b/code/platform/com.mbeddr.doc/languages/com.mbeddr.doc/generator/template/com/mbeddr/doc/generator/template/main@generator.mps
@@ -1245,90 +1245,100 @@
                         </node>
                       </node>
                     </node>
-                    <node concept="3cpWs8" id="4t$H79$cic1" role="3cqZAp">
-                      <node concept="3cpWsn" id="4t$H79$cic2" role="3cpWs9">
-                        <property role="TrG5h" value="fullPath" />
-                        <node concept="3uibUv" id="4t$H79$cic3" role="1tU5fm">
-                          <ref role="3uigEE" to="guwi:~File" resolve="File" />
-                        </node>
-                        <node concept="2ShNRf" id="4t$H79$cic4" role="33vP2m">
-                          <node concept="1pGfFk" id="4t$H79$cic5" role="2ShVmc">
-                            <ref role="37wK5l" to="guwi:~File.&lt;init&gt;(java.io.File,java.lang.String)" resolve="File" />
-                            <node concept="37vLTw" id="4t$H79$cic6" role="37wK5m">
-                              <ref role="3cqZAo" node="5XfUTkPh_0$" resolve="docGenFolder" />
+                    <node concept="3clFbJ" id="51gXBnKcfo$" role="3cqZAp">
+                      <node concept="3clFbS" id="51gXBnKcfoA" role="3clFbx">
+                        <node concept="3cpWs8" id="4t$H79$cic1" role="3cqZAp">
+                          <node concept="3cpWsn" id="4t$H79$cic2" role="3cpWs9">
+                            <property role="TrG5h" value="fullPath" />
+                            <node concept="3uibUv" id="4t$H79$cic3" role="1tU5fm">
+                              <ref role="3uigEE" to="guwi:~File" resolve="File" />
                             </node>
-                            <node concept="2OqwBi" id="4t$H79$cic7" role="37wK5m">
-                              <node concept="2OqwBi" id="4t$H79$cic8" role="2Oq$k0">
-                                <node concept="37vLTw" id="4t$H79$cj7u" role="2Oq$k0">
-                                  <ref role="3cqZAo" node="2fGuOSYbJJU" resolve="path" />
+                            <node concept="2ShNRf" id="4t$H79$cic4" role="33vP2m">
+                              <node concept="1pGfFk" id="4t$H79$cic5" role="2ShVmc">
+                                <ref role="37wK5l" to="guwi:~File.&lt;init&gt;(java.io.File,java.lang.String)" resolve="File" />
+                                <node concept="37vLTw" id="4t$H79$cic6" role="37wK5m">
+                                  <ref role="3cqZAo" node="5XfUTkPh_0$" resolve="docGenFolder" />
                                 </node>
-                                <node concept="3TrEf2" id="4t$H79$cicc" role="2OqNvi">
-                                  <ref role="3Tt5mk" to="2c95:2iGZqsHuOq2" resolve="pathPicker" />
+                                <node concept="2OqwBi" id="4t$H79$cic7" role="37wK5m">
+                                  <node concept="2OqwBi" id="4t$H79$cic8" role="2Oq$k0">
+                                    <node concept="37vLTw" id="4t$H79$cj7u" role="2Oq$k0">
+                                      <ref role="3cqZAo" node="2fGuOSYbJJU" resolve="path" />
+                                    </node>
+                                    <node concept="3TrEf2" id="4t$H79$cicc" role="2OqNvi">
+                                      <ref role="3Tt5mk" to="2c95:2iGZqsHuOq2" resolve="pathPicker" />
+                                    </node>
+                                  </node>
+                                  <node concept="3TrcHB" id="4t$H79$cicd" role="2OqNvi">
+                                    <ref role="3TsBF5" to="68mc:5lKnBeAtODI" resolve="path" />
+                                  </node>
                                 </node>
-                              </node>
-                              <node concept="3TrcHB" id="4t$H79$cicd" role="2OqNvi">
-                                <ref role="3TsBF5" to="68mc:5lKnBeAtODI" resolve="path" />
                               </node>
                             </node>
                           </node>
                         </node>
-                      </node>
-                    </node>
-                    <node concept="3clFbF" id="4t$H79$nA25" role="3cqZAp">
-                      <node concept="2OqwBi" id="4t$H79$nAn7" role="3clFbG">
-                        <node concept="37vLTw" id="4t$H79$nA23" role="2Oq$k0">
-                          <ref role="3cqZAo" node="4t$H79$cic2" resolve="fullPath" />
-                        </node>
-                        <node concept="liA8E" id="4t$H79$nA_k" role="2OqNvi">
-                          <ref role="37wK5l" to="guwi:~File.mkdirs()" resolve="mkdirs" />
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="3cpWs8" id="4t$H79$kPgw" role="3cqZAp">
-                      <node concept="3cpWsn" id="4t$H79$kPgx" role="3cpWs9">
-                        <property role="TrG5h" value="outputFile" />
-                        <node concept="3uibUv" id="4t$H79$kOh9" role="1tU5fm">
-                          <ref role="3uigEE" to="guwi:~File" resolve="File" />
-                        </node>
-                        <node concept="2ShNRf" id="4t$H79$kPgy" role="33vP2m">
-                          <node concept="1pGfFk" id="4t$H79$kPgz" role="2ShVmc">
-                            <ref role="37wK5l" to="guwi:~File.&lt;init&gt;(java.io.File,java.lang.String)" resolve="File" />
-                            <node concept="37vLTw" id="4t$H79$kPg$" role="37wK5m">
+                        <node concept="3clFbF" id="4t$H79$nA25" role="3cqZAp">
+                          <node concept="2OqwBi" id="4t$H79$nAn7" role="3clFbG">
+                            <node concept="37vLTw" id="4t$H79$nA23" role="2Oq$k0">
                               <ref role="3cqZAo" node="4t$H79$cic2" resolve="fullPath" />
                             </node>
-                            <node concept="3cpWs3" id="4t$H79$kPg_" role="37wK5m">
-                              <node concept="Xl_RD" id="4t$H79$kPgA" role="3uHU7w">
-                                <property role="Xl_RC" value=".png" />
-                              </node>
-                              <node concept="2OqwBi" id="4t$H79$kPgB" role="3uHU7B">
-                                <node concept="2GrUjf" id="4t$H79$kPgC" role="2Oq$k0">
-                                  <ref role="2Gs0qQ" node="2fGuOSYbJJC" resolve="v" />
+                            <node concept="liA8E" id="4t$H79$nA_k" role="2OqNvi">
+                              <ref role="37wK5l" to="guwi:~File.mkdirs()" resolve="mkdirs" />
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3cpWs8" id="4t$H79$kPgw" role="3cqZAp">
+                          <node concept="3cpWsn" id="4t$H79$kPgx" role="3cpWs9">
+                            <property role="TrG5h" value="outputFile" />
+                            <node concept="3uibUv" id="4t$H79$kOh9" role="1tU5fm">
+                              <ref role="3uigEE" to="guwi:~File" resolve="File" />
+                            </node>
+                            <node concept="2ShNRf" id="4t$H79$kPgy" role="33vP2m">
+                              <node concept="1pGfFk" id="4t$H79$kPgz" role="2ShVmc">
+                                <ref role="37wK5l" to="guwi:~File.&lt;init&gt;(java.io.File,java.lang.String)" resolve="File" />
+                                <node concept="37vLTw" id="4t$H79$kPg$" role="37wK5m">
+                                  <ref role="3cqZAo" node="4t$H79$cic2" resolve="fullPath" />
                                 </node>
-                                <node concept="2qgKlT" id="4t$H79$kPgD" role="2OqNvi">
-                                  <ref role="37wK5l" to="4gky:2fGuOSYbw1y" resolve="filenameWithoutExtension" />
+                                <node concept="3cpWs3" id="4t$H79$kPg_" role="37wK5m">
+                                  <node concept="Xl_RD" id="4t$H79$kPgA" role="3uHU7w">
+                                    <property role="Xl_RC" value=".png" />
+                                  </node>
+                                  <node concept="2OqwBi" id="4t$H79$kPgB" role="3uHU7B">
+                                    <node concept="2GrUjf" id="4t$H79$kPgC" role="2Oq$k0">
+                                      <ref role="2Gs0qQ" node="2fGuOSYbJJC" resolve="v" />
+                                    </node>
+                                    <node concept="2qgKlT" id="4t$H79$kPgD" role="2OqNvi">
+                                      <ref role="37wK5l" to="4gky:2fGuOSYbw1y" resolve="filenameWithoutExtension" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3clFbF" id="5pyBnOIERrv" role="3cqZAp">
+                          <node concept="2OqwBi" id="5pyBnOIETMT" role="3clFbG">
+                            <node concept="37vLTw" id="5pyBnOIETAA" role="2Oq$k0">
+                              <ref role="3cqZAo" node="5pyBnOIETAw" resolve="reader" />
+                            </node>
+                            <node concept="liA8E" id="5pyBnOIEUyU" role="2OqNvi">
+                              <ref role="37wK5l" to="81o:~SourceStringReader.generateImage(java.io.OutputStream)" resolve="generateImage" />
+                              <node concept="2ShNRf" id="7ymv7GF2fIm" role="37wK5m">
+                                <node concept="1pGfFk" id="7ymv7GF2fYv" role="2ShVmc">
+                                  <property role="373rjd" value="true" />
+                                  <ref role="37wK5l" to="guwi:~FileOutputStream.&lt;init&gt;(java.io.File)" resolve="FileOutputStream" />
+                                  <node concept="37vLTw" id="7ymv7GF2g2Q" role="37wK5m">
+                                    <ref role="3cqZAo" node="4t$H79$kPgx" resolve="outputFile" />
+                                  </node>
                                 </node>
                               </node>
                             </node>
                           </node>
                         </node>
                       </node>
-                    </node>
-                    <node concept="3clFbF" id="5pyBnOIERrv" role="3cqZAp">
-                      <node concept="2OqwBi" id="5pyBnOIETMT" role="3clFbG">
-                        <node concept="37vLTw" id="5pyBnOIETAA" role="2Oq$k0">
-                          <ref role="3cqZAo" node="5pyBnOIETAw" resolve="reader" />
-                        </node>
-                        <node concept="liA8E" id="5pyBnOIEUyU" role="2OqNvi">
-                          <ref role="37wK5l" to="81o:~SourceStringReader.generateImage(java.io.OutputStream)" resolve="generateImage" />
-                          <node concept="2ShNRf" id="7ymv7GF2fIm" role="37wK5m">
-                            <node concept="1pGfFk" id="7ymv7GF2fYv" role="2ShVmc">
-                              <property role="373rjd" value="true" />
-                              <ref role="37wK5l" to="guwi:~FileOutputStream.&lt;init&gt;(java.io.File)" resolve="FileOutputStream" />
-                              <node concept="37vLTw" id="7ymv7GF2g2Q" role="37wK5m">
-                                <ref role="3cqZAo" node="4t$H79$kPgx" resolve="outputFile" />
-                              </node>
-                            </node>
-                          </node>
+                      <node concept="3y3z36" id="51gXBnKcgXt" role="3clFbw">
+                        <node concept="10Nm6u" id="51gXBnKchiL" role="3uHU7w" />
+                        <node concept="37vLTw" id="51gXBnKcfvO" role="3uHU7B">
+                          <ref role="3cqZAo" node="5XfUTkPh_0$" resolve="docGenFolder" />
                         </node>
                       </node>
                     </node>
@@ -1567,62 +1577,68 @@
                 </node>
               </node>
             </node>
-            <node concept="3cpWs8" id="271UTRL8jid" role="3cqZAp">
-              <node concept="3cpWsn" id="271UTRL8jie" role="3cpWs9">
-                <property role="TrG5h" value="docGenFolder" />
-                <node concept="3uibUv" id="271UTRL8ji2" role="1tU5fm">
-                  <ref role="3uigEE" to="guwi:~File" resolve="File" />
-                </node>
-                <node concept="2YIFZM" id="271UTRL8jif" role="33vP2m">
-                  <ref role="37wK5l" to="znf5:2DWJLXXzCiq" resolve="getDocGenFolder" />
-                  <ref role="1Pybhc" to="znf5:6RvWQYjPIDF" resolve="GenerationHelper" />
-                  <node concept="37vLTw" id="271UTRL8jig" role="37wK5m">
-                    <ref role="3cqZAo" node="49PUF$HTiTB" resolve="m" />
-                  </node>
-                </node>
-              </node>
-            </node>
             <node concept="2Gpval" id="49PUF$HTi2x" role="3cqZAp">
               <node concept="2GrKxI" id="49PUF$HTi2y" role="2Gsz3X">
                 <property role="TrG5h" value="doc" />
               </node>
               <node concept="3clFbS" id="49PUF$HTi2$" role="2LFqv$">
-                <node concept="3clFbF" id="49PUF$HTwba" role="3cqZAp">
-                  <node concept="37vLTI" id="49PUF$HTxrL" role="3clFbG">
-                    <node concept="2pJPEk" id="49PUF$HTxEx" role="37vLTx">
-                      <node concept="2pJPED" id="49PUF$HTxJX" role="2pJPEn">
-                        <ref role="2pJxaS" to="2c95:2cjkfC8rZLR" resolve="PlaceInFolder" />
-                        <node concept="2pJxcG" id="49PUF$HTxPY" role="2pJxcM">
-                          <ref role="2pJxcJ" to="2c95:2cjkfC8rZLY" resolve="location" />
-                          <node concept="WxPPo" id="27yO7ubx4VZ" role="28ntcv">
-                            <node concept="2OqwBi" id="49PUF$HTybA" role="WxPPp">
-                              <node concept="liA8E" id="49PUF$HTyqf" role="2OqNvi">
-                                <ref role="37wK5l" to="guwi:~File.getAbsolutePath()" resolve="getAbsolutePath" />
-                              </node>
-                              <node concept="2YIFZM" id="6RvWQYjPPHe" role="2Oq$k0">
-                                <ref role="37wK5l" to="znf5:6RvWQYjPOPp" resolve="getOutputLocation" />
-                                <ref role="1Pybhc" to="znf5:6RvWQYjPIDF" resolve="GenerationHelper" />
-                                <node concept="37vLTw" id="6RvWQYjPPHz" role="37wK5m">
-                                  <ref role="3cqZAo" node="49PUF$HTiTB" resolve="m" />
-                                </node>
-                                <node concept="2GrUjf" id="5mrX3UfrVXZ" role="37wK5m">
-                                  <ref role="2Gs0qQ" node="49PUF$HTi2y" resolve="doc" />
+                <node concept="3cpWs8" id="51gXBnKbzSr" role="3cqZAp">
+                  <node concept="3cpWsn" id="51gXBnKbzSs" role="3cpWs9">
+                    <property role="TrG5h" value="outputLocation" />
+                    <node concept="3uibUv" id="51gXBnKby40" role="1tU5fm">
+                      <ref role="3uigEE" to="guwi:~File" resolve="File" />
+                    </node>
+                    <node concept="2YIFZM" id="51gXBnKbzSt" role="33vP2m">
+                      <ref role="37wK5l" to="znf5:6RvWQYjPOPp" resolve="getOutputLocation" />
+                      <ref role="1Pybhc" to="znf5:6RvWQYjPIDF" resolve="GenerationHelper" />
+                      <node concept="37vLTw" id="51gXBnKbzSu" role="37wK5m">
+                        <ref role="3cqZAo" node="49PUF$HTiTB" resolve="m" />
+                      </node>
+                      <node concept="2GrUjf" id="51gXBnKbzSv" role="37wK5m">
+                        <ref role="2Gs0qQ" node="49PUF$HTi2y" resolve="doc" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbJ" id="51gXBnKb_Sa" role="3cqZAp">
+                  <node concept="3clFbS" id="51gXBnKb_Sc" role="3clFbx">
+                    <node concept="3clFbF" id="49PUF$HTwba" role="3cqZAp">
+                      <node concept="37vLTI" id="49PUF$HTxrL" role="3clFbG">
+                        <node concept="2pJPEk" id="49PUF$HTxEx" role="37vLTx">
+                          <node concept="2pJPED" id="49PUF$HTxJX" role="2pJPEn">
+                            <ref role="2pJxaS" to="2c95:2cjkfC8rZLR" resolve="PlaceInFolder" />
+                            <node concept="2pJxcG" id="49PUF$HTxPY" role="2pJxcM">
+                              <ref role="2pJxcJ" to="2c95:2cjkfC8rZLY" resolve="location" />
+                              <node concept="WxPPo" id="27yO7ubx4VZ" role="28ntcv">
+                                <node concept="2OqwBi" id="49PUF$HTybA" role="WxPPp">
+                                  <node concept="liA8E" id="49PUF$HTyqf" role="2OqNvi">
+                                    <ref role="37wK5l" to="guwi:~File.getAbsolutePath()" resolve="getAbsolutePath" />
+                                  </node>
+                                  <node concept="37vLTw" id="51gXBnKbzSw" role="2Oq$k0">
+                                    <ref role="3cqZAo" node="51gXBnKbzSs" resolve="outputLocation" />
+                                  </node>
                                 </node>
                               </node>
                             </node>
                           </node>
                         </node>
-                      </node>
-                    </node>
-                    <node concept="2OqwBi" id="49PUF$HTwrH" role="37vLTJ">
-                      <node concept="2GrUjf" id="49PUF$HTwb9" role="2Oq$k0">
-                        <ref role="2Gs0qQ" node="49PUF$HTi2y" resolve="doc" />
-                      </node>
-                      <node concept="3CFZ6_" id="49PUF$HTx1K" role="2OqNvi">
-                        <node concept="3CFYIy" id="49PUF$HTx5_" role="3CFYIz">
-                          <ref role="3CFYIx" to="2c95:2cjkfC8rZLR" resolve="PlaceInFolder" />
+                        <node concept="2OqwBi" id="49PUF$HTwrH" role="37vLTJ">
+                          <node concept="2GrUjf" id="49PUF$HTwb9" role="2Oq$k0">
+                            <ref role="2Gs0qQ" node="49PUF$HTi2y" resolve="doc" />
+                          </node>
+                          <node concept="3CFZ6_" id="49PUF$HTx1K" role="2OqNvi">
+                            <node concept="3CFYIy" id="49PUF$HTx5_" role="3CFYIz">
+                              <ref role="3CFYIx" to="2c95:2cjkfC8rZLR" resolve="PlaceInFolder" />
+                            </node>
+                          </node>
                         </node>
                       </node>
+                    </node>
+                  </node>
+                  <node concept="3y3z36" id="51gXBnKbAW2" role="3clFbw">
+                    <node concept="10Nm6u" id="51gXBnKbBm0" role="3uHU7w" />
+                    <node concept="37vLTw" id="51gXBnKbA6O" role="3uHU7B">
+                      <ref role="3cqZAo" node="51gXBnKbzSs" resolve="outputLocation" />
                     </node>
                   </node>
                 </node>
@@ -1703,179 +1719,225 @@
                 </node>
               </node>
               <node concept="3clFbS" id="3k8awrHXR0j" role="2LFqv$">
-                <node concept="3clFbF" id="3k8awrHXXcQ" role="3cqZAp">
-                  <node concept="37vLTI" id="3k8awrHXXRn" role="3clFbG">
-                    <node concept="2OqwBi" id="3k8awrHXXd3" role="37vLTJ">
-                      <node concept="2GrUjf" id="3k8awrHXXcP" role="2Oq$k0">
+                <node concept="3cpWs8" id="51gXBnKbCrq" role="3cqZAp">
+                  <node concept="3cpWsn" id="51gXBnKbCrr" role="3cpWs9">
+                    <property role="TrG5h" value="outputLocation" />
+                    <node concept="3uibUv" id="51gXBnKby4P" role="1tU5fm">
+                      <ref role="3uigEE" to="guwi:~File" resolve="File" />
+                    </node>
+                    <node concept="2YIFZM" id="51gXBnKbCrs" role="33vP2m">
+                      <ref role="1Pybhc" to="znf5:6RvWQYjPIDF" resolve="GenerationHelper" />
+                      <ref role="37wK5l" to="znf5:6RvWQYjPOPp" resolve="getOutputLocation" />
+                      <node concept="37vLTw" id="51gXBnKbCrt" role="37wK5m">
+                        <ref role="3cqZAo" node="49PUF$HTiTB" resolve="m" />
+                      </node>
+                      <node concept="2GrUjf" id="51gXBnKbCru" role="37wK5m">
                         <ref role="2Gs0qQ" node="3k8awrHXR0f" resolve="refWord" />
                       </node>
-                      <node concept="3CFZ6_" id="3k8awrHXXHn" role="2OqNvi">
-                        <node concept="3CFYIy" id="3k8awrHXXHG" role="3CFYIz">
-                          <ref role="3CFYIx" to="2c95:2cjkfC8rZLR" resolve="PlaceInFolder" />
-                        </node>
-                      </node>
                     </node>
-                    <node concept="2pJPEk" id="3k8awrHXXV0" role="37vLTx">
-                      <node concept="2pJPED" id="3k8awrHXXV1" role="2pJPEn">
-                        <ref role="2pJxaS" to="2c95:2cjkfC8rZLR" resolve="PlaceInFolder" />
-                        <node concept="2pJxcG" id="3k8awrHXXV2" role="2pJxcM">
-                          <ref role="2pJxcJ" to="2c95:2cjkfC8rZLY" resolve="location" />
-                          <node concept="WxPPo" id="3k8awrHXXV3" role="28ntcv">
-                            <node concept="2OqwBi" id="3k8awrHXXV4" role="WxPPp">
-                              <node concept="liA8E" id="3k8awrHXXV5" role="2OqNvi">
-                                <ref role="37wK5l" to="guwi:~File.getAbsolutePath()" resolve="getAbsolutePath" />
-                              </node>
-                              <node concept="2YIFZM" id="3k8awrHXXV6" role="2Oq$k0">
-                                <ref role="1Pybhc" to="znf5:6RvWQYjPIDF" resolve="GenerationHelper" />
-                                <ref role="37wK5l" to="znf5:6RvWQYjPOPp" resolve="getOutputLocation" />
-                                <node concept="37vLTw" id="3k8awrHXXV7" role="37wK5m">
-                                  <ref role="3cqZAo" node="49PUF$HTiTB" resolve="m" />
-                                </node>
-                                <node concept="2GrUjf" id="3k8awrHXXV8" role="37wK5m">
-                                  <ref role="2Gs0qQ" node="3k8awrHXR0f" resolve="refWord" />
+                  </node>
+                </node>
+                <node concept="3clFbJ" id="51gXBnKbD1Y" role="3cqZAp">
+                  <node concept="3clFbS" id="51gXBnKbD20" role="3clFbx">
+                    <node concept="3clFbF" id="3k8awrHXXcQ" role="3cqZAp">
+                      <node concept="37vLTI" id="3k8awrHXXRn" role="3clFbG">
+                        <node concept="2OqwBi" id="3k8awrHXXd3" role="37vLTJ">
+                          <node concept="2GrUjf" id="3k8awrHXXcP" role="2Oq$k0">
+                            <ref role="2Gs0qQ" node="3k8awrHXR0f" resolve="refWord" />
+                          </node>
+                          <node concept="3CFZ6_" id="3k8awrHXXHn" role="2OqNvi">
+                            <node concept="3CFYIy" id="3k8awrHXXHG" role="3CFYIz">
+                              <ref role="3CFYIx" to="2c95:2cjkfC8rZLR" resolve="PlaceInFolder" />
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="2pJPEk" id="3k8awrHXXV0" role="37vLTx">
+                          <node concept="2pJPED" id="3k8awrHXXV1" role="2pJPEn">
+                            <ref role="2pJxaS" to="2c95:2cjkfC8rZLR" resolve="PlaceInFolder" />
+                            <node concept="2pJxcG" id="3k8awrHXXV2" role="2pJxcM">
+                              <ref role="2pJxcJ" to="2c95:2cjkfC8rZLY" resolve="location" />
+                              <node concept="WxPPo" id="3k8awrHXXV3" role="28ntcv">
+                                <node concept="2OqwBi" id="3k8awrHXXV4" role="WxPPp">
+                                  <node concept="liA8E" id="3k8awrHXXV5" role="2OqNvi">
+                                    <ref role="37wK5l" to="guwi:~File.getAbsolutePath()" resolve="getAbsolutePath" />
+                                  </node>
+                                  <node concept="37vLTw" id="51gXBnKbCrv" role="2Oq$k0">
+                                    <ref role="3cqZAo" node="51gXBnKbCrr" resolve="outputLocation" />
+                                  </node>
                                 </node>
                               </node>
                             </node>
                           </node>
                         </node>
                       </node>
+                    </node>
+                  </node>
+                  <node concept="3y3z36" id="51gXBnKbDUa" role="3clFbw">
+                    <node concept="10Nm6u" id="51gXBnKbEiy" role="3uHU7w" />
+                    <node concept="37vLTw" id="51gXBnKbD6y" role="3uHU7B">
+                      <ref role="3cqZAo" node="51gXBnKbCrr" resolve="outputLocation" />
                     </node>
                   </node>
                 </node>
               </node>
             </node>
-            <node concept="2Gpval" id="271UTRKZGmU" role="3cqZAp">
-              <node concept="2GrKxI" id="271UTRKZGmW" role="2Gsz3X">
-                <property role="TrG5h" value="imgParagraph" />
-              </node>
-              <node concept="2OqwBi" id="271UTRKZH8b" role="2GsD0m">
-                <node concept="1Q6Npb" id="271UTRKZGZR" role="2Oq$k0" />
-                <node concept="2SmgA7" id="271UTRKZHef" role="2OqNvi">
-                  <node concept="chp4Y" id="271UTRKZHeN" role="1dBWTz">
-                    <ref role="cht4Q" to="2c95:5yxqZJwyOSj" resolve="ImageParagraph" />
+            <node concept="3cpWs8" id="271UTRL8jid" role="3cqZAp">
+              <node concept="3cpWsn" id="271UTRL8jie" role="3cpWs9">
+                <property role="TrG5h" value="docGenFolder" />
+                <node concept="3uibUv" id="271UTRL8ji2" role="1tU5fm">
+                  <ref role="3uigEE" to="guwi:~File" resolve="File" />
+                </node>
+                <node concept="2YIFZM" id="271UTRL8jif" role="33vP2m">
+                  <ref role="37wK5l" to="znf5:2DWJLXXzCiq" resolve="getDocGenFolder" />
+                  <ref role="1Pybhc" to="znf5:6RvWQYjPIDF" resolve="GenerationHelper" />
+                  <node concept="37vLTw" id="271UTRL8jig" role="37wK5m">
+                    <ref role="3cqZAo" node="49PUF$HTiTB" resolve="m" />
                   </node>
                 </node>
               </node>
-              <node concept="3clFbS" id="271UTRKZGn0" role="2LFqv$">
-                <node concept="3clFbJ" id="271UTRKZHgM" role="3cqZAp">
-                  <node concept="3clFbS" id="271UTRKZHgO" role="3clFbx">
-                    <node concept="3cpWs8" id="3b07C_MniZT" role="3cqZAp">
-                      <node concept="3cpWsn" id="3b07C_MniZU" role="3cpWs9">
-                        <property role="TrG5h" value="subpath" />
-                        <node concept="17QB3L" id="3b07C_MmvbL" role="1tU5fm" />
-                        <node concept="2OqwBi" id="3b07C_MniZV" role="33vP2m">
-                          <node concept="2OqwBi" id="3b07C_MniZW" role="2Oq$k0">
-                            <node concept="2OqwBi" id="3b07C_MniZX" role="2Oq$k0">
-                              <node concept="2GrUjf" id="3b07C_MniZY" role="2Oq$k0">
-                                <ref role="2Gs0qQ" node="271UTRKZGmW" resolve="imgParagraph" />
-                              </node>
-                              <node concept="2qgKlT" id="3b07C_MniZZ" role="2OqNvi">
-                                <ref role="37wK5l" to="4gky:3UlEobTHU0G" resolve="getPath" />
-                              </node>
-                            </node>
-                            <node concept="3TrEf2" id="3b07C_Mnj00" role="2OqNvi">
-                              <ref role="3Tt5mk" to="2c95:2iGZqsHuOq2" resolve="pathPicker" />
-                            </node>
-                          </node>
-                          <node concept="3TrcHB" id="3b07C_Mnj01" role="2OqNvi">
-                            <ref role="3TsBF5" to="68mc:5lKnBeAtODI" resolve="path" />
-                          </node>
-                        </node>
+            </node>
+            <node concept="3clFbJ" id="51gXBnKc1G_" role="3cqZAp">
+              <node concept="3clFbS" id="51gXBnKc1GB" role="3clFbx">
+                <node concept="2Gpval" id="271UTRKZGmU" role="3cqZAp">
+                  <node concept="2GrKxI" id="271UTRKZGmW" role="2Gsz3X">
+                    <property role="TrG5h" value="imgParagraph" />
+                  </node>
+                  <node concept="2OqwBi" id="271UTRKZH8b" role="2GsD0m">
+                    <node concept="1Q6Npb" id="271UTRKZGZR" role="2Oq$k0" />
+                    <node concept="2SmgA7" id="271UTRKZHef" role="2OqNvi">
+                      <node concept="chp4Y" id="271UTRKZHeN" role="1dBWTz">
+                        <ref role="cht4Q" to="2c95:5yxqZJwyOSj" resolve="ImageParagraph" />
                       </node>
                     </node>
-                    <node concept="3clFbJ" id="3b07C_Mnlru" role="3cqZAp">
-                      <node concept="3clFbS" id="3b07C_Mnlrw" role="3clFbx">
-                        <node concept="YS8fn" id="3b07C_Mnm3h" role="3cqZAp">
-                          <node concept="2ShNRf" id="3b07C_Mnm3B" role="YScLw">
-                            <node concept="1pGfFk" id="3b07C_Mn$uK" role="2ShVmc">
-                              <ref role="37wK5l" to="wyt6:~IllegalStateException.&lt;init&gt;(java.lang.String)" resolve="IllegalStateException" />
-                              <node concept="3cpWs3" id="3b07C_Mn$X4" role="37wK5m">
-                                <node concept="2OqwBi" id="3b07C_Mn_qv" role="3uHU7w">
-                                  <node concept="2GrUjf" id="3b07C_Mn_0u" role="2Oq$k0">
+                  </node>
+                  <node concept="3clFbS" id="271UTRKZGn0" role="2LFqv$">
+                    <node concept="3clFbJ" id="271UTRKZHgM" role="3cqZAp">
+                      <node concept="3clFbS" id="271UTRKZHgO" role="3clFbx">
+                        <node concept="3cpWs8" id="3b07C_MniZT" role="3cqZAp">
+                          <node concept="3cpWsn" id="3b07C_MniZU" role="3cpWs9">
+                            <property role="TrG5h" value="subpath" />
+                            <node concept="17QB3L" id="3b07C_MmvbL" role="1tU5fm" />
+                            <node concept="2OqwBi" id="3b07C_MniZV" role="33vP2m">
+                              <node concept="2OqwBi" id="3b07C_MniZW" role="2Oq$k0">
+                                <node concept="2OqwBi" id="3b07C_MniZX" role="2Oq$k0">
+                                  <node concept="2GrUjf" id="3b07C_MniZY" role="2Oq$k0">
                                     <ref role="2Gs0qQ" node="271UTRKZGmW" resolve="imgParagraph" />
                                   </node>
-                                  <node concept="iZEcu" id="3b07C_MnAnk" role="2OqNvi" />
+                                  <node concept="2qgKlT" id="3b07C_MniZZ" role="2OqNvi">
+                                    <ref role="37wK5l" to="4gky:3UlEobTHU0G" resolve="getPath" />
+                                  </node>
                                 </node>
-                                <node concept="Xl_RD" id="3b07C_Mn$xH" role="3uHU7B">
-                                  <property role="Xl_RC" value="null path for image " />
+                                <node concept="3TrEf2" id="3b07C_Mnj00" role="2OqNvi">
+                                  <ref role="3Tt5mk" to="2c95:2iGZqsHuOq2" resolve="pathPicker" />
                                 </node>
+                              </node>
+                              <node concept="3TrcHB" id="3b07C_Mnj01" role="2OqNvi">
+                                <ref role="3TsBF5" to="68mc:5lKnBeAtODI" resolve="path" />
                               </node>
                             </node>
                           </node>
                         </node>
-                      </node>
-                      <node concept="3clFbC" id="3b07C_Mnm2M" role="3clFbw">
-                        <node concept="10Nm6u" id="3b07C_Mnm2T" role="3uHU7w" />
-                        <node concept="37vLTw" id="3b07C_Mnls4" role="3uHU7B">
-                          <ref role="3cqZAo" node="3b07C_MniZU" resolve="subpath" />
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="3cpWs8" id="6JxhqyiyMBl" role="3cqZAp">
-                      <node concept="3cpWsn" id="6JxhqyiyMBo" role="3cpWs9">
-                        <property role="TrG5h" value="imgPath" />
-                        <node concept="3uibUv" id="6JxhqyiyMBp" role="1tU5fm">
-                          <ref role="3uigEE" to="guwi:~File" resolve="File" />
-                        </node>
-                        <node concept="2ShNRf" id="6JxhqyiyMBq" role="33vP2m">
-                          <node concept="1pGfFk" id="6JxhqyiyMBr" role="2ShVmc">
-                            <ref role="37wK5l" to="guwi:~File.&lt;init&gt;(java.io.File,java.lang.String)" resolve="File" />
-                            <node concept="37vLTw" id="6JxhqyiyMBs" role="37wK5m">
-                              <ref role="3cqZAo" node="271UTRL8jie" resolve="docGenFolder" />
+                        <node concept="3clFbJ" id="3b07C_Mnlru" role="3cqZAp">
+                          <node concept="3clFbS" id="3b07C_Mnlrw" role="3clFbx">
+                            <node concept="YS8fn" id="3b07C_Mnm3h" role="3cqZAp">
+                              <node concept="2ShNRf" id="3b07C_Mnm3B" role="YScLw">
+                                <node concept="1pGfFk" id="3b07C_Mn$uK" role="2ShVmc">
+                                  <ref role="37wK5l" to="wyt6:~IllegalStateException.&lt;init&gt;(java.lang.String)" resolve="IllegalStateException" />
+                                  <node concept="3cpWs3" id="3b07C_Mn$X4" role="37wK5m">
+                                    <node concept="2OqwBi" id="3b07C_Mn_qv" role="3uHU7w">
+                                      <node concept="2GrUjf" id="3b07C_Mn_0u" role="2Oq$k0">
+                                        <ref role="2Gs0qQ" node="271UTRKZGmW" resolve="imgParagraph" />
+                                      </node>
+                                      <node concept="iZEcu" id="3b07C_MnAnk" role="2OqNvi" />
+                                    </node>
+                                    <node concept="Xl_RD" id="3b07C_Mn$xH" role="3uHU7B">
+                                      <property role="Xl_RC" value="null path for image " />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
                             </node>
-                            <node concept="37vLTw" id="3b07C_Mnj02" role="37wK5m">
+                          </node>
+                          <node concept="3clFbC" id="3b07C_Mnm2M" role="3clFbw">
+                            <node concept="10Nm6u" id="3b07C_Mnm2T" role="3uHU7w" />
+                            <node concept="37vLTw" id="3b07C_Mnls4" role="3uHU7B">
                               <ref role="3cqZAo" node="3b07C_MniZU" resolve="subpath" />
                             </node>
                           </node>
                         </node>
-                      </node>
-                    </node>
-                    <node concept="3clFbF" id="271UTRKZYAE" role="3cqZAp">
-                      <node concept="37vLTI" id="271UTRL00C8" role="3clFbG">
-                        <node concept="2pJPEk" id="271UTRL00YQ" role="37vLTx">
-                          <node concept="2pJPED" id="271UTRL014q" role="2pJPEn">
-                            <ref role="2pJxaS" to="2c95:2cjkfC8rZLR" resolve="PlaceInFolder" />
-                            <node concept="2pJxcG" id="271UTRL01aD" role="2pJxcM">
-                              <ref role="2pJxcJ" to="2c95:2cjkfC8rZLY" resolve="location" />
-                              <node concept="WxPPo" id="27yO7ubx4W0" role="28ntcv">
-                                <node concept="2OqwBi" id="6JxhqyiyZPJ" role="WxPPp">
-                                  <node concept="37vLTw" id="6JxhqyiyZzW" role="2Oq$k0">
-                                    <ref role="3cqZAo" node="6JxhqyiyMBo" resolve="imgPath" />
-                                  </node>
-                                  <node concept="liA8E" id="6Jxhqyiz0jR" role="2OqNvi">
-                                    <ref role="37wK5l" to="guwi:~File.getAbsolutePath()" resolve="getAbsolutePath" />
-                                  </node>
+                        <node concept="3cpWs8" id="6JxhqyiyMBl" role="3cqZAp">
+                          <node concept="3cpWsn" id="6JxhqyiyMBo" role="3cpWs9">
+                            <property role="TrG5h" value="imgPath" />
+                            <node concept="3uibUv" id="6JxhqyiyMBp" role="1tU5fm">
+                              <ref role="3uigEE" to="guwi:~File" resolve="File" />
+                            </node>
+                            <node concept="2ShNRf" id="6JxhqyiyMBq" role="33vP2m">
+                              <node concept="1pGfFk" id="6JxhqyiyMBr" role="2ShVmc">
+                                <ref role="37wK5l" to="guwi:~File.&lt;init&gt;(java.io.File,java.lang.String)" resolve="File" />
+                                <node concept="37vLTw" id="6JxhqyiyMBs" role="37wK5m">
+                                  <ref role="3cqZAo" node="271UTRL8jie" resolve="docGenFolder" />
+                                </node>
+                                <node concept="37vLTw" id="3b07C_Mnj02" role="37wK5m">
+                                  <ref role="3cqZAo" node="3b07C_MniZU" resolve="subpath" />
                                 </node>
                               </node>
                             </node>
                           </node>
                         </node>
-                        <node concept="2OqwBi" id="271UTRKZZ2c" role="37vLTJ">
-                          <node concept="2GrUjf" id="271UTRKZYAC" role="2Oq$k0">
-                            <ref role="2Gs0qQ" node="271UTRKZGmW" resolve="imgParagraph" />
-                          </node>
-                          <node concept="3CFZ6_" id="271UTRKZZAk" role="2OqNvi">
-                            <node concept="3CFYIy" id="271UTRKZZMI" role="3CFYIz">
-                              <ref role="3CFYIx" to="2c95:2cjkfC8rZLR" resolve="PlaceInFolder" />
+                        <node concept="3clFbF" id="271UTRKZYAE" role="3cqZAp">
+                          <node concept="37vLTI" id="271UTRL00C8" role="3clFbG">
+                            <node concept="2pJPEk" id="271UTRL00YQ" role="37vLTx">
+                              <node concept="2pJPED" id="271UTRL014q" role="2pJPEn">
+                                <ref role="2pJxaS" to="2c95:2cjkfC8rZLR" resolve="PlaceInFolder" />
+                                <node concept="2pJxcG" id="271UTRL01aD" role="2pJxcM">
+                                  <ref role="2pJxcJ" to="2c95:2cjkfC8rZLY" resolve="location" />
+                                  <node concept="WxPPo" id="27yO7ubx4W0" role="28ntcv">
+                                    <node concept="2OqwBi" id="6JxhqyiyZPJ" role="WxPPp">
+                                      <node concept="37vLTw" id="6JxhqyiyZzW" role="2Oq$k0">
+                                        <ref role="3cqZAo" node="6JxhqyiyMBo" resolve="imgPath" />
+                                      </node>
+                                      <node concept="liA8E" id="6Jxhqyiz0jR" role="2OqNvi">
+                                        <ref role="37wK5l" to="guwi:~File.getAbsolutePath()" resolve="getAbsolutePath" />
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="2OqwBi" id="271UTRKZZ2c" role="37vLTJ">
+                              <node concept="2GrUjf" id="271UTRKZYAC" role="2Oq$k0">
+                                <ref role="2Gs0qQ" node="271UTRKZGmW" resolve="imgParagraph" />
+                              </node>
+                              <node concept="3CFZ6_" id="271UTRKZZAk" role="2OqNvi">
+                                <node concept="3CFYIy" id="271UTRKZZMI" role="3CFYIz">
+                                  <ref role="3CFYIx" to="2c95:2cjkfC8rZLR" resolve="PlaceInFolder" />
+                                </node>
+                              </node>
                             </node>
                           </node>
                         </node>
                       </node>
-                    </node>
-                  </node>
-                  <node concept="2OqwBi" id="271UTRKZIiL" role="3clFbw">
-                    <node concept="2OqwBi" id="271UTRKZHy2" role="2Oq$k0">
-                      <node concept="2GrUjf" id="271UTRKZHh9" role="2Oq$k0">
-                        <ref role="2Gs0qQ" node="271UTRKZGmW" resolve="imgParagraph" />
-                      </node>
-                      <node concept="3CFZ6_" id="271UTRKZHWT" role="2OqNvi">
-                        <node concept="3CFYIy" id="271UTRKZI2v" role="3CFYIz">
-                          <ref role="3CFYIx" to="2c95:2cjkfC8rZLR" resolve="PlaceInFolder" />
+                      <node concept="2OqwBi" id="271UTRKZIiL" role="3clFbw">
+                        <node concept="2OqwBi" id="271UTRKZHy2" role="2Oq$k0">
+                          <node concept="2GrUjf" id="271UTRKZHh9" role="2Oq$k0">
+                            <ref role="2Gs0qQ" node="271UTRKZGmW" resolve="imgParagraph" />
+                          </node>
+                          <node concept="3CFZ6_" id="271UTRKZHWT" role="2OqNvi">
+                            <node concept="3CFYIy" id="271UTRKZI2v" role="3CFYIz">
+                              <ref role="3CFYIx" to="2c95:2cjkfC8rZLR" resolve="PlaceInFolder" />
+                            </node>
+                          </node>
                         </node>
+                        <node concept="3w_OXm" id="271UTRKZIAL" role="2OqNvi" />
                       </node>
                     </node>
-                    <node concept="3w_OXm" id="271UTRKZIAL" role="2OqNvi" />
                   </node>
+                </node>
+              </node>
+              <node concept="3y3z36" id="51gXBnKc5zo" role="3clFbw">
+                <node concept="10Nm6u" id="51gXBnKc5PZ" role="3uHU7w" />
+                <node concept="37vLTw" id="51gXBnKc2sf" role="3uHU7B">
+                  <ref role="3cqZAo" node="271UTRL8jie" resolve="docGenFolder" />
                 </node>
               </node>
             </node>
@@ -2001,113 +2063,123 @@
                     </node>
                   </node>
                 </node>
-                <node concept="3cpWs8" id="4pIcGABAi7M" role="3cqZAp">
-                  <node concept="3cpWsn" id="4pIcGABAi7N" role="3cpWs9">
-                    <property role="TrG5h" value="defaultImages" />
-                    <node concept="3uibUv" id="4pIcGABAi7p" role="1tU5fm">
-                      <ref role="3uigEE" to="guwi:~File" resolve="File" />
-                    </node>
-                    <node concept="2ShNRf" id="4pIcGABAi7O" role="33vP2m">
-                      <node concept="1pGfFk" id="4pIcGABAi7P" role="2ShVmc">
-                        <ref role="37wK5l" to="guwi:~File.&lt;init&gt;(java.io.File,java.lang.String)" resolve="File" />
-                        <node concept="37vLTw" id="271UTRL8k9a" role="37wK5m">
-                          <ref role="3cqZAo" node="6JxhqyiyX_x" resolve="docGenFolder" />
+                <node concept="3clFbJ" id="51gXBnKc9nK" role="3cqZAp">
+                  <node concept="3clFbS" id="51gXBnKc9nM" role="3clFbx">
+                    <node concept="3cpWs8" id="4pIcGABAi7M" role="3cqZAp">
+                      <node concept="3cpWsn" id="4pIcGABAi7N" role="3cpWs9">
+                        <property role="TrG5h" value="defaultImages" />
+                        <node concept="3uibUv" id="4pIcGABAi7p" role="1tU5fm">
+                          <ref role="3uigEE" to="guwi:~File" resolve="File" />
                         </node>
-                        <node concept="2OqwBi" id="271UTRL8p6X" role="37wK5m">
-                          <node concept="2OqwBi" id="271UTRL8n3x" role="2Oq$k0">
-                            <node concept="2OqwBi" id="271UTRL8lsv" role="2Oq$k0">
-                              <node concept="2GrUjf" id="271UTRL8l2N" role="2Oq$k0">
-                                <ref role="2Gs0qQ" node="5$bT90ZdhP_" resolve="cc" />
-                              </node>
-                              <node concept="2qgKlT" id="271UTRL8m$L" role="2OqNvi">
-                                <ref role="37wK5l" to="4gky:3UlEobTHU0G" resolve="getPath" />
-                              </node>
+                        <node concept="2ShNRf" id="4pIcGABAi7O" role="33vP2m">
+                          <node concept="1pGfFk" id="4pIcGABAi7P" role="2ShVmc">
+                            <ref role="37wK5l" to="guwi:~File.&lt;init&gt;(java.io.File,java.lang.String)" resolve="File" />
+                            <node concept="37vLTw" id="271UTRL8k9a" role="37wK5m">
+                              <ref role="3cqZAo" node="6JxhqyiyX_x" resolve="docGenFolder" />
                             </node>
-                            <node concept="3TrEf2" id="271UTRL8o0U" role="2OqNvi">
-                              <ref role="3Tt5mk" to="2c95:2iGZqsHuOq2" resolve="pathPicker" />
-                            </node>
-                          </node>
-                          <node concept="3TrcHB" id="271UTRL8q6F" role="2OqNvi">
-                            <ref role="3TsBF5" to="68mc:5lKnBeAtODI" resolve="path" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="3clFbF" id="271UTRL9cd7" role="3cqZAp">
-                  <node concept="37vLTI" id="271UTRL9frA" role="3clFbG">
-                    <node concept="2pJPEk" id="271UTRL9gcP" role="37vLTx">
-                      <node concept="2pJPED" id="271UTRL9gim" role="2pJPEn">
-                        <ref role="2pJxaS" to="2c95:2cjkfC8rZLR" resolve="PlaceInFolder" />
-                        <node concept="2pJxcG" id="271UTRL9gou" role="2pJxcM">
-                          <ref role="2pJxcJ" to="2c95:2cjkfC8rZLY" resolve="location" />
-                          <node concept="WxPPo" id="27yO7ubx4W1" role="28ntcv">
-                            <node concept="2OqwBi" id="6JxhqyiyLug" role="WxPPp">
-                              <node concept="37vLTw" id="6JxhqyiyLcj" role="2Oq$k0">
-                                <ref role="3cqZAo" node="4pIcGABAi7N" resolve="defaultImages" />
+                            <node concept="2OqwBi" id="271UTRL8p6X" role="37wK5m">
+                              <node concept="2OqwBi" id="271UTRL8n3x" role="2Oq$k0">
+                                <node concept="2OqwBi" id="271UTRL8lsv" role="2Oq$k0">
+                                  <node concept="2GrUjf" id="271UTRL8l2N" role="2Oq$k0">
+                                    <ref role="2Gs0qQ" node="5$bT90ZdhP_" resolve="cc" />
+                                  </node>
+                                  <node concept="2qgKlT" id="271UTRL8m$L" role="2OqNvi">
+                                    <ref role="37wK5l" to="4gky:3UlEobTHU0G" resolve="getPath" />
+                                  </node>
+                                </node>
+                                <node concept="3TrEf2" id="271UTRL8o0U" role="2OqNvi">
+                                  <ref role="3Tt5mk" to="2c95:2iGZqsHuOq2" resolve="pathPicker" />
+                                </node>
                               </node>
-                              <node concept="liA8E" id="6JxhqyiyM2D" role="2OqNvi">
-                                <ref role="37wK5l" to="guwi:~File.getAbsolutePath()" resolve="getAbsolutePath" />
+                              <node concept="3TrcHB" id="271UTRL8q6F" role="2OqNvi">
+                                <ref role="3TsBF5" to="68mc:5lKnBeAtODI" resolve="path" />
                               </node>
                             </node>
                           </node>
                         </node>
                       </node>
                     </node>
-                    <node concept="2OqwBi" id="271UTRL9cKm" role="37vLTJ">
-                      <node concept="2GrUjf" id="271UTRL9cd5" role="2Oq$k0">
-                        <ref role="2Gs0qQ" node="5$bT90ZdhP_" resolve="cc" />
+                    <node concept="3clFbF" id="271UTRL9cd7" role="3cqZAp">
+                      <node concept="37vLTI" id="271UTRL9frA" role="3clFbG">
+                        <node concept="2pJPEk" id="271UTRL9gcP" role="37vLTx">
+                          <node concept="2pJPED" id="271UTRL9gim" role="2pJPEn">
+                            <ref role="2pJxaS" to="2c95:2cjkfC8rZLR" resolve="PlaceInFolder" />
+                            <node concept="2pJxcG" id="271UTRL9gou" role="2pJxcM">
+                              <ref role="2pJxcJ" to="2c95:2cjkfC8rZLY" resolve="location" />
+                              <node concept="WxPPo" id="27yO7ubx4W1" role="28ntcv">
+                                <node concept="2OqwBi" id="6JxhqyiyLug" role="WxPPp">
+                                  <node concept="37vLTw" id="6JxhqyiyLcj" role="2Oq$k0">
+                                    <ref role="3cqZAo" node="4pIcGABAi7N" resolve="defaultImages" />
+                                  </node>
+                                  <node concept="liA8E" id="6JxhqyiyM2D" role="2OqNvi">
+                                    <ref role="37wK5l" to="guwi:~File.getAbsolutePath()" resolve="getAbsolutePath" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="2OqwBi" id="271UTRL9cKm" role="37vLTJ">
+                          <node concept="2GrUjf" id="271UTRL9cd5" role="2Oq$k0">
+                            <ref role="2Gs0qQ" node="5$bT90ZdhP_" resolve="cc" />
+                          </node>
+                          <node concept="3CFZ6_" id="271UTRL9dWS" role="2OqNvi">
+                            <node concept="3CFYIy" id="271UTRL9e0K" role="3CFYIz">
+                              <ref role="3CFYIx" to="2c95:2cjkfC8rZLR" resolve="PlaceInFolder" />
+                            </node>
+                          </node>
+                        </node>
                       </node>
-                      <node concept="3CFZ6_" id="271UTRL9dWS" role="2OqNvi">
-                        <node concept="3CFYIy" id="271UTRL9e0K" role="3CFYIz">
-                          <ref role="3CFYIx" to="2c95:2cjkfC8rZLR" resolve="PlaceInFolder" />
+                    </node>
+                    <node concept="3cpWs8" id="7PsrBz3kAXL" role="3cqZAp">
+                      <node concept="3cpWsn" id="7PsrBz3kAXM" role="3cpWs9">
+                        <property role="TrG5h" value="ccCopy" />
+                        <node concept="3Tqbb2" id="7PsrBz3kALr" role="1tU5fm">
+                          <ref role="ehGHo" to="2c95:627_yy34G1b" resolve="ModelContentAsImageParagraph" />
+                        </node>
+                        <node concept="2OqwBi" id="7PsrBz3kAXN" role="33vP2m">
+                          <node concept="2GrUjf" id="7PsrBz3kAXO" role="2Oq$k0">
+                            <ref role="2Gs0qQ" node="5$bT90ZdhP_" resolve="cc" />
+                          </node>
+                          <node concept="1$rogu" id="7PsrBz3kAXP" role="2OqNvi" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbF" id="7PsrBz3kAIZ" role="3cqZAp">
+                      <node concept="37vLTI" id="7PsrBz3kDbA" role="3clFbG">
+                        <node concept="2OqwBi" id="7PsrBz3kDyn" role="37vLTx">
+                          <node concept="2GrUjf" id="7PsrBz3kDfW" role="2Oq$k0">
+                            <ref role="2Gs0qQ" node="5$bT90ZdhP_" resolve="cc" />
+                          </node>
+                          <node concept="2qgKlT" id="7PsrBz3kEGc" role="2OqNvi">
+                            <ref role="37wK5l" to="4gky:627_yy34GmM" resolve="uniqueName" />
+                          </node>
+                        </node>
+                        <node concept="2OqwBi" id="7PsrBz3kCnU" role="37vLTJ">
+                          <node concept="37vLTw" id="7PsrBz3kAXQ" role="2Oq$k0">
+                            <ref role="3cqZAo" node="7PsrBz3kAXM" resolve="ccCopy" />
+                          </node>
+                          <node concept="3TrcHB" id="7PsrBz3kCT4" role="2OqNvi">
+                            <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbF" id="7PsrBz30WZ$" role="3cqZAp">
+                      <node concept="2OqwBi" id="7PsrBz30X9G" role="3clFbG">
+                        <node concept="1Q6Npb" id="7PsrBz30WZz" role="2Oq$k0" />
+                        <node concept="3BYIHo" id="7PsrBz30Xg4" role="2OqNvi">
+                          <node concept="37vLTw" id="7PsrBz3kBuF" role="3BYIHq">
+                            <ref role="3cqZAo" node="7PsrBz3kAXM" resolve="ccCopy" />
+                          </node>
                         </node>
                       </node>
                     </node>
                   </node>
-                </node>
-                <node concept="3cpWs8" id="7PsrBz3kAXL" role="3cqZAp">
-                  <node concept="3cpWsn" id="7PsrBz3kAXM" role="3cpWs9">
-                    <property role="TrG5h" value="ccCopy" />
-                    <node concept="3Tqbb2" id="7PsrBz3kALr" role="1tU5fm">
-                      <ref role="ehGHo" to="2c95:627_yy34G1b" resolve="ModelContentAsImageParagraph" />
-                    </node>
-                    <node concept="2OqwBi" id="7PsrBz3kAXN" role="33vP2m">
-                      <node concept="2GrUjf" id="7PsrBz3kAXO" role="2Oq$k0">
-                        <ref role="2Gs0qQ" node="5$bT90ZdhP_" resolve="cc" />
-                      </node>
-                      <node concept="1$rogu" id="7PsrBz3kAXP" role="2OqNvi" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="3clFbF" id="7PsrBz3kAIZ" role="3cqZAp">
-                  <node concept="37vLTI" id="7PsrBz3kDbA" role="3clFbG">
-                    <node concept="2OqwBi" id="7PsrBz3kDyn" role="37vLTx">
-                      <node concept="2GrUjf" id="7PsrBz3kDfW" role="2Oq$k0">
-                        <ref role="2Gs0qQ" node="5$bT90ZdhP_" resolve="cc" />
-                      </node>
-                      <node concept="2qgKlT" id="7PsrBz3kEGc" role="2OqNvi">
-                        <ref role="37wK5l" to="4gky:627_yy34GmM" resolve="uniqueName" />
-                      </node>
-                    </node>
-                    <node concept="2OqwBi" id="7PsrBz3kCnU" role="37vLTJ">
-                      <node concept="37vLTw" id="7PsrBz3kAXQ" role="2Oq$k0">
-                        <ref role="3cqZAo" node="7PsrBz3kAXM" resolve="ccCopy" />
-                      </node>
-                      <node concept="3TrcHB" id="7PsrBz3kCT4" role="2OqNvi">
-                        <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="3clFbF" id="7PsrBz30WZ$" role="3cqZAp">
-                  <node concept="2OqwBi" id="7PsrBz30X9G" role="3clFbG">
-                    <node concept="1Q6Npb" id="7PsrBz30WZz" role="2Oq$k0" />
-                    <node concept="3BYIHo" id="7PsrBz30Xg4" role="2OqNvi">
-                      <node concept="37vLTw" id="7PsrBz3kBuF" role="3BYIHq">
-                        <ref role="3cqZAo" node="7PsrBz3kAXM" resolve="ccCopy" />
-                      </node>
+                  <node concept="3y3z36" id="51gXBnKcazG" role="3clFbw">
+                    <node concept="10Nm6u" id="51gXBnKcaQo" role="3uHU7w" />
+                    <node concept="37vLTw" id="51gXBnKc9Gy" role="3uHU7B">
+                      <ref role="3cqZAo" node="6JxhqyiyX_x" resolve="docGenFolder" />
                     </node>
                   </node>
                 </node>

--- a/code/platform/com.mbeddr.doc/languages/com.mbeddr.doc/languageModels/plugin.mps
+++ b/code/platform/com.mbeddr.doc/languages/com.mbeddr.doc/languageModels/plugin.mps
@@ -52,6 +52,7 @@
     <import index="ao3" ref="7124e466-fc92-4803-a656-d7a6b7eb3910/java:jetbrains.mps.text(MPS.TextGen/)" />
     <import index="v9gs" ref="r:a139668a-5a0e-46e2-a802-102190e497e5(jetbrains.mps.core.tool.environment.util)" />
     <import index="dush" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.persistence(MPS.OpenAPI/)" />
+    <import index="mhfm" ref="3f233e7f-b8a6-46d2-a57f-795d56775243/java:org.jetbrains.annotations(Annotations/)" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
     <import index="hfuk" ref="r:b25dd364-bc3f-4a66-97d1-262009610c5e(jetbrains.mps.make)" implicit="true" />
   </imports>
@@ -137,6 +138,12 @@
       </concept>
       <concept id="1239714755177" name="jetbrains.mps.baseLanguage.structure.AbstractUnaryNumberOperation" flags="nn" index="2$Kvd9">
         <child id="1239714902950" name="expression" index="2$L3a6" />
+      </concept>
+      <concept id="1188207840427" name="jetbrains.mps.baseLanguage.structure.AnnotationInstance" flags="nn" index="2AHcQZ">
+        <reference id="1188208074048" name="annotation" index="2AI5Lk" />
+      </concept>
+      <concept id="1188208481402" name="jetbrains.mps.baseLanguage.structure.HasAnnotation" flags="ngI" index="2AJDlI">
+        <child id="1188208488637" name="annotation" index="2AJF6D" />
       </concept>
       <concept id="2820489544401957797" name="jetbrains.mps.baseLanguage.structure.DefaultClassCreator" flags="nn" index="HV5vD">
         <reference id="2820489544401957798" name="classifier" index="HV5vE" />
@@ -1647,6 +1654,19 @@
             </node>
           </node>
         </node>
+        <node concept="3clFbJ" id="51gXBnKaG0j" role="3cqZAp">
+          <node concept="3clFbS" id="51gXBnKaG0l" role="3clFbx">
+            <node concept="3cpWs6" id="51gXBnKaL0D" role="3cqZAp">
+              <node concept="10Nm6u" id="51gXBnKaLe7" role="3cqZAk" />
+            </node>
+          </node>
+          <node concept="3clFbC" id="51gXBnKaJR1" role="3clFbw">
+            <node concept="10Nm6u" id="51gXBnKaKm6" role="3uHU7w" />
+            <node concept="37vLTw" id="51gXBnKaIZe" role="3uHU7B">
+              <ref role="3cqZAo" node="5FtAU1qmVmp" resolve="docGenRoot" />
+            </node>
+          </node>
+        </node>
         <node concept="3cpWs8" id="5FtAU1qmVmt" role="3cqZAp">
           <node concept="3cpWsn" id="5FtAU1qmVmu" role="3cpWs9">
             <property role="TrG5h" value="mdlOutputRootInGenFolder" />
@@ -1714,6 +1734,9 @@
         <ref role="3uigEE" to="guwi:~File" resolve="File" />
       </node>
       <node concept="3Tm1VV" id="5FtAU1qmVmD" role="1B3o_S" />
+      <node concept="2AHcQZ" id="51gXBnKaOfv" role="2AJF6D">
+        <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
+      </node>
     </node>
     <node concept="2tJIrI" id="6RvWQYjPIE5" role="jymVt" />
     <node concept="2YIFZL" id="6RvWQYjPOPp" role="jymVt">
@@ -1732,6 +1755,19 @@
               <node concept="37vLTw" id="2DWJLXXzD2c" role="37wK5m">
                 <ref role="3cqZAo" node="6RvWQYjPJ8x" resolve="m" />
               </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="51gXBnKauOm" role="3cqZAp">
+          <node concept="3clFbS" id="51gXBnKauOo" role="3clFbx">
+            <node concept="3cpWs6" id="51gXBnKa_V6" role="3cqZAp">
+              <node concept="10Nm6u" id="51gXBnKaA76" role="3cqZAk" />
+            </node>
+          </node>
+          <node concept="3clFbC" id="51gXBnKa$Rw" role="3clFbw">
+            <node concept="10Nm6u" id="51gXBnKa_l6" role="3uHU7w" />
+            <node concept="37vLTw" id="51gXBnKaxdO" role="3uHU7B">
+              <ref role="3cqZAo" node="49PUF$HTiTU" resolve="docGenRoot" />
             </node>
           </node>
         </node>
@@ -1777,6 +1813,9 @@
         <ref role="3uigEE" to="guwi:~File" resolve="File" />
       </node>
       <node concept="3Tm1VV" id="6RvWQYjPII1" role="1B3o_S" />
+      <node concept="2AHcQZ" id="51gXBnKaD6_" role="2AJF6D">
+        <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
+      </node>
     </node>
     <node concept="2tJIrI" id="5mrX3UfrY3F" role="jymVt" />
     <node concept="2YIFZL" id="271UTRL1QGA" role="jymVt">
@@ -1796,6 +1835,19 @@
               <node concept="37vLTw" id="271UTRL1Rw2" role="37wK5m">
                 <ref role="3cqZAo" node="271UTRL1QSJ" resolve="m" />
               </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="51gXBnKajhC" role="3cqZAp">
+          <node concept="3clFbS" id="51gXBnKajhE" role="3clFbx">
+            <node concept="3cpWs6" id="51gXBnKaqZc" role="3cqZAp">
+              <node concept="10Nm6u" id="51gXBnKarb6" role="3cqZAk" />
+            </node>
+          </node>
+          <node concept="3clFbC" id="51gXBnKan5w" role="3clFbw">
+            <node concept="10Nm6u" id="51gXBnKanz5" role="3uHU7w" />
+            <node concept="37vLTw" id="51gXBnKajse" role="3uHU7B">
+              <ref role="3cqZAo" node="271UTRL1Rw0" resolve="docGenFolder" />
             </node>
           </node>
         </node>
@@ -1873,6 +1925,9 @@
           <ref role="ehGHo" to="2c95:5yxqZJwzNUZ" resolve="Resource" />
         </node>
       </node>
+      <node concept="2AHcQZ" id="51gXBnKarfA" role="2AJF6D">
+        <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
+      </node>
     </node>
     <node concept="2tJIrI" id="271UTRL1Qkl" role="jymVt" />
     <node concept="2YIFZL" id="2DWJLXXzCiq" role="jymVt">
@@ -1896,6 +1951,19 @@
                   <ref role="37wK5l" to="z1c3:~AbstractModule.getModuleDescriptor()" resolve="getModuleDescriptor" />
                 </node>
               </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="51gXBnKa8y5" role="3cqZAp">
+          <node concept="3clFbS" id="51gXBnKa8y7" role="3clFbx">
+            <node concept="3cpWs6" id="51gXBnKahid" role="3cqZAp">
+              <node concept="10Nm6u" id="51gXBnKah_E" role="3cqZAk" />
+            </node>
+          </node>
+          <node concept="3clFbC" id="51gXBnKaf62" role="3clFbw">
+            <node concept="10Nm6u" id="51gXBnKagbW" role="3uHU7w" />
+            <node concept="37vLTw" id="51gXBnKaaV4" role="3uHU7B">
+              <ref role="3cqZAo" node="2DWJLXXzCsp" resolve="generatorOutputPath" />
             </node>
           </node>
         </node>
@@ -1954,6 +2022,9 @@
         <node concept="3uibUv" id="2DWJLXXzCre" role="1tU5fm">
           <ref role="3uigEE" to="z1c3:~AbstractModule" resolve="AbstractModule" />
         </node>
+      </node>
+      <node concept="2AHcQZ" id="51gXBnKahLD" role="2AJF6D">
+        <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
       </node>
     </node>
     <node concept="2tJIrI" id="5mrX3UfrY77" role="jymVt" />


### PR DESCRIPTION
Without the checks, we get, for example, `NullPointerExceptions` when executing the generator from the MPS console model.