### PR TITLE
Removed empty modelroot in c.m.spreadsheet.libs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is _loosely_ based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). The project does _not_ follow
 Semantic Versioning and the changes are simply documented in reverse chronological order, grouped by calendar month.
 
+# November 2025
+
+## com.mbeddr.spreadsheet
+
+## Fixed
+
+- Removed empty model root causing warning on library load
+
 # October 2025
 
 ## com.mbeddr.core.base

--- a/code/platform/com.mbeddr.doc/solutions/com.mbeddr.spreadsheet.libs/com.mbeddr.spreadsheet.libs.msd
+++ b/code/platform/com.mbeddr.doc/solutions/com.mbeddr.spreadsheet.libs/com.mbeddr.spreadsheet.libs.msd
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <solution name="com.mbeddr.spreadsheet.libs" uuid="fc506c9e-94ac-4d65-9950-01def4cba278" moduleVersion="0">
   <models>
-    <modelRoot type="default" contentPath="${module}">
-      <sourceRoot location="models" />
-    </modelRoot>
     <modelRoot type="java_classes" contentPath="${module}/lib">
       <sourceRoot location="commons-codec.jar" />
       <sourceRoot location="commons-collections4.jar" />

--- a/code/platform/com.mbeddr.platform.build/solutions/com.mbeddr.platform/models/com/mbeddr/platform/build.mps
+++ b/code/platform/com.mbeddr.platform.build/solutions/com.mbeddr.platform/models/com/mbeddr/platform/build.mps
@@ -15285,28 +15285,6 @@
             <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
           </node>
         </node>
-        <node concept="1BupzO" id="WD9jaaiH6x" role="3bR31x">
-          <property role="3ZfqAx" value="models" />
-          <property role="1Hdu6h" value="true" />
-          <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="WD9jaaiH6y" role="1HemKq">
-            <node concept="398BVA" id="WD9jaaiH6m" role="3LXTmr">
-              <ref role="398BVh" node="1m4fy7Kxwst" resolve="mbeddr.doc" />
-              <node concept="2Ry0Ak" id="WD9jaaiH6n" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="WD9jaaiH6o" role="2Ry0An">
-                  <property role="2Ry0Am" value="com.mbeddr.spreadsheet.libs" />
-                  <node concept="2Ry0Ak" id="WD9jaaiH6p" role="2Ry0An">
-                    <property role="2Ry0Am" value="models" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="WD9jaaiH6z" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
-        </node>
         <node concept="3rtmxn" id="2ma2oLwrVRx" role="3bR31x">
           <node concept="3LXTmp" id="2ma2oLwrVRy" role="3rtmxm">
             <node concept="3qWCbU" id="2ma2oLwrVRz" role="3LXTna">


### PR DESCRIPTION
Removed empty model root in c.m.spreadsheet.libs which was causing warning (Models have not been found within the SourceRoot) during library load, e.g. when running generators or model check with mbeddr library.