### PR TITLE
build: refactor version catalog

### DIFF
--- a/code/platform/build.gradle.kts
+++ b/code/platform/build.gradle.kts
@@ -36,7 +36,7 @@ dependencies {
     if (project.hasProperty("mpsExtensionsZip")) {
         mpsLibraries(files(project.property("mpsExtensionsZip")))
     } else {
-        mpsLibraries(libs.mpsExtensions241)
+        mpsLibraries(libs.mpsExtensions)
     }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,10 +1,14 @@
+[versions]
+# Versions for the 2024.1 branch
+jbr241 = "17.0.11-b1207.30"
+mps241 = "2024.1.6"
+mpsExtensions241 = "2024.1.3599.c271043"
+
 [plugins]
 common = "de.itemis.mps.gradle.common:1.30.+"
 jbr-toolchain = "com.specificlanguages.jbr-toolchain:1.1.0"
 
 [libraries]
-jbr = "com.jetbrains.jdk:jbr_jcef:17.0.11-b1207.30"
-mps = "com.jetbrains:mps:2024.1.6"
-
-# MPS-extensions version for the 2024.1 branch
-mpsExtensions241 = "de.itemis.mps:extensions:2024.1.3599.c271043"
+jbr = { module = "com.jetbrains.jdk:jbr_jcef", version.ref = "jbr241" }
+mps = { module = "com.jetbrains:mps", version.ref = "mps241" }
+mpsExtensions = { module = "de.itemis.mps:extensions", version.ref = "mpsExtensions241" }


### PR DESCRIPTION
Have only versions be MPS-specific, dependency coordinates remain the same. Versions for earlier branches will appear unused on later branches.

Hopefully this will stop Renovate from trying to update MPS-extensions for the 2025.1.x branch on master.