### PR TITLE
Ban path variables from .mps/libraries.xml

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -323,6 +323,10 @@ object PullRequestsBuild : BuildType({
         preliminaryMerge {
             targetBranchName = "%teamcity.pullRequest.target.branch%"
         }
+        script {
+            name = "Check libraries.xml for path variables"
+            scriptContent = "./scripts/check-libraries-no-path-vars.sh"
+        }
         gradle {
             tasks = "test_mbeddr_platform test_mbeddr publish migrate remigrate -PforceBuildPlatform"
             gradleParams = "--info"

--- a/code/applications/HeartBleed/.mps/libraries.xml
+++ b/code/applications/HeartBleed/.mps/libraries.xml
@@ -7,7 +7,7 @@
           <value>
             <Library>
               <option name="name" value="mbeddr" />
-              <option name="path" value="${mbeddr.github.core.home}" />
+              <option name="path" value="$PROJECT_DIR$/../../.." />
             </Library>
           </value>
         </entry>

--- a/code/applications/IntegratedCExample/.mps/libraries.xml
+++ b/code/applications/IntegratedCExample/.mps/libraries.xml
@@ -7,7 +7,7 @@
           <value>
             <Library>
               <option name="name" value="mbeddr" />
-              <option name="path" value="${mbeddr.github.core.home}" />
+              <option name="path" value="$PROJECT_DIR$/../../.." />
             </Library>
           </value>
         </entry>

--- a/code/applications/Pacemaker/.mps/libraries.xml
+++ b/code/applications/Pacemaker/.mps/libraries.xml
@@ -7,7 +7,7 @@
           <value>
             <Library>
               <option name="name" value="mbeddr" />
-              <option name="path" value="${mbeddr.github.core.home}" />
+              <option name="path" value="$PROJECT_DIR$/../../.." />
             </Library>
           </value>
         </entry>

--- a/code/applications/com.mbeddr.build-examples/.mps/libraries.xml
+++ b/code/applications/com.mbeddr.build-examples/.mps/libraries.xml
@@ -7,7 +7,7 @@
           <value>
             <Library>
               <option name="name" value="mbeddr" />
-              <option name="path" value="${mbeddr.github.core.home}" />
+              <option name="path" value="$PROJECT_DIR$/../../.." />
             </Library>
           </value>
         </entry>

--- a/code/applications/com.mbeddr.documentation/.mps/libraries.xml
+++ b/code/applications/com.mbeddr.documentation/.mps/libraries.xml
@@ -7,7 +7,7 @@
           <value>
             <Library>
               <option name="name" value="mbeddr" />
-              <option name="path" value="${mbeddr.github.core.home}" />
+              <option name="path" value="$PROJECT_DIR$/../../.." />
             </Library>
           </value>
         </entry>

--- a/code/applications/com.mbeddr.embedded/.mps/libraries.xml
+++ b/code/applications/com.mbeddr.embedded/.mps/libraries.xml
@@ -7,7 +7,7 @@
           <value>
             <Library>
               <option name="name" value="mbeddr" />
-              <option name="path" value="${mbeddr.github.core.home}" />
+              <option name="path" value="$PROJECT_DIR$/../../.." />
             </Library>
           </value>
         </entry>

--- a/code/applications/tutorial-dsls-extensions/.mps/libraries.xml
+++ b/code/applications/tutorial-dsls-extensions/.mps/libraries.xml
@@ -7,7 +7,7 @@
           <value>
             <Library>
               <option name="name" value="mbeddr" />
-              <option name="path" value="${mbeddr.github.core.home}" />
+              <option name="path" value="$PROJECT_DIR$/../../.." />
             </Library>
           </value>
         </entry>

--- a/code/applications/tutorial/.mps/libraries.xml
+++ b/code/applications/tutorial/.mps/libraries.xml
@@ -7,7 +7,7 @@
           <value>
             <Library>
               <option name="name" value="dependencies" />
-              <option name="path" value="${mbeddr.github.core.home}/build/dependencies/de.itemis.mps.extensions" />
+              <option name="path" value="$PROJECT_DIR$/../../../build/dependencies/de.itemis.mps.extensions" />
             </Library>
           </value>
         </entry>
@@ -15,7 +15,7 @@
           <value>
             <Library>
               <option name="name" value="mbeddr" />
-              <option name="path" value="${mbeddr.github.core.home}/code" />
+              <option name="path" value="$PROJECT_DIR$/../.." />
             </Library>
           </value>
         </entry>

--- a/code/languages/com.mbeddr.build/.mps/libraries.xml
+++ b/code/languages/com.mbeddr.build/.mps/libraries.xml
@@ -7,7 +7,7 @@
           <value>
             <Library>
               <option name="name" value="mps.extensions" />
-              <option name="path" value="${mbeddr.github.core.home}/build/dependencies/de.itemis.mps.extensions" />
+              <option name="path" value="$PROJECT_DIR$/../../../build/dependencies/de.itemis.mps.extensions" />
             </Library>
           </value>
         </entry>
@@ -15,7 +15,7 @@
           <value>
             <Library>
               <option name="name" value="platform.build" />
-              <option name="path" value="${mbeddr.github.core.home}/code/platform/com.mbeddr.platform.build" />
+              <option name="path" value="$PROJECT_DIR$/../../platform/com.mbeddr.platform.build" />
             </Library>
           </value>
         </entry>

--- a/code/languages/com.mbeddr.cc/.mps/libraries.xml
+++ b/code/languages/com.mbeddr.cc/.mps/libraries.xml
@@ -7,7 +7,7 @@
           <value>
             <Library>
               <option name="name" value="core" />
-              <option name="path" value="${mbeddr.github.core.home}/code/languages/com.mbeddr.core" />
+              <option name="path" value="$PROJECT_DIR$/../com.mbeddr.core" />
             </Library>
           </value>
         </entry>
@@ -15,7 +15,7 @@
           <value>
             <Library>
               <option name="name" value="doc" />
-              <option name="path" value="${mbeddr.github.core.home}/code/platform/com.mbeddr.doc" />
+              <option name="path" value="$PROJECT_DIR$/../../platform/com.mbeddr.doc" />
             </Library>
           </value>
         </entry>
@@ -23,7 +23,7 @@
           <value>
             <Library>
               <option name="name" value="ext" />
-              <option name="path" value="${mbeddr.github.core.home}/code/languages/com.mbeddr.ext" />
+              <option name="path" value="$PROJECT_DIR$/../com.mbeddr.ext" />
             </Library>
           </value>
         </entry>
@@ -31,7 +31,7 @@
           <value>
             <Library>
               <option name="name" value="mpsutil" />
-              <option name="path" value="${mbeddr.github.core.home}/code/platform/com.mbeddr.mpsutil" />
+              <option name="path" value="$PROJECT_DIR$/../../platform/com.mbeddr.mpsutil" />
             </Library>
           </value>
         </entry>
@@ -39,7 +39,7 @@
           <value>
             <Library>
               <option name="name" value="mps.extensions" />
-              <option name="path" value="${mbeddr.github.core.home}/build/dependencies/de.itemis.mps.extensions" />
+              <option name="path" value="$PROJECT_DIR$/../../../build/dependencies/de.itemis.mps.extensions" />
             </Library>
           </value>
         </entry>

--- a/code/languages/com.mbeddr.core/.mps/libraries.xml
+++ b/code/languages/com.mbeddr.core/.mps/libraries.xml
@@ -7,7 +7,7 @@
           <value>
             <Library>
               <option name="name" value="doc" />
-              <option name="path" value="${mbeddr.github.core.home}/code/platform/com.mbeddr.doc" />
+              <option name="path" value="$PROJECT_DIR$/../../platform/com.mbeddr.doc" />
             </Library>
           </value>
         </entry>
@@ -15,7 +15,7 @@
           <value>
             <Library>
               <option name="name" value="doc.aspect" />
-              <option name="path" value="${mbeddr.github.core.home}/code/platform/com.mbeddr.doc.aspect" />
+              <option name="path" value="$PROJECT_DIR$/../../platform/com.mbeddr.doc.aspect" />
             </Library>
           </value>
         </entry>
@@ -23,7 +23,7 @@
           <value>
             <Library>
               <option name="name" value="mpsutil" />
-              <option name="path" value="${mbeddr.github.core.home}/code/platform/com.mbeddr.mpsutil" />
+              <option name="path" value="$PROJECT_DIR$/../../platform/com.mbeddr.mpsutil" />
             </Library>
           </value>
         </entry>
@@ -31,7 +31,7 @@
           <value>
             <Library>
               <option name="name" value="mps.extensions" />
-              <option name="path" value="${mbeddr.github.core.home}/build/dependencies/de.itemis.mps.extensions" />
+              <option name="path" value="$PROJECT_DIR$/../../../build/dependencies/de.itemis.mps.extensions" />
             </Library>
           </value>
         </entry>

--- a/code/languages/com.mbeddr.ext/.mps/libraries.xml
+++ b/code/languages/com.mbeddr.ext/.mps/libraries.xml
@@ -7,7 +7,7 @@
           <value>
             <Library>
               <option name="name" value="core" />
-              <option name="path" value="${mbeddr.github.core.home}/code/languages/com.mbeddr.core" />
+              <option name="path" value="$PROJECT_DIR$/../com.mbeddr.core" />
             </Library>
           </value>
         </entry>
@@ -15,7 +15,7 @@
           <value>
             <Library>
               <option name="name" value="mpsutil" />
-              <option name="path" value="${mbeddr.github.core.home}/code/platform/com.mbeddr.mpsutil" />
+              <option name="path" value="$PROJECT_DIR$/../../platform/com.mbeddr.mpsutil" />
             </Library>
           </value>
         </entry>
@@ -23,7 +23,7 @@
           <value>
             <Library>
               <option name="name" value="mps.extensions" />
-              <option name="path" value="${mbeddr.github.core.home}/build/dependencies/de.itemis.mps.extensions" />
+              <option name="path" value="$PROJECT_DIR$/../../../build/dependencies/de.itemis.mps.extensions" />
             </Library>
           </value>
         </entry>

--- a/scripts/check-libraries-no-path-vars.sh
+++ b/scripts/check-libraries-no-path-vars.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+#
+# Verifies that every .mps/libraries.xml file declares library paths relative to
+# $PROJECT_DIR$ instead of an IntelliJ path variable (e.g. ${mbeddr.github.core.home}).
+#
+# Path variables require per-machine configuration and break checkouts that don't
+# define them, so they must not be reintroduced. This check is meant to run on CI
+# for every pull request.
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+# A path variable is a ${...} macro. $PROJECT_DIR$ is fine because it contains no
+# braces, so any occurrence of "${" in a libraries.xml is a forbidden path variable.
+violations=0
+
+while IFS= read -r -d '' file; do
+    if matches=$(grep -nF '${' "$file"); then
+        if [ "$violations" -eq 0 ]; then
+            echo "Path variables are not allowed in .mps/libraries.xml files."
+            echo "Use paths relative to \$PROJECT_DIR\$ instead."
+            echo
+        fi
+        echo "$file:"
+        echo "$matches" | sed 's/^/  /'
+        echo
+        violations=$((violations + 1))
+    fi
+done < <(git ls-files -z '*/.mps/libraries.xml')
+
+if [ "$violations" -ne 0 ]; then
+    echo "Found path variables in $violations file(s)." >&2
+    exit 1
+fi
+
+echo "OK: no path variables found in .mps/libraries.xml files."

--- a/tools/BigProject/.mps/libraries.xml
+++ b/tools/BigProject/.mps/libraries.xml
@@ -7,7 +7,7 @@
           <value>
             <Library>
               <option name="name" value="mps-extensions" />
-              <option name="path" value="${mbeddr.github.core.home}/build/dependencies/de.itemis.mps.extensions" />
+              <option name="path" value="$PROJECT_DIR$/../../build/dependencies/de.itemis.mps.extensions" />
             </Library>
           </value>
         </entry>


### PR DESCRIPTION
Replace the `${mbeddr.github.core.home}` path variable with `$PROJECT_DIR$`-relative paths in all `.mps/libraries.xml` files, and add a CI guard against path variables in libraries.xml.