### PR TITLE
renovate: use custom versioning scheme for MPS-extensions

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -20,10 +20,10 @@
     },
 
     {
-      // MPS-extensions: allow unstable versions on master (snapshots, a/b letters in commit hashes, etc.)
-      "matchBaseBranches": ["master"],
+      // Versioning for MPS extensions: match the typical version number: 2024.1.234.abcdef12, but do not treat commit
+      // hashes with 'a' or 'b' as pre-releases. Only a `-something` suffix is treated as a pre-release.
       "matchPackageNames": ["de.itemis.mps:extensions"],
-      "ignoreUnstable": false,
+      "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)\\.[\\da-f]+[(?:-(?<prerelease>.*))?$",
     },
 
     {


### PR DESCRIPTION
The default versioning scheme treats commit hashes with `a` or `b` in them as pre-releases. The custom scheme only treats `-something` suffix as a pre-release.