### PR TITLE
build: pin xtext and mwe2 version to avoid milestone releases

### DIFF
--- a/code/platform/build.gradle.kts
+++ b/code/platform/build.gradle.kts
@@ -67,7 +67,21 @@ val bundledDeps = listOf(
         BundledDep("plantuml", listOf("net.sourceforge.plantuml:plantuml:1.2026.2"), "com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.plantuml/solutions/pluginSolution"),
         BundledDep("opencsv", listOf("au.com.bytecode:opencsv:2.4"), "com.mbeddr.mpsutil/solutions/com.opencsv"),
         BundledDep("mockito", listOf("org.mockito:mockito-core:5.22.0"), "com.mbeddr.mpsutil/solutions/org.mockito", {}),
-        BundledDep("ecore", listOf("org.eclipse.emf:org.eclipse.emf.ecore.xcore:1.36.0"), "com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.ecore.stubs", {
+        BundledDep("ecore", listOf(
+                "org.eclipse.emf:org.eclipse.emf.ecore.xcore:1.36.0",
+                // xcore 1.36.0's POM requests these xtext modules with open-ended ranges like
+                // [2.13.0,3.0.0). Pin them so we don't accidentally pull an xtext milestone that
+                // targets a Java version newer than the MPS-bundled JBR 17.
+                "org.eclipse.xtext:org.eclipse.xtext:2.42.0",
+                "org.eclipse.xtext:org.eclipse.xtext.util:2.42.0",
+                "org.eclipse.xtext:org.eclipse.xtext.xbase:2.42.0",
+                "org.eclipse.xtext:org.eclipse.xtext.xbase.lib:2.42.0",
+                "org.eclipse.xtext:org.eclipse.xtext.common.types:2.42.0",
+                "org.eclipse.xtext:org.eclipse.xtext.ecore:2.42.0",
+                // Same open-range problem as xtext: xtext modules declare
+                // mwe2.runtime:[2.9.0,3.0.0), and 2.26.0.M1 targets Java 21.
+                "org.eclipse.emf:org.eclipse.emf.mwe2.runtime:2.25.0",
+        ), "com.mbeddr.mpsutil/solutions/com.mbeddr.mpsutil.ecore.stubs", {
             exclude(module = "aopalliance")
             exclude(module = "antlr-runtime")
             exclude(module = "org.eclipse.osgi")


### PR DESCRIPTION
## Summary

- `org.eclipse.emf.ecore.xcore:1.36.0` declares its xtext deps with open-ended version ranges like `[2.13.0,3.0.0)`. On a clean Gradle cache (i.e. TeamCity) this now resolves to **xtext 2.43.0.M1** (milestone, published 2026-04-16), whose JARs have class version 65 (Java 21). The MPS-bundled JBR 17 rejects them during stub compilation: `bad class file ... wrong version 65.0, should be 61.0`.
- Local builds with a warm Gradle cache still hit 2.42.0, which is why this only failed on TC (build [#393061](https://mps.builds.itemis.cloud/buildConfiguration/Mbeddr2_Mbeddr_Gradle_platform/393061)).
- Pin all six xtext modules pulled by xcore to 2.42.0 so resolution is deterministic.
- xtext itself declares `mwe2.runtime:[2.9.0,3.0.0)`, which was also resolving to a Java 21 milestone (`2.26.0.M1`). Pin to the previous stable `2.25.0`. No stub code happened to reference mwe2 classes today but the trap was set.

## Verification

Cleared `~/.gradle/caches/modules-2/files-2.1/org.eclipse.xtext`, `…/org.eclipse.emf.mwe2.runtime`, and `com.mbeddr.mpsutil.ecore.stubs/lib/*.jar`, then re-ran `:com.mbeddr:platform:resolve_ecore_bundled --refresh-dependencies`:

- Resolved xtext jar class version: `ca fe ba be 00 00 00 3d` = **61** (Java 17) ✓, Bundle-Version **2.42.0** ✓
- Resolved mwe2.runtime jar class version: **61** (Java 17) ✓, Bundle-Version **2.25.0** ✓
- `./gradlew :com.mbeddr:platform:dependencies --configuration ecore_bundled` shows every xtext `[2.18.0,3.0.0) -> 2.42.0` and `mwe2.runtime:[2.9.0,3.0.0) -> 2.25.0`. No milestones in the tree.

## Test plan

- [ ] TeamCity green on `Mbeddr2_Mbeddr_Gradle_platform` build config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)