### PR TITLE
feat(assessment): pass MPS project to getSummaries()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is _loosely_ based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). The project does _not_ follow
 Semantic Versioning and the changes are simply documented in reverse chronological order, grouped by calendar month.
 
+# April 2026
+
+## Changed
+
+- `com.mbeddr.core.base`: MPS project is now also passed to `Assessment.getSummaries()`. The overload without the
+  project parameter is deprecated.
+
 # March 2026
 
 ## Fixed

--- a/code/platform/com.mbeddr.mpsutil/languages/com.mbeddr.core.base/models/behavior.mps
+++ b/code/platform/com.mbeddr.mpsutil/languages/com.mbeddr.core.base/models/behavior.mps
@@ -3085,7 +3085,10 @@
               <ref role="2I9WkF" to="vs0r:_gCXGjnZUS" resolve="AssessmentSummary" />
             </node>
             <node concept="BsUDl" id="5L$H31KeLVF" role="33vP2m">
-              <ref role="37wK5l" node="_gCXGjoJQM" resolve="getSummaries" />
+              <ref role="37wK5l" node="10O5aZlk4QE" resolve="getSummaries" />
+              <node concept="37vLTw" id="10O5aZllkN_" role="37wK5m">
+                <ref role="3cqZAo" node="4WjNWxKFdYY" resolve="mpsProject" />
+              </node>
               <node concept="37vLTw" id="5L$H31KeLVH" role="37wK5m">
                 <ref role="3cqZAo" node="4WjNWxKFdZQ" resolve="assessment" />
               </node>
@@ -3325,6 +3328,61 @@
       <node concept="37vLTG" id="_gCXGjoJQQ" role="3clF46">
         <property role="TrG5h" value="ass" />
         <node concept="3Tqbb2" id="_gCXGjoJQR" role="1tU5fm">
+          <ref role="ehGHo" to="vs0r:K292flwCEW" resolve="Assessment" />
+        </node>
+      </node>
+      <node concept="P$JXv" id="10O5aZllY6b" role="lGtFl">
+        <node concept="TZ5HI" id="10O5aZllY6c" role="3nqlJM">
+          <node concept="TZ5HA" id="10O5aZllY6d" role="3HnX3l">
+            <node concept="1dT_AC" id="10O5aZllYHh" role="1dT_Ay">
+              <property role="1dT_AB" value="Use getSummaries with the Project parameter" />
+            </node>
+            <node concept="1dT_AC" id="10O5aZllYHi" role="1dT_Ay">
+              <property role="1dT_AB" value="" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="10O5aZllY6e" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
+        <node concept="2B6LJw" id="10O5aZllYEm" role="2B76xF">
+          <ref role="2B6OnR" to="wyt6:~Deprecated.since()" resolve="since" />
+          <node concept="Xl_RD" id="10O5aZllYFg" role="2B70Vg">
+            <property role="Xl_RC" value="2026-04-27" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="13i0hz" id="10O5aZlk4QE" role="13h7CS">
+      <property role="TrG5h" value="getSummaries" />
+      <property role="13i0it" value="true" />
+      <property role="13i0iv" value="false" />
+      <node concept="3Tm1VV" id="10O5aZlk4QF" role="1B3o_S" />
+      <node concept="2I9FWS" id="10O5aZlk4QG" role="3clF45">
+        <ref role="2I9WkF" to="vs0r:_gCXGjnZUS" resolve="AssessmentSummary" />
+      </node>
+      <node concept="3clFbS" id="10O5aZlk4QH" role="3clF47">
+        <node concept="3clFbF" id="10O5aZlkqsw" role="3cqZAp">
+          <node concept="BsUDl" id="10O5aZlkqsu" role="3clFbG">
+            <ref role="37wK5l" node="_gCXGjoJQM" resolve="getSummaries" />
+            <node concept="37vLTw" id="10O5aZlkqsy" role="37wK5m">
+              <ref role="3cqZAo" node="10O5aZlk4R0" resolve="ass" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="10O5aZlkgnS" role="3clF46">
+        <property role="TrG5h" value="mpsProject" />
+        <node concept="3uibUv" id="10O5aZlkgnT" role="1tU5fm">
+          <ref role="3uigEE" to="z1c3:~Project" resolve="Project" />
+        </node>
+        <node concept="2AHcQZ" id="10O5aZlkgnU" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="10O5aZlk4R0" role="3clF46">
+        <property role="TrG5h" value="ass" />
+        <node concept="3Tqbb2" id="10O5aZlk4R1" role="1tU5fm">
           <ref role="ehGHo" to="vs0r:K292flwCEW" resolve="Assessment" />
         </node>
       </node>

--- a/code/platform/com.mbeddr.mpsutil/tests/test.assessments.testlang/models/test.assessments.testlang.behavior.mps
+++ b/code/platform/com.mbeddr.mpsutil/tests/test.assessments.testlang/models/test.assessments.testlang.behavior.mps
@@ -9,6 +9,7 @@
   <imports>
     <import index="hikj" ref="r:08e46f36-ad08-4837-aae6-df5fffab661d(test.assessments.testlang.structure)" />
     <import index="z1c3" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.project(MPS.Core/)" />
+    <import index="mhfm" ref="3f233e7f-b8a6-46d2-a57f-795d56775243/java:org.jetbrains.annotations(Annotations/)" />
     <import index="hwgx" ref="r:fd2980c8-676c-4b19-b524-18c70e02f8b7(com.mbeddr.core.base.behavior)" implicit="true" />
     <import index="vs0r" ref="r:f7764ca4-8c75-4049-922b-08516400a727(com.mbeddr.core.base.structure)" implicit="true" />
   </imports>
@@ -31,6 +32,12 @@
         <child id="1068498886295" name="lValue" index="37vLTJ" />
       </concept>
       <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
+      <concept id="1188207840427" name="jetbrains.mps.baseLanguage.structure.AnnotationInstance" flags="nn" index="2AHcQZ">
+        <reference id="1188208074048" name="annotation" index="2AI5Lk" />
+      </concept>
+      <concept id="1188208481402" name="jetbrains.mps.baseLanguage.structure.HasAnnotation" flags="ngI" index="2AJDlI">
+        <child id="1188208488637" name="annotation" index="2AJF6D" />
+      </concept>
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
@@ -167,7 +174,7 @@
     </node>
     <node concept="13i0hz" id="6v0bPePAe8A" role="13h7CS">
       <property role="TrG5h" value="getSummaries" />
-      <ref role="13i0hy" to="hwgx:_gCXGjoJQM" resolve="getSummaries" />
+      <ref role="13i0hy" to="hwgx:10O5aZlk4QE" resolve="getSummaries" />
       <node concept="3Tm1VV" id="6v0bPePAe8B" role="1B3o_S" />
       <node concept="3clFbS" id="6v0bPePAe8Y" role="3clF47">
         <node concept="3cpWs6" id="6v0bPePAels" role="3cqZAp">
@@ -202,13 +209,22 @@
           </node>
         </node>
       </node>
-      <node concept="37vLTG" id="6v0bPePAe8Z" role="3clF46">
+      <node concept="37vLTG" id="10O5aZlnbLa" role="3clF46">
+        <property role="TrG5h" value="mpsProject" />
+        <node concept="3uibUv" id="10O5aZlnbLb" role="1tU5fm">
+          <ref role="3uigEE" to="z1c3:~Project" resolve="Project" />
+        </node>
+        <node concept="2AHcQZ" id="10O5aZlnbLc" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="10O5aZlnbLd" role="3clF46">
         <property role="TrG5h" value="ass" />
-        <node concept="3Tqbb2" id="6v0bPePAe90" role="1tU5fm">
+        <node concept="3Tqbb2" id="10O5aZlnbLe" role="1tU5fm">
           <ref role="ehGHo" to="vs0r:K292flwCEW" resolve="Assessment" />
         </node>
       </node>
-      <node concept="2I9FWS" id="6v0bPePAe91" role="3clF45">
+      <node concept="2I9FWS" id="10O5aZlnbLf" role="3clF45">
         <ref role="2I9WkF" to="vs0r:_gCXGjnZUS" resolve="AssessmentSummary" />
       </node>
     </node>


### PR DESCRIPTION
There is an assessment query in IETS3-opensource that does not summarize results in `getSummaries()` but uses it to provide another, 'summary' kind of result. It uses `AssessmentScope.findElements()` and therefore needs the MPS project.

I consider this a valid use case, although a bit unusual.